### PR TITLE
CREATE DATABASE and SHOW DATABASES aliases for CREATE SCHEMA and SHOW SCHEMAS

### DIFF
--- a/rust/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/src/sql/parser.rs
@@ -45,6 +45,17 @@ impl CubeStoreParser {
         })
     }
 
+    /// Parse an aribtrary string token
+    pub fn parse_token_str(&mut self, token_str: &str) -> bool {
+        match self.parser.peek_token() {
+            Token::Word(w) if token_str.to_lowercase() == w.value.to_lowercase() => {
+                    self.parser.next_token();
+                    true
+                }
+                _ => false,
+        }
+    }
+
     pub fn parse_statement(&mut self) -> Result<Statement, ParserError> {
         match self.parser.peek_token() {
             Token::Word(w) => match w.keyword {
@@ -59,7 +70,7 @@ impl CubeStoreParser {
     }
 
     pub fn parse_create(&mut self) -> Result<Statement, ParserError> {
-        if self.parser.parse_keyword(Keyword::SCHEMA) {
+        if self.parser.parse_keyword(Keyword::SCHEMA) || self.parse_token_str("database") {
             self.parse_create_schema()
         } else if self.parser.parse_keyword(Keyword::TABLE) {
             self.parse_create_table()


### PR DESCRIPTION

**Check List**
- [y ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ y] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

MySQL historically has been using CREATE DATABASE / SHOW DATABASES instead of CREATE SCHEMA / SHOW SCHEMA. The change adds those aliases to be compatible with the applications using the original MySQL syntax.