### PR TITLE
fix: avoid querying source database when caching tables from external rollup db

### DIFF
--- a/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
+++ b/packages/cubejs-query-orchestrator/orchestrator/PreAggregations.js
@@ -714,7 +714,7 @@ class PreAggregations {
 
   getLoadCacheQueue() {
     if (!this.loadCacheQueue) {
-      this.loadCacheQueue = QueryCache.createQueue(`SQL_PRE_AGGREGATIONS_CACHE_${this.redisPrefix}`, this.driverFactory, (client, q) => {
+      this.loadCacheQueue = QueryCache.createQueue(`SQL_PRE_AGGREGATIONS_CACHE_${this.redisPrefix}`, () => {}, (_, q) => {
         const {
           preAggregation,
           requestId

--- a/packages/cubejs-query-orchestrator/test/PreAggregations.test.js
+++ b/packages/cubejs-query-orchestrator/test/PreAggregations.test.js
@@ -1,5 +1,5 @@
 /* globals describe, beforeAll, afterAll, beforeEach, test, expect */
-const crypto = require('crypto');
+const R = require('ramda');
 
 class MockDriver {
   constructor() {
@@ -38,10 +38,34 @@ class MockDriver {
     this.tables = this.tables.filter(t => t !== tableName);
     return this.query(`DROP TABLE ${tableName}`);
   }
+
+  async downloadTable(table) {
+    return { rows: await this.query(`SELECT * FROM ${table}`) };
+  }
+
+  async tableColumnTypes(table) {
+    return [];
+  }
+
+  async uploadTable(table, columns, tableData) {
+    await this.createTable(table, columns);
+  }
+
+  createTable(quotedTableName, columns) {
+    this.tables.push(quotedTableName);
+  }
+
+  readOnly() {
+    return false;
+  }
 }
 
 describe('PreAggregations', () => {
   let mockDriver = null;
+  let mockExternalDriver = null;
+  let mockDriverFactory = null;
+  let mockDriverReadOnlyFactory = null;
+  let mockExternalDriverFactory = null;
   let queryCache = null;
   const basicQuery = {
     query: "SELECT \"orders__created_at_week\" \"orders__created_at_week\", sum(\"orders__count\") \"orders__count\" FROM (SELECT * FROM stb_pre_aggregations.orders_number_and_count20191101) as partition_union  WHERE (\"orders__created_at_week\" >= ($1::timestamptz::timestamptz AT TIME ZONE 'UTC') AND \"orders__created_at_week\" <= ($2::timestamptz::timestamptz AT TIME ZONE 'UTC')) GROUP BY 1 ORDER BY 1 ASC LIMIT 10000",
@@ -58,31 +82,33 @@ describe('PreAggregations', () => {
     }],
     requestId: 'basic'
   };
-  const basicQueryWithRenew = {
-    query: "SELECT \"orders__created_at_week\" \"orders__created_at_week\", sum(\"orders__count\") \"orders__count\" FROM (SELECT * FROM stb_pre_aggregations.orders_number_and_count20191101) as partition_union  WHERE (\"orders__created_at_week\" >= ($1::timestamptz::timestamptz AT TIME ZONE 'UTC') AND \"orders__created_at_week\" <= ($2::timestamptz::timestamptz AT TIME ZONE 'UTC')) GROUP BY 1 ORDER BY 1 ASC LIMIT 10000",
-    values: ["2019-11-01T00:00:00Z", "2019-11-30T23:59:59Z"],
-    cacheKeyQueries: {
-      renewalThreshold: 21600,
-      queries: [["SELECT date_trunc('hour', (NOW()::timestamptz AT TIME ZONE 'UTC')) as current_hour", []]]
-    },
-    preAggregations: [{
-      preAggregationsSchema: "stb_pre_aggregations",
-      tableName: "stb_pre_aggregations.orders_number_and_count20191101",
-      loadSql: ["CREATE TABLE stb_pre_aggregations.orders_number_and_count20191101 AS SELECT\n      date_trunc('week', (\"orders\".created_at::timestamptz AT TIME ZONE 'UTC')) \"orders__created_at_week\", count(\"orders\".id) \"orders__count\", sum(\"orders\".number) \"orders__number\"\n    FROM\n      public.orders AS \"orders\"\n  WHERE (\"orders\".created_at >= $1::timestamptz AND \"orders\".created_at <= $2::timestamptz) GROUP BY 1", ["2019-11-01T00:00:00Z", "2019-11-30T23:59:59Z"]],
-      invalidateKeyQueries: [["SELECT date_trunc('hour', (NOW()::timestamptz AT TIME ZONE 'UTC')) as current_hour", []]]
-    }],
-    renewQuery: true,
-    requestId: 'basic'
-  };
+  const basicQueryExternal = R.clone(basicQuery);
+  basicQueryExternal.preAggregations[0].external = true;
+  const basicQueryWithRenew = R.clone(basicQuery);
+  basicQueryWithRenew.renewQuery = true;
+  const basicQueryExternalWithRenew = R.clone(basicQueryExternal);
+  basicQueryExternalWithRenew.renewQuery = true;
 
   beforeEach(() => {
     mockDriver = new MockDriver();
+    mockExternalDriver = new MockDriver();
+    mockDriverFactory = async () => mockDriver;
+    mockDriverReadOnlyFactory = async () => {
+      const driver = mockDriver;
+      jest.spyOn(driver, 'readOnly').mockImplementation(() => true);
+      return driver;
+    }
+    mockExternalDriverFactory = async () => {
+      const driver = mockExternalDriver;
+      driver.createTable("stb_pre_aggregations.orders_number_and_count20191101_kjypcoio_5yftl5il_1593709044209");
+      return driver;
+    }
 
     jest.resetModules();
     const QueryCache = require('../orchestrator/QueryCache');
     queryCache = new QueryCache(
       "TEST",
-      async () => mockDriver,
+      mockDriverFactory,
       (msg, params) => {},
       {
         queueOptions: {
@@ -99,7 +125,7 @@ describe('PreAggregations', () => {
       const PreAggregations = require('../orchestrator/PreAggregations');
       preAggregations = new PreAggregations(
         "TEST",
-        async () => mockDriver,
+        mockDriverFactory,
         (msg, params) => {},
         queryCache,
         {
@@ -116,6 +142,56 @@ describe('PreAggregations', () => {
     });
   });
 
+  describe(`loadAllPreAggregationsIfNeeded with external rollup and writable source`, () => {
+    let preAggregations = null;
+
+    beforeEach(async () => {
+      const PreAggregations = require('../orchestrator/PreAggregations');
+      preAggregations = new PreAggregations(
+        "TEST",
+        mockDriverFactory,
+        (msg, params) => {},
+        queryCache,
+        {
+          queueOptions: {
+            executionTimeout: 1
+          },
+          externalDriverFactory: mockExternalDriverFactory,
+        },
+      );
+    });
+
+    test('refresh external preaggregation with a writable source (refreshImplTempTableExternalStrategy)', async () => {
+      const result = await preAggregations.loadAllPreAggregationsIfNeeded(basicQueryExternal);
+      expect(result[0][1].targetTableName).toMatch(/stb_pre_aggregations.orders_number_and_count20191101_kjypcoio_5yftl5il/);
+    });
+  });
+
+  describe(`loadAllPreAggregationsIfNeeded with external rollup and readonly source`, () => {
+    let preAggregations = null;
+
+    beforeEach(async () => {
+      const PreAggregations = require('../orchestrator/PreAggregations');
+      preAggregations = new PreAggregations(
+        "TEST",
+        mockDriverReadOnlyFactory,
+        (msg, params) => {},
+        queryCache,
+        {
+          queueOptions: {
+            executionTimeout: 1
+          },
+          externalDriverFactory: mockExternalDriverFactory,
+        },
+      );
+    });
+
+    test('refresh external preaggregation with a writable source (refreshImplStreamExternalStrategy)', async () => {
+      const result = await preAggregations.loadAllPreAggregationsIfNeeded(basicQueryExternal);
+      expect(result[0][1].targetTableName).toMatch(/stb_pre_aggregations.orders_number_and_count20191101_kjypcoio_5yftl5il/);
+    });
+  });
+
   describe(`loadAllPreAggregationsIfNeeded with externalRefresh true`, () => {
     let preAggregations = null;
 
@@ -123,7 +199,7 @@ describe('PreAggregations', () => {
       const PreAggregations = require('../orchestrator/PreAggregations');
       preAggregations = new PreAggregations(
         "TEST",
-        async () => mockDriver,
+        mockDriverFactory,
         (msg, params) => {},
         queryCache,
         {
@@ -143,6 +219,37 @@ describe('PreAggregations', () => {
     test('fail if rollup doesn\'t already exist', async () => {
       await expect(preAggregations.loadAllPreAggregationsIfNeeded(basicQuery))
         .rejects.toThrowError(/One or more pre-aggregation tables could not be found to satisfy that query/);
+    });
+  });
+
+  describe(`loadAllPreAggregationsIfNeeded with external rollup and externalRefresh true`, () => {
+    let preAggregations = null;
+
+    beforeEach(async () => {
+      const PreAggregations = require('../orchestrator/PreAggregations');
+      preAggregations = new PreAggregations(
+        "TEST",
+        () => { throw new Error('The source database factory should never be called when externalRefresh is true, as it will trigger testConnection'); },
+        (msg, params) => {},
+        queryCache,
+        {
+          queueOptions: {
+            executionTimeout: 1
+          },
+          externalDriverFactory: mockExternalDriverFactory,
+          externalRefresh: true,
+        },
+      );
+    });
+
+    test('fail if waitForRenew is also specified', async () => {
+      await expect(preAggregations.loadAllPreAggregationsIfNeeded(basicQueryExternalWithRenew))
+        .rejects.toThrowError(/Invalid configuration/);
+    });
+
+    test('load external preaggregation without communicating to the source database', async () => {
+      const result = await preAggregations.loadAllPreAggregationsIfNeeded(basicQueryExternal);
+      expect(result[0][1].targetTableName).toMatch(/stb_pre_aggregations.orders_number_and_count20191101_kjypcoio_5yftl5il/);
     });
   });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Currently,  table caching will cause a test query to be made to BOTH the source and the rollup databases. This PR prevents a connection and query from being ran against the source database when caching the tables in the external rollup database. This is particularly important when `externalRefresh` is being used, as in that architecture the cubejs API instance likely isn't configured with the capability to connect to the source database.

The reason this happens is because `QueryCache.createQueue` will always setup a driver instance for the source database:
https://github.com/cube-js/cube.js/blob/c30a44c26e76e83c3d26234850d5c6b0e76cd924/packages/cubejs-query-orchestrator/orchestrator/QueryCache.js#L190

This normally wouldn't create a connection or run a query, except that there is additional logic in place when creating a driver instance that when it is created for the first time, it will run a query in order to validate that it is configured correctly (`testConnection`):
https://github.com/cube-js/cube.js/blob/c30a44c26e76e83c3d26234850d5c6b0e76cd924/packages/cubejs-server-core/core/index.js#L462-L473
