### PR TITLE
fix(@cubejs-backend/server-core): Allow initApp as server-core option 

### DIFF
--- a/packages/cubejs-server-core/core/index.test.js
+++ b/packages/cubejs-server-core/core/index.test.js
@@ -73,6 +73,7 @@ describe('index.test', () => {
       schemaPath: '/test/path/test/',
       basePath: '/basePath',
       webSocketsBasePath: '/webSocketsBasePath',
+      initApp: () => {},
       devServer: false,
       logger: () => {},
       driverFactory: () => {},

--- a/packages/cubejs-server-core/core/optionsValidate.js
+++ b/packages/cubejs-server-core/core/optionsValidate.js
@@ -24,6 +24,7 @@ const schemaOptions = Joi.object().keys({
   webSocketsBasePath: Joi.string(),
   devServer: Joi.boolean(),
   webSockets: Joi.boolean(),
+  initApp: Joi.func(),
   logger: Joi.func(),
   driverFactory: Joi.func(),
   externalDriverFactory: Joi.func(),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

Add initApp option to server-core validation 