### PR TITLE
fix(api-gateway): bind custom checkAuth functions

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -736,7 +736,7 @@ export class ApiGateway {
     let showWarningAboutNotObject = false;
 
     return (req, res, next) => {
-      fn(req, res, (e) => {
+      fn.bind(this)(req, res, (e) => {
         // We renamed authInfo to securityContext, but users can continue to use both ways
         if (req.securityContext && !req.authInfo) {
           req.authInfo = req.securityContext;
@@ -766,7 +766,7 @@ export class ApiGateway {
     let showWarningAboutNotObject = false;
 
     return async (req, auth) => {
-      await fn(req, auth);
+      await fn.bind(this)(req, auth);
 
       // We renamed authInfo to securityContext, but users can continue to use both ways
       if (req.securityContext && !req.authInfo) {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (issue reference is not provided)**

These functions were previously bound so that the API Gateway context could be accessed by `this` (useful for checkAuthFn when trying to use `enforceSecurityChecks` and `apiSecret`. This restores that functionality.