### PR TITLE
feat: hooks for dynamic schemas

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -48,7 +48,6 @@ Both [CubejsServerCore](@cubejs-backend-server-core) and [CubejsServer](@cubejs-
   logger: (msg: String, params: Object) => any,
   driverFactory: (context: DriverContext) => BaseDriver,
   externalDriverFactory: (context: RequestContext) => BaseDriver,
-  requestToContext: (req: ExpressRequest) => RequestContext,
   contextToAppId: (context: RequestContext) => String,
   contextToDataSourceId: (context: RequestContext) => String,
   repositoryFactory: (context: RequestContext) => String,
@@ -188,18 +187,6 @@ CubejsServerCore.create({
 CubejsServerCore.create({
   contextToAppId: ({ authInfo }) => `CUBEJS_APP_${authInfo.user_id}`,
   contextToDataSourceId: ({ authInfo }) => `CUBEJS_APP_${authInfo.tenantId}`
-});
-```
-
-### requestToContext
-
-`requestToContext` is a function to customize the context object passed to other hooks.  Default implementation sets authInfo from the payload.  Custom headers and query parameters could be separated into a useful context here.
-
-```javascript
-const independantInfoSource = {};
-
-CubejsServerCore.create({
-  requestToContext: (req) => ({ authInfo: req.authInfo, customProp: independantInfoSource.currentValue })
 });
 ```
 

--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -48,12 +48,16 @@ Both [CubejsServerCore](@cubejs-backend-server-core) and [CubejsServer](@cubejs-
   logger: (msg: String, params: Object) => any,
   driverFactory: (context: DriverContext) => BaseDriver,
   externalDriverFactory: (context: RequestContext) => BaseDriver,
+  requestToContext: (req: ExpressRequest) => RequestContext,
   contextToAppId: (context: RequestContext) => String,
   repositoryFactory: (context: RequestContext) => String,
   checkAuthMiddleware: (req: ExpressRequest, res: ExpressResponse, next: ExpressMiddleware) => any,
   queryTransformer: (query: Object, context: RequestContext) => Object,
   preAggregationsSchema: String | (context: RequestContext) => String,
   schemaVersion: (context: RequestContext) => String,
+  compilerCacheSize: Number,
+  maxCompilerCacheKeepAlive: Number,
+  updateCompilerCacheKeepAlive: Boolean,
   telemetry: Boolean,
   allowUngroupedWithoutPrimaryKey: Boolean,
   orchestratorOptions: {
@@ -175,6 +179,18 @@ CubejsServerCore.create({
 })
 ```
 
+### requestToContext
+
+`requestToContext` is a function to customize the context object passed to other hooks.  Default implementation sets authInfo from the payload.  Custom headers and query parameters could be separated into a useful context here.
+
+```javascript
+const independantInfoSource = {};
+
+CubejsServerCore.create({
+  requestToContext: (req) => ({ authInfo: req.authInfo, customProp: independantInfoSource.currentValue })
+});
+```
+
 ### repositoryFactory
 
 This option allows to customize the repository for Cube.js data schema files. It
@@ -259,6 +275,18 @@ CubejsServerCore.create({
   schemaVersion: ({ authInfo }) => tenantIdToDbVersion[authInfo.tenantId]
 });
 ```
+
+### compilerCacheSize
+
+Maximum number of compiled schemas to persist with in-memory cache.  Defaults to 250, but optimum value will depend on deployed environment. When the max is reached, will start dropping the least recently used schemas from the cache.
+
+### maxCompilerCacheKeepAlive
+
+Maximum length of time in ms to keep compiled schemas in memory.  Default keeps schemas in memory indefinitely.
+
+### updateCompilerCacheKeepAlive
+
+Providing `updateCompilerCacheKeepAlive: true` keeps frequently used schemas in memory by reseting their `maxCompilerCacheKeepAlive` every time they are accessed.
 
 ### allowUngroupedWithoutPrimaryKey
 

--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -50,6 +50,7 @@ Both [CubejsServerCore](@cubejs-backend-server-core) and [CubejsServer](@cubejs-
   externalDriverFactory: (context: RequestContext) => BaseDriver,
   requestToContext: (req: ExpressRequest) => RequestContext,
   contextToAppId: (context: RequestContext) => String,
+  contextToDataSourceId: (context: RequestContext) => String,
   repositoryFactory: (context: RequestContext) => String,
   checkAuthMiddleware: (req: ExpressRequest, res: ExpressResponse, next: ExpressMiddleware) => any,
   queryTransformer: (query: Object, context: RequestContext) => Object,
@@ -177,6 +178,17 @@ It is a [Multitenancy Setup](multitenancy-setup) option.
 CubejsServerCore.create({
   contextToAppId: ({ authInfo }) => `CUBEJS_APP_${authInfo.user_id}`
 })
+```
+
+### contextToDataSourceId
+
+`contextToDataSourceId` is a function to determine a DataSource Id which is used to override the `contextToAppId` caching key for managing connection pools.
+
+```javascript
+CubejsServerCore.create({
+  contextToAppId: ({ authInfo }) => `CUBEJS_APP_${authInfo.user_id}`,
+  contextToDataSourceId: ({ authInfo }) => `CUBEJS_APP_${authInfo.tenantId}`
+});
 ```
 
 ### requestToContext

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -218,14 +218,13 @@ class ApiGateway {
     this.queryTransformer = options.queryTransformer || (async (query, context) => query);
     this.subscriptionStore = options.subscriptionStore || new LocalSubscriptionStore();
     this.enforceSecurityChecks = options.enforceSecurityChecks || (process.env.NODE_ENV === 'production');
-    this.requestToContext = options.requestToContext || this.defaultRequestToContext.bind(this);
   }
 
   initApp(app) {
     app.get(`${this.basePath}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.requestToContext(req),
+        context: this.contextByReq(req),
         res: this.resToResultFn(res)
       });
     }));
@@ -233,7 +232,7 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/subscribe`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.requestToContext(req),
+        context: this.contextByReq(req),
         res: this.resToResultFn(res)
       });
     }));
