### PR TITLE
fix(cubejs-client-core): Remove Content-Type header from requests in HttpTransport

### DIFF
--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -30,11 +30,12 @@ class HttpTransport {
 
     let spanCounter = 1;
 
+    // Currently, all methods make GET requests. If a method makes a request with a body payload,
+    // remember to add a 'Content-Type' header.
     const runRequest = () => fetch(
       `${this.apiUrl}/${method}${searchParams.toString().length ? `?${searchParams}` : ''}`, {
         headers: {
           Authorization: this.authorization,
-          'Content-Type': 'application/json',
           'x-request-id': baseRequestId && `${baseRequestId}-span-${spanCounter++}`,
           ...this.headers
         }

--- a/packages/cubejs-client-core/src/HttpTransport.test.js
+++ b/packages/cubejs-client-core/src/HttpTransport.test.js
@@ -1,0 +1,56 @@
+/* eslint-disable import/first */
+/* eslint-disable import/newline-after-import */
+/* globals describe,test,expect,jest,afterEach */
+import '@babel/runtime/regenerator';
+jest.mock('cross-fetch');
+import fetch from 'cross-fetch';
+import HttpTransport from './HttpTransport';
+
+describe('HttpTransport', () => {
+  const apiUrl = 'http://localhost:3000/cubejs-api/v1';
+  const query = {
+    measures: ['Orders.count'],
+    dimensions: ['Users.country']
+  };
+  const queryUrlEncoded = '%7B%22measures%22%3A%5B%22Orders.count%22%5D%2C%22dimensions%22%3A%5B%22Users.country%22%5D%7D';
+
+  afterEach(() => {
+    fetch.mockClear();
+  });
+
+  test('it serializes the query object and sends it in the query string', async () => {
+    const transport = new HttpTransport({
+      authorization: 'token',
+      apiUrl,
+    });
+    const req = transport.request('load', { query });
+    await req.subscribe(() => { });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(`${apiUrl}/load?query=${queryUrlEncoded}`, {
+      headers: {
+        Authorization: 'token',
+      }
+    });
+  });
+
+  test('it passes extra headers and serializes extra params', async () => {
+    const extraParams = { foo: 'bar' };
+    const serializedExtraParams = encodeURIComponent(JSON.stringify(extraParams));
+    const transport = new HttpTransport({
+      authorization: 'token',
+      apiUrl,
+      headers: {
+        'X-Extra-Header': '42'
+      }
+    });
+    const req = transport.request('meta', { extraParams });
+    await req.subscribe(() => { });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(`${apiUrl}/meta?extraParams=${serializedExtraParams}`, {
+      headers: {
+        Authorization: 'token',
+        'X-Extra-Header': '42'
+      }
+    });
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#688

**Description of Changes Made**

- Remove the Content-Type header in the fetch call, as explained in the issue, #688.
- Add some tests for HttpTransport.
