### PR TITLE
fix: Using .end() without the flush parameter is deprecated and throw…

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/RedisPool.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/RedisPool.ts
@@ -48,7 +48,7 @@ export class RedisPool {
     const create = options.createClient || (async () => createRedisClient(getEnv('redisUrl')));
 
     if (max > 0) {
-      const destroy = options.destroyClient || (async (client) => client.end());
+      const destroy = options.destroyClient || (async (client) => client.end(true));
 
       this.pool = genericPool.createPool<AsyncRedisClient>({ create, destroy }, opts);
 


### PR DESCRIPTION
…s from v.3.0.0

Hello!

Thanks