### PR TITLE
docs: fix broken link to `schemaVersion` documentation

### DIFF
--- a/docs/content/Schema/schema-execution-environment.md
+++ b/docs/content/Schema/schema-execution-environment.md
@@ -7,93 +7,125 @@ menuOrder: 9
 subCategory: Reference
 ---
 
-Cube.js Schema Compiler uses [Node.js VM](https://nodejs.org/api/vm.html) to execute schema compiler code.
-It gives required flexibility allowing to transpile schema files before they get executed, allow to store schema in external databases and execute untrusted code in safe manner.
-Cube.js Schema JavaScript is standard JavaScript supported by Node.js starting version 8 with following exceptions.
+Cube.js Schema Compiler uses [Node.js VM](https://nodejs.org/api/vm.html) to
+execute schema compiler code. It gives required flexibility allowing to
+transpile schema files before they get executed, allow to store schema in
+external databases and execute untrusted code in safe manner. Cube.js Schema
+JavaScript is standard JavaScript supported by Node.js starting version 8 with
+following exceptions.
 
 ## Require
 
-Being executed in VM data schema JavaScript code doesn't have access to [Node.js require](https://nodejs.org/api/modules.html#modules_require_id) directly.
-Instead `require()` is implemented by Schema Compiler to provide access to other data schema files and to regular Node.js modules.
-Besides that data schema `require()` can resolve Cube.js packages such as `Funnels` unlike standard Node.js `require()`.
+Being executed in VM data schema JavaScript code doesn't have access to
+[Node.js require](https://nodejs.org/api/modules.html#modules_require_id)
+directly. Instead `require()` is implemented by Schema Compiler to provide
+access to other data schema files and to regular Node.js modules. Besides that
+data schema `require()` can resolve Cube.js packages such as `Funnels` unlike
+standard Node.js `require()`.
 
 ## Node.js globals (process.env, console.log and others)
 
-Data schema JavaScript code doesn't have access to any standard Node.js globals like `process` or `console`.
-In order to access `process.env`, helper service can be introduced outside of `schema` directory:
+Data schema JavaScript code doesn't have access to any standard Node.js globals
+like `process` or `console`. In order to access `process.env`, helper service
+can be introduced outside of `schema` directory:
 
 **tablePrefix.js:**
+
 ```javascript
 exports.tableSchema = () => process.env.TABLE_SCHEMA;
 ```
 
 **schema/Users.js**:
+
 ```javascript
 import { tableSchema } from '../tablePrefix';
 
 cube(`Users`, {
- sql: `SELECT * FROM ${tableSchema()}.users`,
- 
- // ...
+  sql: `SELECT * FROM ${tableSchema()}.users`,
+
+  // ...
 });
 ```
 
 ## console.log
 
-Data schema cannot access `console.log` due to a separate [VM instance](https://nodejs.org/api/vm.html) runs it.
-Suppose you find yourself writing complex logic for SQL generation that depends on a lot of external input. In that case, you probably want to introduce a helper service outside of `schema` directory that you can debug as usual Node.js code.
+Data schema cannot access `console.log` due to a separate
+[VM instance](https://nodejs.org/api/vm.html) runs it. Suppose you find yourself
+writing complex logic for SQL generation that depends on a lot of external
+input. In that case, you probably want to introduce a helper service outside of
+`schema` directory that you can debug as usual Node.js code.
 
 ## Cube.js globals (cube and others)
 
-Cube.js defines `cube()`, `context()` and `asyncModule()` global variable functions in order to provide API for schema configuration which aren't normally accessible outside of Cube.js schema.
+Cube.js defines `cube()`, `context()` and `asyncModule()` global variable
+functions in order to provide API for schema configuration which aren't normally
+accessible outside of Cube.js schema.
 
 ## Import / Export
 
-Data schema JavaScript files are transpiled to convert ES6 `import` and `export` expressions to corresponding Node.js calls.
-In fact `import` is routed to [Require](#require) method.
+Data schema JavaScript files are transpiled to convert ES6 `import` and `export`
+expressions to corresponding Node.js calls. In fact `import` is routed to
+[Require](#require) method.
 
 `export` can be used to define named exports as well as default ones:
 
 **constants.js:**
+
 ```javascript
-export const TEST_USER_IDS = [1,2,3,4,5];
+export const TEST_USER_IDS = [1, 2, 3, 4, 5];
 ```
 
 **usersSql.js:**
+
 ```javascript
-export default (usersTable) => `select * form ${usersTable}`
+export default (usersTable) => `select * form ${usersTable}`;
 ```
 
 Later, you can `import` into the cube, wherever needed:
 
 **Users.js**:
+
 ```javascript
 // in Users.js
 import { TEST_USER_IDS } from './constants';
-import usersSql from './usersSql'
+import usersSql from './usersSql';
 
 cube(`Users`, {
- sql: usersSql(`users`),
- measures: { /* ... */ },
+  sql: usersSql(`users`),
+  measures: {
+    /* ... */
+  },
 
- dimensions: { /* ... */ },
+  dimensions: {
+    /* ... */
+  },
 
- segments: {
-   excludeTestUsers: {
-     sql: `${CUBE}.id NOT IN (${TEST_USER_IDS.join(", ")})`
-   }
- }
+  segments: {
+    excludeTestUsers: {
+      sql: `${CUBE}.id NOT IN (${TEST_USER_IDS.join(', ')})`,
+    },
+  },
 });
 ```
 
 ## asyncModule
 
+<!-- prettier-ignore-start -->
 [[warning | Note]]
-| Each `asyncModule` call will be invoked only once per schema compilation. 
-To trigger schema recompile based on changes of underlying input data, [schemaVersion](@cubejs-backend-server-core#options-reference-schema-version) value should change accordingly.
+| Each `asyncModule` call will be invoked only once per schema compilation.
+<!-- prettier-ignore-end -->
 
-If there's a need to generate schema based on values from external API or database `asyncModule` method can be used for such scenario.
-`asyncModule` method allows to register async function to be executed at the end of data schema file compile phase so additional definitions can be added during this function call.
+To trigger a schema recompile based on changes of underlying input data,
+[schemaVersion][link-config-schema-version] value should change accordingly.
+
+[link-config-schema-version]:
+  https://cube.dev/docs/config#options-reference-schema-version
+
+If there's a need to generate schema based on values from external API or
+database `asyncModule` method can be used for such scenario. `asyncModule`
+method allows to register async function to be executed at the end of data
+schema file compile phase so additional definitions can be added during this
+function call.
 
 For example:
 
@@ -102,7 +134,9 @@ const fetch = require('node-fetch');
 const Funnels = require('Funnels');
 
 asyncModule(async () => {
-  const funnels = await (await fetch('http://your-api-endpoint/funnels')).json();
+  const funnels = await (
+    await fetch('http://your-api-endpoint/funnels')
+  ).json();
 
   class Funnel {
     constructor({ title, steps }) {
@@ -113,37 +147,37 @@ asyncModule(async () => {
     get transformedSteps() {
       return Object.keys(this.steps).map((key, index) => {
         const value = this.steps[key];
-        let where = null
+        let where = null;
         if (value[0] === PAGE_VIEW_EVENT) {
           if (value.length === 1) {
-            where = `event = '${value[0]}'`
+            where = `event = '${value[0]}'`;
           } else {
-            where = `event = '${value[0]}' AND page_title = '${value[1]}'`
+            where = `event = '${value[0]}' AND page_title = '${value[1]}'`;
           }
         } else {
-          where = `event = 'se' AND se_category = '${value[0]}' AND se_action = '${value[1]}'`
+          where = `event = 'se' AND se_category = '${value[0]}' AND se_action = '${value[1]}'`;
         }
 
         return {
           name: key,
           eventsView: {
-            sql: () => `select * from (${eventsSQl}) WHERE ${where}`
+            sql: () => `select * from (${eventsSQl}) WHERE ${where}`,
           },
-          timeToConvert: index > 0 ? '30 day' : null
-        }
+          timeToConvert: index > 0 ? '30 day' : null,
+        };
       });
     }
 
     get config() {
       return {
         userId: {
-          sql: () => `user_id`
+          sql: () => `user_id`,
         },
         time: {
-          sql: () => `time`
+          sql: () => `time`,
         },
-        steps: this.transformedSteps
-      }
+        steps: this.transformedSteps,
+      };
     }
   }
 
@@ -154,45 +188,47 @@ asyncModule(async () => {
       preAggregations: {
         main: {
           type: `originalSql`,
-        }
-      }
+        },
+      },
     });
   });
-})
+});
 ```
 
 ## Context symbols transpile
 
-Cube.js uses custom transpiler to optimize boilerplate code around referencing cubes and cube members.
-There're reserved property names inside `cube` definition that undergo reference resolve transpiling process:
+Cube.js uses custom transpiler to optimize boilerplate code around referencing
+cubes and cube members. There're reserved property names inside `cube`
+definition that undergo reference resolve transpiling process:
 
-- `sql` 
+- `sql`
 - `measureReferences`
 - `dimensionReferences`
 - `segmentReferences`
-- `timeDimensionReference` 
+- `timeDimensionReference`
 - `drillMembers`
 - `drillMemberReferences`
 - `contextMembers`
 
-Each of these properties inside `cube` and `context` definitions are transpiled to functions with resolved arguments.
+Each of these properties inside `cube` and `context` definitions are transpiled
+to functions with resolved arguments.
 
 For example:
 
 ```javascript
 cube(`Users`, {
   // ...
-  
+
   measures: {
     count: {
-      type: `count`
+      type: `count`,
     },
-    
+
     ratio: {
       sql: `sum(${CUBE}.amount) / ${count}`,
-      type: `number`
-    }
-  }
+      type: `number`,
+    },
+  },
 });
 ```
 
@@ -201,37 +237,38 @@ is transpiled to:
 ```javascript
 cube(`Users`, {
   // ...
-  
+
   measures: {
     count: {
-      type: `count`
+      type: `count`,
     },
-    
+
     ratio: {
       sql: (CUBE, count) => `sum(${CUBE}.amount) / ${count}`,
-      type: `number`
-    }
-  }
+      type: `number`,
+    },
+  },
 });
 ```
 
-So for example if you want to pass definition of `ratio` outside of the cube you should define it as:
+So for example if you want to pass definition of `ratio` outside of the cube you
+should define it as:
 
 ```javascript
 const measureRatioDefinition = {
   sql: (CUBE, count) => `sum(${CUBE}.amount) / ${count}`,
-  type: `number`
-}
+  type: `number`,
+};
 
 cube(`Users`, {
   // ...
-  
+
   measures: {
     count: {
-      type: `count`
+      type: `count`,
     },
-    
-    ratio: measureRatioDefinition
-  }
+
+    ratio: measureRatioDefinition,
+  },
 });
 ```

--- a/docs/content/Schema/schema-execution-environment.md
+++ b/docs/content/Schema/schema-execution-environment.md
@@ -8,26 +8,26 @@ subCategory: Reference
 ---
 
 Cube.js Schema Compiler uses [Node.js VM](https://nodejs.org/api/vm.html) to
-execute schema compiler code. It gives required flexibility allowing to
-transpile schema files before they get executed, allow to store schema in
-external databases and execute untrusted code in safe manner. Cube.js Schema
-JavaScript is standard JavaScript supported by Node.js starting version 8 with
-following exceptions.
+execute schema compiler code. It gives required flexibility allowing transpiling
+schema files before they get executed, storing schemas in external databases and
+executing untrusted code in a safe manner. Cube.js Schema JavaScript is standard
+JavaScript supported by Node.js starting in version 8 with the following
+exceptions.
 
 ## Require
 
-Being executed in VM data schema JavaScript code doesn't have access to
+Being executed in VM data schema, JavaScript code doesn't have access to
 [Node.js require](https://nodejs.org/api/modules.html#modules_require_id)
 directly. Instead `require()` is implemented by Schema Compiler to provide
-access to other data schema files and to regular Node.js modules. Besides that
-data schema `require()` can resolve Cube.js packages such as `Funnels` unlike
-standard Node.js `require()`.
+access to other data schema files and to regular Node.js modules. Besides that,
+the data schema `require()` can resolve Cube.js packages such as `Funnels`
+unlike standard Node.js `require()`.
 
 ## Node.js globals (process.env, console.log and others)
 
 Data schema JavaScript code doesn't have access to any standard Node.js globals
-like `process` or `console`. In order to access `process.env`, helper service
-can be introduced outside of `schema` directory:
+like `process` or `console`. In order to access `process.env`, utility functions
+can be added outside the `schema/` directory:
 
 **tablePrefix.js:**
 
@@ -50,10 +50,10 @@ cube(`Users`, {
 ## console.log
 
 Data schema cannot access `console.log` due to a separate
-[VM instance](https://nodejs.org/api/vm.html) runs it. Suppose you find yourself
-writing complex logic for SQL generation that depends on a lot of external
-input. In that case, you probably want to introduce a helper service outside of
-`schema` directory that you can debug as usual Node.js code.
+[VM instance](https://nodejs.org/api/vm.html) that runs it. Suppose you find
+yourself writing complex logic for SQL generation that depends on a lot of
+external input. In that case, you probably want to introduce a helper service
+outside of `schema` directory that you can debug as usual Node.js code.
 
 ## Cube.js globals (cube and others)
 
@@ -122,10 +122,9 @@ To trigger a schema recompile based on changes of underlying input data,
   https://cube.dev/docs/config#options-reference-schema-version
 
 If there's a need to generate schema based on values from external API or
-database `asyncModule` method can be used for such scenario. `asyncModule`
-method allows to register async function to be executed at the end of data
-schema file compile phase so additional definitions can be added during this
-function call.
+database, the `asyncModule` method can be used for such scenario. `asyncModule`
+allows registering an async function to be executed at the end of the data
+schema file compile phase so additional definitions can be added.
 
 For example:
 
@@ -198,7 +197,7 @@ asyncModule(async () => {
 ## Context symbols transpile
 
 Cube.js uses custom transpiler to optimize boilerplate code around referencing
-cubes and cube members. There're reserved property names inside `cube`
+cubes and cube members. There are reserved property names inside `cube`
 definition that undergo reference resolve transpiling process:
 
 - `sql`


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

The link on [this page](https://cube.dev/docs/schema-execution-environment#async-module) pointing to `schemaVersion` is broken.