### PR TITLE
docs: specify `CUBEJS_DB_SSL_*` environment variables can be contents of PEM file

### DIFF
--- a/docs/content/Configuration/Connecting-to-the-Database.md
+++ b/docs/content/Configuration/Connecting-to-the-Database.md
@@ -99,8 +99,8 @@ CUBEJS_DB_SSL_CERT=/ssl/cert.pem
 CUBEJS_DB_SSL_KEY=/ssl/key.pem
 ```
 
-You can also provide the contents of a PEM file as a multi-line environment
-variable:
+You can also set the above environment variables to the contents of the PEM
+files; for example:
 
 ```dotenv
 CUBEJS_DB_SSL_CA="-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
**Description of Changes Made (if issue reference is not provided)**

Specify `CUBEJS_DB_SSL_*` environment variables can be contents of PEM file