### PR TITLE
fix: cube-client-core resolveMember return type

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -673,6 +673,14 @@ declare module '@cubejs-client/core' {
   type TCubeDimension = TCubeMember & {
     suggestFilterValues: boolean;
   };
+
+  type TCubeSegment = Pick<TCubeMember, "name" | 'shortTitle' | "title">
+
+  type TCubeMemberByType<T> =
+    T extends "measures" ? TCubeMeasure :
+    T extends "dimensions" ? TCubeDimension :
+    T extends "segments" ? TCubeSegment :
+    never
   
   type TDryRunResponse = {
     queryType: QueryType;
@@ -709,7 +717,7 @@ declare module '@cubejs-client/core' {
      * @param memberName - Fully qualified member name in a form `Cube.memberName`
      * @return An object containing meta information about member
      */
-    resolveMember(memberName: string, memberType: MemberType): Object;
+    resolveMember<T extends MemberType>(memberName: string, memberType: T): { title: string, error: string } | TCubeMemberByType<T>;
     defaultTimeDimensionNameFor(memberName: string): string;
     filterOperatorsForMember(memberName: string, memberType: MemberType): any;
   }


### PR DESCRIPTION
Add correct return type to Meta.resolveMember. The previous type of `Object` was incorrect.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

No issue

**Description of Changes Made (if issue reference is not provided)**

Updated return types for the Meta function resolveMember. This was previously set as `Object`, but it might actually contain an error object or the returned member details. The returned type is controlled by the `memberType` param provided to the function.
