### PR TITLE
Fix(@cubejs-backend/server-core): Support webSockets option

### DIFF
--- a/packages/cubejs-server-core/core/optionsValidate.js
+++ b/packages/cubejs-server-core/core/optionsValidate.js
@@ -22,6 +22,7 @@ const schemaOptions = Joi.object().keys({
   basePath: Joi.string(),
   webSocketsBasePath: Joi.string(),
   devServer: Joi.boolean(),
+  webSockets: Joi.boolean(),
   logger: Joi.func(),
   driverFactory: Joi.func(),
   externalDriverFactory: Joi.func(),


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

I've got a problem on local after https://github.com/cube-js/cube.js/pull/1089, cC @RusovDmitriy 

```
/Users/ovr/projects/cube/cube.js/packages/cubejs-server-core/core/optionsValidate.js:65
  if (error) throw new Error(`Invalid cube-server-core options: ${error.message || error.toString()}`);
             ^

Error: Invalid cube-server-core options: "webSockets" is not allowed
```

CubejsServer pass `webSockets` options.


![image](https://user-images.githubusercontent.com/572096/93322907-8c02fc00-f81c-11ea-974f-ce2b68da31ba.png)
