### PR TITLE
Check for error and panic if MySQL port binding in cubestore fails.

### DIFF
--- a/rust/cubestore/src/mysql/mod.rs
+++ b/rust/cubestore/src/mysql/mod.rs
@@ -81,7 +81,13 @@ pub struct MySqlServer;
 
 impl MySqlServer {
     pub async fn listen(address: String, sql_service: Arc<dyn SqlService>) -> Result<(), CubeError> {
-        let mut listener = TcpListener::bind(address.clone()).await?;
+        info!("Binding MySQL port");
+        let listener = TcpListener::bind(address.clone()).await;
+
+        let mut listener = match listener {
+            Ok(listener) => listener,
+            Err(error) => panic!("Not able to bind MySQL port: {:?}", error)
+        };
 
         info!("MySQL port open on {}", address);
 


### PR DESCRIPTION
**Check List**
- [ Y] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

Check for error during the bind of MySQL port in cubestore daemon and panic on failure with the explanatory error message rather than silently ignoring the error and continuing to run the daemon without the ability to externally connect to it.

Tested manually for the correct behavior with a local mysqld creating a conflict on port 3306, and without. Also ran `cargo test `
