### PR TITLE
feat: strict cube schema parsing, show duplicate property name errors

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -74,7 +74,8 @@ Both [CubejsServerCore](@cubejs-backend-server-core) `create` method and [Cubejs
     preAggregationsOptions: {
       queueOptions: QueueOptions
     }
-  }
+  },
+  allowDuplicateProps: Boolean
 }
 
 QueueOptions {
@@ -477,3 +478,7 @@ const CubejsServerCore = require('@cubejs-backend/server-core');
 
 console.log(CubejsServerCore.version());
 ```
+
+### allowDuplicateProps
+
+Boolean to enable or disable a check duplicate property names in all objects of a schema. The default value is `false`, and it is means the compiler would use the additional transpiler for check duplicates.

--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -75,7 +75,7 @@ Both [CubejsServerCore](@cubejs-backend-server-core) `create` method and [Cubejs
       queueOptions: QueueOptions
     }
   },
-  allowDuplicateProps: Boolean
+  allowJsDuplicatePropsInSchema: Boolean
 }
 
 QueueOptions {
@@ -479,6 +479,6 @@ const CubejsServerCore = require('@cubejs-backend/server-core');
 console.log(CubejsServerCore.version());
 ```
 
-### allowDuplicateProps
+### allowJsDuplicatePropsInSchema
 
 Boolean to enable or disable a check duplicate property names in all objects of a schema. The default value is `false`, and it is means the compiler would use the additional transpiler for check duplicates.

--- a/packages/cubejs-schema-compiler/compiler/CubeCheckDuplicatePropTranspiler.js
+++ b/packages/cubejs-schema-compiler/compiler/CubeCheckDuplicatePropTranspiler.js
@@ -1,0 +1,35 @@
+const TYPE = {
+  OBJECT_EXPRESSION: 'ObjectExpression'
+};
+
+class CubeCheckDuplicatePropTranspiler {
+  traverseObject() {
+    return {
+      CallExpression: path => {
+        if (path.node.callee.name === 'cube') {
+          path.node.arguments.forEach(arg => {
+            if (arg && arg.type === TYPE.OBJECT_EXPRESSION) this.checkExpression(arg);
+          });
+        }
+      }
+    };
+  }
+
+  checkExpression(astObjectExpression) {
+    const unique = new Set();
+    astObjectExpression.properties.forEach(prop => {
+      const { value, key, loc } = prop || {};
+      if (value && key) {
+        if (value.type === TYPE.OBJECT_EXPRESSION) this.checkExpression(value);
+        if (unique.has(key.name)) {
+          const error = new SyntaxError(`Duplicate property parsing ${key.name}`);
+          error.loc = loc.start;
+          throw error;
+        }
+        unique.add(key.name);
+      }
+    });
+  }
+}
+
+module.exports = CubeCheckDuplicatePropTranspiler;

--- a/packages/cubejs-schema-compiler/compiler/PrepareCompiler.js
+++ b/packages/cubejs-schema-compiler/compiler/PrepareCompiler.js
@@ -1,5 +1,6 @@
 const CubeValidator = require('./CubeValidator');
 const DataSchemaCompiler = require('./DataSchemaCompiler');
+const CubeCheckDuplicatePropTranspiler = require('./CubeCheckDuplicatePropTranspiler');
 const CubePropContextTranspiler = require('./CubePropContextTranspiler');
 const ImportExportTranspiler = require('./ImportExportTranspiler');
 const CubeSymbols = require('./CubeSymbols');
@@ -32,10 +33,20 @@ exports.prepareCompiler = (repo, options) => {
   const metaTransformer = new CubeToMetaTransformer(cubeValidator, cubeEvaluator, contextEvaluator, joinGraph);
   const { maxQueryCacheSize, maxQueryCacheAge } = options;
   const compilerCache = new CompilerCache({ maxQueryCacheSize, maxQueryCacheAge });
+
+  const transpilers = [
+    new ImportExportTranspiler(),
+    new CubePropContextTranspiler(cubeSymbols, cubeDictionary),
+  ];
+
+  if (!options.allowDuplicateProps) {
+    transpilers.push(new CubeCheckDuplicatePropTranspiler());
+  }
+
   const compiler = new DataSchemaCompiler(repo, Object.assign({}, {
     cubeNameCompilers: [cubeDictionary],
     preTranspileCubeCompilers: [cubeSymbols, cubeValidator],
-    transpilers: [new ImportExportTranspiler(), new CubePropContextTranspiler(cubeSymbols, cubeDictionary)],
+    transpilers,
     cubeCompilers: [cubeEvaluator, joinGraph, metaTransformer],
     contextCompilers: [contextEvaluator],
     dashboardTemplateCompilers: [dashboardTemplateEvaluator],

--- a/packages/cubejs-schema-compiler/compiler/PrepareCompiler.js
+++ b/packages/cubejs-schema-compiler/compiler/PrepareCompiler.js
@@ -39,7 +39,7 @@ exports.prepareCompiler = (repo, options) => {
     new CubePropContextTranspiler(cubeSymbols, cubeDictionary),
   ];
 
-  if (!options.allowDuplicateProps) {
+  if (!options.allowJsDuplicatePropsInSchema) {
     transpilers.push(new CubeCheckDuplicatePropTranspiler());
   }
 

--- a/packages/cubejs-schema-compiler/test/DataSchemaCompilerTest.js
+++ b/packages/cubejs-schema-compiler/test/DataSchemaCompilerTest.js
@@ -170,31 +170,45 @@ describe('DataSchemaCompiler', function test() {
     });
 
     describe('Test perfomance', () => {
-      it('Should compile 200 schemas with diff time below than 15%', async () => {
+      const schema = `
+        cube('visitors', {
+          sql: 'select * from visitors',
+          measures: {
+            count: {
+              type: 'count',
+              sql: 'id'
+            },
+            duration: {
+              type: 'avg',
+              sql: 'duration'
+            },
+          },
+          dimensions: {
+            date: {
+              type: 'string',
+              sql: 'date'
+            },
+            browser: {
+              type: 'string',
+              sql: 'browser'
+            }
+          }
+        })
+      `;
+
+      it('Should compile 200 schemas in less than 2500ms * 10', async () => {
         const repeats = 200;
 
-        const compilerWith = prepareCompiler(validSchema, { allowJsDuplicatePropsInSchema: false });
-        const startWith = new Date().getTime();
+        const compilerWith = prepareCompiler(schema, { allowJsDuplicatePropsInSchema: false });
+        const start = new Date().getTime();
         for (let i = 0; i < repeats; i++) {
           delete compilerWith.compiler.compilePromise; // Reset compile result
           await compilerWith.compiler.compile();
         }
-        const endWith = new Date().getTime();
-
-        const compilerWithout = prepareCompiler(validSchema, { allowJsDuplicatePropsInSchema: true });
-        const startWithout = new Date().getTime();
-        for (let i = 0; i < repeats; i++) {
-          delete compilerWithout.compiler.compilePromise; // Reset compile result
-          await compilerWithout.compiler.compile();
-        }
-        const endWithout = new Date().getTime();
-
-        const timeWithout = endWithout - startWithout;
-        const timeWith = endWith - startWith;
+        const end = new Date().getTime();
+        const time = end - start;
         
-        const diffPercent = ((timeWith - timeWithout) * 100 / timeWithout);
-        console.log({ diffPercent, timeWithout, timeWith });
-        diffPercent.should.be.below(15);
+        time.should.be.below(2500 * 10);
       });
     });
   });

--- a/packages/cubejs-schema-compiler/test/DataSchemaCompilerTest.js
+++ b/packages/cubejs-schema-compiler/test/DataSchemaCompilerTest.js
@@ -144,15 +144,15 @@ describe('DataSchemaCompiler', function test() {
       })
     `;
 
-    it('Should compile without error, allowDuplicateProps = false, valid schema', () => {
-      const { compiler } = prepareCompiler(validSchema, { allowDuplicateProps: false });
+    it('Should compile without error, allowJsDuplicatePropsInSchema = false, valid schema', () => {
+      const { compiler } = prepareCompiler(validSchema, { allowJsDuplicatePropsInSchema: false });
       return compiler.compile().then(() => {
         compiler.throwIfAnyErrors();
       });
     });
 
-    it('Should throw error, allowDuplicateProps = false, invalid schema', () => {
-      const { compiler } = prepareCompiler(invalidSchema, { allowDuplicateProps: false });
+    it('Should throw error, allowJsDuplicatePropsInSchema = false, invalid schema', () => {
+      const { compiler } = prepareCompiler(invalidSchema, { allowJsDuplicatePropsInSchema: false });
       return compiler.compile().then(() => {
         compiler.throwIfAnyErrors();
         throw new Error();
@@ -162,8 +162,8 @@ describe('DataSchemaCompiler', function test() {
       });
     });
 
-    it('Should compile without error, allowDuplicateProps = true, invalid schema', () => {
-      const { compiler } = prepareCompiler(invalidSchema, { allowDuplicateProps: true });
+    it('Should compile without error, allowJsDuplicatePropsInSchema = true, invalid schema', () => {
+      const { compiler } = prepareCompiler(invalidSchema, { allowJsDuplicatePropsInSchema: true });
       return compiler.compile().then(() => {
         compiler.throwIfAnyErrors();
       });
@@ -173,7 +173,7 @@ describe('DataSchemaCompiler', function test() {
       it('Should compile 200 schemas with diff time below than 15%', async () => {
         const repeats = 200;
 
-        const compilerWith = prepareCompiler(validSchema, { allowDuplicateProps: false });
+        const compilerWith = prepareCompiler(validSchema, { allowJsDuplicatePropsInSchema: false });
         const startWith = new Date().getTime();
         for (let i = 0; i < repeats; i++) {
           delete compilerWith.compiler.compilePromise; // Reset compile result
@@ -181,7 +181,7 @@ describe('DataSchemaCompiler', function test() {
         }
         const endWith = new Date().getTime();
 
-        const compilerWithout = prepareCompiler(validSchema, { allowDuplicateProps: true });
+        const compilerWithout = prepareCompiler(validSchema, { allowJsDuplicatePropsInSchema: true });
         const startWithout = new Date().getTime();
         for (let i = 0; i < repeats; i++) {
           delete compilerWithout.compiler.compilePromise; // Reset compile result

--- a/packages/cubejs-server-core/core/CompilerApi.js
+++ b/packages/cubejs-server-core/core/CompilerApi.js
@@ -14,6 +14,7 @@ class CompilerApi {
     this.allowUngroupedWithoutPrimaryKey = this.options.allowUngroupedWithoutPrimaryKey;
     this.schemaVersion = this.options.schemaVersion;
     this.compileContext = options.compileContext;
+    this.allowDuplicateProps = options.allowDuplicateProps;
   }
 
   async getCompilers(options) {
@@ -34,7 +35,8 @@ class CompilerApi {
       // TODO check if saving this promise can produce memory leak?
       this.compilers = PrepareCompiler.compile(this.repository, {
         allowNodeRequire: this.allowNodeRequire,
-        compileContext: this.compileContext
+        compileContext: this.compileContext,
+        allowDuplicateProps: this.allowDuplicateProps
       });
       this.compilerVersion = compilerVersion;
     }

--- a/packages/cubejs-server-core/core/CompilerApi.js
+++ b/packages/cubejs-server-core/core/CompilerApi.js
@@ -14,7 +14,7 @@ class CompilerApi {
     this.allowUngroupedWithoutPrimaryKey = this.options.allowUngroupedWithoutPrimaryKey;
     this.schemaVersion = this.options.schemaVersion;
     this.compileContext = options.compileContext;
-    this.allowDuplicateProps = options.allowDuplicateProps;
+    this.allowJsDuplicatePropsInSchema = options.allowJsDuplicatePropsInSchema;
   }
 
   async getCompilers(options) {
@@ -36,7 +36,7 @@ class CompilerApi {
       this.compilers = PrepareCompiler.compile(this.repository, {
         allowNodeRequire: this.allowNodeRequire,
         compileContext: this.compileContext,
-        allowDuplicateProps: this.allowDuplicateProps
+        allowJsDuplicatePropsInSchema: this.allowJsDuplicatePropsInSchema
       });
       this.compilerVersion = compilerVersion;
     }

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -435,7 +435,7 @@ class CubejsServerCore {
           schemaVersion: currentSchemaVersion,
           preAggregationsSchema: this.preAggregationsSchema(context),
           context,
-          allowDuplicateProps: this.options.allowDuplicateProps
+          allowJsDuplicatePropsInSchema: this.options.allowJsDuplicatePropsInSchema
         }
       );
       this.compilerCache.set(appId, compilerApi);
@@ -500,7 +500,7 @@ class CubejsServerCore {
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,
-      allowDuplicateProps: options.allowDuplicateProps
+      allowJsDuplicatePropsInSchema: options.allowJsDuplicatePropsInSchema
     });
   }
 

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -434,7 +434,8 @@ class CubejsServerCore {
           externalDialectClass: this.externalDialectFactory && this.externalDialectFactory(context),
           schemaVersion: currentSchemaVersion,
           preAggregationsSchema: this.preAggregationsSchema(context),
-          context
+          context,
+          allowDuplicateProps: this.options.allowDuplicateProps
         }
       );
       this.compilerCache.set(appId, compilerApi);
@@ -499,6 +500,7 @@ class CubejsServerCore {
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,
+      allowDuplicateProps: options.allowDuplicateProps
     });
   }
 

--- a/packages/cubejs-server-core/core/index.test.js
+++ b/packages/cubejs-server-core/core/index.test.js
@@ -92,7 +92,8 @@ describe('index.test', () => {
         preAggregationsOptions: {
           queueOptions
         }
-      }
+      },
+      allowDuplicateProps: true
     };
 
     expect(new CubejsServerCore(options))

--- a/packages/cubejs-server-core/core/index.test.js
+++ b/packages/cubejs-server-core/core/index.test.js
@@ -93,7 +93,7 @@ describe('index.test', () => {
           queueOptions
         }
       },
-      allowDuplicateProps: true
+      allowJsDuplicatePropsInSchema: true
     };
 
     expect(new CubejsServerCore(options))

--- a/packages/cubejs-server-core/core/optionsValidate.js
+++ b/packages/cubejs-server-core/core/optionsValidate.js
@@ -57,7 +57,7 @@ const schemaOptions = Joi.object().keys({
       queueOptions: schemaQueueOptions
     }
   }),
-  allowDuplicateProps: Joi.boolean()
+  allowJsDuplicatePropsInSchema: Joi.boolean()
 });
 
 

--- a/packages/cubejs-server-core/core/optionsValidate.js
+++ b/packages/cubejs-server-core/core/optionsValidate.js
@@ -56,7 +56,8 @@ const schemaOptions = Joi.object().keys({
     preAggregationsOptions: {
       queueOptions: schemaQueueOptions
     }
-  })
+  }),
+  allowDuplicateProps: Joi.boolean()
 });
 
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]

Added class CubeCheckDuplicatePropTranspiler and require logic in PrepareCompiler.
Added option allowDuplicateProps - schema-compiler, server-core, docs.
