### PR TITLE
fix: allow renewQuery in dev mode with warning

### DIFF
--- a/packages/cubejs-playground/src/components/CachePane.js
+++ b/packages/cubejs-playground/src/components/CachePane.js
@@ -76,6 +76,7 @@ const CachePane = ({ query, cubejsApi }) => (
                   title: 'Refresh Key Value',
                   key: 'value',
                   render: (text, record) => rs && rs.loadResponse.usedPreAggregations
+                    && rs.loadResponse.usedPreAggregations[record.tableName].refreshKeyValues
                     && rs.loadResponse.usedPreAggregations[record.tableName].refreshKeyValues.map(k => (
                       <PrismCode
                         key={JSON.stringify(k)}

--- a/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
@@ -182,7 +182,16 @@ class PreAggregationLoader {
     this.structureVersionPersistTime = preAggregations.structureVersionPersistTime;
     this.externalRefresh = options.externalRefresh;
     if (this.externalRefresh && this.waitForRenew) {
-      throw new Error("Invalid configuration - when externalRefresh is true, it will not perform a renew, therefore you cannot wait for it using waitForRenew.");
+      const message = 'Invalid configuration - when externalRefresh is true, it will not perform a renew, therefore you cannot wait for it using waitForRenew.';
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error(message);
+      } else {
+        this.logger('Invalid Configuration', {
+          requestId: this.requestId,
+          warning: message,
+        });
+        this.waitForRenew = false;
+      }
     }
   }
 

--- a/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
@@ -183,7 +183,7 @@ class PreAggregationLoader {
     this.externalRefresh = options.externalRefresh;
     if (this.externalRefresh && this.waitForRenew) {
       const message = 'Invalid configuration - when externalRefresh is true, it will not perform a renew, therefore you cannot wait for it using waitForRenew.';
-      if (process.env.NODE_ENV === 'production') {
+      if (['production', 'test'].includes(process.env.NODE_ENV)) {
         throw new Error(message);
       } else {
         this.logger('Invalid Configuration', {


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

The combination of `renewQuery` on a query against a server running in `externalRefresh` mode results in a validation error (and correctly so - you can't renew queries against a server running in that mode), but it is breaking the dev playground's Cache tab.

This PR improves the guards for missing data in the Cache section, and also makes a change to allow `renewQuery` to be specified in dev mode, except it will issue a warning and force it back to false.
