### PR TITLE
feat: Health check methods

### DIFF
--- a/packages/cubejs-server-core/core/OrchestratorApi.js
+++ b/packages/cubejs-server-core/core/OrchestratorApi.js
@@ -7,6 +7,7 @@ class OrchestratorApi {
   constructor(driverFactory, logger, options) {
     options = options || {};
     this.orchestrator = new QueryOrchestrator(options.redisPrefix || 'STANDALONE', driverFactory, logger, options);
+    this.driverFactory = driverFactory;
     this.logger = logger;
   }
 
@@ -56,6 +57,13 @@ class OrchestratorApi {
 
       throw { error: err.toString() };
     }
+  }
+
+  async testConnection() {
+    const driver = await this.driverFactory();
+
+    // this.driverFactory() tests the connection on startup, but now we want to explicitly test again.
+    driver.testConnection();
   }
 }
 

--- a/packages/cubejs-server-core/core/OrchestratorApi.js
+++ b/packages/cubejs-server-core/core/OrchestratorApi.js
@@ -69,8 +69,10 @@ class OrchestratorApi {
   }
 
   async testDriverConnection(driverFn) {
-    const driver = await driverFn();
-    await driver.testConnection();
+    if (driverFn) {
+      const driver = await driverFn();
+      await driver.testConnection();
+    }
   }
 
   release() {
@@ -81,9 +83,11 @@ class OrchestratorApi {
   }
 
   async releaseDriver(driverFn) {
-    const driver = await driverFn();
-    if (driver.release) {
-      await driver.release();
+    if (driverFn) {
+      const driver = await driverFn();
+      if (driver.release) {
+        await driver.release();
+      }
     }
   }
 }

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -381,7 +381,7 @@ class CubejsServerCore {
     return DriverDependencies[dbType];
   }
 
-  async testConnections() {
+  testConnections() {
     const tests = [];
     Object.keys(this.dataSourceIdToOrchestratorApi).forEach(dataSourceId => {
       const orchestratorApi = this.dataSourceIdToOrchestratorApi[dataSourceId];

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -380,6 +380,14 @@ class CubejsServerCore {
     }
     return DriverDependencies[dbType];
   }
+
+  async testConnections() {
+    Object.keys(this.dataSourceIdToOrchestratorApi).map((dataSourceId) => {
+      const orchestratorApi = this.dataSourceIdToOrchestratorApi[dataSourceId];
+      orchestratorApi
+      console.log(value);
+    });
+  }
 }
 
 module.exports = CubejsServerCore;

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -382,11 +382,22 @@ class CubejsServerCore {
   }
 
   async testConnections() {
-    Object.keys(this.dataSourceIdToOrchestratorApi).map((dataSourceId) => {
+    const tests = [];
+    Object.keys(this.dataSourceIdToOrchestratorApi).forEach(dataSourceId => {
       const orchestratorApi = this.dataSourceIdToOrchestratorApi[dataSourceId];
-      orchestratorApi
-      console.log(value);
+      tests.push(orchestratorApi.testConnection());
     });
+    return Promise.all(tests);
+  }
+
+  async releaseConnections() {
+    const releases = [];
+    Object.keys(this.dataSourceIdToOrchestratorApi).forEach(dataSourceId => {
+      const orchestratorApi = this.dataSourceIdToOrchestratorApi[dataSourceId];
+      releases.push(orchestratorApi.release());
+    });
+    await Promise.all(releases);
+    this.dataSourceIdToOrchestratorApi = {};
   }
 }
 

--- a/packages/cubejs-server/index.js
+++ b/packages/cubejs-server/index.js
@@ -83,6 +83,10 @@ class CubejsServer {
     }
   }
 
+  testConnections() {
+    return this.core.testConnections();
+  }
+
   async close() {
     try {
       if (this.socketServer) {
@@ -97,6 +101,7 @@ class CubejsServer {
         await this.redirector.close();
         this.redirector = null;
       }
+      await this.core.releaseConnections();
     } catch (e) {
       if (this.core.event) {
         await this.core.event("Dev Server Fatal Error", {

--- a/packages/cubejs-server/index.test.js
+++ b/packages/cubejs-server/index.test.js
@@ -2,6 +2,7 @@ jest.mock("@cubejs-backend/server-core", () => {
   const staticCreate = jest.fn();
   const initApp = jest.fn(() => Promise.resolve())
   const event = jest.fn(() => Promise.resolve())
+  const releaseConnections = jest.fn(() => Promise.resolve())
   class CubejsServerCore {
     static create() {
       staticCreate.call(null, arguments);
@@ -14,11 +15,16 @@ jest.mock("@cubejs-backend/server-core", () => {
     event() {
       return event();
     }
+
+    releaseConnections() {
+      return releaseConnections();
+    }
   }
   CubejsServerCore.mock = {
     staticCreate,
     initApp,
     event,
+    releaseConnections,
   };
   return CubejsServerCore;
 });


### PR DESCRIPTION
#302 

These are methods that can be used for checking health.  I did not explicitly add an endpoint because the format of returning health checks varies slightly.  These are methods that can be called with a custom implementation or using another package, e.g. terminus or lightship.