### PR TITLE
Docs: add framework-specific documentation & custom blocks

### DIFF
--- a/docs-gen/src/resources/helpers/member-symbol.ts
+++ b/docs-gen/src/resources/helpers/member-symbol.ts
@@ -1,25 +1,7 @@
 import {
   DeclarationReflection,
-  // ReflectionKind
 } from 'typedoc';
 
 export function memberSymbol(this: DeclarationReflection) {
-  // const isStatic = this.flags.map(flag => flag).includes('Static');
-  // const symbol = '•';
-  // if (this.kind === ReflectionKind.ConstructorSignature) {
-  //   return '>';
-  // }
-  // if (this.kind === ReflectionKind.CallSignature) {
-  //   return '>';
-  // }
-  // if (this.kind === ReflectionKind.TypeAlias) {
-  //   return '>';
-  // }
-  // if (this.kind === ReflectionKind.ObjectLiteral) {
-  //   return '>';
-  // }
-  // if (this.kind === ReflectionKind.Property && isStatic) {
-  //   return '> static';
-  // }
   return '>';
 }

--- a/docs/Cube.js-Backend/@cubejs-backend-server-core.md
+++ b/docs/Cube.js-Backend/@cubejs-backend-server-core.md
@@ -139,7 +139,8 @@ base path for the websockets server. By default the websocket server will run on
 
 Boolean to enable or disable a development server mode. The default value is based on `NODE_ENV` environment variable value. If the value of `NODE_ENV` is `production` it is `false`, otherwise it is `true`.
 
-**NOTE:** Using dev server in production is a security risk as there're unsecured routes which allows to get access to all data defined in Cube.js schema.
+[[warning | Note]]
+| Using dev server in production is a security risk as there're unsecured routes which allows to get access to all data defined in Cube.js schema.
 
 ### logger
 

