### PR TITLE
fix: Pass query options such as timezone in RefreshScheduler

### DIFF
--- a/packages/cubejs-server-core/core/RefreshScheduler.js
+++ b/packages/cubejs-server-core/core/RefreshScheduler.js
@@ -8,7 +8,7 @@ class RefreshScheduler {
   async refreshQueriesForPreAggregation(context, compilerApi, preAggregation, queryingOptions) {
     const dbType = compilerApi.getDbType();
     const compilers = await compilerApi.getCompilers();
-    const query = compilerApi.createQuery(compilers, dbType, {});
+    const query = compilerApi.createQuery(compilers, dbType, queryingOptions);
     if (preAggregation.preAggregation.partitionGranularity) {
       const dataSource = query.cubeDataSource(preAggregation.cube);
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Fixes RefreshScheduler on postgres.

There is a second place that might need the same change but I'm not sure so I left it:
https://github.com/cube-js/cube.js/blob/93a1250b74e594e68d261825c8f3b917a41adaf5/packages/cubejs-server-core/core/RefreshScheduler.js#L107


```
2020-04-05T22:02:00.288643+00:00 app[web.1]: {"message":"Refresh Scheduler Error","error":"Error: time zone \"undefined\" not recognized","requestId":"scheduler-37b13d44-1695-4562-b8c4-f2e8ebe580e2"}
2020-04-05T22:02:00.290804+00:00 app[web.1]: {"message":"Dropping Cache","cacheKey":["select max((\"test\".created_at::timestamptz AT TIME ZONE 'undefined')) from public.ba AS \"test\"",[],[]],"error":"Error: time zone \"undefined\" not recognized\n    at QueryQueue.parseResult (/app/node_modules/@cubejs-backend/query-orchestrator/orchestrator/QueryQueue.js:97:13)\n    at QueryQueue.executeInQueue (/app/node_modules/@cubejs-backend/query-orchestrator/orchestrator/QueryQueue.js:86:19)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"}
2020-04-05T22:02:00.291120+00:00 app[web.1]: {"message":"Error while renew cycle","query":"select max((\"test\".created_at::timestamptz AT TIME ZONE 'undefined')) from public.ba AS \"test\"","query_values":[],"error":"Error: time zone \"undefined\" not recognized\n    at QueryQueue.parseResult (/app/node_modules/@cubejs-backend/query-orchestrator/orchestrator/QueryQueue.js:97:13)\n    at QueryQueue.executeInQueue (/app/node_modules/@cubejs-backend/query-orchestrator/orchestrator/QueryQueue.js:86:19)\n    at process._tickCallback (internal/process/next_tick.js:68:7)"}
```
