### PR TITLE
Export TimeDimensionGranularity type

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -593,7 +593,7 @@ declare module '@cubejs-client/core' {
 
 
 
-  type TimeDimensionGranularity = 'hour' | 'day' | 'week' | 'month' | 'year';
+  export type TimeDimensionGranularity = 'hour' | 'day' | 'week' | 'month' | 'year';
 
   export type TimeDimension = {
     dimension: string;


### PR DESCRIPTION
Commit 3396fb changed TimeDimensionGranularities enum to TimeDimensionGranularity type
and removed the export. This reintroduces the export of the type.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

No issue created

**Description of Changes Made (if issue reference is not provided)**

Commit 3396fb changed TimeDimensionGranularities enum to TimeDimensionGranularity type
and removed the export. This reintroduces the export of the type.