### PR TITLE
feat(@cubejs-backend/elasticsearch-driver): add cursor support to ElasticSearch driver

### DIFF
--- a/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
+++ b/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
@@ -37,8 +37,8 @@ class ElasticSearchDriver extends BaseDriver {
         await this.sqlClient.sql.query({
           body: {
             query: SqlString.format(query, values),
-            fetch_size: fetchSize,
-          },
+            fetch_size: fetchSize
+          }
         })
       ).body;
       if (result.cursor !== null || result.cursor !== undefined) {
@@ -47,12 +47,12 @@ class ElasticSearchDriver extends BaseDriver {
           const response = (
             await this.sqlClient.sql.query({
               body: {
-                cursor: newCursor,
-              },
+                cursor: newCursor
+              }
             })
           ).body;
           result.rows.push(...response.rows);
-          if (response.cursor !== null || response.cursor !== undefined) {
+          if (response.cursor === null || response.cursor === undefined) {
             break;
           } else {
             newCursor = response.cursor;

--- a/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
+++ b/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
@@ -27,21 +27,46 @@ class ElasticSearchDriver extends BaseDriver {
 
   async query(query, values) {
     try {
-      const result = (await this.sqlClient.sql.query({ // TODO cursor
-        body: {
-          query: SqlString.format(query, values)
+      let querySplit = query.split(' ');
+      let limitIndex = querySplit.indexOf('LIMIT');
+      let fetchSize = 10000;
+      if (limitIndex != -1) {
+        fetchSize = querySplit[limitIndex + 1];
+      }
+      var result = (
+        await this.sqlClient.sql.query({
+          // TODO cursor
+          body: {
+            query: SqlString.format(query, values),
+            fetch_size: fetchSize,
+          },
+        })
+      ).body;
+      if (result.cursor != null) {
+        let newCursor = result.cursor;
+        while (true) {
+          let response = (
+            await this.sqlClient.sql.query({
+              body: {
+                cursor: newCursor,
+              },
+            })
+          ).body;
+          result.rows.push(...response.rows);
+          if (response.cursor != null || response.cursor != undefined) {
+            break;
+          } else {
+            newCursor = response.cursor;
+          }
         }
-      })).body;
-
+      }
       // TODO: Clean this up, will need a better identifier than the cloud setting
       if (this.config.cloud) {
-        const compiled = result.rows.map(
-          r => result.columns.reduce((prev, cur, idx) => ({ ...prev, [cur.name]: r[idx] }), {})
+        const compiled = result.rows.map((r) =>
+          result.columns.reduce((prev, cur, idx) => ({ ...prev, [cur.name]: r[idx] }), {})
         );
-
         return compiled;
       }
-
       return result && result.aggregations && this.traverseAggregations(result.aggregations);
     } catch (e) {
       if (e.body) {

--- a/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
+++ b/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
@@ -27,13 +27,13 @@ class ElasticSearchDriver extends BaseDriver {
 
   async query(query, values) {
     try {
-      let querySplit = query.split(' ');
-      let limitIndex = querySplit.indexOf('LIMIT');
+      const querySplit = query.split(' ');
+      const limitIndex = querySplit.indexOf('LIMIT');
       let fetchSize = 10000;
-      if (limitIndex != -1) {
+      if (limitIndex !== -1) {
         fetchSize = querySplit[limitIndex + 1];
       }
-      var result = (
+      let result = (
         await this.sqlClient.sql.query({
           // TODO cursor
           body: {
@@ -42,10 +42,10 @@ class ElasticSearchDriver extends BaseDriver {
           },
         })
       ).body;
-      if (result.cursor != null) {
+      if (result.cursor !== null) {
         let newCursor = result.cursor;
         while (true) {
-          let response = (
+          const response = (
             await this.sqlClient.sql.query({
               body: {
                 cursor: newCursor,
@@ -53,7 +53,7 @@ class ElasticSearchDriver extends BaseDriver {
             })
           ).body;
           result.rows.push(...response.rows);
-          if (response.cursor != null || response.cursor != undefined) {
+          if (response.cursor !== null || response.cursor !== undefined) {
             break;
           } else {
             newCursor = response.cursor;
@@ -63,8 +63,7 @@ class ElasticSearchDriver extends BaseDriver {
       // TODO: Clean this up, will need a better identifier than the cloud setting
       if (this.config.cloud) {
         const compiled = result.rows.map((r) =>
-          result.columns.reduce((prev, cur, idx) => ({ ...prev, [cur.name]: r[idx] }), {})
-        );
+          result.columns.reduce((prev, cur, idx) => ({ ...prev, [cur.name]: r[idx] }), {}));
         return compiled;
       }
       return result && result.aggregations && this.traverseAggregations(result.aggregations);

--- a/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
+++ b/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
@@ -35,14 +35,13 @@ class ElasticSearchDriver extends BaseDriver {
       }
       let result = (
         await this.sqlClient.sql.query({
-          // TODO cursor
           body: {
             query: SqlString.format(query, values),
             fetch_size: fetchSize,
           },
         })
       ).body;
-      if (result.cursor !== null) {
+      if (result.cursor !== null || result.cursor !== undefined) {
         let newCursor = result.cursor;
         while (true) {
           const response = (
@@ -62,8 +61,7 @@ class ElasticSearchDriver extends BaseDriver {
       }
       // TODO: Clean this up, will need a better identifier than the cloud setting
       if (this.config.cloud) {
-        const compiled = result.rows.map((r) =>
-          result.columns.reduce((prev, cur, idx) => ({ ...prev, [cur.name]: r[idx] }), {}));
+        const compiled = result.rows.map((r) => result.columns.reduce((prev, cur, idx) => ({ ...prev, [cur.name]: r[idx] }), {}));
         return compiled;
       }
       return result && result.aggregations && this.traverseAggregations(result.aggregations);

--- a/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
+++ b/packages/cubejs-elasticsearch-driver/driver/ElasticSearchDriver.js
@@ -41,7 +41,7 @@ class ElasticSearchDriver extends BaseDriver {
           }
         })
       ).body;
-      if (result.cursor !== null || result.cursor !== undefined) {
+      if (result.cursor !== null && result.cursor !== undefined) {
         let newCursor = result.cursor;
         while (true) {
           const response = (


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This change has been made to add the cursor logic in the Elastic Search driver. It will help us in getting the next set of records with the help of a cursor key returning in the previous response. The LIMIT value sent in the query is set as the fetch_size to get that many records from the elastic index.

**References**

https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest-format.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-pagination.html

**Looking Forward**

It would be more helpful if you could make the LIMIT value accept String. So that we could set the limit to ALL in the query and get the records by having a feasible fetch_size.

**Expected changes**

File path -> @cubejs-backend\api-gateway\index.js
limit: Joi.number().integer().min(1).max(50000)   (_existing_)
limit: Joi.string()

File path -> cubejs-schema-compiler\adapter\BaseQuery.js
const limitClause = this.rowLimit === null ? '' : ` LIMIT ${this.rowLimit && parseInt(this.rowLimit, 10) || 10000}`   (_existing_)
const limitClause = this.rowLimit === null ? '' : ` LIMIT ${this.rowLimit && this.rowLimit || 10000}`;

