### PR TITLE
fix(@cubejs-backend/mysql-driver): Use text type for GenericType text

### DIFF
--- a/packages/cubejs-mysql-driver/driver/MySqlDriver.js
+++ b/packages/cubejs-mysql-driver/driver/MySqlDriver.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 
 const GenericTypeToMySql = {
   string: 'varchar(255) CHARACTER SET utf8mb4',
-  text: 'varchar(255) CHARACTER SET utf8mb4'
+  text: 'TEXT CHARACTER SET utf8mb4'
 };
 
 const MySqlToGenericType = {


### PR DESCRIPTION
Hello!

Thanks