### PR TITLE
fix: correct type for `orchestratorOptions`

### DIFF
--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -39,7 +39,7 @@ export interface CreateOptions {
   updateCompilerCacheKeepAlive?: boolean;
   telemetry?: boolean;
   allowUngroupedWithoutPrimaryKey?: boolean;
-  orchestratorOptions?: OrchestratorOptions;
+  orchestratorOptions?: OrchestratorOptions | ((context: RequestContext) => OrchestratorOptions);
 }
 
 export interface OrchestratorOptions {


### PR DESCRIPTION
The orchestratorOptions configuration field allows for configuration via a function, but the types did not reflect that.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#1421
