### PR TITLE
fix: typings export

### DIFF
--- a/packages/cubejs-bigquery-driver/driver/index.d.ts
+++ b/packages/cubejs-bigquery-driver/driver/index.d.ts
@@ -1,8 +1,7 @@
 import { BigQueryOptions } from "@google-cloud/bigquery";
 
 declare module "@cubejs-backend/bigquery-driver" {
-  class BigQueryDriver {
+  export default class BigQueryDriver {
     constructor(options?: BigQueryOptions);
   }
-  export = BigQueryDriver;
 }

--- a/packages/cubejs-postgres-driver/driver/index.d.ts
+++ b/packages/cubejs-postgres-driver/driver/index.d.ts
@@ -1,8 +1,7 @@
 import { PoolConfig } from "pg";
 
 declare module "@cubejs-backend/postgres-driver" {
-  class PostgresDriver {
+  export default class PostgresDriver {
     constructor(options?: PoolConfig);
   }
-  export = PostgresDriver;
 }

--- a/packages/cubejs-postgres-driver/package.json
+++ b/packages/cubejs-postgres-driver/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/pg": "^7.14.1",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -128,7 +128,7 @@ declare module "@cubejs-backend/server-core" {
 
   export interface QueryTimeDimension {
     dimension: string;
-    dateRange?: string[];
+    dateRange?: string[] | string;
     granularity?: QueryTimeDimensionGranularity;
   }
 

--- a/packages/cubejs-sqlite-driver/driver/index.d.ts
+++ b/packages/cubejs-sqlite-driver/driver/index.d.ts
@@ -3,8 +3,7 @@ declare module "@cubejs-backend/sqlite-driver" {
     database: string;
   }
 
-  class SqliteDriver {
+  export default class SqliteDriver {
     constructor(options?: SqliteOptions);
   }
-  export = SqliteDriver;
 }


### PR DESCRIPTION
Fix my previous PR #369.

It introduced an issue in module augmentation exports and miss a `@types/pg` devDependency to properly work when installing from scratch.

I'm sorry for that.