### PR TITLE
chore(cubestore): allow to import base64-encoded bytes in CSV

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1058,6 +1058,7 @@ dependencies = [
  "async-trait",
  "aws-creds",
  "aws-region",
+ "base64 0.13.0",
  "bigdecimal 0.2.0",
  "bincode",
  "byteorder",

--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/cube-js/cube.js"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64 = "0.13.0"
 tokio = { version = "1.0", features = ["full", "rt"] }
 warp = "0.2"
 sqlparser = "0.7.0"

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -335,3 +335,9 @@ impl From<cloud_storage::Error> for CubeError {
         return CubeError::from_error(v);
     }
 }
+
+impl From<base64::DecodeError> for CubeError {
+    fn from(v: base64::DecodeError) -> Self {
+        return CubeError::from_error(v);
+    }
+}

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -7,8 +7,8 @@ use sqlparser::ast::*;
 use sqlparser::dialect::Dialect;
 
 use crate::metastore::{
-    table::Table, HllFlavour, IdRow, ImportFormat, Index, IndexDef, MetaStoreTable, RowKey, Schema,
-    TableId,
+    is_valid_hll, table::Table, HllFlavour, IdRow, ImportFormat, Index, IndexDef, MetaStoreTable,
+    RowKey, Schema, TableId,
 };
 use crate::table::{Row, TableValue, TimestampValue};
 use crate::CubeError;
@@ -547,15 +547,8 @@ fn decode_byte(s: &str) -> Option<u8> {
 
 fn parse_hyper_log_log(v: &Value, f: HllFlavour) -> Result<Vec<u8>, CubeError> {
     let bytes = parse_binary_string(v)?;
-    // TODO: check without memory allocations. this is run on hot path.
-    match f {
-        HllFlavour::Airlift => {
-            cubehll::HllSketch::read(&bytes)?;
-        }
-        HllFlavour::ZetaSketch => {
-            cubezetasketch::HyperLogLogPlusPlus::read(&bytes)?;
-        }
-    }
+    is_valid_hll(&bytes, f)?;
+
     return Ok(bytes);
 }
 


### PR DESCRIPTION
BigQuery driver exports binary data:
- in base64 for csv-import mode,
- in hex-encoded string literals in sql-import mode.

Hence both use-cases work. Happy to revisit this if we'll run into trouble while adding support for csv export into other drivers.