### PR TITLE
feat: Include version in startup message

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -195,7 +195,6 @@ CubejsServerCore.create({
 })
 ```
 
-
 ### contextToAppId
 
 It is a [Multitenancy Setup](multitenancy-setup) option.
@@ -319,7 +318,7 @@ It is usually used in [Multitenancy Setup](multitenancy-setup).
 
 ### schemaVersion
 
-Schema version can be used to tell Cube.js schema should be recompiled in case schema code depends on dynamic definitions fetched from some external database or API. 
+Schema version can be used to tell Cube.js schema should be recompiled in case schema code depends on dynamic definitions fetched from some external database or API.
 This method is called on each request however `RequestContext` parameter is reused per application id returned by [contextToAppId](#options-reference-context-to-app-id).
 If returned string has been changed, schema will be recompiled.
 It can be used in both multitenant and single tenant environments.
@@ -369,7 +368,7 @@ Providing `updateCompilerCacheKeepAlive: true` keeps frequently used schemas in 
 
 ### allowUngroupedWithoutPrimaryKey
 
-Providing `allowUngroupedWithoutPrimaryKey: true` disables primary key inclusion check for `ungrouped` queries. 
+Providing `allowUngroupedWithoutPrimaryKey: true` disables primary key inclusion check for `ungrouped` queries.
 
 ### telemetry
 
@@ -454,4 +453,14 @@ class ApiFileRepository {
 CubejsServerCore.create({
   repositoryFactory: ({authInfo}) => new ApiFileRepository()
 });
+```
+
+## Version
+
+`CubejsServerCore.version` is a method that returns the semantic package version of `@cubejs-backend/server`.
+
+```javascript
+const CubejsServerCore = require('@cubejs-backend/server-core');
+
+console.log(CubejsServerCore.version());
 ```

--- a/docs/Cube.js-Backend/@cubejs-backend-server.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server.md
@@ -25,8 +25,8 @@ const CubejsServer = require('@cubejs-backend/server');
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -62,8 +62,8 @@ const { createTerminus } = require('@godaddy/terminus');
 
 const cubejsServer = new CubejsServer();
 
