### PR TITLE
feat: solve empty order query format

### DIFF
--- a/packages/cubejs-vue/src/QueryBuilder.js
+++ b/packages/cubejs-vue/src/QueryBuilder.js
@@ -30,7 +30,7 @@ export default {
       limit: null,
       offset: null,
       renewQuery: false,
-      order: {}
+      order: null,
     };
 
     data.granularities = [
@@ -233,7 +233,7 @@ export default {
       this.limit = (limit || null);
       this.offset = (offset || null);
       this.renewQuery = (renewQuery || false);
-      this.order = (order || {});
+      this.order = (order || null);
     },
     addMember(element, member) {
       const name = element.charAt(0).toUpperCase() + element.slice(1);

--- a/packages/cubejs-vue/tests/unit/QueryBuilder.spec.js
+++ b/packages/cubejs-vue/tests/unit/QueryBuilder.spec.js
@@ -409,7 +409,7 @@ describe('QueryBuilder.vue', () => {
       expect(wrapper.vm.filters.length).toBe(1);
       expect(wrapper.vm.filters[0].member.name).toBe('Orders.status');
       expect(wrapper.vm.filters[0].values).toContain('valid');
-    });    
+    });
 
     it('sets filters when using measure', async () => {
       const cube = CubejsApi('token');
@@ -464,7 +464,7 @@ describe('QueryBuilder.vue', () => {
       await flushPromises();
 
       expect(wrapper.vm.limit).toBe(10);
-    });   
+    });
 
     it('sets offset', async () => {
       const cube = CubejsApi('token');
@@ -518,6 +518,32 @@ describe('QueryBuilder.vue', () => {
       await flushPromises();
 
       expect(wrapper.vm.renewQuery).toBe(true);
+    });
+
+    it('ignore order if empty', async () => {
+      const cube = CubejsApi('token');
+      jest.spyOn(cube, 'request')
+        .mockImplementation(fetchMock(load))
+        .mockImplementationOnce(fetchMock(meta));
+
+      const filter = {
+        member: 'Orders.status',
+        operator: 'equals',
+        values: ['invalid'],
+      };
+
+      const wrapper = mount(QueryBuilder, {
+        propsData: {
+          cubejsApi: cube,
+          query: {
+            filters: [filter],
+          },
+        },
+      });
+
+      await flushPromises();
+
+      expect(wrapper.vm.order).toBe(null);
     });
 
     it('sets order', async () => {


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

No referred issue

**Description of Changes Made (if issue reference is not provided)**

When order is empty `QueryBuilder` object passes it to the `QueryRenderer` as an empty object but `@cubejs-server/core` does not allow it so we get a error
