### PR TITLE
fix(@cubejs-client/core): improve types

### DIFF
--- a/packages/cubejs-client-core/dist/index.d.ts
+++ b/packages/cubejs-client-core/dist/index.d.ts
@@ -51,7 +51,7 @@ export type Column = {
   title: string;
 }
 
-export class ResultSet<T extends {} = {}> {
+export class ResultSet<T = any> {
   static measureFromAxis(axisValues: string[]): string;
 
   loadResponse: LoadResponse<T>;
@@ -147,14 +147,14 @@ export class Meta {
 export class CubejsApi {
   new(apiToken: string, options: CubeJSApiOptions): CubejsApi;
 
-  load(query: Query, options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
   load(query: Query, options?: LoadMethodOptions): Promise<ResultSet>;
+  load(query: Query, options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
 
-  sql(query: Query, options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
   sql(query: Query, options?: LoadMethodOptions): Promise<SqlQuery>;
+  sql(query: Query, options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
 
-  meta(options?: LoadMethodOptions, callback?: LoadMethodCallback<Meta>): void;
   meta(options?: LoadMethodOptions): Promise<Meta>;
+  meta(options?: LoadMethodOptions, callback?: LoadMethodCallback<Meta>): void;
 }
 
 declare function cubejs(


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Loosen the types enough so that common issues go away. Long term, it might be better to replace the default generic type for `ResultSet` from `any` to `unknown`.
