### PR TITLE
add support for extra params in generating schema for tables.

### DIFF
--- a/packages/cubejs-cli/src/command/generate.ts
+++ b/packages/cubejs-cli/src/command/generate.ts
@@ -77,7 +77,8 @@ const generate = async (options) => {
     }
   );
   const scaffoldingTemplate = new ScaffoldingTemplate(dbSchema, driver);
-  const files = scaffoldingTemplate.generateFilesByTableNames(options.tables);
+  const { tables, dataSource } = options;
+  const files = scaffoldingTemplate.generateFilesByTableNames(tables, { dataSource });
   await Promise.all(files.map(file => fs.writeFile(path.join('schema', file.fileName), file.content)));
 
   await event({

--- a/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
@@ -26,12 +26,12 @@ export class ScaffoldingTemplate {
     return !!name.match(/^[a-z0-9_]+$/);
   }
 
-  generateFilesByTableNames(tableNames, extraParams = {}) {
+  generateFilesByTableNames(tableNames, schemaContext = {}) {
     const schemaForTables = this.scaffoldingSchema.generateForTables(tableNames.map(n => this.resolveTableName(n)));
     return schemaForTables.map(tableSchema => ({
       // eslint-disable-next-line prefer-template
       fileName: tableSchema.cube + '.js',
-      content: this.renderFile(this.schemaDescriptorForTable(tableSchema, extraParams))
+      content: this.renderFile(this.schemaDescriptorForTable(tableSchema, schemaContext))
     }));
   }
 
@@ -66,7 +66,7 @@ export class ScaffoldingTemplate {
     }
   }
 
-  schemaDescriptorForTable(tableSchema, extraParams = {}) {
+  schemaDescriptorForTable(tableSchema, schemaContext = {}) {
     return {
       cube: tableSchema.cube,
       sql: `SELECT * FROM ${this.escapeName(tableSchema.schema)}.${this.escapeName(tableSchema.table)}`, // TODO escape
@@ -96,7 +96,7 @@ export class ScaffoldingTemplate {
           primaryKey: m.isPrimaryKey ? true : undefined
         }
       })).reduce((a, b) => ({ ...a, ...b }), {}),
-      ...extraParams
+      ...schemaContext
     };
   }
 

--- a/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
@@ -26,7 +26,7 @@ export class ScaffoldingTemplate {
     return !!name.match(/^[a-z0-9_]+$/);
   }
 
-  generateFilesByTableNames(tableNames, extraParams) {
+  generateFilesByTableNames(tableNames, extraParams = {}) {
     const schemaForTables = this.scaffoldingSchema.generateForTables(tableNames.map(n => this.resolveTableName(n)));
     return schemaForTables.map(tableSchema => ({
       // eslint-disable-next-line prefer-template

--- a/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
@@ -26,12 +26,12 @@ export class ScaffoldingTemplate {
     return !!name.match(/^[a-z0-9_]+$/);
   }
 
-  generateFilesByTableNames(tableNames) {
+  generateFilesByTableNames(tableNames, dataSource) {
     const schemaForTables = this.scaffoldingSchema.generateForTables(tableNames.map(n => this.resolveTableName(n)));
     return schemaForTables.map(tableSchema => ({
       // eslint-disable-next-line prefer-template
       fileName: tableSchema.cube + '.js',
-      content: this.renderFile(this.schemaDescriptorForTable(tableSchema))
+      content: this.renderFile(this.schemaDescriptorForTable(tableSchema, dataSource))
     }));
   }
 
@@ -66,7 +66,7 @@ export class ScaffoldingTemplate {
     }
   }
 
-  schemaDescriptorForTable(tableSchema) {
+  schemaDescriptorForTable(tableSchema, dataSource) {
     return {
       cube: tableSchema.cube,
       sql: `SELECT * FROM ${this.escapeName(tableSchema.schema)}.${this.escapeName(tableSchema.table)}`, // TODO escape
@@ -95,7 +95,8 @@ export class ScaffoldingTemplate {
           title: this.memberTitle(m),
           primaryKey: m.isPrimaryKey ? true : undefined
         }
-      })).reduce((a, b) => ({ ...a, ...b }), {})
+      })).reduce((a, b) => ({ ...a, ...b }), {}),
+      dataSource,
     };
   }
 

--- a/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
+++ b/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingTemplate.js
@@ -26,12 +26,12 @@ export class ScaffoldingTemplate {
     return !!name.match(/^[a-z0-9_]+$/);
   }
 
-  generateFilesByTableNames(tableNames, dataSource) {
+  generateFilesByTableNames(tableNames, extraParams) {
     const schemaForTables = this.scaffoldingSchema.generateForTables(tableNames.map(n => this.resolveTableName(n)));
     return schemaForTables.map(tableSchema => ({
       // eslint-disable-next-line prefer-template
       fileName: tableSchema.cube + '.js',
-      content: this.renderFile(this.schemaDescriptorForTable(tableSchema, dataSource))
+      content: this.renderFile(this.schemaDescriptorForTable(tableSchema, extraParams))
     }));
   }
 
@@ -66,7 +66,7 @@ export class ScaffoldingTemplate {
     }
   }
 
-  schemaDescriptorForTable(tableSchema, dataSource) {
+  schemaDescriptorForTable(tableSchema, extraParams = {}) {
     return {
       cube: tableSchema.cube,
       sql: `SELECT * FROM ${this.escapeName(tableSchema.schema)}.${this.escapeName(tableSchema.table)}`, // TODO escape
@@ -96,7 +96,7 @@ export class ScaffoldingTemplate {
           primaryKey: m.isPrimaryKey ? true : undefined
         }
       })).reduce((a, b) => ({ ...a, ...b }), {}),
