### PR TITLE
fix: Cannot create proxy with a non-object as target or handler

### DIFF
--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -27,6 +27,7 @@
     "dist/src/*"
   ],
   "dependencies": {
+    "@cubejs-backend/shared": "^0.26.0",
     "@hapi/joi": "^15.1.1",
     "body-parser": "^1.19.0",
     "chrono-node": "1.4.4",
@@ -39,7 +40,6 @@
   },
   "devDependencies": {
     "@cubejs-backend/linter": "^0.26.0",
-    "@cubejs-backend/shared": "^0.26.0",
     "@types/express": "^4.17.9",
     "@types/hapi__joi": "^15.0.4",
     "@types/jest": "^26.0.20",

--- a/packages/cubejs-backend-shared/src/helpers.ts
+++ b/packages/cubejs-backend-shared/src/helpers.ts
@@ -1,0 +1,7 @@
+export function getRealType(value: any): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  return typeof value;
+}

--- a/packages/cubejs-backend-shared/src/index.ts
+++ b/packages/cubejs-backend-shared/src/index.ts
@@ -4,3 +4,4 @@ export * from './track';
 export * from './errors';
 export * from './promises';
 export * from './convert';
+export * from './helpers';

--- a/packages/cubejs-backend-shared/test/helper.test.ts
+++ b/packages/cubejs-backend-shared/test/helper.test.ts
@@ -1,0 +1,7 @@
+import { getRealType } from '../src';
+
+test('getRealType', () => {
+  expect(getRealType(1)).toBe('number');
+  expect(getRealType({})).toBe('object');
+  expect(getRealType(null)).toBe('null');
+});


### PR DESCRIPTION
Hello!

Some users are storing original JWT (as string) inside authInfo/securityContext by using custom checkAuth or checkAuthMiddleware, which is unexpected (must be object) and can cause this issue. I started to use {} as the default value for securityContext when it's not an object before passing it to schema-compiler. I've added a warning when a user is storing not object inside securityContext to indicate that they are doing something wrong.

Thanks