### PR TITLE
Resolve 773: Update query format API to support ordered order specification

### DIFF
--- a/docs/Cube.js-Backend/Query-Format.md
+++ b/docs/Cube.js-Backend/Query-Format.md
@@ -66,6 +66,22 @@ If the `order` property is not specified in the query, Cube.js sorts results by 
 - The first measure, descending. If no measure exists...
 - The first dimension, ascending.
 
+### Аlternative order format
+
+Also you can control the ordering of the `order` specification, Cube.js support alternative order format - array of tuples:  
+
+```js
+{
+  ...,
+  order: [
+      ['Stories.time', 'asc'],
+      ['Stories.count', 'asc']
+    ]
+  },
+  ...
+}
+```
+
 ## Filters Format
 
 A filter is a Javascript object with the following properties:

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -146,7 +146,10 @@ const querySchema = Joi.object().keys({
       Joi.string()
     ]
   })),
-  order: Joi.object().pattern(id, Joi.valid('asc', 'desc')),
+  order: Joi.alternatives(
+    Joi.object().pattern(id, Joi.valid('asc', 'desc')),
+    Joi.array().items(Joi.array().min(2).ordered(id, Joi.valid('asc', 'desc')))
+  ),
   segments: Joi.array().items(id),
   timezone: Joi.string(),
   limit: Joi.number().integer().min(1).max(50000),
@@ -154,6 +157,20 @@ const querySchema = Joi.object().keys({
   renewQuery: Joi.boolean(),
   ungrouped: Joi.boolean()
 });
+
+const normalizeQueryOrder = order => {
+  let result = [];
+  const normalizeOrderItem = (k, direction) => ({
+    id: k,
+    desc: direction === 'desc'
+  });
+  if (order) {
+    result = Array.isArray(order) ?
+      order.map(([k, direction]) => normalizeOrderItem(k, direction)) :
+      Object.keys(order).map(k => normalizeOrderItem(k, order[k]));
+  }
+  return result;
+};
 
 const DateRegex = /^\d\d\d\d-\d\d-\d\d$/;
 
@@ -209,15 +226,11 @@ const normalizeQuery = (query) => {
     granularity: d.split('.')[2]
   }));
   const timezone = query.timezone || 'UTC';
-  const order = query.order && Object.keys(query.order).map(k => ({
-    id: k,
-    desc: query.order[k] === 'desc'
-  }));
   return {
     ...query,
     rowLimit: query.rowLimit || query.limit,
     timezone,
-    order,
+    order: normalizeQueryOrder(query.order),
     filters: (query.filters || []).map(f => (
       {
         ...f,

--- a/packages/cubejs-api-gateway/index.test.js
+++ b/packages/cubejs-api-gateway/index.test.js
@@ -90,4 +90,35 @@ describe(`API Gateway`, () => {
       "2020-01-01T23:59:59.999"
     ]);
   });
+
+  test(`order support object format`, async () => {
+    const query = {
+      measures: ["Foo.bar"],
+      order: {
+        'Foo.bar': 'asc'
+      },
+    };
+    const res = await request(app)
+      .get(`/cubejs-api/v1/load?query=${JSON.stringify(query)}`)
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(200);
+
+    expect(res.body.query.order).toStrictEqual([{ id: 'Foo.bar', desc: false }]);
+  });
+
+  test(`order support array of tuples`, async () => {
+    const query = {
+      measures: ["Foo.bar"],
+      order: [
+        ['Foo.bar', 'asc'],
+        ['Foo.foo', 'desc']
+      ],
+    };
+    const res = await request(app)
+      .get(`/cubejs-api/v1/load?query=${JSON.stringify(query)}`)
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(200);
+
+    expect(res.body.query.order).toStrictEqual([{ id: 'Foo.bar', desc: false }, { id: 'Foo.foo', desc: true }]);
+  });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

[Update query format API to support ordered `order` specification #773]

**Description of Changes Made (if issue reference is not provided)**

Compiler API already support `array of object` format, example `[{ id: 'Sessions.count', desc: true }]` and current API-Gateway already transform public format to Compiler API.

I added support `array of tuples` alternative in Api-gateway layer, that also transform to `array of object` format for Compiler API:

- New rule in joi validation schema for order property
- New function `normalizeQueryOrder`
- Updated docs: Cube.js-Backend => Query-Format

