### PR TITLE
build(deps): bump hapi/joi from 14.0.6 to 15.1.1

### DIFF
--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -16,7 +16,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@hapi/joi": "^14.0.6",
+    "@hapi/joi": "^15.1.1",
     "chrono-node": "^1.3.11",
     "jsonwebtoken": "^8.3.0",
     "moment": "^2.24.0",

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -39,7 +39,7 @@
     "mssql": "^6.1.0",
     "mysql": "^2.17.1",
     "pg-promise": "^7.3.2",
-    "ramda": "^0.27.0",
+    "ramda": "^0.24.1",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "should": "^11.2.1",


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [n/a] Linter has been run for changed code
- [n/a] Tests for the changes have been added if not covered yet
- [n/a] Docs have been added / updated if required

**Issue Reference this PR resolves**
Continuing of 
https://github.com/cube-js/cube.js/pull/412 and 
https://github.com/cube-js/cube.js/issues/411

[For example #12]

**Description of Changes Made (if issue reference is not provided)**
Dependencies for cubejs-api-gateway in package.json updated to latest non-breaking version. @hapi/joi": "^15.1.1",

