### PR TITLE
fix(postgres-driver): Clean-up deprecation warning

### DIFF
--- a/packages/cubejs-postgres-driver/driver/PostgresDriver.js
+++ b/packages/cubejs-postgres-driver/driver/PostgresDriver.js
@@ -32,7 +32,7 @@ class PostgresDriver extends BaseDriver {
       port: process.env.CUBEJS_DB_PORT,
       user: process.env.CUBEJS_DB_USER,
       password: process.env.CUBEJS_DB_PASS,
-      ssl: (process.env.CUBEJS_DB_SSL || 'false').toLowerCase() === 'true' ? {} : undefined,
+      ssl: (process.env.CUBEJS_DB_SSL || 'false').toLowerCase() === 'true' ? { rejectUnauthorized: true } : undefined,
       ...config
     });
     this.pool.on('error', (err) => {


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

When the pg driver is used with ssl set to true (e.g. `CUBEJS_DB_SSL=true`), the following deprecation warning is logged:
```
(node:23) DeprecationWarning: Implicit disabling of certificate verification is deprecated and will be removed in pg 8. Specify `rejectUnauthorized: true` to require a valid CA or `rejectUnauthorized: false` to explicitly opt out of MITM protection.
```

This PR updates how the ssl configuration options for the pg driver are set to address the deprecation.

Reference: 
https://github.com/GSG-G8/Books-store/issues/26
https://github.com/brianc/node-postgres/issues/2089
