### PR TITLE
fix(types): Fix index.d.ts errors in cubejs-server.

### DIFF
--- a/packages/cubejs-server/index.d.ts
+++ b/packages/cubejs-server/index.d.ts
@@ -1,4 +1,4 @@
-import { CreateOptions as CoreCreateOptions, CreateOptions } from "@cubejs-backend/server-core";
+import { CreateOptions as CoreCreateOptions } from "@cubejs-backend/server-core";
 import express from 'express';
 import https from 'https';
 import http from 'http';
@@ -15,4 +15,4 @@ declare class CubejsServer {
   testConnections(): Promise<void>;
 }
 
-export = CubejsServer;
+export default CubejsServer;


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

So... when I did [this](https://github.com/cube-js/cube.js/pull/518) I didn't realize there were some problems in the index.d.ts file.  :P

* index.d.ts imports a `CreateOptions` from server-core, but also defined a new conflicting CreateOptions.
* index.d.ts has an `export =`, which is forbidden because it also has an `export interface CreateOptions`, and you can't use`export =` if you have other exports in the same module.

This fixes both of these problems.