### PR TITLE
fix(@cubejs-schema-compilter): MSSQL rollingWindow with granularity

### DIFF
--- a/packages/cubejs-schema-compiler/test/unit/MssqlQueryTest.js
+++ b/packages/cubejs-schema-compiler/test/unit/MssqlQueryTest.js
@@ -1,0 +1,69 @@
+/* globals it, describe, after */
+/* eslint-disable quote-props */
+const MssqlQuery = require('../../adapter/MssqlQuery');
+const PrepareCompiler = require('./PrepareCompiler');
+require('should');
+
+const { prepareCompiler } = PrepareCompiler;
+
+describe('MssqlQuery', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareCompiler(`
+    cube(\`visitors\`, {
+      sql: \`
+      select * from visitors
+      \`,
+
+      measures: {
+        count: {
+          type: 'count'
+        },
+
+        unboundedCount: {
+          type: 'count',
+          rollingWindow: {
+            trailing: 'unbounded'
+          }
+        }
+      },
+
+      dimensions: {
+        createdAt: {
+          type: 'time',
+          sql: 'created_at'
+        }
+      }
+    });
+    `);
+
+  it('group by the date_from field on unbounded trailing windows', () =>
+    compiler.compile().then(() => {
+      const query = new MssqlQuery(
+        { joinGraph, cubeEvaluator, compiler },
+        {
+          measures: ['visitors.count', 'visitors.unboundedCount'],
+          timeDimensions: [
+            {
+              dimension: 'visitors.createdAt',
+              granularity: 'week',
+              dateRange: ['2017-01-01', '2017-01-30'],
+            },
+          ],
+          timezone: 'America/Los_Angeles',
+          order: [
+            {
+              id: 'visitors.createdAt',
+            },
+          ],
+        }
+      );
+
+      const queryAndParams = query.buildSqlAndParams();
+
+      const queryString = queryAndParams[0];
+      const lastGroupByIdx = queryString.lastIndexOf('GROUP BY');
+      const queryCloseIdx = queryString.indexOf(')', lastGroupByIdx + 1);
+      const finalGroupBy = queryString.substring(lastGroupByIdx, queryCloseIdx);
+
+      finalGroupBy.should.equal('GROUP BY "visitors.createdAt_series"."date_from"');
+    }));
+});


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
#997 


**Description of Changes Made (if issue reference is not provided)**
The base query adapter uses ordinal values for group by clauses; unfortunately MSSQL does not support such.  When this.groupByClause() is called, it returns the group by clause for the 'inner query', not the current select statement being created.  In base query, or for databases like Postgres which support ordinal group by clauses, this is fine - 1,2 is still 1,2; but in MSSQL which uses the aliases of the columns being grouped, this is an issue.
Changes here implement a MSSQL specific overTimeSeriesSelect function which creates then uses the proper group by clause; also fixes syntax on the seriesSql() function to properly alias the date columns.
