### PR TITLE
fix: Cleanup redis pool properly in tests

### DIFF
--- a/packages/cubejs-query-orchestrator/orchestrator/QueryOrchestrator.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/QueryOrchestrator.js
@@ -18,6 +18,7 @@ class QueryOrchestrator {
       throw new Error(`Only 'redis' or 'memory' are supported for cacheAndQueueDriver option`);
     }
 
+    this.redisPool = redisPool;
     this.queryCache = new QueryCache(
       this.redisPrefix, this.driverFactory, this.logger, {
         externalDriverFactory,
@@ -86,6 +87,10 @@ class QueryOrchestrator {
 
   resultFromCacheIfExists(queryBody) {
     return this.queryCache.resultFromCacheIfExists(queryBody);
+  }
+
+  async cleanup() {
+    await this.redisPool.cleanup();
   }
 }
 

--- a/packages/cubejs-query-orchestrator/test/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/QueryOrchestrator.test.js
@@ -32,14 +32,17 @@ class MockDriver {
 
 describe('QueryOrchestrator', () => {
   let mockDriver = null;
+  const queryOrchestrator = new QueryOrchestrator(
+    'TEST', async () => mockDriver, (msg, params) => console.log(msg, params)
+  );
 
   beforeAll(() => {
     mockDriver = new MockDriver();
   });
 
-  const queryOrchestrator = new QueryOrchestrator(
-    'TEST', async () => mockDriver, (msg, params) => console.log(msg, params)
-  );
+  afterAll(async () => {
+    await queryOrchestrator.cleanup();
+  });
 
   test('basic', async () => {
     const query = {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes tests hanging

**Description of Changes Made (if issue reference is not provided)**

Was only cleaning up redis pool in one of two test files in Orchestrar, doh. No idea why specs passed on the original branch.
