### PR TITLE
refactor: Use options pattern in RedisPool constructor

### DIFF
--- a/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
@@ -523,7 +523,7 @@ class PreAggregations {
     this.logger = logger;
     this.queryCache = queryCache;
     this.cacheDriver = options.cacheAndQueueDriver === 'redis' ?
-      new RedisCacheDriver(options.redisPool) :
+      new RedisCacheDriver({ pool: options.redisPool }) :
       new LocalCacheDriver();
     this.externalDriverFactory = options.externalDriverFactory;
   }

--- a/packages/cubejs-query-orchestrator/orchestrator/QueryCache.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/QueryCache.js
@@ -12,7 +12,7 @@ class QueryCache {
     this.externalDriverFactory = options.externalDriverFactory;
     this.logger = logger;
     this.cacheDriver = options.cacheAndQueueDriver === 'redis' ?
-      new RedisCacheDriver(options.redisPool) :
+      new RedisCacheDriver({ pool: options.redisPool }) :
       new LocalCacheDriver();
   }
 

--- a/packages/cubejs-query-orchestrator/orchestrator/RedisCacheDriver.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisCacheDriver.js
@@ -1,10 +1,10 @@
 class RedisCacheDriver {
-  constructor(pool) {
+  constructor({ pool }) {
     this.redisPool = pool;
   }
 
   async getClient() {
-    return await this.redisPool.getClient();
+    return this.redisPool.getClient();
   }
 
   async get(key) {

--- a/packages/cubejs-query-orchestrator/orchestrator/RedisPool.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/RedisPool.js
@@ -2,13 +2,14 @@ const genericPool = require('generic-pool');
 const createRedisClient = require('./RedisFactory');
 
 class RedisPool {
-  constructor(poolMin, poolMax, createClient, destroyClient) {
+  constructor(options) {
+    options = options || {};
     const defaultMin = process.env.CUBEJS_REDIS_POOL_MIN ? parseInt(process.env.CUBEJS_REDIS_POOL_MIN, 10) : 2;
     const defaultMax = process.env.CUBEJS_REDIS_POOL_MAX ? parseInt(process.env.CUBEJS_REDIS_POOL_MAX, 10) : 1000;
-    const min = (typeof poolMin !== 'undefined') ? poolMin : defaultMin;
-    const max = (typeof poolMax !== 'undefined') ? poolMax : defaultMax;
-    const create = createClient || (() => createRedisClient(process.env.REDIS_URL));
-    const destroy = destroyClient || (client => client.end(true));
+    const min = (typeof options.poolMin !== 'undefined') ? options.poolMin : defaultMin;
+    const max = (typeof options.poolMax !== 'undefined') ? options.poolMax : defaultMax;
+    const create = options.createClient || (() => createRedisClient(process.env.REDIS_URL));
+    const destroy = options.destroyClient || (client => client.end(true));
     const opts = {
       min,
       max,

--- a/packages/cubejs-query-orchestrator/test/QueryQueue.test.js
+++ b/packages/cubejs-query-orchestrator/test/QueryQueue.test.js
@@ -141,4 +141,4 @@ const QueryQueueTest = (name, options) => {
 
 QueryQueueTest('Local');
 QueryQueueTest('RedisPool', { cacheAndQueueDriver: 'redis', redisPool: new RedisPool() });
-QueryQueueTest('RedisNoPool', { cacheAndQueueDriver: 'redis', redisPool: new RedisPool(0, 0) });
+QueryQueueTest('RedisNoPool', { cacheAndQueueDriver: 'redis', redisPool: new RedisPool({ poolMin: 0, poolMax: 0 }) });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Instead of passing in values directly through the constructor, use the options pattern for easier extensibility.

From a review of https://github.com/cube-js/cube.js/pull/433
