### PR TITLE
fix(@cubejs-backend/api-gateway): Add missing exports

### DIFF
--- a/packages/cubejs-api-gateway/src/index.ts
+++ b/packages/cubejs-api-gateway/src/index.ts
@@ -1,2 +1,4 @@
 export * from './gateway';
 export * from './interfaces';
+export * from './CubejsHandlerError';
+export * from './UserError';


### PR DESCRIPTION
#1474 hid two classes I was relying on.