### PR TITLE
Update optionsValidate.js

### DIFF
--- a/packages/cubejs-server-core/core/optionsValidate.js
+++ b/packages/cubejs-server-core/core/optionsValidate.js
@@ -58,7 +58,8 @@ const schemaOptions = Joi.object().keys({
       queueOptions: schemaQueueOptions
     }
   }),
-  allowJsDuplicatePropsInSchema: Joi.boolean()
+  allowJsDuplicatePropsInSchema: Joi.boolean(),
+  scheduledRefreshContexts: Joi.func()
 });
 
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

Added `scheduledRefreshContexts` to validation schema - I think the omission of this broke our deploy: 
```
2020-09-17T10:21:33.00008478Z /home/node/app/node_modules/@cubejs-backend/server-core/core/optionsValidate.js:67
2020-09-17T10:21:33.000148387Z   if (error) throw new Error(`Invalid cube-server-core options: ${error.message || error.toString()}`);
2020-09-17T10:21:33.00015392Z              ^
2020-09-17T10:21:33.000157474Z 
2020-09-17T10:21:33.000160715Z Error: Invalid cube-server-core options: "scheduledRefreshContexts" is not allowed
2020-09-17T10:21:33.000164349Z     at module.exports (/home/node/app/node_modules/@cubejs-backend/server-core/core/optionsValidate.js:67:20)
2020-09-17T10:21:33.000179623Z     at new CubejsServerCore (/home/node/app/node_modules/@cubejs-backend/server-core/core/index.js:155:5)
2020-09-17T10:21:33.000183695Z     at Function.create (/home/node/app/node_modules/@cubejs-backend/server-core/core/index.js:381:12)
2020-09-17T10:21:33.000187063Z     at new CubejsServer (/home/node/app/node_modules/@cubejs-backend/server/index.js:11:34)
2020-09-17T10:21:33.000190558Z     at Object.<anonymous> (/home/node/app/index.js:42:16)
2020-09-17T10:21:33.00019421Z     at Module._compile (internal/modules/cjs/loader.js:778:30)
2020-09-17T10:21:33.00019751Z     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
2020-09-17T10:21:33.000200808Z     at Module.load (internal/modules/cjs/loader.js:653:32)
2020-09-17T10:21:33.000204114Z     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
2020-09-17T10:21:33.000207411Z     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```
