### PR TITLE
feat(postgres-driver): `CUBEJS_DB_MAX_POOL` env variable

### DIFF
--- a/packages/cubejs-postgres-driver/driver/PostgresDriver.js
+++ b/packages/cubejs-postgres-driver/driver/PostgresDriver.js
@@ -25,7 +25,7 @@ class PostgresDriver extends BaseDriver {
     super();
     this.config = config || {};
     this.pool = new Pool({
-      max: 8,
+      max: process.env.CUBEJS_DB_MAX_POOL && parseInt(process.env.CUBEJS_DB_MAX_POOL, 10) || 8,
       idleTimeoutMillis: 30000,
       host: process.env.CUBEJS_DB_HOST,
       database: process.env.CUBEJS_DB_NAME,


### PR DESCRIPTION
**Check List**
- [ X ] Tests has been run in packages where changes made if available
- [ X] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
#527 

**Description of Changes Made (if issue reference is not provided)**
use environment variable `CUBEJS_DB_MAX_POOL`in PostgresDriver