--- a/docs/Cube.js-Backend/Caching.md
+++ b/docs/Cube.js-Backend/Caching.md
@@ -31,7 +31,8 @@ Cube.js takes great care to prevent unnecessary queries from hitting your databa
 
 So, Cube.js defines a `refreshKey` for each cube. [refreshKeys](cube#parameters-refresh-key) can be evaluated by Cube.js to assess if cube data has changed.
 
-> **Note**: Cube.js *also caches* the results of `refreshKeys` for a fixed time interval in order to avoid issuing them too often. If you need Cube.js to immediately respond to changes in data, see the [Force Query Renewal](#in-memory-cache-force-query-renewal) section.
+[[warning | Note]] 
+| Cube.js *also caches* the results of `refreshKeys` for a fixed time interval in order to avoid issuing them too often. If you need Cube.js to immediately respond to changes in data, see the [Force Query Renewal](#in-memory-cache-force-query-renewal) section.
 
 When a query's result needs to be refreshed, Cube.js will re-execute the query in the foreground and repopulate the cache.
 This means that cached results may still be served to users requesting them while `refreshKey` values aren't changed from Cube.js perspective.
@@ -195,7 +196,8 @@ server.listen().then(({ version, port }) => {
 
 There's also [REST API](rest-api#api-reference-v-1-run-scheduled-refresh) available to trigger run.
 
-> **NOTE:** `runScheduledRefresh()` call is idempotent and just updates pre-aggregations if required by `refreshKey`. It always uses refreshKey to check if refresh is required or not. In the case `refreshKey` doesn't change it's value it doesn't matter how often you call `runScheduledRefresh()`: such pre-aggregation won't be refreshed.
+[[warning | Note]]
+| `runScheduledRefresh()` call is idempotent and just updates pre-aggregations if required by `refreshKey`. It always uses refreshKey to check if refresh is required or not. In the case `refreshKey` doesn't change it's value it doesn't matter how often you call `runScheduledRefresh()`: such pre-aggregation won't be refreshed.
 
 
 ## Inspecting Queries
@@ -206,7 +208,8 @@ Playground can be used to inspect a single query. To do that, click the "cache" 
 To inspect multiple queries or list existing pre-aggregations, you can use Cube Cloud.
 
 
-> **NOTE:** Cube Cloud currently is in early access. If you don't have an account yet, you can [sign up to the waitlist here](https://cube.dev/cloud).
+[[warning | Note]]
+| Cube Cloud currently is in early access. If you don't have an account yet, you can [sign up to the waitlist here](https://cube.dev/cloud).
 
 To inspect queries in the Cube Cloud, navigate to the "History" page. You can filter queries by multiple parameters on this page, including whether they hit the cache, pre-aggregations, or raw data. Additionally, you can click on the query to see its details, such as time spent in the database, the database queue's size when the query was executed, generated SQL, query timeline, and more. It will also show you the optimal pre-aggregation that can be used for this query.
 

--- a/docs/Cube.js-Backend/Deployment.md
+++ b/docs/Cube.js-Backend/Deployment.md
@@ -28,7 +28,8 @@ Set `REDIS_URL` environment variable to provide Cube.js with Redis connection. I
 Make sure, your Redis allows at least 15 concurrent connections.
 Set `REDIS_TLS` env variable to `true` if you want to enable secure connection.
 
-> **NOTE:** Cube.js server instances used by same tenant environments should have same Redis instances. Otherwise they will have different query queues which can lead to incorrect pre-aggregation states and intermittent data access errors.
+[[warning | Note]]
+| Cube.js server instances used by same tenant environments should have same Redis instances. Otherwise they will have different query queues which can lead to incorrect pre-aggregation states and intermittent data access errors.
 
 ### Redis Pool
 
@@ -45,13 +46,15 @@ Lower number of connections still can work however Redis becomes performance bot
 
 If you want to run Cube.js in production without redis you can use `CUBEJS_CACHE_AND_QUEUE_DRIVER=memory` env setting.
 
-> **NOTE:** Serverless and clustered deployments can't be run without Redis as it's used to manage querying queue.
+[[warning | Note]]
+| Serverless and clustered deployments can't be run without Redis as it's used to manage querying queue.
 
 ## Express
 
 Cube.js server is an Express application itself and it can be served as part of an existing Express application.
 
-> **NOTE:** It is suitable to host single node applications this way without any significant load anticipated. Please consider deploying Cube.js as a micro service if you need to host multiple Cube.js instances.
+[[warning | Note]]
+| It is suitable to host single node applications this way without any significant load anticipated. Please consider deploying Cube.js as a micro service if you need to host multiple Cube.js instances.
 
 Minimal setup for such serving looks as following:
 

--- a/docs/Cube.js-Backend/REST-API.md
+++ b/docs/Cube.js-Backend/REST-API.md
@@ -129,7 +129,8 @@ Example response:
 }
 ```
 
-> **NOTE:** Currently all fetched numericals are returned in the same format as driver returns it without any additional processing. Most of drivers return numerical values as strings instead of javascript integer or float to ensure there's no loss of significance. Client code should take care of parsing such numerical values. 
+[[warning | Note]]
+| Currently all fetched numericals are returned in the same format as driver returns it without any additional processing. Most of drivers return numerical values as strings instead of javascript integer or float to ensure there's no loss of significance. Client code should take care of parsing such numerical values. 
 
 ### /v1/sql
 
@@ -259,7 +260,8 @@ Example response:
 
 Trigger scheduled refresh run to refresh pre-aggregations.
 
-> **NOTE:** Single call to this API may be not enough to refresh everything is pending. This call just populates queue with refresh workload and it should be continously called until refresh jobs are done. Otherwise refresh jobs will be marked orphaned and they will be removed from queue.
+[[warning | Note]]
+| Single call to this API may be not enough to refresh everything is pending. This call just populates queue with refresh workload and it should be continously called until refresh jobs are done. Otherwise refresh jobs will be marked orphaned and they will be removed from queue.
 
 Learn more about [scheduled refresh here](caching#keeping-cache-up-to-date).
 

--- a/docs/Cube.js-Frontend/Introduction-angular.md
+++ b/docs/Cube.js-Frontend/Introduction-angular.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
-frameworkOfChoice: vanilla
-permalink: /frontend-introduction
+frameworkOfChoice: angular
+permalink: /frontend-introduction/angular
 category: Cube.js Frontend
 ---
 
@@ -23,30 +23,37 @@ The client provides methods to solve common tasks:
 
 [Learn more](https://cube.dev/docs/@cubejs-client-core) in the documentation for the `@cubejs-client/core` package.
 
+## Cube.js Angular Package
+
+The package provides convenient tools to work with Cube.js in Angular:
+
+**Modules.** Inject [CubejsClientModule](https://cube.dev/docs/@cubejs-client-vue#query-builder) and [CubejsClient](https://cube.dev/docs/@cubejs-client-vue#query-renderer) into your components and services to get access to `@cubejs-client/core` API. 
+
+**Subjects.** Use [RxJS Subject](https://cube.dev/docs/@cubejs-client-ngx#api) and query to watch changes.
+
 ## Example Usage
 
-Here are the typical steps to query and visualize analytical data:
+Here are the typical steps to query and visualize analytical data in Due:
 
-- **Import the `@cubejs-client/core` package.** This package provides all the necessary methods.
+- **Import `@cubejs-client/core` and `@cubejs-client/ngx` packages.** These packages provide all the necessary methods and convenient Angular tools.
 - **Create an instance of Cube.js JavaScript Client.** The client is initialized with Cube.js API URL. In development mode, the default URL is [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1). The client is also initialized with an [API token](https://cube.dev/docs/security), but it takes effect only in [production](https://cube.dev/docs/deployment#production-mode).
-- **Query data from Cube.js Backend.** The client accepts a query, which is a plain JavaScript object. See [Query Format](https://cube.dev/docs/query-format) for details.
-- **Transform data for visualization.** The result set has convenient methods, such as `series` and `chartPivot`, to prepare data for charting.
+- **Query data from Cube.js Backend and Transform data for visualization.** Use [CubejsClient](https://cube.dev/docs/@cubejs-client-ngx#api) to load data. The client accepts a query, which is a plain JavaScript object. See [Query Format](https://cube.dev/docs/query-format) for details.
 - **Visualize the data.** Use tools of your choice to draw charts and create visualizations.
 
-See an example of using Cube.js with vanilla JavaScript and Chart.js library. Note that you can always use a different charting library that suits your needs:
+See an example of using Cube.js with Angular and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv](https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv)
+[https://codesandbox.io/s/cubejs-angular-client-cuyen](https://codesandbox.io/s/cubejs-angular-client-cuyen)
 
 ## Getting Started
 
-You can install Cube.js JavaScript Client with npm or Yarn:
+You can install Cube.js JavaScript Client and the Angular package with npm or Yarn:
 
 ```bash
 # npm
-$ npm install --save @cubejs-client/core
+$ npm install --save @cubejs-client/core @cubejs-client/ngx
 
 # Yarn
-$ yarn add @cubejs-client/core
+$ yarn add @cubejs-client/core @cubejs-client/ngx
 ```
 
 Now you can build your application from scratch or generate the code with [Cube.js Playground](https://cube.dev/docs/dashboard-app). You can also [explore example applications](https://cube.dev/docs/examples) built with Cube.js.

--- a/docs/Cube.js-Frontend/Introduction-angular.md
+++ b/docs/Cube.js-Frontend/Introduction-angular.md
@@ -43,7 +43,7 @@ Here are the typical steps to query and visualize analytical data in Due:
 
 See an example of using Cube.js with Angular and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-angular-client-cuyen](https://codesandbox.io/s/cubejs-angular-client-cuyen)
+<iframe src="https://codesandbox.io/embed/cubejs-angular-client-cuyen?fontsize=14&hidenavigation=1&theme=dark&view=preview" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ## Getting Started
 

--- a/docs/Cube.js-Frontend/Introduction-angular.md
+++ b/docs/Cube.js-Frontend/Introduction-angular.md
@@ -1,5 +1,6 @@
 ---
-title: Introduction
+title: Introduction for Angular Developers
+menuTitle: Introduction
 frameworkOfChoice: angular
 permalink: /frontend-introduction/angular
 category: Cube.js Frontend

--- a/docs/Cube.js-Frontend/Introduction-react.md
+++ b/docs/Cube.js-Frontend/Introduction-react.md
@@ -44,7 +44,7 @@ Here are the typical steps to query and visualize analytical data in React:
 
 See an example of using Cube.js with React and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-react-client-5y9s1](https://codesandbox.io/s/cubejs-react-client-5y9s1)
+<iframe src="https://codesandbox.io/embed/cubejs-react-client-5y9s1?fontsize=14&hidenavigation=1&theme=dark&view=preview" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ## Getting Started
 

--- a/docs/Cube.js-Frontend/Introduction-react.md
+++ b/docs/Cube.js-Frontend/Introduction-react.md
@@ -1,5 +1,6 @@
 ---
-title: Introduction
+title: Introduction for React Developers
+menuTitle: Introduction
 frameworkOfChoice: react
 permalink: /frontend-introduction/react
 category: Cube.js Frontend

--- a/docs/Cube.js-Frontend/Introduction-react.md
+++ b/docs/Cube.js-Frontend/Introduction-react.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
-frameworkOfChoice: vanilla
-permalink: /frontend-introduction
+frameworkOfChoice: react
+permalink: /frontend-introduction/react
 category: Cube.js Frontend
 ---
 
@@ -23,30 +23,38 @@ The client provides methods to solve common tasks:
 
 [Learn more](https://cube.dev/docs/@cubejs-client-core) in the documentation for the `@cubejs-client/core` package.
 
+## Cube.js React Package
+
+The package provides convenient tools to work with Cube.js in React:
+
+**Hooks.** You can add the [useCubeQuery hook](https://cube.dev/docs/@cubejs-client-react#use-cube-query) to functional React components to execute Cube.js queries.
+
+**Components.** You can use [QueryBuilder](https://cube.dev/docs/@cubejs-client-react#query-builder) and [QueryRenderer](https://cube.dev/docs/@cubejs-client-react#query-renderer) components to separate state management and API calls from your rendering code. You can also use [CubeProvider](https://cube.dev/docs/@cubejs-client-react#cube-provider) and [CubeContext](https://cube.dev/docs/@cubejs-client-react#cube-context) components for direct access to Cube.js Client anywhere in your application. 
+
 ## Example Usage
 
-Here are the typical steps to query and visualize analytical data:
+Here are the typical steps to query and visualize analytical data in React:
 
-- **Import the `@cubejs-client/core` package.** This package provides all the necessary methods.
+- **Import `@cubejs-client/core` and `@cubejs-client/react` packages.** These packages provide all the necessary methods and convenient React tools.
 - **Create an instance of Cube.js JavaScript Client.** The client is initialized with Cube.js API URL. In development mode, the default URL is [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1). The client is also initialized with an [API token](https://cube.dev/docs/security), but it takes effect only in [production](https://cube.dev/docs/deployment#production-mode).
-- **Query data from Cube.js Backend.** The client accepts a query, which is a plain JavaScript object. See [Query Format](https://cube.dev/docs/query-format) for details.
+- **Query data from Cube.js Backend.** In functional React components, use the `useCubeQuery` hook to execute a query, which is a plain JavaScript object. See [Query Format](https://cube.dev/docs/query-format) for details.
 - **Transform data for visualization.** The result set has convenient methods, such as `series` and `chartPivot`, to prepare data for charting.
 - **Visualize the data.** Use tools of your choice to draw charts and create visualizations.
 
-See an example of using Cube.js with vanilla JavaScript and Chart.js library. Note that you can always use a different charting library that suits your needs:
+See an example of using Cube.js with React and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv](https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv)
+[https://codesandbox.io/s/cubejs-react-client-5y9s1](https://codesandbox.io/s/cubejs-react-client-5y9s1)
 
 ## Getting Started
 
-You can install Cube.js JavaScript Client with npm or Yarn:
+You can install Cube.js JavaScript Client and the React package with npm or Yarn:
 
 ```bash
 # npm
-$ npm install --save @cubejs-client/core
+$ npm install --save @cubejs-client/core @cubejs-client/react
 
 # Yarn
-$ yarn add @cubejs-client/core
+$ yarn add @cubejs-client/core @cubejs-client/react
 ```
 
-Now you can build your application from scratch or generate the code with [Cube.js Playground](https://cube.dev/docs/dashboard-app). You can also [explore example applications](https://cube.dev/docs/examples) built with Cube.js.
+Now you can build your project from scratch or generate a [sample dashboard application](https://cube.dev/docs/dashboard-app/) with Cube.js Playground. You can also [explore example applications](https://cube.dev/docs/examples) built with Cube.js.

--- a/docs/Cube.js-Frontend/Introduction-vue.md
+++ b/docs/Cube.js-Frontend/Introduction-vue.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
-frameworkOfChoice: vanilla
-permalink: /frontend-introduction
+frameworkOfChoice: vue
+permalink: /frontend-introduction/vue
 category: Cube.js Frontend
 ---
 
@@ -23,30 +23,36 @@ The client provides methods to solve common tasks:
 
 [Learn more](https://cube.dev/docs/@cubejs-client-core) in the documentation for the `@cubejs-client/core` package.
 
+## Cube.js Vue Package
+
+The package provides convenient tools to work with Cube.js in Vue:
+
+**Components.** You can use [QueryBuilder](https://cube.dev/docs/@cubejs-client-vue#query-builder) and [QueryRenderer](https://cube.dev/docs/@cubejs-client-vue#query-renderer) components to abstract state management and API calls from your rendering code.  
+
 ## Example Usage
 
-Here are the typical steps to query and visualize analytical data:
+Here are the typical steps to query and visualize analytical data in Vue:
 
-- **Import the `@cubejs-client/core` package.** This package provides all the necessary methods.
+- **Import `@cubejs-client/core` and `@cubejs-client/vue` packages.** These packages provide all the necessary methods and convenient Vue tools.
 - **Create an instance of Cube.js JavaScript Client.** The client is initialized with Cube.js API URL. In development mode, the default URL is [http://localhost:4000/cubejs-api/v1](http://localhost:4000/cubejs-api/v1). The client is also initialized with an [API token](https://cube.dev/docs/security), but it takes effect only in [production](https://cube.dev/docs/deployment#production-mode).
-- **Query data from Cube.js Backend.** The client accepts a query, which is a plain JavaScript object. See [Query Format](https://cube.dev/docs/query-format) for details.
-- **Transform data for visualization.** The result set has convenient methods, such as `series` and `chartPivot`, to prepare data for charting.
+- **Query data from Cube.js Backend.** Use [QueryBuilder](https://cube.dev/docs/@cubejs-client-vue#query-builder) or [QueryRenderer](https://cube.dev/docs/@cubejs-client-vue#query-renderer) and their props to execute a query and transform the result set. See [Query Format](https://cube.dev/docs/query-format) for details.
+- **Transform data for visualization.** Use [QueryBuilder](https://cube.dev/docs/@cubejs-client-vue#query-builder) and [QueryRenderer](https://cube.dev/docs/@cubejs-client-vue#query-renderer) slots props to transform the result set. Furthermore,  the result set has convenient methods, such as `series` and `chartPivot`, to prepare data for charting.
 - **Visualize the data.** Use tools of your choice to draw charts and create visualizations.
 
-See an example of using Cube.js with vanilla JavaScript and Chart.js library. Note that you can always use a different charting library that suits your needs:
+See an example of using Cube.js with Vue and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv](https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv)
+[https://codesandbox.io/s/cubejs-vue-client-b784j](https://codesandbox.io/s/cubejs-vue-client-b784j)
 
 ## Getting Started
 
-You can install Cube.js JavaScript Client with npm or Yarn:
+You can install Cube.js JavaScript Client and the Vue package with npm or Yarn:
 
 ```bash
 # npm
-$ npm install --save @cubejs-client/core
+$ npm install --save @cubejs-client/core @cubejs-client/vue
 
 # Yarn
-$ yarn add @cubejs-client/core
+$ yarn add @cubejs-client/core @cubejs-client/vue
 ```
 
 Now you can build your application from scratch or generate the code with [Cube.js Playground](https://cube.dev/docs/dashboard-app). You can also [explore example applications](https://cube.dev/docs/examples) built with Cube.js.

--- a/docs/Cube.js-Frontend/Introduction-vue.md
+++ b/docs/Cube.js-Frontend/Introduction-vue.md
@@ -42,7 +42,7 @@ Here are the typical steps to query and visualize analytical data in Vue:
 
 See an example of using Cube.js with Vue and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-vue-client-b784j](https://codesandbox.io/s/cubejs-vue-client-b784j)
+<iframe src="https://codesandbox.io/embed/cubejs-vue-client-b784j?fontsize=14&hidenavigation=1&theme=dark&view=preview" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ## Getting Started
 

--- a/docs/Cube.js-Frontend/Introduction-vue.md
+++ b/docs/Cube.js-Frontend/Introduction-vue.md
@@ -1,5 +1,6 @@
 ---
-title: Introduction
+title: Introduction for Vue Developers
+menuTitle: Introduction
 frameworkOfChoice: vue
 permalink: /frontend-introduction/vue
 category: Cube.js Frontend

--- a/docs/Cube.js-Frontend/Introduction.md
+++ b/docs/Cube.js-Frontend/Introduction.md
@@ -35,7 +35,7 @@ Here are the typical steps to query and visualize analytical data:
 
 See an example of using Cube.js with vanilla JavaScript and Chart.js library. Note that you can always use a different charting library that suits your needs:
 
-[https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv](https://codesandbox.io/s/cubejs-vanilla-javascript-client-yezyv)
+<iframe src="https://codesandbox.io/embed/cubejs-vanilla-javascript-client-yezyv?fontsize=14&hidenavigation=1&theme=dark&view=preview" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 ## Getting Started
 

--- a/docs/Guides/Direction-of-Joins.md
+++ b/docs/Guides/Direction-of-Joins.md
@@ -180,7 +180,8 @@ You'll get an error: `Error: Can't find join path to join 'A', 'C'`.
 The problem is joins are directed and if we try to connect `A` and `C` there's no path from `A` to `C` or either from `C` to `A`.
 On possible solution is to move `A-B` join from `B` cube to `A`:
 
-> **NOTE:** Moving the join affects semantics and results of a join which are discussed in previous section.
+[[warning | Note]]
+| Moving the join affects semantics and results of a join which are discussed in previous section.
 
 ```javascript
 cube(`A`, {

--- a/docs/Guides/Incremental-Pre-Aggregations.md
+++ b/docs/Guides/Incremental-Pre-Aggregations.md
@@ -10,7 +10,8 @@ menuOrder: 25
 When you use partitioned rollups on immutable data there's an opportunity to build pre-aggregations incrementally.
 Cube.js allows to set `refreshKey` in a way that partitions in past would be never refreshed without a need which leads to significant performance boost.
 
-> **NOTE:** Since 0.15.0 `incremental` flag is a built-in [pre-aggregations refreshKey](pre-aggregations#refresh-key) parameter.
+[[warning | Note]]
+| Since 0.15.0 `incremental` flag is a built-in [pre-aggregations refreshKey](pre-aggregations#refresh-key) parameter.
 
 As usually there're multiple cubes that require incremental partitions building it's best practice to introduce separate `RefreshKeyHelper.js` file which will contain this reusable logic.
 Typical immutable partition rollup will look like:

--- a/docs/Schema/cube.md
+++ b/docs/Schema/cube.md
@@ -436,7 +436,8 @@ cube(`Orders`, {
 
 ### Unsafe Value
 
-> **NOTE:** Use of this feature entails SQL injection security risk. Use it with caution.
+[[warning | Note]]
+| Use of this feature entails SQL injection security risk. Use it with caution.
 
 You can access values of context variables directly in javascript in order to use it during your SQL generation.
 For example:
@@ -459,7 +460,8 @@ cube(`Orders`, {
 
 In case you need to convert your timestamp to user request timezone in cube or member SQL you can use `SQL_UTILS.convertTz()` method. Note that Cube.js will automatically convert timezones for `timeDimensions` fields in [queries](Query-Format#query-properties). 
 
-> **NOTE:** Dimensions that use `SQL_UTILS.convertTz()` should not be used as `timeDimensions` in queries. Doing so will apply the conversion multiple times and yield wrong results. 
+[[warning | Note]]
+| Dimensions that use `SQL_UTILS.convertTz()` should not be used as `timeDimensions` in queries. Doing so will apply the conversion multiple times and yield wrong results. 
 
 In case the same database field needs to be queried in `dimensions` and `timeDimensions`, create dedicated dimensions in the cube definition for the respective use:
 
@@ -485,7 +487,8 @@ cube(`visitors`, {
 There's global `COMPILE_CONTEXT` that captured as [RequestContext](@cubejs-backend-server-core#request-context) at the time of schema compilation.
 It contains `authInfo` and any other variables provided by [extendContext](@cubejs-backend-server-core#options-reference-extend-context).
 
-> **NOTE:** While `authInfo` defined in `COMPILE_CONTEXT` it doesn't change it's value for different users. It may change however for different tenants.
+[[warning | Note]]
+| While `authInfo` defined in `COMPILE_CONTEXT` it doesn't change it's value for different users. It may change however for different tenants.
 
 ```javascript
 const { authInfo: { deploymentId } } = COMPILE_CONTEXT;

--- a/docs/Schema/dimensions.md
+++ b/docs/Schema/dimensions.md
@@ -122,13 +122,8 @@ Specify which dimension is a primary key for a cube. The default value is `false
 
 A primary key is used to make [joins](joins) work properly.
 
-<div class="block help-block">
-  <p>
-    <b>Note:</b>
-    Setting <code>primaryKey</code> to <code>true</code> will change the default value of <code>shown</code>
-    parameter to <code>false</code>. If you still want <code>shown</code> to be <code>true</code> - set it manually.
-  </p>
-</div>
+[[warning | Note]]
+| Setting `primaryKey` to `true` will change the default value of `shown` parameter to `false`. If you still want `shown` to be `true` - set it manually.
 
 ```javascript
 dimensions: {

--- a/docs/Schema/joins.md
+++ b/docs/Schema/joins.md
@@ -168,7 +168,8 @@ dimensions: {
 
 ## Transitive joins
 
-> **NOTE:** Join graph is directed and `A-B` join is different from `B-A`. [Learn more about it here](direction-of-joins).
+[[warning | Note]]
+| Join graph is directed and `A-B` join is different from `B-A`. [Learn more about it here](direction-of-joins).
 
 Cube.js automatically takes care of transitive joins. For example if you have following schema:
 

--- a/docs/Schema/measures.md
+++ b/docs/Schema/measures.md
@@ -117,7 +117,8 @@ ordersCompletedCount: {
 ### rollingWindow
 If you want to calculate some metric within a window, for example a week or a month, you should use a `rollingWindow` parameter. The `trailing` and `leading` parameters define window size. 
 
-> **NOTE:** `rollingWindow` only works for a query where there's a single `timeDimension` with a defined date range.
+[[warning | Note]]
+| `rollingWindow` only works for a query where there's a single `timeDimension` with a defined date range.
 
 These parameters have a format defined as `(-?\d+) (minute|hour|day|week|month|year)`. The `trailing` and `leading` parameters can also be set to an `unbounded` value, which means infinite size for the corresponding window part. You can define `trailing` and `leading` parameters using negative integers.
 

--- a/docs/Schema/pre-aggregations.md
+++ b/docs/Schema/pre-aggregations.md
@@ -331,7 +331,8 @@ cube(`Orders`, {
 
 As in case of cube pre-aggregations `refreshKey` can define `every` parameter which can be used to refresh pre-aggregations based on time interval.
 
-> **NOTE:** `every` parameter doesn't force Cube.js to fetch `refreshKey` based on it's interval. It generates SQL which result set change at least once per defined interval and adjusts `refreshKeyRenewalThreshold` accordingly. [Learn more](cube#parameters-refresh-key).
+[[warning | Attention]]
+| `every` parameter doesn't force Cube.js to fetch `refreshKey` based on it's interval. It generates SQL which result set change at least once per defined interval and adjusts `refreshKeyRenewalThreshold` accordingly. [Learn more](cube#parameters-refresh-key).
 
 For example:
 
@@ -465,7 +466,8 @@ Without this flag pre-aggregations are always built on-demand.
 `refreshKey` is used to determine if there's a need to update specific pre-aggregation on each scheduled refresh run.
 For partitioned pre-aggregations `min` and `max` dates for `timeDimensionReference` are fetched to determine range for refresh.
 
-> **NOTE:** Refresh Scheduler isn't enabled by default. You should trigger it externally. [Learn how to do it here](caching#keeping-cache-up-to-date).
+[[warning | Note]]
+| Refresh Scheduler isn't enabled by default. You should trigger it externally. [Learn how to do it here](caching#keeping-cache-up-to-date).
 
 Example usage:
 ```javascript

--- a/docs/Schema/schema-execution-environment.md
+++ b/docs/Schema/schema-execution-environment.md
@@ -83,7 +83,8 @@ cube(`Users`, {
 
 ## asyncModule
 
-> **NOTE:** Each `asyncModule` call will be invoked only once per schema compilation. 
+[[warning | Note]]
+| Each `asyncModule` call will be invoked only once per schema compilation. 
 To trigger schema recompile based on changes of underlying input data, [schemaVersion](@cubejs-backend-server-core#options-reference-schema-version) value should change accordingly.
 
 If there's a need to generate schema based on values from external API or database `asyncModule` method can be used for such scenario.


### PR DESCRIPTION
- support for framework-specific documentation.
- support for custom blocks (like Warnings)
- unification for all signatures.
