### PR TITLE
Fix string concat for MySQL

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/MysqlQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/MysqlQuery.js
@@ -56,6 +56,11 @@ class MysqlQuery extends BaseQuery {
     ).join(' UNION ALL ');
     return `SELECT TIMESTAMP(dates.f) date_from, TIMESTAMP(dates.t) date_to FROM (${values}) AS dates`;
   }
+
+  concatStringsSql(strings) {
+    return `CONCAT(${strings.join(", ")})`;
+  }
+
 }
 
 module.exports = MysqlQuery;


### PR DESCRIPTION
Unfortunately, MySQL uses CONCAT() for string concat instead of the more common '||'.  This fixes that in cube.js.