### PR TITLE
docs: fixes typo on apiToken param description

### DIFF
--- a/docs/content/Cube.js-Frontend/@cubejs-client-core.md
+++ b/docs/content/Cube.js-Frontend/@cubejs-client-core.md
@@ -36,7 +36,7 @@ const cubejsApi = cubejs(
 
 Name | Type | Description |
 ------ | ------ | ------ |
-apiToken | string &#124;  () => *Promise‹string›* | [API token](security) is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube.js Backend will print the API token to the console on on startup. In case of async function `authorization` is updated for `options.transport` on each request. |
+apiToken | string &#124;  () => *Promise‹string›* | [API token](security) is used to authorize requests and determine SQL database you're accessing. In the development mode, Cube.js Backend will print the API token to the console on startup. In case of async function `authorization` is updated for `options.transport` on each request. |
 options | [CubeJSApiOptions](#types-cube-js-api-options) | - |
 
 >  **cubejs**(**options**: [CubeJSApiOptions](#types-cube-js-api-options)): *[CubejsApi](#cubejs-api)*


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Just a small typo fix that I saw while reading the documentation: 

"console on ~on~startup"

**Note**

I didn't find a specific section on how to contribute to the docs. Please point me to that if I'm missing something.