### PR TITLE
cast double to decimal for postgres

### DIFF
--- a/packages/cubejs-postgres-driver/driver/PostgresDriver.js
+++ b/packages/cubejs-postgres-driver/driver/PostgresDriver.js
@@ -6,7 +6,8 @@ const BaseDriver = require('@cubejs-backend/query-orchestrator/driver/BaseDriver
 const { Pool } = pg;
 
 const GenericTypeToPostgres = {
-  string: 'text'
+  string: 'text',
+  double: 'decimal'
 };
 
 const timestampDataTypes = [1114, 1184];


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

While pre-aggregating data from Aws Athena to postgres, there was an issue because Athena supports "double" whereas postgres does not.

Added a mapping to convert "double" fields to "decimal"
