### PR TITLE
refactor: compiler should not rely on query instance

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseQuery.js
@@ -1239,6 +1239,10 @@ class BaseQuery {
   }
 
   aliasName(name) {
+    return BaseQuery.aliasName(name);
+  }
+
+  static aliasName(name) {
     return inflection.underscore(name).replace(/\./g, '__');
   }
 

--- a/packages/cubejs-schema-compiler/compiler/CubeToMetaTransformer.js
+++ b/packages/cubejs-schema-compiler/compiler/CubeToMetaTransformer.js
@@ -1,16 +1,16 @@
 const R = require('ramda');
 const inflection = require('inflection');
 const BaseMeasure = require('../adapter/BaseMeasure');
+const BaseQuery = require('../adapter/BaseQuery');
 const UserError = require('./UserError');
 
 class CubeToMetaTransformer {
-  constructor(cubeValidator, cubeEvaluator, contextEvaluator, joinGraph, adapter) {
+  constructor(cubeValidator, cubeEvaluator, contextEvaluator, joinGraph) {
     this.cubeValidator = cubeValidator;
     this.cubeSymbols = cubeEvaluator;
     this.cubeEvaluator = cubeEvaluator;
     this.contextEvaluator = contextEvaluator;
     this.joinGraph = joinGraph;
-    this.adapter = adapter;
   }
 
   compile(cubes, errorReporter) {
@@ -39,7 +39,7 @@ class CubeToMetaTransformer {
             title: this.title(cubeTitle, nameToDimension),
             type: nameToDimension[1].type,
             description: nameToDimension[1].description,
-            aliasName: this.adapter.aliasName(`${cube.name}.${nameToDimension[0]}`),
+            aliasName: BaseQuery.aliasName(`${cube.name}.${nameToDimension[0]}`),
             shortTitle: this.title(cubeTitle, nameToDimension, true),
             suggestFilterValues:
               nameToDimension[1].suggestFilterValues == null ? true : nameToDimension[1].suggestFilterValues,
@@ -102,7 +102,7 @@ class CubeToMetaTransformer {
       description: nameToMetric[1].description,
       shortTitle: this.title(cubeTitle, nameToMetric, true),
       format: nameToMetric[1].format,
-      aliasName: this.adapter.aliasName(name),
+      aliasName: BaseQuery.aliasName(name),
       cumulativeTotal: nameToMetric[1].cumulative || BaseMeasure.isCumulative(nameToMetric[1]),
       cumulative: nameToMetric[1].cumulative || BaseMeasure.isCumulative(nameToMetric[1]),
       type: 'number', // TODO

--- a/packages/cubejs-schema-compiler/compiler/PrepareCompiler.js
+++ b/packages/cubejs-schema-compiler/compiler/PrepareCompiler.js
@@ -8,7 +8,6 @@ const CubeEvaluator = require('./CubeEvaluator');
 const ContextEvaluator = require('./ContextEvaluator');
 const DashboardTemplateEvaluator = require('./DashboardTemplateEvaluator');
 const JoinGraph = require('./JoinGraph');
-const QueryBuilder = require('../adapter/QueryBuilder');
 const Funnels = require('../extensions/Funnels');
 const CubeToMetaTransformer = require('./CubeToMetaTransformer');
 
@@ -27,12 +26,7 @@ exports.prepareCompiler = (repo, options) => {
   const contextEvaluator = new ContextEvaluator(cubeEvaluator);
   const joinGraph = new JoinGraph(cubeValidator, cubeEvaluator);
   const dashboardTemplateEvaluator = new DashboardTemplateEvaluator(cubeEvaluator);
-  const query = QueryBuilder.query(
-    { cubeEvaluator, joinGraph },
-    options.adapter,
-    {}
-  );
-  const metaTransformer = new CubeToMetaTransformer(cubeValidator, cubeEvaluator, contextEvaluator, joinGraph, query);
+  const metaTransformer = new CubeToMetaTransformer(cubeValidator, cubeEvaluator, contextEvaluator, joinGraph);
   const compiler = new DataSchemaCompiler(repo, Object.assign({}, {
     cubeNameCompilers: [cubeDictionary],
     preTranspileCubeCompilers: [cubeSymbols, cubeValidator],


### PR DESCRIPTION
**Description of Changes Made (if issue reference is not provided)**

Based on the compiled schema, Query builder can convert the incoming queries to SQL.
Creating a query builder instance during compile schema seems strange and out of reason.
I add a static `aliasName` method to avoid creating instances for `CubeToMetaTransformer`.