### PR TITLE
Fix(@cubejs-backend/mysql-driver): Correct dates casting, fix #1117

### DIFF
--- a/packages/cubejs-mysql-driver/driver/MySqlDriver.js
+++ b/packages/cubejs-mysql-driver/driver/MySqlDriver.js
@@ -19,6 +19,7 @@ class MySqlDriver extends BaseDriver {
       port: process.env.CUBEJS_DB_PORT,
       user: process.env.CUBEJS_DB_USER,
       password: process.env.CUBEJS_DB_PASS,
+      timezone: 'Z',
       ...restConfig
     };
     this.pool = genericPool.createPool({
@@ -34,6 +35,7 @@ class MySqlDriver extends BaseDriver {
         conn.execute = promisify(conn.query.bind(conn));
 
         await connect();
+
         return conn;
       },
       destroy: (connection) => promisify(connection.end.bind(connection))(),


### PR DESCRIPTION
**Issue Reference this PR resolves**

Fix: https://github.com/cube-js/cube.js/issues/1117

**Description of Changes Made (if issue reference is not provided)**

MySQL driver casting dates to `Date` by default,  see `dateStrings ` parameter
It's `TIMESTAMP, DATETIME, DATE` by default

There are ways how to resolve this issue:

#### 1. In this PR - Use `timezone` parameter and use `Z` timezone

> timezone: The timezone configured on the MySQL server. This is used to type cast server date/time values to JavaScript Date object and vice versa. This can be 'local', 'Z', or an offset in the form +HH:MM or -HH:MM. (Default: 'local')

#### 2. Change `dateStrings` to `false`

Not working, lol

#### 3. Pass own type-cast function to `typeCast`

https://github.com/cube-js/cube.js/pull/1159