### PR TITLE
fix: schemaVersion called with old context

### DIFF
--- a/packages/cubejs-server-core/core/CompilerApi.js
+++ b/packages/cubejs-server-core/core/CompilerApi.js
@@ -11,11 +11,12 @@ class CompilerApi {
     this.logger = this.options.logger;
     this.preAggregationsSchema = this.options.preAggregationsSchema;
     this.allowUngroupedWithoutPrimaryKey = this.options.allowUngroupedWithoutPrimaryKey;
+    this.schemaVersion = this.options.schemaVersion;
   }
 
   async getCompilers() {
     let compilerVersion = (
-      this.options.schemaVersion && this.options.schemaVersion() ||
+      this.schemaVersion && this.schemaVersion() ||
       'default_schema_version'
     ).toString();
     if (this.options.devServer) {

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -286,17 +286,20 @@ class CubejsServerCore {
   getCompilerApi(context) {
     const appId = this.contextToAppId(context);
     let compilerApi = this.compilerCache.get(appId);
+    const currentSchemaVersion = this.options.schemaVersion && (() => this.options.schemaVersion(context));
     if (!compilerApi) {
       compilerApi = this.createCompilerApi(
         this.repositoryFactory(context), {
           dbType: (dataSourceContext) => this.contextToDbType({ ...context, ...dataSourceContext }),
           externalDbType: this.contextToExternalDbType(context),
-          schemaVersion: this.options.schemaVersion && (() => this.options.schemaVersion(context)),
+          schemaVersion: currentSchemaVersion,
           preAggregationsSchema: this.preAggregationsSchema(context)
         }
       );
       this.compilerCache.set(appId, compilerApi);
     }
+
+    compilerApi.schemaVersion = currentSchemaVersion;
     return compilerApi;
   }
 


### PR DESCRIPTION
Fix for #294 

If you override `schemaVersion(context)`, `context` is not the current request's context. This is because the `schemaVersion()` called in `CompilerApi` is a closure.  By adding the `schemaVersion` to the key for the `compilerCache`, `CompilerApi` will effectively recompile with new schemaVersions.

Note: If the server has not specified a `maxCompilerCacheKeepAlive`, the old compilers will remain in memory until `compilerCacheSize` is reached. At that point, the LRU cache will start evicting the old schemas.

Note for `OrchestratorApi`: Current workaround for incorrect context in schemaVersion is to tack the schemaVersion into your `contextToAppId`.  This introduces many `OrchestratorApi`s when there should be far fewer.  Passing the correct `context` to `schemaVersion(context)` resolves this issue.

Note for `CompilerApi`: This was left untouched to allow customizations directly calling `createCompilerApi` to still behave the same without a call to `schemaVersion(context)`, and because `options.devServer` is handled there.  It's starting to feel messy, so probably schemaVersion needs to be restructured overall.