### PR TITLE
fix(@cubejs-client/react): useCubeQuery - clear resultSet on exception

### DIFF
--- a/packages/cubejs-client-react/src/hooks/cube-query.js
+++ b/packages/cubejs-client-react/src/hooks/cube-query.js
@@ -86,6 +86,7 @@ export default (query, options = {}) => {
         } catch (e) {
           if (isMounted) {
             setError(e);
+            setResultSet(null);
             setLoading(false);
             setProgress(null);
           }


### PR DESCRIPTION
Hello!

Exception on server side can do unexpected behaviour on client code:

```
const renderChart = Component => ({ resultSet, error, height, ...props }) =>
  (resultSet && <Component resultSet={resultSet} height={height} {...props} />) ||
  (error && error.toString()) || <Loader height={height} />;
```

`resultSet` can be not empty on error

Thanks