### PR TITLE
change playground urls to ralative urls

### DIFF
--- a/packages/cubejs-playground/src/App.js
+++ b/packages/cubejs-playground/src/App.js
@@ -44,7 +44,7 @@ class App extends Component {
       });
     });
 
-    const res = await fetch('/playground/context');
+    const res = await fetch('playground/context');
     const result = await res.json();
     if (window.analytics) {
       window.analytics.identify(result.anonymousId, {

--- a/packages/cubejs-playground/src/DashboardPage.js
+++ b/packages/cubejs-playground/src/DashboardPage.js
@@ -27,7 +27,7 @@ class DashboardPage extends Component {
       appCode: !this.dashboardSource.loadError && this.dashboardSource.dashboardAppCode(),
       loadError: this.dashboardSource.loadError
     });
-    const dashboardStatus = await (await fetch('/playground/dashboard-app-status')).json();
+    const dashboardStatus = await (await fetch('playground/dashboard-app-status')).json();
     this.setState({
       dashboardRunning: dashboardStatus.running,
       dashboardPort: dashboardStatus.dashboardPort,
@@ -39,7 +39,7 @@ class DashboardPage extends Component {
     this.setState({
       dashboardStarting: true
     });
-    await fetch('/playground/start-dashboard-app');
+    await fetch('playground/start-dashboard-app');
     await this.loadDashboard();
   }
 

--- a/packages/cubejs-playground/src/DashboardSource.js
+++ b/packages/cubejs-playground/src/DashboardSource.js
@@ -64,9 +64,9 @@ class DashboardSource {
   async load(createApp) {
     this.loadError = null;
     if (createApp) {
-      await fetchWithRetry('/playground/ensure-dashboard-app', undefined, 5);
+      await fetchWithRetry('playground/ensure-dashboard-app', undefined, 5);
     }
-    const res = await fetchWithRetry('/playground/dashboard-app-files', undefined, 5);
+    const res = await fetchWithRetry('playground/dashboard-app-files', undefined, 5);
     const result = await res.json();
     if (result.error) {
       this.loadError = result.error;
@@ -80,7 +80,7 @@ class DashboardSource {
     const updateIndexCss = this.appLayoutAdded ? [
       { ...this.indexCssFile, content: this.indexCssFile.content + indexCss }
     ] : [];
-    await fetchWithRetry('/playground/dashboard-app-files', {
+    await fetchWithRetry('playground/dashboard-app-files', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -99,7 +99,7 @@ class DashboardSource {
         const dependency = importName[0].indexOf('@') === 0 ? [importName[0], importName[1]].join('/') : importName[0];
         return { [dependency]: 'latest' };
       }).reduce((a, b) => ({ ...a, ...b }));
-    await fetchWithRetry('/playground/ensure-dependencies', {
+    await fetchWithRetry('playground/ensure-dependencies', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/packages/cubejs-playground/src/ExplorePage.js
+++ b/packages/cubejs-playground/src/ExplorePage.js
@@ -14,7 +14,7 @@ class ExplorePage extends Component {
   }
 
   async componentDidMount() {
-    const res = await fetch('/playground/context');
+    const res = await fetch('playground/context');
     const result = await res.json();
     this.setState({
       cubejsToken: result.cubejsToken,

--- a/packages/cubejs-playground/src/IndexPage.js
+++ b/packages/cubejs-playground/src/IndexPage.js
@@ -14,7 +14,7 @@ class IndexPage extends Component {
   }
 
   async loadFiles() {
-    const res = await fetch('/playground/files');
+    const res = await fetch('playground/files');
     const result = await res.json();
     this.setState({
       files: result.files

--- a/packages/cubejs-playground/src/SchemaPage.js
+++ b/packages/cubejs-playground/src/SchemaPage.js
@@ -74,7 +74,7 @@ class SchemaPage extends Component {
   async loadDBSchema() {
     this.setState({ schemaLoading: true });
     try {
-      const res = await fetch('/playground/db-schema');
+      const res = await fetch('playground/db-schema');
       const result = await res.json();
       this.setState({
         tablesSchema: result.tablesSchema
@@ -87,7 +87,7 @@ class SchemaPage extends Component {
   }
 
   async loadFiles() {
-    const res = await fetch('/playground/files');
+    const res = await fetch('playground/files');
     const result = await res.json();
     this.setState({
       files: result.files
@@ -98,7 +98,7 @@ class SchemaPage extends Component {
     const { checkedKeys } = this.state;
     const { history } = this.props;
     playgroundAction('Generate Schema');
-    const res = await fetch('/playground/generate-schema', {
+    const res = await fetch('playground/generate-schema', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required



**Description of Changes Made (if issue reference is not provided)**

I changed the urls for the playground api in to relative urls. Becaus i mounted the playground as express subapp and its wanted to call the playound from the root level.