-cubejsServer.listen().then(({ port, server }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+cubejsServer.listen().then(({ version, port, server }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 
     createTerminus(server, {
     healthChecks: {

--- a/docs/Cube.js-Backend/@cubejs-backend-server.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server.md
@@ -18,7 +18,7 @@ Creates an instance of `CubejsServer`.
 
 You can set server port using `PORT` environment variable. Default port is `4000`.
 
-### Example
+#### Example
 
 ```javascript
 const CubejsServer = require('@cubejs-backend/server');
@@ -30,13 +30,25 @@ server.listen().then(({ port }) => {
 });
 ```
 
+### CubejsServer.version()
+
+`CubejsServer.version` is a method that returns the semantic package version of `@cubejs-backend/server`.
+
+```javascript
+const CubejsServer = require('@cubejs-backend/server');
+
+console.log(CubejsServer.version());
+```
+
 ### this.listen([options])
 
 Instantiates the Express.js App to listen to the specified `PORT`. Returns a promise that resolves with the following members:
 
 * `port {number}` The port at which CubejsServer is listening for insecure connections for redirection to HTTPS, as specified by the environment variable `PORT`. Defaults to 4000.
+* `tlsPort {number}` If TLS is enabled, the port at which CubejsServer is listening for secure connections, as specified by the environment variable `TLS_PORT`. Defaults to 4433.
 * `app {Express.Application}` The express App powering CubejsServer
 * `server {http.Server}` The `http` Server instance. If TLS is enabled, returns a `https.Server` instance instead.
+* `version {string}` The semantic package version of `@cubejs-backend/server`
 
 Cube.js can also support TLS encryption. See the [Security page on how to enable tls](security#enabling-tls) for more information.
 

--- a/docs/Cube.js-Backend/Caching.md
+++ b/docs/Cube.js-Backend/Caching.md
@@ -19,7 +19,7 @@ The second in-database level is called **pre-aggregations** and requires explici
 Cube.js caches the results of executed queries using in-memory cache. The cache
 key is generated SQL with any existing query dependent pre-aggregations.
 
-Upon incoming request Cube.js first checks the cache using this key. 
+Upon incoming request Cube.js first checks the cache using this key.
 If nothing is found it executes the query in database, returns result back alongside writing to the cache.
 Since 0.15.0 in case there's an existing value in cache it will be returned only if `refreshKey` value for query isn't changed.
 Otherwise [query renewal](#in-memory-cache-force-query-renewal) will be performed.
@@ -33,12 +33,12 @@ So, Cube.js defines a `refreshKey` for each cube. [refreshKeys](cube#parameters-
 
 __Note__: Cube.js *also caches* the results of `refreshKeys` for a fixed time interval in order to avoid issuing them too often. If you need Cube.js to immediately respond to changes in data, see the [Force Query Renewal](#in-memory-cache-force-query-renewal) section.
 
-When a query's result needs to be refreshed, Cube.js will re-execute the query in the foreground and repopulate the cache. 
-This means that cached results may still be served to users requesting them while `refreshKey` values aren't changed from Cube.js perspective. 
+When a query's result needs to be refreshed, Cube.js will re-execute the query in the foreground and repopulate the cache.
+This means that cached results may still be served to users requesting them while `refreshKey` values aren't changed from Cube.js perspective.
 The cache entry will be refreshed in the foreground if one of the two following conditions is met:
 
 - Query cache entry is expired. The default expiration time is 6 hours for cubes with default `refreshKey` and 24 hours where it was set.
-- The result of the `refreshKey` SQL query is different from the previous one. At this stage `refreshKey` won't be refreshed in foreground if it's available in cache. 
+- The result of the `refreshKey` SQL query is different from the previous one. At this stage `refreshKey` won't be refreshed in foreground if it's available in cache.
 
 ### Refresh Key Implementation
 
@@ -57,8 +57,8 @@ You can set up a custom refresh check SQL by changing [refreshKey](cube#paramete
 
 In these instances, Cube.js needs a query crafted to detect updates to the rows that power the cubes. Often, a `MAX(updated_at_timestamp)` for OLTP data will accomplish this, or examining a metadata table for whatever system is managing the data to see when it last ran.
 
-Note that the result of `refreshKey` query itself is cached for 10 seconds for RDBMS backends and for 2 minutes for big data backends by default. 
-You can change it by passing [refreshKey every](cube#parameters-refresh-key) parameter. 
+Note that the result of `refreshKey` query itself is cached for 10 seconds for RDBMS backends and for 2 minutes for big data backends by default.
+You can change it by passing [refreshKey every](cube#parameters-refresh-key) parameter.
 This cache is useful so that Cube.js can build query result cache keys without issuing database queries and respond to cached requests very quickly.
 
 ### Force Query Renewal
@@ -75,8 +75,8 @@ If you need to force a specific query to load fresh data from the database (if i
 
 The `renewQuery` option applies to the `refreshKey` caching system mentioned above, *not* the actual query result cache. If `renewQuery` is passed, Cube.js will always re-execute the `refreshKey` query, skipping that layer of caching, but, if the result of the `refreshKey` query is the same as the last time it ran, that indicates any current query result cache entries are valid, and they will be served. This means that cached data may still be served by Cube.js even if `renewQuery` is passed. This is a good thing: if the underlying data hasn't changed, the expensive query doesn't need to be re-run, and the database doesn't have to work as hard. This does mean that the `refreshKey` SQL must accurately report data freshness for the `renewQuery` to actually work and renew the query.
 
-For situations like real-time analytics or responding to live user changes to underlying data, the `refreshKey` query cache can prevent fresh data from showing up immediately. 
-For these situations, you can mostly disable the `refreshKey` cache by setting the [refreshKey every](cube#parameters-refresh-key) parameter to something very low, like `1 second`. 
+For situations like real-time analytics or responding to live user changes to underlying data, the `refreshKey` query cache can prevent fresh data from showing up immediately.
+For these situations, you can mostly disable the `refreshKey` cache by setting the [refreshKey every](cube#parameters-refresh-key) parameter to something very low, like `1 second`.
 This means Cube.js will always check the data freshness before executing a query, and notice any changed data underneath.
 
 ## Pre-Aggregations
@@ -100,7 +100,7 @@ reference.](pre-aggregations)
 ```javascript
 cube(`Orders`, {
   // ...
-  
+
   preAggregations: {
     amountByCreated: {
       type: `rollup`,
@@ -113,7 +113,7 @@ cube(`Orders`, {
 ```
 
 ### Refresh Strategy
- 
+
 Refresh strategy can be customized by setting the [refreshKey](pre-aggregations#refresh-key) property for the pre-aggregation.
 
 The default value of the `refreshKey` is the same as for cube that defines pre-aggregation.
@@ -123,7 +123,7 @@ It can be redefined either by providing SQL
 ```javascript
 cube(`Orders`, {
   // ...
-  
+
   preAggregations: {
     amountByCreated: {
       type: `rollup`,
@@ -143,7 +143,7 @@ or by providing refresh time interval
 ```javascript
 cube(`Orders`, {
   // ...
-  
+
   preAggregations: {
     amountByCreated: {
       type: `rollup`,
@@ -183,8 +183,8 @@ const server = new CubejsServer();
 
 setInterval(() => server.runScheduledRefresh(), 5000);
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 }).catch(e => {
   console.error('Fatal error during server start: ');
   console.error(e.stack || e);

--- a/docs/Cube.js-Backend/Deployment.md
+++ b/docs/Cube.js-Backend/Deployment.md
@@ -15,16 +15,16 @@ Below you can find guides for popular deployment environments:
 
 ## Production Mode
 
-When running Cube.js Backend in production make sure `NODE_ENV` is set to `production`. 
+When running Cube.js Backend in production make sure `NODE_ENV` is set to `production`.
 Such platforms, such as Heroku, do it by default.
 In this mode Cube.js unsecured development server and Playground will be disabled by default because there's a security risk serving those in production environments.
-Production Cube.js servers can be accessed only with [REST API](rest-api) and Cube.js frontend libraries. 
+Production Cube.js servers can be accessed only with [REST API](rest-api) and Cube.js frontend libraries.
 
 ### Redis
 
-Also, Cube.js requires [Redis](https://redis.io/), in-memory data structure store, to run in production. 
-It uses Redis for query caching and queue. 
-Set `REDIS_URL` environment variable to provide Cube.js with Redis connection. In case your Redis instance has password, please set password via `REDIS_PASSWORD` environment variable. 
+Also, Cube.js requires [Redis](https://redis.io/), in-memory data structure store, to run in production.
+It uses Redis for query caching and queue.
+Set `REDIS_URL` environment variable to provide Cube.js with Redis connection. In case your Redis instance has password, please set password via `REDIS_PASSWORD` environment variable.
 Make sure, your Redis allows at least 15 concurrent connections.
 Set `REDIS_TLS` env variable to `true` if you want to enable secure connection.
 
@@ -65,7 +65,7 @@ app.listen(port, (err) => {
     console.error('Fatal error during server start: ');
     console.error(e.stack || e);
   }
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${CubejsServerCore.version()}) is listening on ${port}`);
 });
 ```
 
@@ -143,7 +143,7 @@ server.listen(port, (err) => {
     console.error('Fatal error during server start: ');
     console.error(e.stack || e);
   }
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${CubejsServerCore.version()}) is listening on ${port}`);
 });
 ```
 
@@ -370,7 +370,7 @@ $ docker stop cubejs-docker-demo
 
 ## Docker Compose
 
-To run the server in docker-compose we need to add a redis server and a .env file to include the environment variables needed to connect to the database, the secret api secret and redis hostname. 
+To run the server in docker-compose we need to add a redis server and a .env file to include the environment variables needed to connect to the database, the secret api secret and redis hostname.
 
 Example .env file
 
@@ -411,7 +411,7 @@ Build the containers
 $ docker-compose build
 ```
 
-### Start/Stop the containers 
+### Start/Stop the containers
 
 ```bash
 $ docker-compose up
@@ -420,5 +420,3 @@ $ docker-compose up
 ```bash
 $ docker-compose stop
 ```
-
-

--- a/docs/Cube.js-Backend/Multitenancy-Setup.md
+++ b/docs/Cube.js-Backend/Multitenancy-Setup.md
@@ -9,7 +9,7 @@ Cube.js supports multitenancy out of the box, both on database and data schema l
 Multiple drivers are also supported, meaning that you can have one customer’s data in MongoDB and others in Postgres with one Cube.js instance.
 
 There are 7 [configuration options](@cubejs-backend-server-core#options-reference) you can leverage to make your multitenancy setup.
-You can use all of them or just a couple, depending on your specific case. 
+You can use all of them or just a couple, depending on your specific case.
 The options are:
 
 - `contextToAppId`
@@ -62,11 +62,11 @@ const server = new CubejsServer({
     } else if (dataSource === 'googleAnalytics') {
       return new BigQueryDriver();
     } else if (dataSource === 'financials'){
-      return new PostgresDriver({ 
-        database: 'financials', 
-        host: 'financials-db.acme.com', 
-        user: process.env.FINANCIALS_DB_USER, 
-        password: process.env.FINANCIALS_DB_PASS 
+      return new PostgresDriver({
+        database: 'financials',
+        host: 'financials-db.acme.com',
+        user: process.env.FINANCIALS_DB_USER,
+        password: process.env.FINANCIALS_DB_PASS
       });
     } else {
       return new PostgresDriver();
@@ -74,8 +74,8 @@ const server = new CubejsServer({
   }
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -103,8 +103,8 @@ const server = new CubejsServer({
   }
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -142,8 +142,8 @@ const server = new CubejsServer({
   contextToAppId: ({ authInfo }) => `CUBEJS_APP_${authInfo.appId}_${authInfo.userId}`
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -163,8 +163,8 @@ const server = new CubejsServer({
     })
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -182,8 +182,8 @@ const server = new CubejsServer({
   preAggregationsSchema: ({ authInfo }) => `pre_aggregations_${authInfo.userId}`
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -224,8 +224,8 @@ const server = new CubejsServer({
   }
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
@@ -265,8 +265,8 @@ const server = new CubejsServer({
   repositoryFactory: ({ authInfo }) => new FileRepository(`schema/${authInfo.appId}`)
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 

--- a/docs/Cube.js-Backend/Security.md
+++ b/docs/Cube.js-Backend/Security.md
@@ -175,8 +175,8 @@ var tlsOptions = {
 
 const cubejsServer = new CubejsServer();
 
-cubejsServer.listen(tlsOptions).then(({ tlsPort }) => {
-  console.log(`🚀 Cube.js server is listening securely on ${tlsPort}`);
+cubejsServer.listen(tlsOptions).then(({ version, tlsPort }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening securely on ${tlsPort}`);
 });
 ```
 
@@ -209,10 +209,10 @@ async function main() {
   const certOptions = { days: 2, selfSigned: true };
   const tlsOptions = await createCertificate(certOptions);
 
-  const ({ tlsPort, server }) = await cubejsServer.listen(tlsOptions);
-  
-  console.log(`🚀 Cube.js server is listening securely on ${tlsPort}`);
-  
+  const ({ version, tlsPort, server }) = await cubejsServer.listen(tlsOptions);
+
+  console.log(`🚀 Cube.js server (${version}) is listening securely on ${tlsPort}`);
+
   scheduleCertificateRenewal(server, certOptions, (err, result) => {
     if (err !== null) {
       console.error(

--- a/examples/d3-dashboard/index.js
+++ b/examples/d3-dashboard/index.js
@@ -6,7 +6,7 @@ const http = require("http");
 const serveStatic = require('serve-static');
 require('dotenv').config();
 
-var app = express();
+const app = express();
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(require('cors')());
 
@@ -26,5 +26,5 @@ const port = process.env.PORT || 4000;
 const server = http.createServer({}, app);
 
 server.listen(port, () => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${CubejsServerCore.version()}) is listening on ${port}`);
 });

--- a/examples/event-analytics/backend/index.js
+++ b/examples/event-analytics/backend/index.js
@@ -2,6 +2,6 @@ const CubejsServer = require('@cubejs-backend/server');
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });

--- a/examples/external-rollups/README.md
+++ b/examples/external-rollups/README.md
@@ -34,7 +34,7 @@ CUBEJS_EXT_DB_PASS=12345
 
 ```
 
-Here we set credentials for both the main DB (BigQuery) and external DB for pre-aggregations (MySQL). You can learn more about obtaining BigQuery credentials at the [Cube.js docs here](https://cube.dev/docs/connecting-to-the-database#notes-google-big-query). Also, in order to build pre-aggregations inside MySQL, Cube.js should have write access to the `stb_pre_aggregations` schema where pre-aggregation tables will be stored. 
+Here we set credentials for both the main DB (BigQuery) and external DB for pre-aggregations (MySQL). You can learn more about obtaining BigQuery credentials at the [Cube.js docs here](https://cube.dev/docs/connecting-to-the-database#notes-google-big-query). Also, in order to build pre-aggregations inside MySQL, Cube.js should have write access to the `stb_pre_aggregations` schema where pre-aggregation tables will be stored.
 
 Now, let’s install the Cube.js MySQL driver.
 
@@ -58,12 +58,12 @@ const server = new CubejsServer({
   })
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 
-That is all we need to let Cube.js connect to both BigQuery and MySQL. Now, we can create our first Cube.js data schema file. Cube.js uses the data schema to generate an SQL code, which will be executed in your database. 
+That is all we need to let Cube.js connect to both BigQuery and MySQL. Now, we can create our first Cube.js data schema file. Cube.js uses the data schema to generate an SQL code, which will be executed in your database.
 
 Create the `schema/Stories.js` file with the following content.
 

--- a/examples/hn-insights/devServer.js
+++ b/examples/hn-insights/devServer.js
@@ -12,6 +12,6 @@ const server = new CubejsServer({
   })
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });

--- a/examples/react-dashboard/backend/index.js
+++ b/examples/react-dashboard/backend/index.js
@@ -2,6 +2,6 @@ const CubejsServer = require('@cubejs-backend/server');
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });

--- a/examples/real-time-dashboard/index.js
+++ b/examples/real-time-dashboard/index.js
@@ -1,18 +1,18 @@
 const CubejsServerCore = require('@cubejs-backend/server-core');
 const WebSocketServer = require('@cubejs-backend/server/WebSocketServer');
 const express = require('express');
-const bodyParser = require("body-parser");
-const http = require("http");
-const path = require("path");
-const MongoClient = require('mongodb').MongoClient;
+const bodyParser = require('body-parser');
+const http = require('http');
+const path = require('path');
+const { MongoClient } = require('mongodb');
 const serveStatic = require('serve-static');
-const moment = require('moment');
 require('dotenv').config();
 
-var app = express();
+const app = express();
 
-app.use(require("cors")());
-app.use(bodyParser.json({ limit: "50mb" }));
+app.use(require('cors')());
+
+app.use(bodyParser.json({ limit: '50mb' }));
 
 const cubejsServer = CubejsServerCore.create({
   orchestratorOptions: {
@@ -36,17 +36,16 @@ app.post('/collect', (req, res) => {
   console.log(req.body);
   const client = new MongoClient(process.env.MONGO_URL);
   client.connect((err) => {
-
     const db = client.db();
     const collection = db.collection('events');
-    collection.insertOne({ timestamp:  new Date(), ...req.body }, ((err, result) => {
+    collection.insertOne({ timestamp: new Date(), ...req.body }, ((err, result) => {
       client.close();
-      res.send("ok");
-    }))
+      res.send('ok');
+    }));
   });
 });
 
 const port = process.env.PORT || 4000;
 server.listen(port, () => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${CubejsServerCore.version()}) is listening on ${port}`);
 });

--- a/examples/vue-dashboard/backend/index.js
+++ b/examples/vue-dashboard/backend/index.js
@@ -2,6 +2,6 @@ const CubejsServer = require('@cubejs-backend/server');
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });

--- a/examples/web-analytics/index.js
+++ b/examples/web-analytics/index.js
@@ -1,16 +1,16 @@
 const CubejsServerCore = require('@cubejs-backend/server-core');
 const MySQLDriver = require('@cubejs-backend/mysql-driver');
 const express = require('express');
-const bodyParser = require("body-parser");
-const path = require("path");
-const http = require("http");
+const bodyParser = require('body-parser');
+const path = require('path');
+const http = require('http');
 const serveStatic = require('serve-static');
 const session = require('express-session');
 const passport = require('passport');
 require('dotenv').config();
 
-var app = express();
-app.use(bodyParser.json({ limit: "50mb" }));
+const app = express();
+app.use(bodyParser.json({ limit: '50mb' }));
 app.use(require('cors')());
 
 const cubejsServer = CubejsServerCore.create({
@@ -35,29 +35,25 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 if (process.env.GOOGLE_AUTH_DOMAIN) {
-  const GoogleStrategy = require('passport-google-oauth20').Strategy;
+  const { Strategy: GoogleStrategy } = require('passport-google-oauth20');
+  const authURL = process.env.NODE_ENV === 'production' ? `${process.env.GOOGLE_AUTH_REDIRECT}` : 'http://localhost:4000';
   passport.use(new GoogleStrategy({
-      clientID: process.env.GOOGLE_AUTH_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_AUTH_CLIENT_SECRET,
-      callbackURL: (
-        process.env.NODE_ENV === 'production' ?
-        `${process.env.GOOGLE_AUTH_REDIRECT}` :
-        'http://localhost:4000'
-      ) + '/auth/google/callback'
-    },
-    (accessToken, refreshToken, profile, cb) => {
-      if (profile.emails && profile.emails.find(e => e.value.match(new RegExp(`@${process.env.GOOGLE_AUTH_DOMAIN}$`)) && e.verified)) {
-        return cb(null, profile);
-      }
-      return cb(`${profile.emails && profile.emails[0] && profile.emails[0].value} not within @${process.env.GOOGLE_AUTH_DOMAIN}`);
+    clientID: process.env.GOOGLE_AUTH_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_AUTH_CLIENT_SECRET,
+    callbackURL: `${authURL}/auth/google/callback`
+  },
+  (accessToken, refreshToken, profile, cb) => {
+    if (profile.emails && profile.emails.find(e => e.value.match(new RegExp(`@${process.env.GOOGLE_AUTH_DOMAIN}$`)) && e.verified)) {
+      return cb(null, profile);
     }
-  ));
+    return cb(`${profile.emails && profile.emails[0] && profile.emails[0].value} not within @${process.env.GOOGLE_AUTH_DOMAIN}`);
+  }));
 
-  passport.serializeUser(function(user, done) {
+  passport.serializeUser((user, done) => {
     done(null, user);
   });
 
-  passport.deserializeUser(function(user, done) {
+  passport.deserializeUser((user, done) => {
     done(null, user);
   });
 
@@ -66,11 +62,10 @@ if (process.env.GOOGLE_AUTH_DOMAIN) {
 
   app.get('/auth/google/callback',
     passport.authenticate('google', { failureRedirect: '/auth/google' }),
-    function(req, res) {
+    (req, res) => {
       // Successful authentication, redirect home.
       res.redirect('/');
-    }
-  );
+    });
 
   app.use((req, res, next) => {
     if (!req.user) {
@@ -91,5 +86,5 @@ const port = process.env.PORT || 4000;
 const server = http.createServer({}, app);
 
 server.listen(port, () => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${CubejsServerCore.version()}) is listening on ${port}`);
 });

--- a/guides/react-dashboard/content/2_authentication_and_graphql_backend.md
+++ b/guides/react-dashboard/content/2_authentication_and_graphql_backend.md
@@ -167,8 +167,8 @@ const server = new CubejsServer({
   }
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });
 ```
 

--- a/guides/react-dashboard/demo/index.js
+++ b/guides/react-dashboard/demo/index.js
@@ -2,6 +2,6 @@ const CubejsServer = require('@cubejs-backend/server');
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 });

--- a/guides/real-time-dashboard/content/3_frontend_dashboard.md
+++ b/guides/real-time-dashboard/content/3_frontend_dashboard.md
@@ -54,8 +54,8 @@ const server = new CubejsServer({
   }
 });
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 }).catch(e => {
   console.error('Fatal error during server start: ');
   console.error(e.stack || e);

--- a/guides/real-time-dashboard/content/5_deployment.md
+++ b/guides/real-time-dashboard/content/5_deployment.md
@@ -28,23 +28,23 @@ $ heroku config:set \
 ```
 
 Next, we need to make some changes to our `index.js` file to make it serve
-static files from the `dashboard-app/build` folder. Update the content of 
+static files from the `dashboard-app/build` folder. Update the content of
 `index.js` with the following.
 
 ```javascript
 const CubejsServerCore = require('@cubejs-backend/server-core');
 const WebSocketServer = require('@cubejs-backend/server/WebSocketServer');
 const express = require('express');
-const bodyParser = require("body-parser");
-const http = require("http");
-const path = require("path");
+const bodyParser = require('body-parser');
+const http = require('http');
+const path = require('path');
 const serveStatic = require('serve-static');
 require('dotenv').config();
 
-var app = express();
+const app = express();
 
-app.use(require("cors")());
-app.use(bodyParser.json({ limit: "50mb" }));
+app.use(require('cors')());
+app.use(bodyParser.json({ limit: '50mb' }));
 
 const cubejsServer = CubejsServerCore.create({
   orchestratorOptions: {
@@ -69,7 +69,7 @@ if (process.env.NODE_ENV === 'production') {
 
 const port = process.env.PORT || 4000;
 server.listen(port, () => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${CubejsServerCore.version()}) is listening on ${port}`);
 });
 ```
 

--- a/packages/cubejs-cli/templates.js
+++ b/packages/cubejs-cli/templates.js
@@ -1,9 +1,10 @@
 const indexJs = `const CubejsServer = require('@cubejs-backend/server');
+const cubeVersion = require('./node_modules/@cubejs-backend/server/package.json').version;
 
 const server = new CubejsServer();
 
 server.listen().then(({ port }) => {
-  console.log(\`🚀 Cube.js server is listening on \${port}\`);
+  console.log(\`🚀 Cube.js server (\${cubeVersion}) is listening on \${port}\`);
 }).catch(e => {
   console.error('Fatal error during server start: ');
   console.error(e.stack || e);

--- a/packages/cubejs-cli/templates.js
+++ b/packages/cubejs-cli/templates.js
@@ -1,10 +1,9 @@
 const indexJs = `const CubejsServer = require('@cubejs-backend/server');
-const cubeVersion = require('./node_modules/@cubejs-backend/server/package.json').version;
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(\`🚀 Cube.js server (\${cubeVersion}) is listening on \${port}\`);
+server.listen().then(({ version, port }) => {
+  console.log(\`🚀 Cube.js server (\${version}) is listening on \${port}\`);
 }).catch(e => {
   console.error('Fatal error during server start: ');
   console.error(e.stack || e);

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -13,6 +13,7 @@ const FileRepository = require('./FileRepository');
 const DevServer = require('./DevServer');
 const track = require('./track');
 const agentCollect = require('./agentCollect');
+const { version } = require('../package.json');
 
 const DriverDependencies = {
   postgres: '@cubejs-backend/postgres-driver',
@@ -215,6 +216,7 @@ class CubejsServerCore {
       typeof options.orchestratorOptions === 'function' ?
         options.orchestratorOptions :
         () => options.orchestratorOptions;
+    this.version = version;
 
     // proactively free up old cache values occassionally
     if (options.maxCompilerCacheKeepAlive) {

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -216,7 +216,6 @@ class CubejsServerCore {
       typeof options.orchestratorOptions === 'function' ?
         options.orchestratorOptions :
         () => options.orchestratorOptions;
-    this.version = version;
 
     // proactively free up old cache values occassionally
     if (options.maxCompilerCacheKeepAlive) {
@@ -518,6 +517,10 @@ class CubejsServerCore {
     });
     await Promise.all(releases);
     this.dataSourceIdToOrchestratorApi = {};
+  }
+
+  static version() {
+    return version;
   }
 }
 

--- a/packages/cubejs-server/bin/dev-server.js
+++ b/packages/cubejs-server/bin/dev-server.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 const CubejsServer = require('../');
-const cubeVersion = require('../package.json').version;
 
 const server = new CubejsServer();
 
-server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server (${cubeVersion}) is listening on ${port}`);
+server.listen().then(({ version, port }) => {
+  console.log(`🚀 Cube.js server (${version}) is listening on ${port}`);
 }).catch(e => {
   console.error('Fatal error during server start: ');
   console.error(e.stack || e);

--- a/packages/cubejs-server/bin/dev-server.js
+++ b/packages/cubejs-server/bin/dev-server.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 const CubejsServer = require('../');
+const cubeVersion = require('../package.json').version;
 
 const server = new CubejsServer();
 
 server.listen().then(({ port }) => {
-  console.log(`🚀 Cube.js server is listening on ${port}`);
+  console.log(`🚀 Cube.js server (${cubeVersion}) is listening on ${port}`);
 }).catch(e => {
   console.error('Fatal error during server start: ');
   console.error(e.stack || e);

--- a/packages/cubejs-server/index.d.ts
+++ b/packages/cubejs-server/index.d.ts
@@ -10,7 +10,7 @@ export interface CreateOptions extends CoreCreateOptions {
 declare class CubejsServer {
   constructor(options: CreateOptions);
 
-  listen(options?: https.ServerOptions | http.ServerOptions): Promise<{ server: http.Server | https.Server, port: number, tlsPort?: number, app: express.Application }>;
+  listen(options?: https.ServerOptions | http.ServerOptions): Promise<{ server: http.Server | https.Server, version: string, port: number, tlsPort?: number, app: express.Application }>;
   close(): Promise<void>;
   testConnections(): Promise<void>;
 }

--- a/packages/cubejs-server/index.js
+++ b/packages/cubejs-server/index.js
@@ -2,6 +2,7 @@
 require('dotenv').config();
 const CubejsServerCore = require('@cubejs-backend/server-core');
 const WebSocketServer = require('./WebSocketServer');
+const { version } = require('./package.json');
 
 class CubejsServer {
   constructor(config) {
@@ -11,6 +12,7 @@ class CubejsServer {
     this.webSockets = config.webSockets;
     this.redirector = null;
     this.server = null;
+    this.version = version;
   }
 
   async listen(options = {}) {

--- a/packages/cubejs-server/index.js
+++ b/packages/cubejs-server/index.js
@@ -12,7 +12,6 @@ class CubejsServer {
     this.webSockets = config.webSockets;
     this.redirector = null;
     this.server = null;
-    this.version = version;
   }
 
   async listen(options = {}) {
@@ -129,6 +128,10 @@ class CubejsServer {
 
   static apiSecret() {
     return process.env.CUBEJS_API_SECRET;
+  }
+
+  static version() {
+    return version;
   }
 }
 

--- a/packages/cubejs-server/index.js
+++ b/packages/cubejs-server/index.js
@@ -71,7 +71,8 @@ class CubejsServer {
             app,
             port: PORT,
             tlsPort: process.env.CUBEJS_ENABLE_TLS === "true" ? TLS_PORT : undefined,
-            server: this.server
+            server: this.server,
+            version
           });
         });
       });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Includes the Cube.js version in the startup message:
![image](https://user-images.githubusercontent.com/6880880/80185403-82f16400-85c9-11ea-99ce-c7c2c7e95f10.png)

The version is available in three places:

1. `CubejsServer.version()`
1. `CubejsServerCore.version()`
1. `const { version, port } = await cubejsServer.listen();`

