### PR TITLE
fix(snowflake): Reorder snowflake execute statement to prevent undefined errors

### DIFF
--- a/packages/cubejs-snowflake-driver/driver/SnowflakeDriver.js
+++ b/packages/cubejs-snowflake-driver/driver/SnowflakeDriver.js
@@ -101,6 +101,11 @@ class SnowflakeDriver extends BaseDriver {
       binds: values,
       fetchAsString: ['Number'],
       complete: (err, stmt, rows) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
         if (rehydrate && rows.length) {
           const hydrationMap = {};
           const columns = stmt.getColumns();
@@ -127,11 +132,7 @@ class SnowflakeDriver extends BaseDriver {
           }
         }
 
-        if (err) {
-          reject(err);
-        } else {
-          resolve(rows);
-        }
+        resolve(rows);
       }
     }));
   }


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

This PR reorders the snowflake execute statement to check for errors before attempting to access `rows.length`since `rows` can be undefined.

Prevents the following error from occurring:
```
TypeError: Cannot read property 'length' of undefined
    at EventEmitter.complete (/srv/node_modules/@cubejs-backend/snowflake-driver/driver/SnowflakeDriver.js:104:31)
    at RowStream.<anonymous> (/srv/node_modules/snowflake-sdk/lib/connection/statement.js:579:19)
    at RowStream.emit (events.js:315:20)
    at RowStream.EventEmitter.emit (domain.js:467:12)
    at emitError (/srv/node_modules/snowflake-sdk/lib/connection/result/row_stream.js:292:10)
    at close (/srv/node_modules/snowflake-sdk/lib/connection/result/row_stream.js:256:7)
    at init (/srv/node_modules/snowflake-sdk/lib/connection/result/row_stream.js:133:7)
    at processTicksAndRejections (internal/process/task_queues.js:75:11)
```
