### PR TITLE
fix: Publish index.d.ts for @cubejs-backend/server.

### DIFF
--- a/packages/cubejs-server/package.json
+++ b/packages/cubejs-server/package.json
@@ -15,6 +15,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "index.d.ts",
     "WebSocketServer.js",
     "bin"
   ],


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

The package.json for @cubejs-backend/server specifies a [`"types": "index.d.ts"`](https://github.com/cube-js/cube.js/blob/c2ee5eed8bfdc48de185122e518ba0dc6b83abc7/packages/cubejs-server/package.json#L6), but because index.d.ts is not published to npm, these types are unavailable to third parties using the package.  This fixes it so the types get published correctly.