### PR TITLE
fix: using limit and offset together in MSSql

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/MssqlQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/MssqlQuery.js
@@ -75,10 +75,17 @@ class MssqlQuery extends BaseQuery {
   }
 
   groupByDimensionLimit() {
-    return this.offset ? ` OFFSET ${parseInt(this.offset, 10)} ROWS` : '';
+    if (this.rowLimit) {
+      return this.offset ? ` OFFSET ${parseInt(this.offset, 10)} ROWS FETCH NEXT ${parseInt(this.rowLimit, 10)} ROWS ONLY` : '';
+    } else {
+      return this.offset ? ` OFFSET ${parseInt(this.offset, 10)} ROWS` : '';
+    }
   }
 
   topLimit() {
+    if (this.offset) {
+      return '';
+    }
     return this.rowLimit === null ? '' : ` TOP ${this.rowLimit && parseInt(this.rowLimit, 10) || 10000}`;
   }
 


### PR DESCRIPTION
…a OFFSET.' when using limit and offset together in the query for MSSQL.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#891 

**Description of Changes Made (if issue reference is not provided)**
Automatically adjust the parameters when limit and offset are both used in the query.
