### PR TITLE
fix(@cubejs-client/playground): always show scrollbars in menu

### DIFF
--- a/packages/cubejs-playground/src/components/GlobalStyles.js
+++ b/packages/cubejs-playground/src/components/GlobalStyles.js
@@ -24,6 +24,20 @@ const GlobalStyles = createGlobalStyle`
     border-radius: 3px;
   }
   
+  .ant-dropdown-menu::-webkit-scrollbar-track {
+    background: var(--light-color);
+  }
+  
+  .ant-dropdown-menu::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background: var(--dark-03-color);
+  }
+  
+  .ant-dropdown-menu::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  } 
+  
   .schema-sidebar .ant-tabs-top-bar {
     padding: 0 16px;
   }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

The scrollbar in a menu (dropdown) is not visible without interaction. (MacOS, Setting selected: Show scroll bars: When scrolling)

**Description of Changes Made (if issue reference is not provided)**

Apply CSS styles to always show scrollbar if the content is too big to be displayed without scrolling.
