### PR TITLE
feat(@cubejs-client/react): Expose progress in useCubeQuery hook

### DIFF
--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -295,7 +295,7 @@ declare module '@cubejs-client/react' {
    *   });
    *
    *   if (isLoading) {
-   *     return <div>{progress ? progress.message : 'Loading...'}</div>;
+   *     return <div>{progress && progress.stage && progress.stage.stage || 'Loading...'}</div>;
    *   }
    *
    *   if (error) {
@@ -338,10 +338,7 @@ declare module '@cubejs-client/react' {
     error: Error | null;
     isLoading: boolean;
     resultSet: ResultSet<TData> | null;
-    progress: {
-      rawResponse: ProgressResponse;
-      message: string;
-    } | null;
+    progress: ProgressResponse;
   };
 
   /**

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -9,6 +9,7 @@ import {
   TCubeMeasure,
   TCubeDimension,
   TCubeMember,
+  ProgressResponse,
 } from '@cubejs-client/core';
 
 /**
@@ -288,13 +289,13 @@ declare module '@cubejs-client/react' {
    * import { useCubeQuery }  from '@cubejs-client/react';
    *
    * export default function App() {
-   *   const { resultSet, isLoading, error } = useCubeQuery({
+   *   const { resultSet, isLoading, error, progress } = useCubeQuery({
    *     measures: ['Orders.count'],
    *     dimensions: ['Orders.createdAt.month'],
    *   });
    *
    *   if (isLoading) {
-   *     return <div>Loading...</div>;
+   *     return <div>{progress ? progress.message : 'Loading...'}</div>;
    *   }
    *
    *   if (error) {
@@ -337,6 +338,10 @@ declare module '@cubejs-client/react' {
     error: Error | null;
     isLoading: boolean;
     resultSet: ResultSet<TData> | null;
+    progress: {
+      rawResponse: ProgressResponse;
+      message: string;
+    } | null;
   };
 
   /**

--- a/packages/cubejs-client-react/src/useCubeQuery.js
+++ b/packages/cubejs-client-react/src/useCubeQuery.js
@@ -17,14 +17,7 @@ export default (query, options = {}) => {
 
   let subscribeRequest = null;
 
-  const progressCallback = ({ progressResponse }) => {
-    setProgress({
-      rawResponse: progressResponse,
-      message: progressResponse.stage
-        ? progressResponse.stage.stage
-        : 'Loading...'
-    });
-  };
+  const progressCallback = ({ progressResponse }) => setProgress(progressResponse);
 
   useEffect(() => {
     const { skip = false, resetResultSetOnChange } = options;

--- a/packages/cubejs-client-react/src/useCubeQuery.js
+++ b/packages/cubejs-client-react/src/useCubeQuery.js
@@ -11,10 +11,20 @@ export default (query, options = {}) => {
   const [currentQuery, setCurrentQuery] = useState(null);
   const [isLoading, setLoading] = useState(false);
   const [resultSet, setResultSet] = useState(null);
+  const [progress, setProgress] = useState(null);
   const [error, setError] = useState(null);
   const context = useContext(CubeContext);
 
   let subscribeRequest = null;
+
+  const progressCallback = ({ progressResponse }) => {
+    setProgress({
+      rawResponse: progressResponse,
+      message: progressResponse.stage
+        ? progressResponse.stage.stage
+        : 'Loading...'
+    });
+  };
 
   useEffect(() => {
     const { skip = false, resetResultSetOnChange } = options;
@@ -43,7 +53,8 @@ export default (query, options = {}) => {
           if (options.subscribe) {
             subscribeRequest = cubejsApi.subscribe(query, {
               mutexObj: mutexRef.current,
-              mutexKey: 'query'
+              mutexKey: 'query',
+              progressCallback
             }, (e, result) => {
               if (e) {
                 setError(e);
@@ -51,17 +62,21 @@ export default (query, options = {}) => {
                 setResultSet(result);
               }
               setLoading(false);
+              setProgress(null);
             });
           } else {
             setResultSet(await cubejsApi.load(query, {
               mutexObj: mutexRef.current,
-              mutexKey: 'query'
+              mutexKey: 'query',
+              progressCallback
             }));
             setLoading(false);
+            setProgress(null);
           }
         } catch (e) {
           setError(e);
           setLoading(false);
+          setProgress(null);
         }
       }
     }
@@ -80,5 +95,10 @@ export default (query, options = {}) => {
     context
   ]));
 
-  return { isLoading, resultSet, error };
+  return {
+    isLoading,
+    resultSet,
+    error,
+    progress
+  };
 };


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Tests:**
There are no tests for this package at the moment, so I wasn't able to add any for this extension.

**Docs:**
I updated the `index.d.ts` file, but have not updated the other docs/examples. Are they automatically generated somehow or shall I do it manually?

**Description of Changes Made (if issue reference is not provided)**
When loading a Cube Query, it might take some due to waiting in the queue or because pre-aggregations are being built.

By exposing the ProgressResponse from the CubeJS API, the UI can share more information with the user when the query is loading.

This allows us to show the following in our UI (big win for our users):
![Screenshot 2020-08-13 at 13 41 48](https://user-images.githubusercontent.com/1349225/90130462-cc2d1580-dd6a-11ea-8ddf-98c2b58de4d2.png)



___

I hope you find this to be a useful addition to Cube.JS :) 