### PR TITLE
feat(@cubejs-backend/schema-compiler): add context variables `START_DATE` & `END_DATE` to `rollingWindow`

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/BaseMeasure.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseMeasure.js
@@ -88,7 +88,7 @@ class BaseMeasure {
     const rollingWindow = this.measureDefinition().rollingWindow;
     if (rollingWindow) {
       return this.query.rollingWindowDateJoinCondition(
-        rollingWindow.trailing, rollingWindow.leading, rollingWindow.offset
+        rollingWindow.trailing, rollingWindow.leading, rollingWindow.offset, this.cube().name
       );
     }
     return null;
@@ -110,7 +110,7 @@ class BaseMeasure {
   }
 
   granularityFromInterval(interval) {
-    if (!interval) {
+    if (!interval || typeof interval === 'object') {
       return undefined;
     }
     if (interval.match(/day/)) {

--- a/packages/cubejs-schema-compiler/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/compiler/CubeSymbols.js
@@ -5,7 +5,9 @@ const FunctionRegex = /function\s+\w+\(([A-Za-z0-9_,]*)|\(([\s\S]*?)\)\s+|\(?(\w
 const CONTEXT_SYMBOLS = {
   USER_CONTEXT: 'userContext',
   FILTER_PARAMS: 'filterParams',
-  SQL_UTILS: 'sqlUtils'
+  SQL_UTILS: 'sqlUtils',
+  START_DATE: 'startDate',
+  END_DATE: 'endDate'
 };
 
 const CURRENT_CUBE_CONSTANTS = ['CUBE', 'TABLE'];
@@ -114,7 +116,9 @@ class CubeSymbols {
     if (CONTEXT_SYMBOLS[name]) {
       // always resolves if contextSymbols aren't passed for transpile step
       const symbol = contextSymbols && contextSymbols[CONTEXT_SYMBOLS[name]] || {};
-      symbol._objectWithResolvedProperties = true;
+      if (typeof symbol === 'object') {
+        symbol._objectWithResolvedProperties = true;
+      }
       return symbol;
     }
     let cube = this.isCurrentCube(name) && this.symbols[cubeName] || this.symbols[name];

--- a/packages/cubejs-schema-compiler/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/compiler/CubeValidator.js
@@ -5,7 +5,11 @@ const identifier = Joi.string().regex(/^[_a-zA-Z][_a-zA-Z0-9]*$/, 'identifier');
 const timeInterval =
   Joi.alternatives([
     Joi.string().regex(/^(-?\d+) (minute|hour|day|week|month|year)$/, 'time interval'),
-    Joi.any().valid('unbounded')
+    Joi.any().valid('unbounded'),
+    Joi.object().keys({
+      sql: Joi.func().required(),
+      inclusive: Joi.boolean()
+    })
   ]);
 
 const BaseDimensionWithoutSubQuery = {


### PR DESCRIPTION
This PR allows users to define arbitrary date ranges using `START_DATE` and `END_DATE` context variables in the `leading` and `trailing` properties of `rollingWindow`.

See issue #209 for more details

Example: To calculate rolling count since the start of the current month of the date range.

```javascript
monthToDateCount: {
  type: 'count',
  sql: 'id',
  rollingWindow: {
    trailing: {
      sql: `DATE_FORMAT(${START_DATE}, '%Y-%m-01')`
    },
    leading: {
      sql: `${END_DATE}`,
      inclusive: true
    }
  }
}
```

By default, the trailing start is inclusive, while the leading end is exclusive. This behavior can be changed by setting the `inclusive` property to `true` or `false`. In the example above, both the trailing start and the leading end are **inclusive**.