@@ -241,14 +240,14 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
       await this.sql({
         query: req.query.query,
-        context: this.requestToContext(req),
+        context: this.contextByReq(req),
         res: this.resToResultFn(res)
       });
     }));
 
     app.get(`${this.basePath}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
       await this.meta({
-        context: this.requestToContext(req),
+        context: this.contextByReq(req),
         res: this.resToResultFn(res)
       });
     }));
@@ -423,7 +422,7 @@ class ApiGateway {
     return this.adapterApi;
   }
 
-  defaultRequestToContext(req) {
+  contextByReq(req) {
     return { authInfo: req.authInfo };
   }
 

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -218,13 +218,14 @@ class ApiGateway {
     this.queryTransformer = options.queryTransformer || (async (query, context) => query);
     this.subscriptionStore = options.subscriptionStore || new LocalSubscriptionStore();
     this.enforceSecurityChecks = options.enforceSecurityChecks || (process.env.NODE_ENV === 'production');
+    this.requestToContext = options.requestToContext || this.defaultRequestToContext.bind(this);
   }
 
   initApp(app) {
     app.get(`${this.basePath}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.contextByReq(req),
+        context: this.requestToContext(req),
         res: this.resToResultFn(res)
       });
     }));
@@ -232,7 +233,7 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/subscribe`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.contextByReq(req),
+        context: this.requestToContext(req),
         res: this.resToResultFn(res)
       });
     }));
@@ -240,14 +241,14 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
       await this.sql({
         query: req.query.query,
-        context: this.contextByReq(req),
+        context: this.requestToContext(req),
         res: this.resToResultFn(res)
       });
     }));
 
     app.get(`${this.basePath}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
       await this.meta({
-        context: this.contextByReq(req),
+        context: this.requestToContext(req),
         res: this.resToResultFn(res)
       });
     }));
@@ -422,7 +423,7 @@ class ApiGateway {
     return this.adapterApi;
   }
 
