### PR TITLE
feat: Update type defs for query transformer

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -290,7 +290,7 @@ CubejsServerCore.create({
     const user = authInfo.u;
     if (user.filterByRegion) {
       query.filters.push({
-        dimension: 'Regions.id',
+        member: 'Regions.id',
         operator: 'equals',
         values: [user.regionId]
       })
@@ -319,7 +319,7 @@ It is usually used in [Multitenancy Setup](multitenancy-setup).
 
 ### schemaVersion
 
-Schema version can be used to tell Cube.js schema should be recompiled in case schema code depends on dynamic definitions fetched from some external database or API. 
+Schema version can be used to tell Cube.js schema should be recompiled in case schema code depends on dynamic definitions fetched from some external database or API.
 This method is called on each request however `RequestContext` parameter is reused per application id returned by [contextToAppId](#options-reference-context-to-app-id).
 If returned string has been changed, schema will be recompiled.
 It can be used in both multitenant and single tenant environments.
@@ -369,7 +369,7 @@ Providing `updateCompilerCacheKeepAlive: true` keeps frequently used schemas in 
 
 ### allowUngroupedWithoutPrimaryKey
 
-Providing `allowUngroupedWithoutPrimaryKey: true` disables primary key inclusion check for `ungrouped` queries. 
+Providing `allowUngroupedWithoutPrimaryKey: true` disables primary key inclusion check for `ungrouped` queries.
 
 ### telemetry
 

--- a/packages/cubejs-api-gateway/index.d.ts
+++ b/packages/cubejs-api-gateway/index.d.ts
@@ -1,0 +1,57 @@
+declare module "@cubejs-backend/api-gateway" {
+  export interface QueryFilter {
+    member: string;
+    operator:
+      | "equals"
+      | "notEquals"
+      | "contains"
+      | "notContains"
+      | "gt"
+      | "gte"
+      | "lt"
+      | "lte"
+      | "set"
+      | "notSet"
+      | "inDateRange"
+      | "notInDateRange"
+      | "beforeDate"
+      | "afterDate";
+    values?: string[];
+  }
+
+  export type QueryTimeDimensionGranularity =
+    | "hour"
+    | "day"
+    | "week"
+    | "month"
+    | "year";
+
+  export interface QueryTimeDimension {
+    dimension: string;
+    dateRange?: string[] | string;
+    granularity?: QueryTimeDimensionGranularity;
+  }
+
+  export interface Query {
+    measures: string[];
+    dimensions?: string[];
+    filters?: QueryFilter[];
+    timeDimensions?: QueryTimeDimension[];
+    segments?: string[];
+    limit?: number;
+    offset?: number;
+    order?: "asc" | "desc";
+    timezone?: string;
+    renewQuery?: boolean;
+    ungrouped?: boolean;
+  }
+
+  export interface NormalizedQuery extends Query {
+    filters?: NormalizedQueryFilter[];
+    rowLimit?: number;
+  }
+
+  export interface NormalizedQueryFilter extends QueryFilter {
+    dimension: string;
+  }
+}

--- a/packages/cubejs-api-gateway/index.d.ts
+++ b/packages/cubejs-api-gateway/index.d.ts
@@ -52,6 +52,6 @@ declare module "@cubejs-backend/api-gateway" {
   }
 
   export interface NormalizedQueryFilter extends QueryFilter {
-    dimension: string;
+    dimension?: string;
   }
 }

--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -15,6 +15,7 @@
     "test": "jest"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "dependencies": {
     "@hapi/joi": "^15.1.1",
     "chrono-node": "^1.3.11",

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -3,6 +3,7 @@ import {
   Response as ExpressResponse,
   NextFunction as ExpressNextFunction
 } from "express";
+import { NormalizedQuery as Query } from "@cubejs-backend/api-gateway";
 
 declare module "@cubejs-backend/server-core" {
   export function create(options?: CreateOptions): any;
@@ -99,51 +100,4 @@ declare module "@cubejs-backend/server-core" {
     | "redshift"
     | "snowflake"
     | "sqlite";
-
-  export interface QueryFilter {
-    member: string;
-    operator:
-      | "equals"
-      | "notEquals"
-      | "contains"
-      | "notContains"
-      | "gt"
-      | "gte"
-      | "lt"
-      | "lte"
-      | "set"
-      | "notSet"
-      | "inDateRange"
-      | "notInDateRange"
-      | "beforeDate"
-      | "afterDate";
-    values?: string[];
-  }
-
-  export type QueryTimeDimensionGranularity =
-    | "hour"
-    | "day"
-    | "week"
-    | "month"
-    | "year";
-
-  export interface QueryTimeDimension {
-    dimension: string;
-    dateRange?: string[] | string;
-    granularity?: QueryTimeDimensionGranularity;
-  }
-
-  export interface Query {
-    measures: string[];
-    dimensions?: string[];
-    filters?: QueryFilter[];
-    timeDimensions?: QueryTimeDimension[];
-    segments?: string[];
-    limit?: number;
-    offset?: number;
-    order?: "asc" | "desc";
-    timezone?: string;
-    renewQuery?: boolean;
-    ungrouped?: boolean;
-  }
 }


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR builds on #369 and moves the Query type to be owned by the package that is responsible for it - `api-gateway`. Query now means the incoming query - nothing is actually using this at this point, although methods like `load` could be declared to use it.

Internally, `api-gateway` "normalizes" the incoming query and adds a few things to the structure - this is represented by the new `NormalizedQuery` and `NormalizedQueryFilter` types. Since it is actually the `NormalizedQuery` that is made available to query transformers, I was running into a problem where TypeScript was complaining about the use of `dimension`, which it thought wasn't available but it actually is - this will now work properly.
