### PR TITLE
ci: do not create Deploy Previews for non-documentation PRs

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 publish = "public/"
 command = "./build-netlify.sh"
+ignore = "cd .. && git diff --quiet HEAD^ HEAD -- docs/"
 
 [[redirects]]
 from = "/favicons/*"


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This should stop non-documentation PRs from generating Deploy Previews