### PR TITLE
fix(@cubejs-client/playground): fix user select on tab content

### DIFF
--- a/packages/cubejs-playground/src/components/Tabs.js
+++ b/packages/cubejs-playground/src/components/Tabs.js
@@ -3,10 +3,9 @@ import { Tabs as AntdTabs } from 'antd';
 
 const StyledTabs = styled(AntdTabs)`
   && {
-    user-select: none;
-  
     .ant-tabs-nav {
       padding: 0 16px;
+      user-select: none;
     }
     
     .ant-tabs-content-holder {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

Fixes the bug: The user can't select text inside the warning in tab content.
