### PR TITLE
docs: remove title attribute from content sections

### DIFF
--- a/docs/src/components/Layout/index.jsx
+++ b/docs/src/components/Layout/index.jsx
@@ -6,7 +6,6 @@ import { Layout, Row, Col } from 'antd';
 import { StaticQuery, graphql } from 'gatsby';
 
 import FrameworkOfChoiceStore, {
-  FRAMEWORKS,
   useFrameworkOfChoice
 } from '../../stores/frameworkOfChoice';
 import Search from '../Search';
@@ -24,7 +23,6 @@ import { renameCategory } from '../../../rename-category';
 export const trimSlashes = (str) => str.replace(/^\/|\/$/g, '');
 
 const { Content } = Layout;
-const FRAMEWORK_LIST = FRAMEWORKS.map(fr => fr.slug);
 
 const MOBILE_MODE_SET = ['content', 'menu', 'search'];
 

--- a/docs/src/templates/DocTemplate.jsx
+++ b/docs/src/templates/DocTemplate.jsx
@@ -177,7 +177,6 @@ class DocTemplate extends Component {
         key: item.id,
         id: item.id,
         type: item.type,
-        title: item.title,
         className: item.className
       }, item.nodes);
     });


### PR DESCRIPTION
It removes `title` attribute in content sections.
Also, I changed `line-height` of the font-size and made minor refactoring to styles with the designer's consent.
