### PR TITLE
cubestore: Update user-facing "Cube Store" mentions to the correct form

### DIFF
--- a/.github/workflows/rust-master.yml
+++ b/.github/workflows/rust-master.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cubestore-docker-image-dev:
-    name: Release cubestore :dev image
+    name: Release Cube Store :dev image
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/packages/cubejs-cubestore-driver/README.md
+++ b/packages/cubejs-cubestore-driver/README.md
@@ -5,12 +5,12 @@
 [![npm version](https://badge.fury.io/js/%40cubejs-backend%2Fserver.svg)](https://badge.fury.io/js/%40cubejs-backend%2Fserver)
 [![GitHub Actions](https://github.com/cube-js/cube.js/workflows/Build/badge.svg)](https://github.com/cube-js/cube.js/actions?query=workflow%3ABuild+branch%3Amaster)
 
-# Cube.js store Driver
+# Cube Store Driver
 
-MySQL protocol based cubestore driver.
+MySQL protocol based Cube Store driver.
 
 [Learn more](https://github.com/cube-js/cube.js#getting-started)
 
 ### License
 
-Cube.js store Driver is [Apache 2.0 licensed](./LICENSE).
+Cube Store driver is [Apache 2.0 licensed](./LICENSE).

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cubejs-backend/cubestore-driver",
-  "description": "Cube.js store driver",
+  "description": "Cube Store driver",
   "author": "Cube Dev, Inc.",
   "version": "0.23.15",
   "repository": {

--- a/rust/README.md
+++ b/rust/README.md
@@ -7,7 +7,7 @@
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fcube-js%2Fcube.js.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fcube-js%2Fcube.js?ref=badge_shield)
 
 
-Cubestore
+Cube Store
 ==========
 
 Cube.js pre-aggregation storage layer.
@@ -34,4 +34,4 @@ It should point to checked out Apache Arrow fork and it'll allow you to build pr
 
 ## License
 
-Cubestore is [Apache 2.0 licensed](./cubestore/LICENSE).
+Cube Store is [Apache 2.0 licensed](./cubestore/LICENSE).

--- a/rust/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/src/bin/cubestored.rs
@@ -44,7 +44,7 @@ fn main() {
         let services = config.configure().await;
         services.start_processing_loops().await.unwrap();
 
-        track_event("Cubestore Start".to_string(), HashMap::new()).await;
+        track_event("Cube Store Start".to_string(), HashMap::new()).await;
 
         MySqlServer::listen("0.0.0.0:3306".to_string(), services.sql_service.clone()).await.unwrap();
     });

--- a/rust/cubestore/src/telemetry/mod.rs
+++ b/rust/cubestore/src/telemetry/mod.rs
@@ -126,7 +126,7 @@ impl Log for ReportingLogger {
     fn log(&self, record: &Record<'a>) {
         if let Level::Error = record.metadata().level() {
             track_event_spawn(
-                "Cubestore Error".to_string(),
+                "Cube Store Error".to_string(),
                 vec![
                     ("error".to_string(), format!("{}", record.args()))
                 ].into_iter().collect()


### PR DESCRIPTION
Following a recent discussion, I've updated all user-facing `/(cube).*(store)/i` appearances in our code base to be spelled as "Cube Store".