### PR TITLE
Adjust client options to send credentials when needed

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -21,6 +21,7 @@ declare module '@cubejs-client/core' {
      * custom headers
      */
     headers?: Record<string, string>;
+    credentials: 'omit' | 'same-origin' | 'include';
   };
 
   export interface ITransport {
@@ -47,6 +48,7 @@ declare module '@cubejs-client/core' {
     transport?: ITransport;
     headers?: Record<string, string>;
     pollInterval?: number;
+    credentials: 'omit' | 'same-origin' | 'include';
   };
 
   export type LoadMethodOptions = {
@@ -646,7 +648,7 @@ declare module '@cubejs-client/core' {
 
   /**
    * Main class for accessing Cube.js API
-   * 
+   *
    * @order 2
    */
   export class CubejsApi {

--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -21,7 +21,7 @@ declare module '@cubejs-client/core' {
      * custom headers
      */
     headers?: Record<string, string>;
-    credentials: 'omit' | 'same-origin' | 'include';
+    credentials?: 'omit' | 'same-origin' | 'include';
   };
 
   export interface ITransport {
@@ -48,7 +48,7 @@ declare module '@cubejs-client/core' {
     transport?: ITransport;
     headers?: Record<string, string>;
     pollInterval?: number;
-    credentials: 'omit' | 'same-origin' | 'include';
+    credentials?: 'omit' | 'same-origin' | 'include';
   };
 
   export type LoadMethodOptions = {

--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -2,7 +2,7 @@ import fetch from 'cross-fetch';
 import 'url-search-params-polyfill';
 
 class HttpTransport {
-  constructor({ authorization, apiUrl, headers = {}, credentials = 'same-origin' }) {
+  constructor({ authorization, apiUrl, headers = {}, credentials }) {
     this.authorization = authorization;
     this.apiUrl = apiUrl;
     this.headers = headers;

--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -22,13 +22,13 @@ class HttpTransport {
     // remember to add a 'Content-Type' header.
     const runRequest = () => fetch(
       `${this.apiUrl}/${method}${searchParams.toString().length ? `?${searchParams}` : ''}`, {
-      headers: {
-        Authorization: this.authorization,
-        'x-request-id': baseRequestId && `${baseRequestId}-span-${spanCounter++}`,
-        ...this.headers
-      },
-      credentials: this.credentials
-    }
+        headers: {
+          Authorization: this.authorization,
+          'x-request-id': baseRequestId && `${baseRequestId}-span-${spanCounter++}`,
+          ...this.headers
+        },
+        credentials: this.credentials
+      }
     );
 
     return {

--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -2,10 +2,11 @@ import fetch from 'cross-fetch';
 import 'url-search-params-polyfill';
 
 class HttpTransport {
-  constructor({ authorization, apiUrl, headers = {} }) {
+  constructor({ authorization, apiUrl, headers = {}, credentials = 'same-origin' }) {
     this.authorization = authorization;
     this.apiUrl = apiUrl;
     this.headers = headers;
+    this.credentials = credentials;
   }
 
   request(method, { baseRequestId, ...params }) {
@@ -21,12 +22,13 @@ class HttpTransport {
     // remember to add a 'Content-Type' header.
     const runRequest = () => fetch(
       `${this.apiUrl}/${method}${searchParams.toString().length ? `?${searchParams}` : ''}`, {
-        headers: {
-          Authorization: this.authorization,
-          'x-request-id': baseRequestId && `${baseRequestId}-span-${spanCounter++}`,
-          ...this.headers
-        }
-      }
+      headers: {
+        Authorization: this.authorization,
+        'x-request-id': baseRequestId && `${baseRequestId}-span-${spanCounter++}`,
+        ...this.headers
+      },
+      credentials: this.credentials
+    }
     );
 
     return {

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -25,7 +25,7 @@ class CubejsApi {
     this.apiToken = apiToken;
     this.apiUrl = options.apiUrl || API_URL;
     this.headers = options.headers || {};
-    this.credentials = options.credentials || 'same-origin';
+    this.credentials = options.credentials;
     this.transport = options.transport || new HttpTransport({
       authorization: typeof apiToken === 'function' ? undefined : apiToken,
       apiUrl: this.apiUrl,

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -25,10 +25,12 @@ class CubejsApi {
     this.apiToken = apiToken;
     this.apiUrl = options.apiUrl || API_URL;
     this.headers = options.headers || {};
+    this.credentials = options.credentials || 'same-origin';
     this.transport = options.transport || new HttpTransport({
       authorization: typeof apiToken === 'function' ? undefined : apiToken,
       apiUrl: this.apiUrl,
-      headers: this.headers
+      headers: this.headers,
+      credentials: this.credentials
     });
     this.pollInterval = options.pollInterval || 5;
     this.parseDateMeasures = options.parseDateMeasures;


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Note: the build instructions in the contribution guide are not working for me, so I can't build/run/test this change myself. Sorry about that!**

**Issue Reference this PR resolves**

Original request here: https://github.com/cube-js/cube.js/issues/788

**Description of Changes Made (if issue reference is not provided)**

The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) supports a credentials option to control the session cookies sent along with a request. By adjusting the Cube.js Client to support this option, we will be able to route our cube queries through a different sub-domain.

For example. If your site is running at secure.mydomain.com and your API calls need to go to api.mydomain.com it can be handy to pass the cookies over in the cross-domain API call. In order to support such a request pattern, the cube client must allow us to set credentials: 'include' when calling fetch().
