### PR TITLE
docs: Update pre-aggregations on time hierarchy

### DIFF
--- a/docs/Schema/pre-aggregations.md
+++ b/docs/Schema/pre-aggregations.md
@@ -141,10 +141,10 @@ In this particular example these queries will use `categoryAndDate` pre-aggregat
 - Order Count by Created At Day this year
 - Order Count for all time
 - Order Average Revenue by Category this month
-
-These queries won't use `categoryAndDate` pre-aggregation:
 - Order Revenue by Created At Week this year
 - Order Revenue by Created At Month this year
+
+These queries won't use `categoryAndDate` pre-aggregation:
 - Order Count by Customer Name this year
 
 ### Time partitioning


### PR DESCRIPTION
Update doc since we have already support pre-aggregation on time hierarchy.

I also think maybe we should consider the time priority when searching for matchable pre-aggregations.
e.g. If there exists both a pre-aggregation on `month` and a pre-aggregation on `day`,  query on `month` should be matched to the pre-aggregation on `month` firstly.