### PR TITLE
feat: add schema path as an environment variable.

### DIFF
--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -189,7 +189,7 @@ class CubejsServerCore {
     this.driverFactory = options.driverFactory;
     this.externalDriverFactory = options.externalDriverFactory;
     this.apiSecret = options.apiSecret;
-    this.schemaPath = options.schemaPath || 'schema';
+    this.schemaPath = options.schemaPath || process.env.CUBEJS_SCHEMA_PATH || 'schema';
     this.dbType = options.dbType;
     this.logger = options.logger ||
       (process.env.NODE_ENV !== 'production' ?


### PR DESCRIPTION
fixes #695

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] ~~Tests for the changes have been added if not covered yet~~
- [ ] ~~Docs have been added / updated if required~~

**Issue Reference this PR resolves**

Fixes #695

**Description of Changes Made (if issue reference is not provided)**

This change adds CUBEJS_SCHEMA_PATH as an environment variable parameter for the schema path.  Precedence is `options.schemaPath` -> `process.env.CUBEJS_SCHEMA_PATH` -> `'schema`.

I did not see the environment variables documented anywhere, so I did not add this to the documentation.
