### PR TITLE
feat: Extendable context

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -55,6 +55,7 @@ Both [CubejsServerCore](@cubejs-backend-server-core) and [CubejsServer](@cubejs-
   queryTransformer: (query: Object, context: RequestContext) => Object,
   preAggregationsSchema: String | (context: RequestContext) => String,
   schemaVersion: (context: RequestContext) => String,
+  extendContext: (req: ExpressRequest) => any,
   compilerCacheSize: Number,
   maxCompilerCacheKeepAlive: Number,
   updateCompilerCacheKeepAlive: Boolean,
@@ -81,7 +82,8 @@ QueueOptions {
 }
 
 RequestContext {
-  authInfo: Object
+  authInfo: Object,
+  requestId: String
 }
 
 DriverContext extends RequestContext {
@@ -294,6 +296,10 @@ CubejsServerCore.create({
   schemaVersion: ({ authInfo }) => tenantIdToDbVersion[authInfo.tenantId]
 });
 ```
+
+### extendContext
+
+Option to extend the `RequestContext` with custom values. This method is called on each request.  Can be async.
 
 ### compilerCacheSize
 

--- a/packages/cubejs-api-gateway/SubscriptionServer.js
+++ b/packages/cubejs-api-gateway/SubscriptionServer.js
@@ -61,7 +61,7 @@ class SubscriptionServer {
       }
 
       const requestId = message.requestId || `${connectionId}-${message.messageId}`;
-      const context = this.apiGateway.contextByReq(message, authContext.authInfo, requestId);
+      const context = await this.apiGateway.contextByReq(message, authContext.authInfo, requestId);
 
       const allowedParams = methodParams[message.method];
       const params = allowedParams.map(k => ({ [k]: (message.params || {})[k] }))

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -440,7 +440,7 @@ class ApiGateway {
   }
 
   requestIdByReq(req) {
-    return req.headers && req.headers['x-request-id'] || req.headers && req.headers.traceparent || uuid();
+    return req.headers['x-request-id'] || req.headers.traceparent || uuid();
   }
 
   handleError({

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -227,7 +227,7 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
+        context: await this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
@@ -235,7 +235,7 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/subscribe`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
+        context: await this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
@@ -243,14 +243,14 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
       await this.sql({
         query: req.query.query,
-        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
+        context: await this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
 
     app.get(`${this.basePath}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
       await this.meta({
-        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
+        context: await this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
@@ -430,8 +430,9 @@ class ApiGateway {
     return this.adapterApi;
   }
 
-  contextByReq(req, authInfo, requestId) {
-    const extensions = typeof this.extendContext === 'function' ? this.extendContext(req) : {};
+  async contextByReq(req, authInfo, requestId) {
+    const extensions = await Promise.resolve(typeof this.extendContext === 'function' ? this.extendContext(req) : {});
+
     return {
       authInfo,
       requestId,

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -227,7 +227,7 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/load`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.contextByReq(req),
+        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
@@ -235,7 +235,7 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/subscribe`, this.checkAuthMiddleware, (async (req, res) => {
       await this.load({
         query: req.query.query,
-        context: this.contextByReq(req),
+        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
@@ -243,14 +243,14 @@ class ApiGateway {
     app.get(`${this.basePath}/v1/sql`, this.checkAuthMiddleware, (async (req, res) => {
       await this.sql({
         query: req.query.query,
-        context: this.contextByReq(req),
+        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
 
     app.get(`${this.basePath}/v1/meta`, this.checkAuthMiddleware, (async (req, res) => {
       await this.meta({
-        context: context,
+        context: this.contextByReq(req, req.authInfo, this.requestIdByReq(req)),
         res: this.resToResultFn(res)
       });
     }));
@@ -430,12 +430,12 @@ class ApiGateway {
     return this.adapterApi;
   }
 
-  contextByReq(req) {
-    let overrides = typeof this.extendContext === 'function' ? this.extendContext(req) : {};
+  contextByReq(req, authInfo, requestId) {
+    const extensions = typeof this.extendContext === 'function' ? this.extendContext(req) : {};
     return {
-      authInfo: req.authInfo,
-      requestId: this.requestIdByReq(req),
-      ...overrides
+      authInfo,
+      requestId,
+      ...extensions
     };
   }
 

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -8,6 +8,7 @@ declare module '@cubejs-backend/server-core' {
     basePath?: string;
     checkAuthMiddleware?: (req: any, res: any, next: any) => any;
     queryTransformer?: () => (query: any, context: any) => any;
+    extendContext?: (req: any) => any;
     contextToAppId?: any;
     contextToDataSourceId?: (context: any) => string;
     devServer?: boolean;

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -276,7 +276,8 @@ class CubejsServerCore {
           basePath: this.options.basePath,
           checkAuthMiddleware: this.options.checkAuthMiddleware,
           checkAuth: this.options.checkAuth,
-          queryTransformer: this.options.queryTransformer
+          queryTransformer: this.options.queryTransformer,
+          extendContext: this.options.extendContext
         }
       );
     }


### PR DESCRIPTION
Proposal for #295 and #296 questions.

Ability to extend context object per request (http or web socket).  Essentially, divide responsibilities of `authInfo` and `context`.  This supports two approaches living side-by-side.

1. Current approach, where every component of the request is considered an authenticated security context. "I certify that this user is id 4 and has a mole on his left cheek."
2. Extended approach where authenticated request identifies a user, and additional request information can be added for customization a developer might need. "I certify that this user is id 4.  Btw, he says he has a mole on his left cheek, if that matters to you."

`requestId` now lives within the `context`, can be accessed for requests made external to cubejs, and can be overridden if not using `x-request-id` header.

With API:
```javascript
const server = new CubejsServer({
  checkAuth: (req, auth) => { req.authInfo = verify(auth); },
  extendContext: (req) => ({
    schemaName: req.query.schemaName, // TODO: verify if this is important
    hasMoleOnLeftCheek: req.headers['wh-hasMoleOnLeftCheek'] // validation irrelevant. informational
  }),
  contextToAppId({ authInfo }) => `${authInfo.tenantId}`,
  schemaVersion({ authInfo, schemaName }) => `${schemaName}-${authInfo.u.id}`,
  repositoryFactory({ authInfo, schemaName, hasMoleOnLeftCheek }) => {
    // implementation where we call a microservice using `authInfo.jwt` with `schemaName`
    // and `hasMoleOnLeftCheek` as additional parameters (route or query)
  }
});
```

Or with web sockets:
```javascript
const server = new CubejsServer({
  checkAuth: (req, auth) => { req.authInfo = verify(auth); },
  extendContext: (message) => ({
    schemaName: message.params.schemaName, // TODO: verify if this is important
    hasMoleOnLeftCheek: message.params.hasMoleOnLeftCheek // validation irrelevant. informational
  }),
  contextToAppId({ authInfo }) => `${authInfo.tenantId}`,
  schemaVersion({ authInfo, schemaName }) => `${schemaName}-${authInfo.u.id}`,
  repositoryFactory({ authInfo, schemaName, hasMoleOnLeftCheek }) => {
    // implementation where we call a microservice using `authInfo.jwt` with `schemaName`
    // and `hasMoleOnLeftCheek` as additional parameters (route or query)
  }
});
```

The only difference is how you interact with `extendContext()`, and websockets will pass in `{ isSubscription: true }`, so your server could handle both situations if it needed to.

```javascript
const server = new CubejsServer({
  checkAuth: (req, auth) => { req.authInfo = verify(auth); },
  extendContext: (req) =>
    req.isSubscription ? { // web sockets
      schemaName: req.params.schemaName, // TODO: verify if this is important
      hasMoleOnLeftCheek: req.params.hasMoleOnLeftCheek // validation irrelevant. informational
    } : { // https
      schemaName: req.query.schemaName,
      hasMoleOnLeftCheek: req.headers['wh-hasMoleOnLeftCheek']
    },
  contextToAppId({ authInfo }) => `${authInfo.tenantId}`,
  schemaVersion({ authInfo, schemaName }) => `${schemaName}-${authInfo.u.id}`,
  repositoryFactory({ authInfo, schemaName, hasMoleOnLeftCheek }) => {
    // implementation where we call a microservice using `authInfo.jwt` with `schemaName`
    // and `hasMoleOnLeftCheek` as additional parameters (route or query)
  }
});
```