### PR TITLE
feat(api-gateway): Support POST for /v1/dry-run

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -262,6 +262,14 @@ export class ApiGateway {
         res: this.resToResultFn(res)
       });
     }));
+
+    app.post(`${this.basePath}/v1/dry-run`, jsonParser, this.requestMiddleware, (async (req, res) => {
+      await this.dryRun({
+        query: req.body.query,
+        context: req.context,
+        res: this.resToResultFn(res)
+      });
+    }));
   }
 
   public initSubscriptionServer(sendMessage) {


### PR DESCRIPTION
Hello!

I think it's expected to support POST for `/v1/dry-run` in flavour of https://github.com/cube-js/cube.js/pull/1608

Thanks