### PR TITLE
feat(cubejs-cli): Use index.js file instead of cube.js for serverless template

### DIFF
--- a/packages/cubejs-cli/src/templates.ts
+++ b/packages/cubejs-cli/src/templates.ts
@@ -94,7 +94,7 @@ provider:
 
 functions:
   cubejs:
-    handler: cube.api
+    handler: index.api
     timeout: 30
     events:
       - http:
@@ -104,7 +104,7 @@ functions:
           path: /{proxy+}
           method: ANY
   cubejsProcess:
-    handler: cube.process
+    handler: index.process
     timeout: 630
     events:
       - sns: "\${self:service.name}-\${self:provider.stage}-process"
@@ -275,7 +275,7 @@ const templates = {
       dev: './node_modules/.bin/cubejs-dev-server',
     },
     files: {
-      'cube.js': () => handlerJs,
+      'index.js': () => handlerJs,
       'serverless.yml': serverlessYml,
       '.env': dotEnv,
       '.gitignore': () => gitIgnore,


### PR DESCRIPTION
Hello!

Thanks