### PR TITLE
docs(@cubejs-docs/site): fix alignment of heading anchors

### DIFF
--- a/docs/static/styles/_layout.scss
+++ b/docs/static/styles/_layout.scss
@@ -787,8 +787,12 @@ span.group-header {
     font-size: inherit;
     margin-top: 6px;
     position: absolute;
-    left: 5px;
+    left: -0.75rem;
     padding-right: 10px;
+
+    @media screen and (min-width: 2000px) {
+      left: 0.75rem;
+    }
 
     &:hover {
       display: inline;


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Fixed the following issue:

![image-1](https://user-images.githubusercontent.com/1781985/102191137-ec9fe480-3eb0-11eb-9ada-0310238bac33.png)

