### PR TITLE
feat(react): support 'compareDateRange' when updating 'timeDimensions'

### DIFF
--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -142,11 +142,16 @@ export default class QueryBuilder extends React.Component {
 
   prepareRenderProps(queryRendererProps) {
     const getName = (member) => member.name;
-    const toTimeDimension = (member) => ({
-      dimension: member.dimension.name,
-      granularity: member.granularity,
-      dateRange: member.dateRange
-    });
+    const toTimeDimension = (member) => {
+      const rangeSelection = member.compareDateRange
+        ? { compareDateRange: member.compareDateRange }
+        : { dateRange: member.dateRange };
+      return {
+        dimension: member.dimension.name,
+        granularity: member.granularity,
+        ...rangeSelection
+      };
+    };
     const toFilter = (member) => ({
       dimension: member.dimension.name,
       operator: member.operator,


### PR DESCRIPTION
**Check List**
- [x ] Tests has been run in packages where changes made if available
- [x ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x ] Docs have been added / updated if required

**Issue Reference this PR resolves**
[#1348 ](https://github.com/cube-js/cube.js/issues/1348)

**Description of Changes Made (if issue reference is not provided)**
Allows either "compareDateRange" or "dateRange" to be passed as an update within the QueryBuilder.
