### PR TITLE
Fix continueWaitTimout is ignored

### DIFF
--- a/packages/cubejs-query-orchestrator/orchestrator/LocalQueueDriver.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/LocalQueueDriver.js
@@ -34,7 +34,7 @@ class LocalQueueDriverConnection {
 
     const res = await Promise.race([
       this.getResultPromise(resultListKey),
-      timeoutPromise(continueWaitTimeout || this.continueWaitTimeout * 1000),
+      timeoutPromise((this.continueWaitTimeout || continueWaitTimeout) * 1000),
     ]);
     if (res) {
       delete this.resultPromises[resultListKey];

--- a/packages/cubejs-query-orchestrator/orchestrator/LocalQueueDriver.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/LocalQueueDriver.js
@@ -28,13 +28,13 @@ class LocalQueueDriverConnection {
     return this.resultPromises[resultListKey];
   }
 
-  async getResultBlocking(queryKey, continueWaitTimeout) {
+  async getResultBlocking(queryKey) {
     const resultListKey = this.resultListKey(queryKey);
     const timeoutPromise = (timeout) => new Promise((resolve) => setTimeout(() => resolve(null), timeout));
 
     const res = await Promise.race([
       this.getResultPromise(resultListKey),
-      timeoutPromise((this.continueWaitTimeout || continueWaitTimeout) * 1000),
+      timeoutPromise(this.continueWaitTimeout * 1000),
     ]);
     if (res) {
       delete this.resultPromises[resultListKey];
@@ -45,7 +45,7 @@ class LocalQueueDriverConnection {
   async getResult(queryKey) {
     const resultListKey = this.resultListKey(queryKey);
     if (this.resultPromises[resultListKey]) {
-      return this.getResultBlocking(queryKey, 5);
+      return this.getResultBlocking(queryKey);
     }
     return null;
   }


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**
I am not familiar with the internals of cube, however I am experiencing a problem where `continueWaitTimeout` is not being honored and upon inspecting the code it seems that the option is only used as a fallback to an argument that is never undefined.

Furthermore it seems thar a pair of parentheses is missing (?) otherwise it will wait for 5ms instead of 5s.

I might be missing something as I am really not familiar with the code, please review.

Thank you.