### PR TITLE
fix: Wrong interval functions for BigQuery

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseQuery.js
@@ -312,6 +312,14 @@ class BaseQuery {
     return `${date} + interval '${interval}'`;
   }
 
+  addTimestampInterval(timestamp, interval) {
+    return this.addInterval(timestamp, interval);
+  }
+
+  subtractTimestampInterval(timestamp, interval) {
+    return this.subtractInterval(timestamp, interval);
+  }
+
   cumulativeMeasures() {
     return this.measures.filter(m => m.isCumulative());
   }
@@ -1529,7 +1537,7 @@ class BaseQuery {
           query.timeDimensions[0].path()[0]
         ][
           query.timeDimensions[0].path()[1]
-        ].filter((from, to) => `${query.nowTimestampSql()} < ${updateWindow ? this.addInterval(this.timeStampCast(to), updateWindow) : this.timeStampCast(to)}`),
+        ].filter((from, to) => `${query.nowTimestampSql()} < ${updateWindow ? this.addTimestampInterval(this.timeStampCast(to), updateWindow) : this.timeStampCast(to)}`),
         label: originalRefreshKey
       }])
     );

--- a/packages/cubejs-schema-compiler/adapter/BigqueryQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BigqueryQuery.js
@@ -87,10 +87,18 @@ class BigqueryQuery extends BaseQuery {
   }
 
   subtractInterval(date, interval) {
-    return `TIMESTAMP_SUB(${date}, INTERVAL ${interval})`;
+    return `DATETIME_SUB(${date}, INTERVAL ${interval})`;
   }
 
   addInterval(date, interval) {
+    return `DATETIME_ADD(${date}, INTERVAL ${interval})`;
+  }
+
+  subtractTimestampInterval(date, interval) {
+    return `TIMESTAMP_SUB(${date}, INTERVAL ${interval})`;
+  }
+
+  addTimestampInterval(date, interval) {
     return `TIMESTAMP_ADD(${date}, INTERVAL ${interval})`;
   }
 

--- a/packages/cubejs-schema-compiler/adapter/BigqueryQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BigqueryQuery.js
@@ -87,11 +87,11 @@ class BigqueryQuery extends BaseQuery {
   }
 
   subtractInterval(date, interval) {
-    return `DATETIME_SUB(${date}, INTERVAL ${interval})`;
+    return `TIMESTAMP_SUB(${date}, INTERVAL ${interval})`;
   }
 
   addInterval(date, interval) {
-    return `DATETIME_ADD(${date}, INTERVAL ${interval})`;
+    return `TIMESTAMP_ADD(${date}, INTERVAL ${interval})`;
   }
 
   nowTimestampSql() {


### PR DESCRIPTION
Fix BigQuery error:

```
Dropping Cache: {
  "cacheKey": [
    "SELECT CASE\n    WHEN CURRENT_TIMESTAMP() < DATETIME_ADD(TIMESTAMP(?), INTERVAL 7 day) THEN FLOOR(UNIX_SECONDS(CURRENT_TIMESTAMP()) / 86400) END",
    [
      "2020-01-12T23:59:59Z"
    ]
  ]
} 
Error: No matching signature for function DATETIME_ADD for argument types: TIMESTAMP, INTERVAL INT64 DATE_TIME_PART. Supported signature: DATETIME_ADD(DATETIME, INTERVAL INT64 DATE_TIME_PART) at [2:32]
```

