### PR TITLE
fix: propagate drill down parent filters

### DIFF
--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -294,9 +294,10 @@ const normalizeQuery = (query) => {
     timezone,
     order: normalizeQueryOrder(query.order),
     filters: (query.filters || []).map(f => {
+      const { dimension, member, ...filter } = f;
       const normalizedFlter = {
-        ...f,
-        member: (f.dimension || f.member)
+        ...filter,
+        member: member || dimension
       };
 
       Object.defineProperty(normalizedFlter, "dimension", {

--- a/packages/cubejs-client-core/src/ResultSet.js
+++ b/packages/cubejs-client-core/src/ResultSet.js
@@ -103,6 +103,7 @@ class ResultSet {
     normalizedPivotConfig.x.forEach((member, currentIndex) => values.push([member, xValues[currentIndex]]));
     normalizedPivotConfig.y.forEach((member, currentIndex) => values.push([member, yValues[currentIndex]]));
 
+    const { filters: parentFilters = [] } = this.query();
     const { measures } = this.loadResponses[0].annotation;
     let [, measureName] = values.find(([member]) => member === 'measures') || [];
 
@@ -114,10 +115,13 @@ class ResultSet {
       return null;
     }
 
-    const filters = [{
-      member: measureName,
-      operator: 'measureFilter',
-    }];
+    const filters = [
+      {
+        member: measureName,
+        operator: 'measureFilter',
+      },
+      ...parentFilters
+    ];
     const timeDimensions = [];
 
     values.filter(([member]) => member !== 'measures')

--- a/packages/cubejs-client-core/src/tests/drill-down.test.js
+++ b/packages/cubejs-client-core/src/tests/drill-down.test.js
@@ -1,0 +1,178 @@
+import 'jest';
+import ResultSet from '../ResultSet';
+
+jest.mock('moment-range', () => {
+  const Moment = jest.requireActual('moment');
+  const MomentRange = jest.requireActual('moment-range');
+  const moment = MomentRange.extendMoment(Moment);
+  return {
+    extendMoment: () => moment,
+  };
+});
+
+const loadResponse = (query = {}) => ({
+  queryType: 'regularQuery',
+  results: [
+    {
+      query: {
+        measures: ['Orders.count'],
+        timeDimensions: [
+          {
+            dimension: 'Orders.ts',
+            granularity: 'day',
+            dateRange: ['2020-08-01T00:00:00.000', '2020-08-07T23:59:59.999'],
+          },
+        ],
+        filters: [],
+        timezone: 'UTC',
+        order: [],
+        dimensions: [],
+        ...query,
+      },
+      data: [
+        {
+          'Orders.ts.day': '2020-08-01T00:00:00.000',
+          'Orders.ts': '2020-08-01T00:00:00.000',
+          'Orders.count': 1,
+        },
+        {
+          'Orders.ts.day': '2020-08-02T00:00:00.000',
+          'Orders.ts': '2020-08-02T00:00:00.000',
+          'Orders.count': 2,
+        },
+      ],
+      annotation: {
+        measures: {
+          'Orders.count': {
+            title: 'Orders Count',
+            shortTitle: 'Count',
+            type: 'number',
+            drillMembers: ['Orders.id', 'Orders.title'],
+            drillMembersGrouped: {
+              measures: [],
+              dimensions: ['Orders.id', 'Orders.title'],
+            },
+          },
+        },
+        dimensions: {},
+        segments: {},
+        timeDimensions: {
+          'Orders.ts.day': { title: 'Orders Ts', shortTitle: 'Ts', type: 'time' },
+          'Orders.ts': { title: 'Orders Ts', shortTitle: 'Ts', type: 'time' },
+        },
+      },
+    },
+  ],
+  pivotQuery: {
+    measures: ['Orders.count'],
+    timeDimensions: [
+      {
+        dimension: 'Orders.ts',
+        granularity: 'day',
+        dateRange: ['2020-08-01T00:00:00.000', '2020-08-07T23:59:59.999'],
+      },
+    ],
+    filters: [],
+    timezone: 'UTC',
+    order: [],
+    dimensions: [],
+    ...query,
+  },
+});
+
+describe('drill down query', () => {
+  const resultSet1 = new ResultSet(loadResponse());
+  const resultSet2 = new ResultSet(
+    loadResponse({
+      timezone: 'America/Los_Angeles',
+    })
+  );
+  const resultSet3 = new ResultSet(
+    loadResponse({
+      filters: [
+        {
+          member: 'Users.country',
+          operator: 'equals',
+          values: ['Los Angeles'],
+        },
+      ],
+    })
+  );
+
+  it('handles a query with a time dimension', () => {
+    expect(
+      resultSet1.drillDown({
+        xValues: ['2020-08-01T00:00:00.000'],
+      })
+    ).toEqual({
+      measures: [],
+      dimensions: ['Orders.id', 'Orders.title'],
+      filters: [
+        {
+          member: 'Orders.count',
+          operator: 'measureFilter',
+        },
+      ],
+      timeDimensions: [
+        {
+          dimension: 'Orders.ts',
+          dateRange: ['2020-08-01T00:00:00.000', '2020-08-01T23:59:59.999'],
+        },
+      ],
+      timezone: 'UTC',
+    });
+  });
+
+  it('respects the time zone', () => {
+    expect(
+      resultSet2.drillDown({
+        xValues: ['2020-08-01T00:00:00.000'],
+      })
+    ).toEqual({
+      measures: [],
+      dimensions: ['Orders.id', 'Orders.title'],
+      filters: [
+        {
+          member: 'Orders.count',
+          operator: 'measureFilter',
+        },
+      ],
+      timeDimensions: [
+        {
+          dimension: 'Orders.ts',
+          dateRange: ['2020-08-01T00:00:00.000', '2020-08-01T23:59:59.999'],
+        },
+      ],
+      timezone: 'America/Los_Angeles',
+    });
+  });
+
+  it('propagates parent filters', () => {
+    expect(
+      resultSet3.drillDown({
+        xValues: ['2020-08-01T00:00:00.000'],
+      })
+    ).toEqual({
+      measures: [],
+      dimensions: ['Orders.id', 'Orders.title'],
+      filters: [
+        {
+          member: 'Orders.count',
+          operator: 'measureFilter',
+        },
+        {
+          member: 'Users.country',
+          operator: 'equals',
+          values: ['Los Angeles'],
+        },
+      ],
+      timeDimensions: [
+        {
+          dimension: 'Orders.ts',
+          dateRange: ['2020-08-01T00:00:00.000', '2020-08-01T23:59:59.999'],
+        },
+      ],
+      timezone: 'UTC',
+    });
+  });
+});


### PR DESCRIPTION
**Issue Reference this PR resolves**

#1138

**Description of Changes Made (if issue reference is not provided)**

Propagate drill down parent filters to the query, fix query normalization to use only the `member` field for filters.
