### PR TITLE
Typo in joins.md

### DIFF
--- a/docs/Schema/joins.md
+++ b/docs/Schema/joins.md
@@ -141,7 +141,7 @@ different depending on your database._
 dimensions: {
   id: {
     sql: `${CUBE}.user_id || '-' || ${CUBE}.signup_week || '-' || ${CUBE}.activity_week`,
-    type: `number`,
+    type: `string`,
     primaryKey: true
   }
 }


### PR DESCRIPTION
Obviously you can not use number type on TEXT strings.