### PR TITLE
feat(@cubejs-backend/schema-compiler): Add index clustering, compression

### DIFF
--- a/docs/Schema/pre-aggregations.md
+++ b/docs/Schema/pre-aggregations.md
@@ -511,8 +511,8 @@ cube(`Orders`, {
       type: `originalSql`,
       indexes: {
         clustered: {
-          columnstore: true,
-          clustered: true
+          clustered: true,
+          compression: 'columnstore'
         },
         orders: {
           columns: ['id'],

--- a/docs/Schema/pre-aggregations.md
+++ b/docs/Schema/pre-aggregations.md
@@ -496,7 +496,7 @@ Currently, supported options are:
 cover more queries, thus reducing the need to retrieve values from missing columns from the underlying table or clustered index.  Not permitted when `clustered` is specified, or when
 `columnstore` compression is used.
  * **clustered** (mssql) - When `true`, indicates that the index should be used as the clustering index for the table.  Only one clustering index may be specified per table.
- * **unique** (mssql) - When `true`, indicates that values in the key columns of the index are unique, which can help the query compiler come up with better estimates when the index is used.
+ * **unique** (mssql, pgsql) - When `true`, indicates that values in the key columns of the index are unique, which can help the query compiler come up with better estimates when the index is used.
  * **compression** (mssql) - Supported values are `page`, `row`, or `columnstore`.  `row` and `page` compression levels can improve performance by reducing the amount of disk io.
 In addition to reducing the size of the table, `columnstore` compression unlocks [additional query performance improvements](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/columnstore-indexes-query-performance?view=sql-server-ver15) such as column and rowgroup elimination, batch mode execution, and aggregate and predicate pushdown.
 

--- a/packages/cubejs-schema-compiler/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseQuery.js
@@ -1676,7 +1676,7 @@ class BaseQuery {
       );
     } else if (index.clustered && index.compression === "columnstore") {
       return this.paramAllocator.buildSqlAndParams(
-        this.createIndexSql(indexName, tableName, undefined, undefined, {clustered: true, compression: "columnstore"})
+        this.createIndexSql(indexName, tableName, undefined, undefined, { clustered: true, compression: "columnstore" })
       );
     } else {
       throw new Error(`Index SQL support is not implemented`);
@@ -1684,7 +1684,7 @@ class BaseQuery {
   }
 
   createIndexSql(indexName, tableName, escapedColumns) {
-       return `CREATE INDEX ${indexName} ON ${tableName} (${escapedColumns.join(', ')})`;
+    return `CREATE INDEX ${indexName} ON ${tableName} (${escapedColumns.join(', ')})`;
   }
 
   preAggregationSql(cube, preAggregation) {

--- a/packages/cubejs-schema-compiler/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/BaseQuery.js
@@ -1665,12 +1665,18 @@ class BaseQuery {
         include.map(escapeColumn).map(c => this.escapeColumnName(c)) :
         undefined;
 
+      const indexOptions = {
+        clustered: index.clustered,
+        unique: index.unique,
+        compression: index.compression
+      };
+
       return this.paramAllocator.buildSqlAndParams(
-        this.createIndexSql(indexName, tableName, escapedColumns, escapedInclude, index.clustered, index.compression)
+        this.createIndexSql(indexName, tableName, escapedColumns, escapedInclude, indexOptions)
       );
     } else if (index.clustered && index.compression === "columnstore") {
       return this.paramAllocator.buildSqlAndParams(
-        this.createIndexSql(indexName, tableName, undefined, undefined, index.clustered, index.compression)
+        this.createIndexSql(indexName, tableName, undefined, undefined, {clustered: true, compression: "columnstore"})
       );
     } else {
       throw new Error(`Index SQL support is not implemented`);

--- a/packages/cubejs-schema-compiler/adapter/MssqlQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/MssqlQuery.js
@@ -103,7 +103,7 @@ class MssqlQuery extends BaseQuery {
   }
 
   createIndexSql(indexName, tableName, escapedColumns, escapedInclude, indexOptions) {
-    const {clustered, compression, unique} = indexOptions;
+    const { clustered, compression, unique } = indexOptions;
 
     if (compression === "columnstore") {
       return this.createColumnstoreIndexSql(indexName, tableName, clustered, escapedColumns);

--- a/packages/cubejs-schema-compiler/adapter/PostgresQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/PostgresQuery.js
@@ -41,6 +41,11 @@ class PostgresQuery extends BaseQuery {
   countDistinctApprox(sql) {
     return `round(hll_cardinality(hll_add_agg(hll_hash_any(${sql}))))`;
   }
+
+  createIndexSql(indexName, tableName, escapedColumns, _, indexOptions) {
+    const { unique } = indexOptions;
+    return `CREATE ${unique ? "UNIQUE " : ""}INDEX ${indexName} ON ${tableName} (${escapedColumns.join(', ')})`;
+  }
 }
 
 module.exports = PostgresQuery;

--- a/packages/cubejs-schema-compiler/compiler/CubePropContextTranspiler.js
+++ b/packages/cubejs-schema-compiler/compiler/CubePropContextTranspiler.js
@@ -34,7 +34,7 @@ class CubePropContextTranspiler {
 
   sqlAndReferencesFieldVisitor(cubeName) {
     return this.knownIdentifiersInjectVisitor(
-      /^(sql|measureReferences|dimensionReferences|segmentReferences|timeDimensionReference|drillMembers|drillMemberReferences|contextMembers|columns)$/,
+      /^(sql|measureReferences|dimensionReferences|segmentReferences|timeDimensionReference|drillMembers|drillMemberReferences|contextMembers|columns|include)$/,
       name => this.cubeSymbols.resolveSymbol(cubeName, name) || this.cubeSymbols.isCurrentCube(name)
     );
   }

--- a/packages/cubejs-schema-compiler/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/compiler/CubeValidator.js
@@ -81,7 +81,14 @@ const BasePreAggregation = {
       sql: Joi.func().required()
     }),
     Joi.object().keys({
-      columns: Joi.func().required()
+      columns: Joi.func().required(),
+      include: Joi.func(),
+      clustered: Joi.boolean(),
+      compression: Joi.any().valid('columnstore', 'row', 'page')
+    }),
+    Joi.object().keys({
+      clustered: Joi.valid(true).required(),
+      compression: Joi.valid('columnstore').required()
     })
   )),
 };

--- a/packages/cubejs-schema-compiler/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/compiler/CubeValidator.js
@@ -84,6 +84,7 @@ const BasePreAggregation = {
       columns: Joi.func().required(),
       include: Joi.func(),
       clustered: Joi.boolean(),
+      unique: Joi.boolean(),
       compression: Joi.any().valid('columnstore', 'row', 'page')
     }),
     Joi.object().keys({

--- a/packages/cubejs-schema-compiler/test/MSSqlPreAggregationsTest.js
+++ b/packages/cubejs-schema-compiler/test/MSSqlPreAggregationsTest.js
@@ -172,7 +172,8 @@ describe('MSSqlPreAggregations', function test() {
             clustered: {
               columns: ['id'],
               clustered: true,
-              compression: 'row'
+              compression: 'row',
+              unique: true
             },
             columnstore: {
               columns: ['created_at'],
@@ -200,7 +201,7 @@ describe('MSSqlPreAggregations', function test() {
     return [
       preAggregation.reduce(
         (replacedQuery, desc) => replacedQuery.replace(new RegExp(desc.tableName, 'g'), `##${desc.tableName}_${suffix}`)
-          .replace(/CREATE( CLUSTERED)?( COLUMNSTORE)? INDEX (?!i_)/, `CREATE$1$2 INDEX i_${suffix}_`), toReplace
+          .replace(/CREATE( UNIQUE)?( CLUSTERED)?( COLUMNSTORE)? INDEX (?!i_)/, `CREATE$1$2$3 INDEX i_${suffix}_`), toReplace
       ),
       params
     ];

--- a/packages/cubejs-schema-compiler/test/MSSqlPreAggregationsTest.js
+++ b/packages/cubejs-schema-compiler/test/MSSqlPreAggregationsTest.js
@@ -235,6 +235,7 @@ describe('MSSqlPreAggregations', function test() {
     const queryAndParams = query.buildSqlAndParams();
     console.log(queryAndParams);
     const preAggregationsDescription = query.preAggregations.preAggregationsDescription();
+    console.log(preAggregationsDescription);
 
     return dbRunner.testQueries(tempTablePreAggregations(preAggregationsDescription).concat([
       query.buildSqlAndParams()

--- a/packages/cubejs-schema-compiler/test/PreAggregationsTest.js
+++ b/packages/cubejs-schema-compiler/test/PreAggregationsTest.js
@@ -92,7 +92,8 @@ describe('PreAggregations', function test() {
           },
           indexes: {
             source: {
-              columns: ['source', 'created_at']
+              columns: ['source', 'created_at'],
+              unique: true
             }
           },
           partitionGranularity: 'month',
@@ -251,8 +252,8 @@ describe('PreAggregations', function test() {
     return [
       preAggregation.reduce(
         (replacedQuery, desc) => replacedQuery
-          .replace(new RegExp(desc.tableName, 'g'), desc.tableName + '_' + suffix)
-          .replace(/CREATE INDEX (?!i_)/, `CREATE INDEX i_${suffix}_`),
+          .replace(new RegExp(desc.tableName, 'g'), `${desc.tableName}_${suffix}`)
+          .replace(/CREATE( UNIQUE)? INDEX (?!i_)/, `CREATE$1 INDEX i_${suffix}_`),
         toReplace
       ),
       params


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**
Currently, with respect to `mssql`, pre-aggregations are stored in [heap tables](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/heaps-tables-without-clustered-indexes?view=sql-server-ver15) (`SELECT [...] INTO`), which for most cases will have a negative impact on the performance of queries referencing those tables, particularly those involving filtering by a range of values or grouping.  In these cases, it is recommended to add a `CLUSTERED` index to the table, e.g. `CREATE CLUSTERED INDEX ON orders(id)`.

`mssql` also offers some additional features that may help query performance:
* [`row`- and `page`-level compression](https://docs.microsoft.com/en-us/sql/relational-databases/data-compression/data-compression?view=sql-server-ver15) for rowstore indexes, which reduces the size of the index on disk, and thus the disk io operations that must be performed when accessing data within the index.
* The `unique` keyword, which indicates that the index key comprises unique values, [helping the query planner come up with better estimates](https://www.brentozar.com/archive/2015/08/performance-benefits-of-unique-indexes/)
* `columnstore` compression, which can greatly improve query performance (up to 100x according to MS) on large tables for [a variety of reasons](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/columnstore-indexes-query-performance?view=sql-server-ver15)
* [included columns](https://docs.microsoft.com/en-us/sql/relational-databases/indexes/create-indexes-with-included-columns?view=sql-server-ver15) via the `INCLUDE` keyword, which can improve query performance by increasing the chances that the index covers the query, thus eliminating the need for including non-key columns in the index key or requiring an additional lookup on the underlying table to retrieve values from columns missing in the index.

This PR allows these index options to be specified via properties of the `indexes` object in a pre-aggregation:

```javascript
{
    include: ['column_a', 'column_b', ...],
    clustered: boolean,
    unique: boolean,
    compression: 'row' | 'page' | 'columnstore'
}
```

For example:
```javascript
cube(`Orders`, {
  sql: `select * from orders where completed = true`,

  preAggregations: {
    main: {
      type: `originalSql`,
      indexes: {
        clustered: {
          clustered: true,
          compression: 'columnstore',
        },
        orders: {
          columns: ['id'],
          include: ['timestamp']
          unique: true,
          compression: 'row'
        }
      }
    }
  }
});
```
which would (approximately) result in the following SQL statements:
```tsql
CREATE CLUSTERED COLUMNSTORE INDEX orders_clustered ON orders;
CREATE UNIQUE INDEX orders_orders ON orders (id) INCLUDE(timestamp) WITH(DATA_COMPRESSION = ROW);
```

**postgres**
Postgres supports the `UNIQUE` [keyword](https://www.postgresql.org/docs/9.6/indexes-unique.html) for indexes.

As of version 11, Postgres also supports the [INCLUDE clause](https://www.postgresql.org/docs/11/sql-createindex.html) for indexes, however I did not implement this since the postgres containers in the package's tests are currently using 9.6.
