### PR TITLE
ungrouped condition check in ElasticSearchQuery

### DIFF
--- a/packages/cubejs-schema-compiler/adapter/ElasticSearchQuery.js
+++ b/packages/cubejs-schema-compiler/adapter/ElasticSearchQuery.js
@@ -53,6 +53,9 @@ class ElasticSearchQuery extends BaseQuery {
   }
 
   groupByClause() {
+    if (this.ungrouped) {
+      return '';
+    }
     const dimensionsForSelect = this.dimensionsForSelect();
     const dimensionColumns = R.flatten(
       dimensionsForSelect.map(s => s.selectColumns() && s.dimensionSql())


### PR DESCRIPTION
ungrouped condition check for groupByClause function in ElasticSearchQuery

ungrouped: true query still groups by the dimension list

```
{
  "limit": 5,
  "dimensions": [
    "sales_data.State",
    "sales_data.Region"
  ],
  "ungrouped": true
}
```

This is the input query that I am passing to cube


```
SELECT
      sales_data.State sales_data___state, sales_data.Region sales_data___region
    FROM
      sales_data AS sales_data
  GROUP BY sales_data.State, sales_data.Region ORDER BY sales_data.State ASC LIMIT 5
```

Above is the corresponding SQL query formed

```
const cubeCore = CubejsServerCore.create({
  devServer: true,
  telemetry: false,
  schemaPath: "./src/schema/",
  dbType: "elasticsearch",
  basePath: appPrefixURL,
  apiSecret: cubeSecretKey,
  allowUngroupedWithoutPrimaryKey: true,
  driverFactory: () =>
    new ElasticSearchDriver({ elastic config })
});
```

This is the cube core configuration. 


