### PR TITLE
Allow array props on query renderer to allow datablending usage

### DIFF
--- a/packages/cubejs-client-vue/src/QueryRenderer.js
+++ b/packages/cubejs-client-vue/src/QueryRenderer.js
@@ -3,7 +3,7 @@ import { toPairs, fromPairs } from 'ramda';
 export default {
   props: {
     query: {
-      type: Object,
+      type: [Object, Array],
       default: () => ({}),
     },
     // TODO: validate with current react implementation


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Since data blending was introduced and allows for an array of queries, `QueryRenderer` component complains when passing Array instead of an Object, although it still handles it properly
