### PR TITLE
fix: add parentheses to pre aggregation sql for clickhouse 

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/ClickHouseQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/ClickHouseQuery.js
@@ -216,7 +216,7 @@ class ClickHouseQuery extends BaseQuery {
     }
     const firstIndexName = Object.keys(preAggregation.indexes)[0];
     const indexColumns = this.evaluateIndexColumns(cube, preAggregation.indexes[firstIndexName]);
-    return [`CREATE TABLE ${tableName} ENGINE = MergeTree() ORDER BY ${indexColumns.join(', ')} ${this.asSyntaxTable} ${sqlAndParams[0]}`, sqlAndParams[1]];
+    return [`CREATE TABLE ${tableName} ENGINE = MergeTree() ORDER BY (${indexColumns.join(', ')}) ${this.asSyntaxTable} ${sqlAndParams[0]}`, sqlAndParams[1]];
   }
 
   createIndexSql(indexName, tableName, escapedColumns) {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

No issue created.

**Description of Changes Made (if issue reference is not provided)**

The order by clause in the pre aggregation sql failes because multiple order by columns need to be supplied in a tuple (surrounded by parentheses).