-      dataSource,
+      ...extraParams
     };
   }
 

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
@@ -545,14 +545,14 @@ describe('ScaffoldingSchema', () => {
     const template = new ScaffoldingTemplate({
       public: {
         orders: [{
-          'name': 'id',
-          'type': 'integer',
-          'attributes': []
+          name: 'id',
+          type: 'integer',
+          attributes: []
         }, {
-          'name': 'some.dimension.inside',
-          'nestedName': ['some', 'dimension', 'inside'],
-          'type': 'string',
-          'attributes': []
+          name: 'some.dimension.inside',
+          nestedName: ['some', 'dimension', 'inside'],
+          type: 'string',
+          attributes: []
         }]
       }
     }, bigQueryDriver);

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
@@ -531,4 +531,58 @@ describe('ScaffoldingSchema', () => {
       }
     ]);
   });
+
+  it('should add dataSource if passed', () => {
+    const dataSource = 'testDataSource';
+    const template = new ScaffoldingTemplate({
+      public: {
+        orders: [{
+          'name': 'id',
+          'type': 'integer',
+          'attributes': []
+        }, {
+          'name': 'some.dimension.inside',
+          'nestedName': ['some', 'dimension', 'inside'],
+          'type': 'string',
+          'attributes': []
+        }]
+      }
+    }, bigQueryDriver);
+    template.generateFilesByTableNames(['public.orders'], dataSource).should.be.deepEqual([
+      {
+        fileName: 'Orders.js',
+        content: `cube(\`Orders\`, {
+  sql: \`SELECT * FROM public.orders\`,
+  
+  joins: {
+    
+  },
+  
+  measures: {
+    count: {
+      type: \`count\`,
+      drillMembers: [id, someDimensionInside]
+    }
+  },
+  
+  dimensions: {
+    id: {
+      sql: \`id\`,
+      type: \`number\`,
+      primaryKey: true
+    },
+    
+    someDimensionInside: {
+      sql: \`\${CUBE}.some.dimension.inside\`,
+      type: \`string\`,
+      title: \`Some.dimension.inside\`
+    }
+  },
+  
+  dataSource: \`testDataSource\`
+});
+`
+      }
+    ]);
+  });
 });

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
@@ -533,7 +533,7 @@ describe('ScaffoldingSchema', () => {
   });
 
   it('should add options if passed', () => {
-    const extraParams = {
+    const schemaContext = {
       dataSource: 'testDataSource',
       preAggregations: {
         main: {
@@ -556,7 +556,7 @@ describe('ScaffoldingSchema', () => {
         }]
       }
     }, bigQueryDriver);
-    expect(template.generateFilesByTableNames(['public.orders'], extraParams)).toEqual([
+    expect(template.generateFilesByTableNames(['public.orders'], schemaContext)).toEqual([
       {
         fileName: 'Orders.js',
         content: `cube(\`Orders\`, {

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
@@ -532,8 +532,16 @@ describe('ScaffoldingSchema', () => {
     ]);
   });
 
-  it('should add dataSource if passed', () => {
-    const dataSource = 'testDataSource';
+  it('should add options if passed', () => {
+    const extraParams = {
+      dataSource: 'testDataSource',
+      preAggregations: {
+        main: {
+          type: `originalSql`
+        }
+      }
+    };
+
     const template = new ScaffoldingTemplate({
       public: {
         orders: [{
@@ -548,7 +556,7 @@ describe('ScaffoldingSchema', () => {
         }]
       }
     }, bigQueryDriver);
-    template.generateFilesByTableNames(['public.orders'], dataSource).should.be.deepEqual([
+    template.generateFilesByTableNames(['public.orders'], extraParams).should.be.deepEqual([
       {
         fileName: 'Orders.js',
         content: `cube(\`Orders\`, {
@@ -579,7 +587,13 @@ describe('ScaffoldingSchema', () => {
     }
   },
   
-  dataSource: \`testDataSource\`
+  dataSource: \`testDataSource\`,
+  
+  preAggregations: {
+    main: {
+      type: \`originalSql\`
+    }
+  }
 });
 `
       }

--- a/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/scaffolding-schema.test.ts
@@ -556,7 +556,7 @@ describe('ScaffoldingSchema', () => {
         }]
       }
     }, bigQueryDriver);
-    template.generateFilesByTableNames(['public.orders'], extraParams).should.be.deepEqual([
+    expect(template.generateFilesByTableNames(['public.orders'], extraParams)).toEqual([
       {
         fileName: 'Orders.js',
         content: `cube(\`Orders\`, {

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -106,8 +106,10 @@ export class DevServer {
         throw new Error('You have to select at least one table');
       }
 
+      const dataSource = req.body.dataSource || 'default';
+
       const driver = await this.cubejsServer.getDriver({
-        dataSource: req.body.dataSource || 'default',
+        dataSource,
         authInfo: null,
         securityContext: null,
         requestId: getRequestIdFromRequest(req),
@@ -116,7 +118,7 @@ export class DevServer {
 
       const ScaffoldingTemplate = require('@cubejs-backend/schema-compiler/scaffolding/ScaffoldingTemplate');
       const scaffoldingTemplate = new ScaffoldingTemplate(tablesSchema, driver);
-      const files = scaffoldingTemplate.generateFilesByTableNames(req.body.tables);
+      const files = scaffoldingTemplate.generateFilesByTableNames(req.body.tables, { dataSource });
 
       const schemaPath = options.schemaPath || 'schema';
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet

This changes will add support to pass `extraParams` objects while creating the schema from tables.
I am using `generateFilesByTableNames` function to dynamically generate schema for all the tables but I have to manually add `dataSource`  to the schema files after generating.
This change will add options to pass  `dataSource` along with other params to the cube schema file