### PR TITLE
docs(@cubejs-docs/site): exclude `CHANGELOG.md` from linting

### DIFF
--- a/docs/.lintstagedrc
+++ b/docs/.lintstagedrc
@@ -1,7 +1,10 @@
 {
+  "CHANGELOG.md": [
+    ""
+  ],
   "*.md": [
-    "markdownlint-cli2",
-    "prettier --write"
+    "prettier --write",
+    "markdownlint-cli2"
   ],
   "*.scss": [
   ],


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

The automatically-generated `CHANGELOG.md` was causing lint errors and preventing new releases. The Lint-Staged configuration file has been updated to exclude it.