### PR TITLE
Improve TimeDimensionGranularity Type

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -593,7 +593,7 @@ declare module '@cubejs-client/core' {
 
 
 
-  export type TimeDimensionGranularity = 'hour' | 'day' | 'week' | 'month' | 'year';
+  export type TimeDimensionGranularity = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
 
   export type TimeDimension = {
     dimension: string;


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

No issue

**Description of Changes Made (if issue reference is not provided)**

Adds the `second` and `minute` option to the `TimeDimensionGranularity` type exposed by `cubejs-client-core`. Do note that from trying to find prior issues/PRs regarding this, I found [this](https://github.com/cube-js/cube.js/issues/177#issuecomment-530034036) and [this](https://github.com/cube-js/cube.js/issues/340#issuecomment-571446275) comment from @paveltiunov on semi-related issues, so I wonder if the omission of these strings from this type is intentional. Where I work, we currently use the `second` granularity in a small number of queries, so we want this so that we have full type safety for such queries.