### PR TITLE
fix: use `decimal(38,10)` for external MySQL and Postgres pre-aggregations

### DIFF
--- a/packages/cubejs-mysql-driver/driver/MySqlDriver.js
+++ b/packages/cubejs-mysql-driver/driver/MySqlDriver.js
@@ -3,11 +3,11 @@ const genericPool = require('generic-pool');
 const { promisify } = require('util');
 const { BaseDriver } = require('@cubejs-backend/query-orchestrator');
 const crypto = require('crypto');
-const fs = require('fs');
 
 const GenericTypeToMySql = {
   string: 'varchar(255) CHARACTER SET utf8mb4',
-  text: 'varchar(255) CHARACTER SET utf8mb4'
+  text: 'varchar(255) CHARACTER SET utf8mb4',
+  decimal: 'decimal(38,10)',
 };
 
 const MySqlToGenericType = {

--- a/packages/cubejs-postgres-driver/driver/PostgresDriver.js
+++ b/packages/cubejs-postgres-driver/driver/PostgresDriver.js
@@ -2,7 +2,6 @@ const pg = require('pg');
 const { types } = require('pg');
 const moment = require('moment');
 const { BaseDriver } = require('@cubejs-backend/query-orchestrator');
-const fs = require('fs');
 
 const { Pool } = pg;
 


### PR DESCRIPTION
Hello!

refs https://github.com/cube-js/cube.js/issues/1563

Thanks