### PR TITLE
fix(server-core): add support for async driverFactory

### DIFF
--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -615,7 +615,7 @@ export class CubejsServerCore {
 
   public async getDriver(ctx: DriverContext) {
     if (!this.driver) {
-      const driver = this.options.driverFactory(ctx);
+      const driver = await this.options.driverFactory(ctx);
       await driver.testConnection(); // TODO mutex
       this.driver = driver;
     }


### PR DESCRIPTION
This will fix the issue of not able to pass async driverFactory in config.