-  contextByReq(req) {
+  defaultRequestToContext(req) {
     return { authInfo: req.authInfo };
   }
 

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -10,7 +10,6 @@ declare module '@cubejs-backend/server-core' {
     queryTransformer?: () => (query: any, context: any) => any;
     contextToAppId?: any;
     contextToDataSourceId?: (context: any) => string;
-    requestToContext?: (req: any) => any;
     devServer?: boolean;
     dbType?: DatabaseType;
     driverFactory?: DriverFactory;

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -9,6 +9,7 @@ declare module '@cubejs-backend/server-core' {
     checkAuthMiddleware?: (req: any, res: any, next: any) => any;
     queryTransformer?: () => (query: any, context: any) => any;
     contextToAppId?: any;
+    requestToContext?: (req: any) => any;
     devServer?: boolean;
     dbType?: DatabaseType;
     driverFactory?: DriverFactory;
@@ -18,6 +19,9 @@ declare module '@cubejs-backend/server-core' {
     preAggregationsSchema?: string | (() => string)
     repositoryFactory?: any;
     schemaPath?: string;
+    compilerCacheSize?: number;
+    maxCompilerCacheKeepAlive?: number;
+    updateCompilerCacheKeepAlive?: boolean;
   }
 
   export interface DriverFactory {

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -9,6 +9,7 @@ declare module '@cubejs-backend/server-core' {
     checkAuthMiddleware?: (req: any, res: any, next: any) => any;
     queryTransformer?: () => (query: any, context: any) => any;
     contextToAppId?: any;
+    contextToDataSourceId?: (context: any) => string;
     requestToContext?: (req: any) => any;
     devServer?: boolean;
     dbType?: DatabaseType;

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -254,7 +254,8 @@ class CubejsServerCore {
           basePath: this.options.basePath,
           checkAuthMiddleware: this.options.checkAuthMiddleware,
           checkAuth: this.options.checkAuth,
-          queryTransformer: this.options.queryTransformer
+          queryTransformer: this.options.queryTransformer,
+          requestToContext: this.options.requestToContext
         }
       );
     }

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -265,8 +265,7 @@ class CubejsServerCore {
           basePath: this.options.basePath,
           checkAuthMiddleware: this.options.checkAuthMiddleware,
           checkAuth: this.options.checkAuth,
-          queryTransformer: this.options.queryTransformer,
-          requestToContext: this.options.requestToContext
+          queryTransformer: this.options.queryTransformer
         }
       );
     }

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -3,6 +3,7 @@ const ApiGateway = require('@cubejs-backend/api-gateway');
 const crypto = require('crypto');
 const fs = require('fs-extra');
 const path = require('path');
+const LRUCache = require('lru-cache');
 const CompilerApi = require('./CompilerApi');
 const OrchestratorApi = require('./OrchestratorApi');
 const FileRepository = require('./FileRepository');
@@ -121,14 +122,23 @@ class CubejsServerCore {
       options.externalDbType :
       () => options.externalDbType;
     this.preAggregationsSchema =
-      typeof options.preAggregationsSchema === 'function' ? options.preAggregationsSchema : () => options.preAggregationsSchema;
-    this.appIdToCompilerApi = {};
+    typeof options.preAggregationsSchema === 'function' ? options.preAggregationsSchema : () => options.preAggregationsSchema;
+    this.compilerCache = new LRUCache({
+      max: options.compilerCacheSize || 250,
+      maxAge: options.maxCompilerCacheKeepAlive,
+      updateAgeOnGet: options.updateCompilerCacheKeepAlive
+    });
     this.dataSourceIdToOrchestratorApi = {};
     this.contextToAppId = options.contextToAppId || (() => process.env.CUBEJS_APP || 'STANDALONE');
     this.orchestratorOptions =
       typeof options.orchestratorOptions === 'function' ?
         options.orchestratorOptions :
         () => options.orchestratorOptions;
+
+    // proactively free up old cache values occassionally
+    if (options.maxCompilerCacheKeepAlive) {
+      setInterval(() => this.compilerCache.prune(), options.maxCompilerCacheKeepAlive);
+    }
 
     const { machineIdSync } = require('node-machine-id');
     let anonymousId = 'unknown';
@@ -264,8 +274,9 @@ class CubejsServerCore {
 
   getCompilerApi(context) {
     const appId = this.contextToAppId(context);
-    if (!this.appIdToCompilerApi[appId]) {
-      this.appIdToCompilerApi[appId] = this.createCompilerApi(
+    let compilerApi = this.compilerCache.get(appId);
+    if (!compilerApi) {
+      compilerApi = this.createCompilerApi(
         this.repositoryFactory(context), {
           dbType: (dataSourceContext) => this.contextToDbType({ ...context, ...dataSourceContext }),
           externalDbType: this.contextToExternalDbType(context),
@@ -273,8 +284,9 @@ class CubejsServerCore {
           preAggregationsSchema: this.preAggregationsSchema(context)
         }
       );
+      this.compilerCache.set(appId, compilerApi);
     }
-    return this.appIdToCompilerApi[appId];
+    return compilerApi;
   }
 
   contextToDataSourceId(context) {

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -122,7 +122,7 @@ class CubejsServerCore {
       options.externalDbType :
       () => options.externalDbType;
     this.preAggregationsSchema =
-    typeof options.preAggregationsSchema === 'function' ? options.preAggregationsSchema : () => options.preAggregationsSchema;
+      typeof options.preAggregationsSchema === 'function' ? options.preAggregationsSchema : () => options.preAggregationsSchema;
     this.compilerCache = new LRUCache({
       max: options.compilerCacheSize || 250,
       maxAge: options.maxCompilerCacheKeepAlive,
@@ -130,6 +130,7 @@ class CubejsServerCore {
     });
     this.dataSourceIdToOrchestratorApi = {};
     this.contextToAppId = options.contextToAppId || (() => process.env.CUBEJS_APP || 'STANDALONE');
+    this.contextToDataSourceId = options.contextToDataSourceId || this.defaultContextToDataSourceId.bind(this);
     this.orchestratorOptions =
       typeof options.orchestratorOptions === 'function' ?
         options.orchestratorOptions :
@@ -289,7 +290,7 @@ class CubejsServerCore {
     return compilerApi;
   }
 
-  contextToDataSourceId(context) {
+  defaultContextToDataSourceId(context) {
     return `${this.contextToAppId(context)}_${context.dataSource}`;
   }
 

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -38,6 +38,7 @@
     "cross-spawn": "^6.0.5",
     "fs-extra": "^7.0.1",
     "jsonwebtoken": "^8.4.0",
+    "lru-cache": "^5.1.1",
     "node-fetch": "^2.6.0",
     "node-machine-id": "^1.1.10",
     "prettier": "^1.16.4",

--- a/packages/cubejs-server-core/yarn.lock
+++ b/packages/cubejs-server-core/yarn.lock
@@ -833,10 +833,10 @@
     moment-timezone "^0.5.27"
     ramda "^0.25.0"
 
-"@cubejs-backend/query-orchestrator@^0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@cubejs-backend/query-orchestrator/-/query-orchestrator-0.12.1.tgz#e8b7ea46f9a7e695b6d7a299616b68cb0ae42818"
-  integrity sha512-yINa38E+BWTrKS42ByqL0qpTDZAuWVNMWj1Ea+ajFtyInu2MDD7sUCF5HkIMD0H8m4nMtsXl/D4X0rZb0EthCw==
+"@cubejs-backend/query-orchestrator@^0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@cubejs-backend/query-orchestrator/-/query-orchestrator-0.12.2.tgz#13c3be7c3fa150a7a8047810143f0eb4bc5854bb"
+  integrity sha512-fy+8Mfhez1MF4eVpGFpBjYHxqf4AX9nRBqXKg+8BBrc6Rz7xLOoh3xvI7IGMrtahCo+HyuCgHpBqejryB24TEQ==
   dependencies:
     ramda "^0.24.1"
     redis "^2.8.0"
@@ -3620,6 +3620,13 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -5566,7 +5573,7 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yallist@^3.0.0, yallist@^3.0.3:
+yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**
Exposes option to customize the `RequestContext` and pass it to the `CompilerApi` and `FileRepository` per request.

Adds `lru-cache` to `CompilerApi` for managing many schemas per tenant.  Exposes options to optimize the cache size, and automatically prune the cache for expired items.

**Business Justification**
If schemas need to change based on grant permissions for row and column level security, the number of variations become a memory limitation.  A LRU Cache allows the most frequently used schemas to stay in memory until they are no longer needed, or a defined amount of time passes and grants should be checked again.
Exposing the creation of the context lets you send additional information to your cube server for use in dynamically generating schemas without requiring you to override the checkAuth hooks.

**New server create options**
`requestToContext` customizes the context. (Should consider enforcing `authInfo` is added?)
`schemaKey` for using more than 1 entry in the `CompilerApi` cache.
`compilerCacheSize` is the maxSize of the `lru-cache`.
`maxCompilerCacheKeepAlive` is the maxAge of the `lru-cache` in ms.

**Breaking changes**
`FileRepository.dataSchemaFiles(options)` instead of `FileRepository.dataSchemaFiles(includeDependencies)`.  `includeDependencies` is still supported through destructuring.  Packages in this repo are not using this option, so it affects adopters who customized the server but used the provided `FileRepository`.

**Example usage**
```javascript
CubejsServerCore.create({
  requestToContext: (req) => ({ authInfo: req.authInfo, schemaName: req.query.schemaName }),
  schemaKey: ({ authInfo, schemaName }) => `${schemaName}-${authInfo.sub}`,
  maxCompilerCacheKeepAlive: 30 * 60 * 1000, // 30 minutes
  repositoryFactory: () => ({
    dataSchemaFiles: async ({ authInfo, schemaName }) => {
      // ...
    }
  })
});
```