### PR TITLE
feat(docs-build): add `gatsby-remark-check-links` to detect broken links

### DIFF
--- a/docs-build/gatsby-config.js
+++ b/docs-build/gatsby-config.js
@@ -94,6 +94,7 @@ const config = {
               },
             },
           },
+          'gatsby-remark-check-links',
         ]
       }
     },

--- a/docs-build/package.json
+++ b/docs-build/package.json
@@ -24,6 +24,7 @@
     "gatsby-plugin-sharp": "^2.6.31",
     "gatsby-plugin-sitemap": "^2.1.0",
     "gatsby-redirect-from": "^0.2.4",
+    "gatsby-remark-check-links": "^2.1.0",
     "gatsby-remark-copy-linked-files": "^2.0.11",
     "gatsby-remark-custom-blocks": "^2.3.13",
     "gatsby-remark-images": "^3.0.10",

--- a/docs-build/yarn.lock
+++ b/docs-build/yarn.lock
@@ -7644,6 +7644,13 @@ gatsby-redirect-from@^0.2.4:
   resolved "https://registry.yarnpkg.com/gatsby-redirect-from/-/gatsby-redirect-from-0.2.4.tgz#23862e1e53163a750b314e7a3466d72f07b1e014"
   integrity sha512-A+nxoZo7JMmTmHKAcdVmIvVZhyIXvTObuX9eawjHKavzDWvigV+TEARk7nK0h/BFuVfcnMlF7bTku1OIaeFCmg==
 
+gatsby-remark-check-links@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-check-links/-/gatsby-remark-check-links-2.1.0.tgz#8e8a2b1b82ac6c516fcc2074e8f806e2c0d53571"
+  integrity sha512-TbhT8oVlAgJfxe0WUQWDOb0kLkMUYo1N4AfFstejClPWO4OjRlznt3IMW3weQkwuweiovF5cxVpQcFrkCGVFBw==
+  dependencies:
+    unist-util-visit "^1.4.1"
+
 gatsby-remark-copy-linked-files@^2.0.11:
   version "2.3.19"
   resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.3.19.tgz#fde9fb73c9fea59285d7fac8e5aeae4d80aed4e2"


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

We've had a few instances where we accidentally deployed broken links. To prevent this, I've added a Gatsby plugin that reports any broken links. I've included the output below, and will be fixing the reported issues in this PR.

<details>
<summary>Plugin Output</summary>

