### PR TITLE
Bump peer dependency @cubejs-client/core

### DIFF
--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -14,7 +14,7 @@
     "ramda": "^0.27.0"
   },
   "peerDependencies": {
-    "@cubejs-client/core": "^0.19.43",
+    "@cubejs-client/core": "^0.23.6",
     "react": "^16.10.2"
   },
   "main": "dist/cubejs-client-react.js",

--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -10,11 +10,11 @@
   "author": "Cube Dev, Inc.",
   "dependencies": {
     "@babel/runtime": "^7.1.2",
+    "@cubejs-client/core": "^0.23.6",
     "core-js": "^3.6.5",
     "ramda": "^0.27.0"
   },
   "peerDependencies": {
-    "@cubejs-client/core": "^0.23.6",
     "react": "^16.10.2"
   },
   "main": "dist/cubejs-client-react.js",


### PR DESCRIPTION
Since the release >=0.20 we are getting a warning caused by the latest `@cubejs-client/core` not satisfying the defined peer dependency of `@cubejs-client/react`:

```
@cubejs-client/react@0.23.6" has incorrect peer dependency "@cubejs-client/core@^0.19.43".
```

Additionally using `@cubejs-client/react@0.23.6` with `@cubejs-client/core@^0.19.43` does not seem to work producing the warnings below:

```
WARNING in ../../node_modules/@cubejs-client/react/dist/cubejs-client-react.esm.js 649:28-43
export 'moveItemInArray' (imported as 'moveItemInArray') was not found in '@cubejs-client/core' (possible exports: HttpTransport, ResultSet, __esModule, default)

WARNING in ../../node_modules/@cubejs-client/react/dist/cubejs-client-react.esm.js 736:32-44
export 'defaultOrder' (imported as 'defaultOrder') was not found in '@cubejs-client/core' (possible exports: HttpTransport, ResultSet, __esModule, default)
```

With this in mind this PR bumps the version of the peer dependency `@cubejs-client/core` to `^0.23.6`.