### PR TITLE
feat(@cubejs-backend/dremio-driver): Add HTTPS support for Dremio

### DIFF
--- a/packages/cubejs-dremio-driver/driver/DremioDriver.js
+++ b/packages/cubejs-dremio-driver/driver/DremioDriver.js
@@ -21,10 +21,13 @@ class DremioDriver extends BaseDriver {
       port: config.port || process.env.CUBEJS_DB_PORT || 9047,
       user: config.user || process.env.CUBEJS_DB_USER,
       password: config.password || process.env.CUBEJS_DB_PASS,
-      database: config.database || process.env.CUBEJS_DB_NAME
+      database: config.database || process.env.CUBEJS_DB_NAME,
+      ssl: config.ssl || process.env.CUBEJS_DB_SSL
     };
 
-    this.config.url = `http://${this.config.host}:${this.config.port}`;
+    const protocol = (this.config.ssl === true || this.config.ssl === "true") ? "https" : "http";
+
+    this.config.url = `${protocol}://${this.config.host}:${this.config.port}`;
   }
 
   async testConnection() {

--- a/packages/cubejs-dremio-driver/driver/DremioDriver.js
+++ b/packages/cubejs-dremio-driver/driver/DremioDriver.js
@@ -25,7 +25,7 @@ class DremioDriver extends BaseDriver {
       ssl: config.ssl || process.env.CUBEJS_DB_SSL
     };
 
-    const protocol = (this.config.ssl === true || this.config.ssl === "true") ? "https" : "http";
+    const protocol = (this.config.ssl === true || this.config.ssl === 'true') ? 'https' : 'http';
 
     this.config.url = `${protocol}://${this.config.host}:${this.config.port}`;
   }


### PR DESCRIPTION

Set CUBEJS_DB_SSL=true or config.ssl=true to connect to Dremio via HTTPS. Default is HTTP.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

Set CUBEJS_DB_SSL=true or config.ssl=true to connect to Dremio via HTTPS. Default is HTTP.