```
warning 1 broken links found on /active-users
warning  15:112  /measures#parameters-rolling-window
⠀
warning 1 broken links found on /pre-aggregations
warning  89:79   #use-original-sql-pre-aggregations
⠀
warning 1 broken links found on /schema-execution-environment
warning  53:31   #require
⠀
warning 4 broken links found on /deployment/guide
warning  20:3    #docker
warning  21:3    #aws-serverless
warning  22:3    #gcp-serverless
warning  23:3    #heroku
⠀
warning 136 broken links found on /@cubejs-client-core
warning  13:77   #types-cube-js-api-options
warning  13:127  #cubejs-api
warning  40:11   #types-cube-js-api-options
warning  42:28   #types-cube-js-api-options
warning  42:78   #cubejs-api
warning  46:40   #types-query
warning  46:77   #types-query
warning  46:113  #types-t-default-heuristics-options
warning  50:32   #types-query
warning  54:39   #types-pivot-config
warning  54:195  #types-pivot-config
warning  62:26   #types-query
warning  62:50   #types-query
warning  62:89   #types-load-method-options
warning  62:148  #types-t-dry-run-response
warning  64:26   #types-query
warning  64:50   #types-query
warning  64:88   #types-load-method-options
warning  64:152  #types-load-method-callback
warning  64:202  #types-t-dry-run-response
warning  70:24   #types-query
warning  70:48   #types-query
warning  70:87   #types-load-method-options
warning  70:146  #result-set
warning  72:24   #types-query
warning  72:48   #types-query
warning  72:87   #types-load-method-options
warning  72:151  #types-load-method-callback
warning  72:201  #result-set
warning 100:9    #types-query
warning 100:38   #types-query
warning 101:12   #types-load-method-options
warning 102:13   #types-load-method-callback
warning 102:63   #result-set
warning 106:27   #types-load-method-options
warning 106:86   #meta
warning 108:27   #types-load-method-options
warning 108:91   #types-load-method-callback
warning 108:141  #meta
warning 114:23   #types-query
warning 114:47   #types-query
warning 114:86   #types-load-method-options
warning 114:145  #sql-query
warning 116:23   #types-query
warning 116:47   #types-query
warning 116:86   #types-load-method-options
warning 116:150  #types-load-method-callback
warning 116:200  #sql-query
warning 124:9    #types-query
warning 124:38   #types-query
warning 125:12   #types-load-method-options
warning 126:13   #types-load-method-callback
warning 126:63   #sql-query
warning 130:29   #types-query
warning 130:53   #types-query
warning 130:91   #types-load-method-options
warning 130:161  #types-load-method-callback
warning 130:211  #result-set
warning 161:39   #types-transport-options
warning 161:87   #http-transport
warning 179:73   #types-member-type
warning 179:108  #types-member-type
warning 183:35   #types-query
warning 183:81   #types-member-type
warning 183:117  #types-t-cube-measure
warning 183:159  #types-t-cube-dimension
warning 183:205  #types-t-cube-member
warning 192:9    #types-query
warning 193:14   #types-member-type
warning 197:89   #types-t-cube-member-by-type
warning 214:11   #types-member-type
warning 239:23   #types-query-annotations
warning 243:37   #types-pivot-config
warning 243:75   #types-chart-pivot-row
warning 247:54   #pivot-config
warning 281:40   #types-drill-down-locator
warning 281:105  #types-pivot-config
warning 281:143  #types-query
warning 342:32   #types-pivot-config
warning 342:70   #types-pivot-row
warning 344:26   #result-set
warning 345:50   #result-set-chart-pivot
warning 348:54   #pivot-config
warning 385:18   #types-query
warning 395:75   #result-set-deserialize
warning 399:49   #types-pivot-config
warning 399:87   #types-series
warning 434:38   #types-pivot-config
warning 434:76   #types-series-names-column
warning 460:39   #types-pivot-config
warning 460:77   #types-table-column
warning 556:37   #types-pivot-config
warning 560:54   #pivot-config
warning 585:81   #result-set
warning 606:31   #result-set-serialize
warning 611:52   #types-pivot-query
warning 611:112  #types-pivot-config
warning 611:151  #types-pivot-config
warning 617:21   #types-sql-data
warning 644:8    #types-binary-filter
warning 647:12   #types-binary-operator
warning 648:7    #types-binary-filter
warning 679:14   #i-transport
warning 679:76   #http-transport
warning 690:16   #types-binary-filter
warning 690:55   #types-unary-filter
warning 709:14   #types-pivot-query
warning 710:13   #types-query-type
warning 711:11   #types-load-response-result
warning 717:14   #types-query-annotations
warning 720:9    #types-query
warning 790:20   #types-query
warning 811:12   #types-filter
warning 815:10   #types-t-query-order-object
warning 815:66   #types-t-query-order-array
warning 818:19   #types-time-dimension
warning 826:29   #types-annotation
warning 827:27   #types-annotation
warning 828:33   #types-annotation
warning 858:7    #types-sql-data
warning 868:7    #types-sql-query-tuple
warning 876:24   #types-t-cube-member
warning 880:22   #types-t-cube-member
warning 889:8    #types-t-cube-member-type
warning 901:27   #types-t-cube-member
warning 907:8    #meta
warning 908:23   #types-time-dimension-granularity
warning 914:21   #types-query
warning 915:14   #types-pivot-query
warning 917:13   #types-query-type
warning 921:41   #types-query-order
warning 929:13   #types-table-column
warning 944:16   #types-time-dimension-granularity
warning 963:8    #types-unary-filter
warning 966:12   #types-unary-operator
warning 967:7    #types-unary-filter
⠀
warning 2 broken links found on /@cubejs-client-ngx
warning  72:49   /@cubejs-client-core#cubejs-api
warning  74:14   /@cubejs-client-core#result-set
⠀
warning 6 broken links found on /@cubejs-client-ws-transport
warning  15:64   #web-socket-transport
warning  31:48   #types-subscription
warning  35:22   #types-message
warning  63:70   #web-socket-transport-result
warning  92:26   #web-socket-transport-result
warning  93:11   #types-message
⠀
warning 23 broken links found on /@cubejs-client-react
warning  13:74   #use-cube-query-use-cube-query-options
warning  13:139  #use-cube-query-use-cube-query-result
warning  77:49   #query-builder-query-builder-props
warning  77:106  #query-builder-query-builder-state
warning 144:21   #types-chart-type
warning 147:29   #query-builder-query-builder-render-props
warning 149:32   #types-viz-state
warning 150:39   #query-builder-query-builder-state
warning 150:100  #query-builder-query-builder-state
warning 151:13   #types-viz-state
warning 165:17   #types-t-loading-state
warning 170:20   #types-member-updater
warning 171:18   #types-member-updater
warning 173:18   #types-member-updater
warning 174:24   #types-member-updater
warning 178:27   #types-viz-state
warning 182:50   #query-renderer-query-renderer-props
warning 194:29   #query-renderer-query-renderer-render-props
warning 203:16   #types-t-loading-state
warning 208:31   #types-cube-provider-props
warning 235:29   #types-cube-context-props
warning 316:104  #query-builder-query-builder-render-props
warning 371:14   #types-chart-type
⠀
warning 1 broken links found on /@cubejs-backend-server
warning   9:246  /deployment
⠀
warning 3 broken links found on /query-format
warning  24:67   #filters-format
warning  25:110  #time-dimensions-format
warning 260:61   #time-dimensions-format
⠀
warning 5 broken links found on /caching
warning  10:9    #in-memory-cache
warning  10:172  #pre-aggregations
warning  28:1    #in-memory-cache-force-query-renewal
warning  36:188  #in-memory-cache-force-query-renewal
warning  95:35   /config#options-reference-scheduled-refresh-timer
⠀
warning 14 broken links found on /config
warning  98:22   #options-reference-context-to-app-id
warning 102:36   #external-driver-factory
warning 107:22   #options-reference-context-to-app-id
warning 141:17   #options-reference-context-to-data-source-id
warning 159:17   #options-reference-context-to-app-id
warning 207:41   #SchemaFileRepository
warning 209:22   #options-reference-context-to-app-id
warning 251:30   #options-reference-check-auth
warning 287:17   #options-reference-context-to-app-id
warning 300:115  #options-reference-context-to-app-id
warning 423:50   #options-reference-check-auth
warning 424:27   #options-reference-check-auth
warning 428:142  #repositoryFactory
warning 428:316  #schemaPath
⠀
warning 1 broken links found on /reference/environment-variables
warning  23:57   /config#options-reference-scheduled-refresh-timer
```

</details>