### PR TITLE
feat(cubestore): filter rowgroups when reading parquet files

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e45703e2d906af19a006a1d8af4d24c044456380"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#d7968e901b774c238fbdc0550a152fa8e98c46fc"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e45703e2d906af19a006a1d8af4d24c044456380"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#d7968e901b774c238fbdc0550a152fa8e98c46fc"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e45703e2d906af19a006a1d8af4d24c044456380"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#d7968e901b774c238fbdc0550a152fa8e98c46fc"
 dependencies = [
  "ahash 0.6.3",
  "arrow",
@@ -2766,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e45703e2d906af19a006a1d8af4d24c044456380"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#d7968e901b774c238fbdc0550a152fa8e98c46fc"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/rust/cubestore/src/queryplanner/mod.rs
+++ b/rust/cubestore/src/queryplanner/mod.rs
@@ -17,7 +17,7 @@ use arrow::{array::Array, datatypes::Schema, datatypes::SchemaRef};
 use arrow::{datatypes::DataType, record_batch::RecordBatch};
 use async_trait::async_trait;
 use core::fmt;
-use datafusion::datasource::datasource::Statistics;
+use datafusion::datasource::datasource::{Statistics, TableProviderFilterPushDown};
 use datafusion::error::DataFusionError;
 use datafusion::logical_plan::{DFSchemaRef, Expr, LogicalPlan, ToDFSchema};
 use datafusion::physical_plan::memory::MemoryExec;
@@ -369,5 +369,12 @@ impl TableProvider for CubeTableLogical {
             total_byte_size: None,
             column_statistics: None,
         }
+    }
+
+    fn supports_filter_pushdown(
+        &self,
+        _filter: &Expr,
+    ) -> Result<TableProviderFilterPushDown, DataFusionError> {
+        return Ok(TableProviderFilterPushDown::Inexact);
     }
 }

--- a/rust/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/src/queryplanner/query_executor.rs
@@ -18,11 +18,12 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use core::fmt;
-use datafusion::datasource::datasource::Statistics;
+use datafusion::datasource::datasource::{Statistics, TableProviderFilterPushDown};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::error::Result as DFResult;
 use datafusion::execution::context::{ExecutionConfig, ExecutionContext};
+use datafusion::logical_plan;
 use datafusion::logical_plan::{DFSchemaRef, Expr, ToDFSchema};
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::hash_aggregate::HashAggregateExec;
@@ -409,6 +410,7 @@ impl CubeTable {
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
+        filters: &[Expr],
     ) -> Result<Arc<dyn ExecutionPlan>, CubeError> {
         let table = self.index_snapshot.table();
         let index = self.index_snapshot.index();
@@ -423,6 +425,7 @@ impl CubeTable {
                 .collect::<Vec<_>>()
         });
 
+        let predicate = combine_filters(filters);
         for partition_snapshot in partition_snapshots {
             if !self
                 .worker_partition_ids
@@ -440,7 +443,7 @@ impl CubeTable {
                 let arc: Arc<dyn ExecutionPlan> = Arc::new(ParquetExec::try_from_path(
                     &local_path,
                     mapped_projection.clone(),
-                    None, // TODO
+                    predicate.clone(),
                     batch_size,
                     1,
                 )?);
@@ -457,7 +460,7 @@ impl CubeTable {
                 let node = Arc::new(ParquetExec::try_from_path(
                     local_path,
                     mapped_projection.clone(),
-                    None, // TODO
+                    predicate.clone(),
                     batch_size,
                     1,
                 )?);
@@ -700,9 +703,9 @@ impl TableProvider for CubeTable {
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
-        _filters: &[Expr],
+        filters: &[Expr],
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let res = self.async_scan(projection, batch_size)?;
+        let res = self.async_scan(projection, batch_size, filters)?;
         Ok(res)
     }
 
@@ -713,6 +716,13 @@ impl TableProvider for CubeTable {
             total_byte_size: None,
             column_statistics: None,
         }
+    }
+
+    fn supports_filter_pushdown(
+        &self,
+        _filter: &Expr,
+    ) -> Result<TableProviderFilterPushDown, DataFusionError> {
+        return Ok(TableProviderFilterPushDown::Inexact);
     }
 }
 
@@ -962,4 +972,21 @@ impl SerializedRecordBatchStream {
         let reader = StreamReader::try_new(cursor)?;
         Ok(reader.collect::<Result<Vec<_>, _>>()?)
     }
+}
+/// Note: copy of the function in 'datafusion/src/datasource/parquet.rs'.
+///
+/// Combines an array of filter expressions into a single filter expression
+/// consisting of the input filter expressions joined with logical AND.
+/// Returns None if the filters array is empty.
+fn combine_filters(filters: &[Expr]) -> Option<Expr> {
+    if filters.is_empty() {
+        return None;
+    }
+    let combined_filter = filters
+        .iter()
+        .skip(1)
+        .fold(filters[0].clone(), |acc, filter| {
+            logical_plan::and(acc, filter.clone())
+        });
+    Some(combined_filter)
 }


### PR DESCRIPTION
Greatly reduces query execution time on properly organized data.
This requires a fix for arrow: https://github.com/cube-js/arrow/pull/9
I'll update the PR with the new arrow commit SHA when the arrow fix lands