### PR TITLE
feat(@cubejs-backend/query-orchestrator): add support for MSSQL nvarchar

### DIFF
--- a/packages/cubejs-query-orchestrator/driver/BaseDriver.js
+++ b/packages/cubejs-query-orchestrator/driver/BaseDriver.js
@@ -16,6 +16,7 @@ const DbTypeToGenericType = {
   integer: 'int',
   'character varying': 'text',
   varchar: 'text',
+  nvarchar: 'text',
   text: 'text',
   string: 'text',
   boolean: 'boolean',


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
N/A
**Description of Changes Made (if issue reference is not provided)**
MSSQL has a type of nvarchar - this type is not being mapped in the DbTypeToGenericType object.  Leads to situation where if you have a MSSQL source system readonly, and a target that does not support that data type, it sends along 'nvarchar' and then preaggregation steps fail.  Added nvarchar to the mapping object, treating it like varchar mapped to text.