### PR TITLE
feat(@cubejs-backend/query-orchestrator): set pool options from server config

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.js
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.js
@@ -17,7 +17,7 @@ export class QueryOrchestrator {
     if (cacheAndQueueDriver !== 'redis' && cacheAndQueueDriver !== 'memory') {
       throw new Error('Only \'redis\' or \'memory\' are supported for cacheAndQueueDriver option');
     }
-    const redisPool = cacheAndQueueDriver === 'redis' ? new RedisPool() : undefined;
+    const redisPool = cacheAndQueueDriver === 'redis' ? new RedisPool(options.poolOptions) : undefined;
 
     this.redisPool = redisPool;
     this.queryCache = new QueryCache(

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -44,6 +44,12 @@ export interface CreateOptions {
 
 export interface OrchestratorOptions {
   redisPrefix?: string;
+  poolOptions?: {
+    poolMin?: number;
+    poolMax?: number;
+    createClient?: (redisUrl: string) => {}
+    destroyClient?: (client) => {}
+  }
   queryCacheOptions?: QueryCacheOptions;
   preAggregationsOptions?: PreAggregationsOptions;
   rollupOnlyMode?: boolean;

--- a/packages/cubejs-server-core/core/index.d.ts
+++ b/packages/cubejs-server-core/core/index.d.ts
@@ -47,8 +47,8 @@ export interface OrchestratorOptions {
   poolOptions?: {
     poolMin?: number;
     poolMax?: number;
-    createClient?: (redisUrl: string) => {}
-    destroyClient?: (client) => {}
+    createClient?: (redisUrl: string) => RedisClient
+    destroyClient?: (client: RedisClient) => void
   }
   queryCacheOptions?: QueryCacheOptions;
   preAggregationsOptions?: PreAggregationsOptions;


### PR DESCRIPTION
Allows to set Redis pool options from server config.
Can be used to pick another Redis client or define properties (ex. poolMax) without environment variables.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

None

**Description of Changes Made (if issue reference is not provided)**

Added `poolOptions` to `OrchestratorOptions` interface
`poolOptions` are now passed to `RedisPool` constructor
