### PR TITLE
chore: improve drivers typescript definitions

### DIFF
--- a/packages/cubejs-athena-driver/driver/index.d.ts
+++ b/packages/cubejs-athena-driver/driver/index.d.ts
@@ -1,3 +1,4 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
 import { ClientConfiguration } from "aws-sdk/clients/athena";
 
 declare module "@cubejs-backend/athena-driver" {
@@ -7,7 +8,7 @@ declare module "@cubejs-backend/athena-driver" {
     pollMaxInterval?: number,
   }
 
-  export default class AthenaDriver {
+  export default class AthenaDriver extends BaseDriver {
     constructor(options?: AthenaDriverOptions);
   }
 }

--- a/packages/cubejs-bigquery-driver/driver/index.d.ts
+++ b/packages/cubejs-bigquery-driver/driver/index.d.ts
@@ -1,3 +1,4 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
 import { BigQueryOptions } from "@google-cloud/bigquery";
 
 declare module "@cubejs-backend/bigquery-driver" {
@@ -7,7 +8,7 @@ declare module "@cubejs-backend/bigquery-driver" {
     pollMaxInterval?: number,
   }
 
-  export default class BigQueryDriver {
+  export default class BigQueryDriver extends BaseDriver {
     constructor(options?: BigQueryDriverOptions);
   }
 }

--- a/packages/cubejs-cubestore-driver/driver/index.d.ts
+++ b/packages/cubejs-cubestore-driver/driver/index.d.ts
@@ -1,3 +1,5 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
+
 interface ConnectionConfig {
   /**
    * The hostname of the database you are connecting to. (Default: localhost)
@@ -21,7 +23,7 @@ interface ConnectionConfig {
 }
 
 declare module "@cubejs-backend/cubestore-driver" {
-  export default class CubeStoreDriver {
+  export default class CubeStoreDriver extends BaseDriver {
     constructor(options?: ConnectionConfig);
   }
 }

--- a/packages/cubejs-mongobi-driver/driver/index.d.ts
+++ b/packages/cubejs-mongobi-driver/driver/index.d.ts
@@ -1,7 +1,8 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
 import { ConnectionOptions } from "mysql2";
 
 declare module "@cubejs-backend/mongobi-driver" {
-  export default class MongoBIDriver {
+  export default class MongoBIDriver extends BaseDriver {
     constructor(options?: ConnectionOptions);
   }
 }

--- a/packages/cubejs-mongobi-driver/driver/index.d.ts
+++ b/packages/cubejs-mongobi-driver/driver/index.d.ts
@@ -4,5 +4,6 @@ import { ConnectionOptions } from "mysql2";
 declare module "@cubejs-backend/mongobi-driver" {
   export default class MongoBIDriver extends BaseDriver {
     constructor(options?: ConnectionOptions);
+    release(): Promise<void>
   }
 }

--- a/packages/cubejs-mysql-driver/driver/index.d.ts
+++ b/packages/cubejs-mysql-driver/driver/index.d.ts
@@ -1,7 +1,8 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
 import { ConnectionConfig } from "mysql";
 
 declare module "@cubejs-backend/mysql-driver" {
-  export default class MySqlDriver {
+  export default class MySqlDriver extends BaseDriver {
     constructor(options?: ConnectionConfig);
   }
 }

--- a/packages/cubejs-mysql-driver/driver/index.d.ts
+++ b/packages/cubejs-mysql-driver/driver/index.d.ts
@@ -4,5 +4,6 @@ import { ConnectionConfig } from "mysql";
 declare module "@cubejs-backend/mysql-driver" {
   export default class MySqlDriver extends BaseDriver {
     constructor(options?: ConnectionConfig);
+    release(): Promise<void>
   }
 }

--- a/packages/cubejs-postgres-driver/driver/index.d.ts
+++ b/packages/cubejs-postgres-driver/driver/index.d.ts
@@ -4,5 +4,6 @@ import { PoolConfig } from "pg";
 declare module "@cubejs-backend/postgres-driver" {
   export default class PostgresDriver extends BaseDriver {
     constructor(options?: PoolConfig);
+    release(): Promise<void>
   }
 }

--- a/packages/cubejs-postgres-driver/driver/index.d.ts
+++ b/packages/cubejs-postgres-driver/driver/index.d.ts
@@ -1,7 +1,8 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
 import { PoolConfig } from "pg";
 
 declare module "@cubejs-backend/postgres-driver" {
-  export default class PostgresDriver {
+  export default class PostgresDriver extends BaseDriver {
     constructor(options?: PoolConfig);
   }
 }

--- a/packages/cubejs-sqlite-driver/driver/index.d.ts
+++ b/packages/cubejs-sqlite-driver/driver/index.d.ts
@@ -4,7 +4,7 @@ declare module "@cubejs-backend/sqlite-driver" {
     database: string;
   }
 
-  export default class SqliteDriver extends BaseDriver{
+  export default class SqliteDriver extends BaseDriver {
     constructor(options?: SqliteOptions);
     release(): Promise<void>
   }

--- a/packages/cubejs-sqlite-driver/driver/index.d.ts
+++ b/packages/cubejs-sqlite-driver/driver/index.d.ts
@@ -6,5 +6,6 @@ declare module "@cubejs-backend/sqlite-driver" {
 
   export default class SqliteDriver extends BaseDriver{
     constructor(options?: SqliteOptions);
+    release(): Promise<void>
   }
 }

--- a/packages/cubejs-sqlite-driver/driver/index.d.ts
+++ b/packages/cubejs-sqlite-driver/driver/index.d.ts
@@ -1,9 +1,10 @@
+import { BaseDriver } from "@cubejs-backend/query-orchestrator";
 declare module "@cubejs-backend/sqlite-driver" {
   interface SqliteOptions {
     database: string;
   }
 
-  export default class SqliteDriver {
+  export default class SqliteDriver extends BaseDriver{
     constructor(options?: SqliteOptions);
   }
 }


### PR DESCRIPTION
The drivers are missing type definition as there are not extended by BaseDriver in the definitions file.
Due to this, there are errors in the Typescript project while accessing the methods on the driver.