### PR TITLE
fix(docs): Rename REST to HTTP

### DIFF
--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -129,7 +129,7 @@ Path to schema files. The default value is `/schema`.
 
 ### basePath
 
-[REST API](/rest-api) base path. The default value is `/cubejs-api`.
+[HTTP API](/rest-api) base path. The default value is `/cubejs-api`.
 
 ### webSocketsBasePath
 
@@ -251,7 +251,7 @@ CubejsServerCore.create({
 
 ### checkAuth
 
-Used in both REST and Websocket API.
+Used in both HTTP and Websocket API.
 Can be `async` functon.
 Default implementation parses [JSON Web Tokens (JWT)](https://jwt.io/) in `Authorization` and sets payload to `req.authInfo` if it's verified.
 More info on how to generate such tokens is [here](security#security-context).
@@ -358,7 +358,7 @@ CUBEJS_SCHEDULED_REFRESH_TIMEZONES=America/Los_Angeles,UTC
 ```
 
 Best practice is to run `scheduledRefreshTimer` in a separate worker Cube.js instance.
-For serverless deployments [REST API](rest-api#api-reference-v-1-run-scheduled-refresh) should be used instead of timer.
+For serverless deployments [HTTP API](rest-api#api-reference-v-1-run-scheduled-refresh) should be used instead of timer.
 
 ### extendContext
 

--- a/docs/Cube.js-Backend/Caching.md
+++ b/docs/Cube.js-Backend/Caching.md
@@ -193,7 +193,7 @@ server.listen().then(({ version, port }) => {
 });
 ```
 
-There's also [REST API](rest-api#api-reference-v-1-run-scheduled-refresh) available to trigger run.
+There's also [HTTP API](rest-api#api-reference-v-1-run-scheduled-refresh) available to trigger run.
 
 > **NOTE:** `runScheduledRefresh()` call is idempotent and just updates pre-aggregations if required by `refreshKey`. It always uses refreshKey to check if refresh is required or not. In the case `refreshKey` doesn't change it's value it doesn't matter how often you call `runScheduledRefresh()`: such pre-aggregation won't be refreshed.
 

--- a/docs/Cube.js-Backend/Deployment.md
+++ b/docs/Cube.js-Backend/Deployment.md
@@ -18,7 +18,7 @@ Below you can find guides for popular deployment environments:
 When running Cube.js Backend in production make sure `NODE_ENV` is set to `production`.
 Such platforms, such as Heroku, do it by default.
 In this mode Cube.js unsecured development server and Playground will be disabled by default because there's a security risk serving those in production environments.
-Production Cube.js servers can be accessed only with [REST API](rest-api) and Cube.js frontend libraries.
+Production Cube.js servers can be accessed only with [HTTP API](rest-api) and Cube.js frontend libraries.
 
 ### Redis
 

--- a/docs/Cube.js-Backend/REST-API.md
+++ b/docs/Cube.js-Backend/REST-API.md
@@ -1,5 +1,5 @@
 ---
-title: REST API
+title: HTTP API
 permalink: /rest-api
 category: Cube.js Backend
 menuOrder: 2
@@ -8,7 +8,7 @@ menuOrder: 2
 ## Prerequisites
 ### Base path
 
-REST API is used to communicate with Cube.js backend.
+HTTP API is used to communicate with Cube.js backend.
 All requests are prefixed with **basePath** described in [Backend Server Core](@cubejs-backend-server-core). By default it's `/cubejs-api`.
 
 ### Authentication
@@ -40,7 +40,7 @@ Possible reasons of **Continue wait**:
 
 ### Error Handling
 
-Cube.js REST API has basic errors and HTTP Error codes for all requests.
+Cube.js HTTP API has basic errors and HTTP Error codes for all requests.
 
 | Status | Error response | Description |
 | --- | --- | --- |

--- a/docs/Cube.js-Backend/Security.md
+++ b/docs/Cube.js-Backend/Security.md
@@ -17,7 +17,7 @@ Cube.js tokens are designed to work well in microservice-based environments. Typ
 2. The web server should generate an expirable cube.js token to achieve this. The server could include the token in the HTML it serves or provide the token to the front-end via an XHR request, which stores it in local storage or a cookie.
 3. The JS client is initialized using this token, and includes it in calls to the cube.js server API.
 
-If you are using the [REST API](rest-api) you must pass the API Token via the Authorization Header. The Cube.js Javascript client accepts an authentication token as the first argument to the [cubejs(authToken, options) function](@cubejs-client-core#cubejs).
+If you are using the [HTTP API](rest-api) you must pass the API Token via the Authorization Header. The Cube.js Javascript client accepts an authentication token as the first argument to the [cubejs(authToken, options) function](@cubejs-client-core#cubejs).
 
 **In the development environment the token is not required for authorization**, but
 you can still use it to [pass a security context](security#security-context).

--- a/docs/Cube.js-Frontend/Introduction.md
+++ b/docs/Cube.js-Frontend/Introduction.md
@@ -4,7 +4,7 @@ permalink: /frontend-introduction
 category: Cube.js Frontend
 ---
 
-You can send queries to Cube.js Backend using JSON [Query Format](query-format) via [REST API](rest-api).
+You can send queries to Cube.js Backend using JSON [Query Format](query-format) via [HTTP API](rest-api).
 
 Alongside with it, Cube.js comes with Javascript client and bindings for
 popular frameworks such as React and Vue.

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -107,7 +107,7 @@ $ npm run dev
 
 Then open `http://localhost:4000` to see visualization examples. This will open a Developer Playground app. You can change the metrics and dimensions of the example to use the schema you defined above, change the chart types, generate sample code out of it and more!
 
-Cube.js Backend also provides [REST API](/rest-api) for accessing your data.
+Cube.js Backend also provides [HTTP API](/rest-api) for accessing your data.
 
 ### Cube.js Client Installation
 

--- a/docs/Schema/Getting-Started-with-Cube.js-Schema.md
+++ b/docs/Schema/Getting-Started-with-Cube.js-Schema.md
@@ -182,5 +182,5 @@ Same as for other measures, `payingPercentage` can be used with dimensions.
 
 1. [Examples](examples)
 2. [Query format](query-format)
-3. [REST API](rest-api)
+3. [HTTP API](rest-api)
 4. [Schema reference documentation](cube)

--- a/guides/d3-dashboard/content/3_rendering_chart_with_d3.md
+++ b/guides/d3-dashboard/content/3_rendering_chart_with_d3.md
@@ -11,7 +11,7 @@ A Cube.js query is a simple JSON object containing several properties. The main 
 
 Cube.js backend accepts this query and then uses it and the schema we created earlier to generate an SQL query. This SQL query will be executed in our database and the result will be sent back to the client.
 
-Although Cube.js can be queried via plain HTTP REST API, we’re going to use the Cube.js JavaScript client library. Among other things it provides useful tools to process the data after it has been returned from the backend.
+Although Cube.js can be queried via plain HTTP API, we’re going to use the Cube.js JavaScript client library. Among other things it provides useful tools to process the data after it has been returned from the backend.
 
 Once the data is loaded, the Cube.js client creates a `ResultSet` object, which provides a set of methods to access and manipulate the data. We’re going to use two of them now: `ResultSet.series` and `ResultSet.chartPivot`. You can learn about all the features of the [Cube.js client library in the docs](https://cube.dev/docs/@cubejs-client-core).
 

--- a/packages/cubejs-api-gateway/index.js
+++ b/packages/cubejs-api-gateway/index.js
@@ -848,7 +848,7 @@ class ApiGateway {
 
   async requestLogger(req, res, next) {
     const details = requestParser(req, res);
-    this.log(req.context, { type: 'REST API Request', ...details });
+    this.log(req.context, { type: 'HTTP API Request', ...details });
     if (next) {
       next();
     }

--- a/packages/cubejs-server-core/core/index.js
+++ b/packages/cubejs-server-core/core/index.js
@@ -128,7 +128,7 @@ const prodLogger = (level) => (msg, params) => {
     // eslint-disable-next-line no-fallthrough
     case "info":
       if ([
-        'REST API Request',
+        'HTTP API Request',
       ].includes(msg)) {
         logMessage();
         break;


### PR DESCRIPTION
It's not really relevant to call Cube.js API a REST API. It's better to call it a HTTP API.

Checklist:
- [x] Update docs
- [x] Update guides
- [x] Update packages
- [ ] Review the changes to packages
- [ ] Rename the `/docs/rest-api` page (?)
- [ ] Redeploy the docs