### PR TITLE
feat: type for returning specific http status codes

### DIFF
--- a/packages/cubejs-api-gateway/CubejsHandlerError.js
+++ b/packages/cubejs-api-gateway/CubejsHandlerError.js
@@ -1,4 +1,4 @@
-class HttpError extends Error {
+class CubejsHandlerError extends Error {
   constructor(status, type, message) {
     super(message || type);
     this.status = status;
@@ -6,4 +6,4 @@ class HttpError extends Error {
   }
 }
 
-module.exports = HttpError;
+module.exports = CubejsHandlerError;

--- a/packages/cubejs-api-gateway/HttpError.js
+++ b/packages/cubejs-api-gateway/HttpError.js
@@ -1,0 +1,9 @@
+class HttpError extends Error {
+  constructor(status, type, message) {
+    super(message || type);
+    this.status = status;
+    this.type = type;
+  }
+}
+
+module.exports = HttpError;

--- a/packages/cubejs-api-gateway/UserError.js
+++ b/packages/cubejs-api-gateway/UserError.js
@@ -1,3 +1,9 @@
-class UserError extends Error {}
+const CubejsHandlerError = require('./CubejsHandlerError');
+
+class UserError extends CubejsHandlerError {
+  constructor(message) {
+    super(400, 'User Error', message);
+  }
+}
 
 module.exports = UserError;

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -5,7 +5,7 @@ const moment = require('moment');
 const dateParser = require('./dateParser');
 
 const UserError = require('./UserError');
-const HttpError = require('./HttpError');
+const CubejsHandlerError = require('./CubejsHandlerError');
 const SubscriptionServer = require('./SubscriptionServer');
 const LocalSubscriptionStore = require('./LocalSubscriptionStore');
 
@@ -430,22 +430,13 @@ class ApiGateway {
   handleError({
     e, context, query, res, requestStarted
   }) {
-    if (e instanceof UserError) {
-      this.log(context, {
-        type: 'User Error',
-        query,
-        error: e.message,
-        duration: this.duration(requestStarted)
-      });
-      res({ error: e.message }, { status: 400 });
-    } else if (e instanceof HttpError) {
+    if (e instanceof CubejsHandlerError) {
       this.log(context, {
         type: e.type,
         query,
         error: e.message,
         duration: this.duration(requestStarted)
       });
-      console.log(`status: ${e.status}`);
       res({ error: e.message }, { status: e.status });
     } else if (e.error === 'Continue wait') {
       this.log(context, {

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 const dateParser = require('./dateParser');
 
 const UserError = require('./UserError');
+const HttpError = require('./HttpError');
 const SubscriptionServer = require('./SubscriptionServer');
 const LocalSubscriptionStore = require('./LocalSubscriptionStore');
 
@@ -437,6 +438,15 @@ class ApiGateway {
         duration: this.duration(requestStarted)
       });
       res({ error: e.message }, { status: 400 });
+    } else if (e instanceof HttpError) {
+      this.log(context, {
+        type: e.type,
+        query,
+        error: e.message,
+        duration: this.duration(requestStarted)
+      });
+      console.log(`status: ${e.status}`);
+      res({ error: e.message }, { status: e.status });
     } else if (e.error === 'Continue wait') {
       this.log(context, {
         type: 'Continue wait',


### PR DESCRIPTION
Simple type that can be thrown to return status codes other than 200, 400, or 500.

Specifically useful for communicating with another server within `repositoryFactory` and propagating a 401 for unauthorized access to a schema.