### PR TITLE
fix:PostgresDriver execution timeout is hardcoded to 10 minutes #651

### DIFF
--- a/packages/cubejs-postgres-driver/driver/PostgresDriver.js
+++ b/packages/cubejs-postgres-driver/driver/PostgresDriver.js
@@ -82,7 +82,7 @@ class PostgresDriver extends BaseDriver {
     const client = await this.pool.connect();
     try {
       await client.query(`SET TIME ZONE '${this.config.storeTimezone || 'UTC'}'`);
-      await client.query("set statement_timeout to 600000");
+      await client.query(`set statement_timeout to ${(this.config.hasOwnProperty('executionTimeout')) ? this.config.executionTimeout * 1000 : 600000}`);
       const res = await client.query({
         text: query,
         values: values || [],


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
#651 

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
executionTimeout (in seconds) can be added to the driver config argument and will be used as statetment_timeout for postgres. config.executionTimeout=0 will, set statemtent_timeout to infinite. if executionTimeout is undefined, the original default value of 10 min will be used.