### PR TITLE
fix(cubestore): return physical memory to the system at rest

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "reqwest 0.11.0",
  "rocksdb",
  "rust-s3",
+ "scopeguard",
  "serde",
  "serde_derive",
  "serde_json",

--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -61,3 +61,4 @@ cloud-storage = "0.7.0"
 tokio-util = { version = "0.6.2", features=["compat"] }
 futures-timer = "3.0.2"
 tokio-stream = { version = "0.1.2", features=["io-util"] }
+scopeguard = "1.1.0"

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -39,6 +39,7 @@ pub mod remotefs;
 pub mod scheduler;
 pub mod sql;
 pub mod store;
+pub mod sys;
 pub mod table;
 pub mod telemetry;
 pub mod util;

--- a/rust/cubestore/src/sys/malloc.rs
+++ b/rust/cubestore/src/sys/malloc.rs
@@ -1,0 +1,24 @@
+/// Ask the memory allocator to returned the freed memory to the system.
+/// This only has effect when compiled for glibc, this is a no-op on other systems.
+///
+/// Cubestore produces allocation patterns that hit the limitations of glibc`s malloc, which results
+/// in too many physical memory pages being retained in the allocator's arena. This leads to the
+/// resident set size growing over the acceptable limits.
+/// Probably related to https://sourceware.org/bugzilla/show_bug.cgi?id=11261.
+///
+/// Use this function after code that produces considerable amount of memory allocations that
+/// **have been already freed**.
+#[cfg(target_os = "linux")] // We use `linux` to test for glibc.
+pub fn trim_allocs() {
+    unsafe {
+        malloc_trim(0);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn trim_memory() {}
+
+#[cfg(target_os = "linux")] // we assume glibc is linked on linux.
+extern "C" {
+    fn malloc_trim(pad: usize) -> i32;
+}

--- a/rust/cubestore/src/sys/mod.rs
+++ b/rust/cubestore/src/sys/mod.rs
@@ -1,0 +1,1 @@
+pub mod malloc;


### PR DESCRIPTION
We seem to hit limitations of `malloc` from glibc, which causes physical
memory to be retained by the allocator even after calls to `free`.

Call `malloc_trim` on allocation-heavy operations to ensure we return
freed memory to the system.

See the comment in the code for details.