### PR TITLE
Add HTTPS and readOnly support to ClickHouse driver

### DIFF
--- a/docs/content/Configuration/Connecting-to-the-Database.md
+++ b/docs/content/Configuration/Connecting-to-the-Database.md
@@ -218,6 +218,14 @@ You can connect to an SSL-enabled ClickHouse database by setting `CUBEJS_DB_SSL`
 `true`. All other SSL-related environment variables can be left unset. See
 [Enabling SSL][link-enabling-ssl] for more details.
 
+You can connect to a ClickHouse database when your user's permissions are
+[restricted][link-clickhouse-readonly] to read-only, by setting the `readOnly`
+driver option to `true`. Please refer to [Multitenancy Guide][link-multitenancy]
+to learn more.
+
+[link-enabling-ssl]: #enabling-ssl
+[link-clickhouse-readonly]: https://clickhouse.tech/docs/en/operations/settings/permissions-for-queries/#settings_readonly
+
 [link-enabling-ssl]: #enabling-ssl
 
 ### Connecting to Multiple Databases

--- a/docs/content/Configuration/Connecting-to-the-Database.md
+++ b/docs/content/Configuration/Connecting-to-the-Database.md
@@ -59,8 +59,9 @@ databases:
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | PostgreSQL, MySQL, AWS Redshift, ClickHouse, Hive/SparkSQL, Oracle | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                                        |
 | MS SQL                                                             | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_DOMAIN`                                                                                                                    |
+| ClickHouse                                                         | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_SSL`                                                                                                                    |
 | AWS Athena                                                         | `CUBEJS_AWS_KEY`, `CUBEJS_AWS_SECRET`, `CUBEJS_AWS_REGION`, `CUBEJS_AWS_S3_OUTPUT_LOCATION`                                                                                                                                     |
-| Google Bigquery                                                    | `CUBEJS_DB_BQ_PROJECT_ID`, `CUBEJS_DB_BQ_KEY_FILE or CUBEJS_DB_BQ_CREDENTIALS`                                                                                                                                                  |
+| Google BigQuery                                                    | `CUBEJS_DB_BQ_PROJECT_ID`, `CUBEJS_DB_BQ_KEY_FILE or CUBEJS_DB_BQ_CREDENTIALS`                                                                                                                                                  |
 | MongoDB                                                            | `CUBEJS_DB_HOST`, `CUBEJS_DB_NAME`, `CUBEJS_DB_PORT`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_SSL`, `CUBEJS_DB_SSL_CA`, `CUBEJS_DB_SSL_CERT`, `CUBEJS_DB_SSL_CIPHERS`, `CUBEJS_DB_SSL_PASSPHRASE`                        |
 | Snowflake                                                          | `CUBEJS_DB_SNOWFLAKE_ACCOUNT`, `CUBEJS_DB_SNOWFLAKE_REGION`, `CUBEJS_DB_SNOWFLAKE_WAREHOUSE`, `CUBEJS_DB_SNOWFLAKE_ROLE`, `CUBEJS_DB_SNOWFLAKE_CLIENT_SESSION_KEEP_ALIVE`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS` |
 | Presto                                                             | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_CATALOG`, `CUBEJS_DB_SCHEMA`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                 |
@@ -88,7 +89,7 @@ CUBEJS_EXT_DB_TYPE=<SUPPORTED_DB_TYPE_HERE>
 
 ## Enabling SSL
 
-Cube.js supports SSL-encrypted connections for **Postgres**, **MongoDB**, **MS
+Cube.js supports SSL-encrypted connections for **ClickHouse**, **Postgres**, **MongoDB**, **MS
 SQL**, and **MySQL**. To enable it set the `CUBEJS_DB_SSL` environment variable
 to `true`. Cube.js can also be configured to use custom connection settings. For
 example, to use a custom CA and certificates, you could do the following:
@@ -208,6 +209,12 @@ To connect to a local MySQL database using a UNIX socket use
 `CUBEJS_DB_SOCKET_PATH`, by doing so, `CUBEJS_DB_HOST` will be ignored.
 
 You can connect to an SSL-enabled MySQL database by setting `CUBEJS_DB_SSL` to
+`true`. All other SSL-related environment variables can be left unset. See
+[Enabling SSL][link-enabling-ssl] for more details.
+
+### ClickHouse
+
+You can connect to an SSL-enabled ClickHouse database by setting `CUBEJS_DB_SSL` to
 `true`. All other SSL-related environment variables can be left unset. See
 [Enabling SSL][link-enabling-ssl] for more details.
 

--- a/docs/content/Configuration/Connecting-to-the-Database.md
+++ b/docs/content/Configuration/Connecting-to-the-Database.md
@@ -55,18 +55,18 @@ CUBEJS_API_SECRET=secret
 The table below shows which environment variables are used for different
 databases:
 
-| Database                                                           | Credentials                                                                                                                                                                                                                     |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PostgreSQL, MySQL, AWS Redshift, ClickHouse, Hive/SparkSQL, Oracle | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                                        |
-| MS SQL                                                             | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_DOMAIN`                                                                                                                    |
-| ClickHouse                                                         | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_SSL`                                                                                                                    |
-| AWS Athena                                                         | `CUBEJS_AWS_KEY`, `CUBEJS_AWS_SECRET`, `CUBEJS_AWS_REGION`, `CUBEJS_AWS_S3_OUTPUT_LOCATION`                                                                                                                                     |
-| Google BigQuery                                                    | `CUBEJS_DB_BQ_PROJECT_ID`, `CUBEJS_DB_BQ_KEY_FILE or CUBEJS_DB_BQ_CREDENTIALS`                                                                                                                                                  |
-| MongoDB                                                            | `CUBEJS_DB_HOST`, `CUBEJS_DB_NAME`, `CUBEJS_DB_PORT`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_SSL`, `CUBEJS_DB_SSL_CA`, `CUBEJS_DB_SSL_CERT`, `CUBEJS_DB_SSL_CIPHERS`, `CUBEJS_DB_SSL_PASSPHRASE`                        |
-| Snowflake                                                          | `CUBEJS_DB_SNOWFLAKE_ACCOUNT`, `CUBEJS_DB_SNOWFLAKE_REGION`, `CUBEJS_DB_SNOWFLAKE_WAREHOUSE`, `CUBEJS_DB_SNOWFLAKE_ROLE`, `CUBEJS_DB_SNOWFLAKE_CLIENT_SESSION_KEEP_ALIVE`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS` |
-| Presto                                                             | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_CATALOG`, `CUBEJS_DB_SCHEMA`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                 |
-| Druid                                                              | `CUBEJS_DB_URL`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                                                                             |
-| SQLite                                                             | `CUBEJS_DB_NAME`                                                                                                                                                                                                                |
+| Database                                               | Credentials                                                                                                                                                                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PostgreSQL, MySQL, AWS Redshift, Hive/SparkSQL, Oracle | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                                        |
+| MS SQL                                                 | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_DOMAIN`                                                                                                                    |
+| ClickHouse                                             | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_SSL`, `CUBEJS_DB_CLICKHOUSE_READONLY`                                                                                      |
+| AWS Athena                                             | `CUBEJS_AWS_KEY`, `CUBEJS_AWS_SECRET`, `CUBEJS_AWS_REGION`, `CUBEJS_AWS_S3_OUTPUT_LOCATION`                                                                                                                                     |
+| Google BigQuery                                        | `CUBEJS_DB_BQ_PROJECT_ID`, `CUBEJS_DB_BQ_KEY_FILE or CUBEJS_DB_BQ_CREDENTIALS`                                                                                                                                                  |
+| MongoDB                                                | `CUBEJS_DB_HOST`, `CUBEJS_DB_NAME`, `CUBEJS_DB_PORT`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`, `CUBEJS_DB_SSL`, `CUBEJS_DB_SSL_CA`, `CUBEJS_DB_SSL_CERT`, `CUBEJS_DB_SSL_CIPHERS`, `CUBEJS_DB_SSL_PASSPHRASE`                        |
+| Snowflake                                              | `CUBEJS_DB_SNOWFLAKE_ACCOUNT`, `CUBEJS_DB_SNOWFLAKE_REGION`, `CUBEJS_DB_SNOWFLAKE_WAREHOUSE`, `CUBEJS_DB_SNOWFLAKE_ROLE`, `CUBEJS_DB_SNOWFLAKE_CLIENT_SESSION_KEEP_ALIVE`, `CUBEJS_DB_NAME`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS` |
+| Presto                                                 | `CUBEJS_DB_HOST`, `CUBEJS_DB_PORT`, `CUBEJS_DB_CATALOG`, `CUBEJS_DB_SCHEMA`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                 |
+| Druid                                                  | `CUBEJS_DB_URL`, `CUBEJS_DB_USER`, `CUBEJS_DB_PASS`                                                                                                                                                                             |
+| SQLite                                                 | `CUBEJS_DB_NAME`                                                                                                                                                                                                                |
 
 ## External Pre-aggregations Database
 
@@ -214,19 +214,16 @@ You can connect to an SSL-enabled MySQL database by setting `CUBEJS_DB_SSL` to
 
 ### ClickHouse
 
-You can connect to an SSL-enabled ClickHouse database by setting `CUBEJS_DB_SSL` to
+You can connect to an HTTPS-enabled ClickHouse database by setting `CUBEJS_DB_SSL` to
 `true`. All other SSL-related environment variables can be left unset. See
 [Enabling SSL][link-enabling-ssl] for more details.
 
 You can connect to a ClickHouse database when your user's permissions are
-[restricted][link-clickhouse-readonly] to read-only, by setting the `readOnly`
-driver option to `true`. Please refer to [Multitenancy Guide][link-multitenancy]
-to learn more.
+[restricted][link-clickhouse-readonly] to read-only, by setting `CUBEJS_DB_CLICKHOUSE_READONLY`
+to `true`.
 
 [link-enabling-ssl]: #enabling-ssl
 [link-clickhouse-readonly]: https://clickhouse.tech/docs/en/operations/settings/permissions-for-queries/#settings_readonly
-
-[link-enabling-ssl]: #enabling-ssl
 
 ### Connecting to Multiple Databases
 

--- a/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
+++ b/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
@@ -11,6 +11,7 @@ class ClickHouseDriver extends BaseDriver {
       host: process.env.CUBEJS_DB_HOST,
       port: process.env.CUBEJS_DB_PORT,
       auth: process.env.CUBEJS_DB_USER || process.env.CUBEJS_DB_PASS ? `${process.env.CUBEJS_DB_USER}:${process.env.CUBEJS_DB_PASS}` : '',
+      protocol: process.env.CUBEJS_DB_SSL ? 'https:' : 'http:',
       queryOptions: {
         database: process.env.CUBEJS_DB_NAME || config && config.database || 'default'
       },

--- a/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
+++ b/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
@@ -81,6 +81,10 @@ class ClickHouseDriver extends BaseDriver {
     return this.query("SELECT 1");
   }
 
+  readOnly() {
+    return !!this.config.readOnly || this.readOnlyMode;
+  }
+
   query(query, values) {
     const formattedQuery = sqlstring.format(query, values);
 

--- a/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
+++ b/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
@@ -12,7 +12,7 @@ class ClickHouseDriver extends BaseDriver {
       port: process.env.CUBEJS_DB_PORT,
       auth: process.env.CUBEJS_DB_USER || process.env.CUBEJS_DB_PASS ? `${process.env.CUBEJS_DB_USER}:${process.env.CUBEJS_DB_PASS}` : '',
       protocol: process.env.CUBEJS_DB_SSL ? 'https:' : 'http:',
-      readonly: config && config.readOnly,
+      readonly: Boolean(process.env.CUBEJS_DB_CLICKHOUSE_READONLY),
       queryOptions: {
         database: process.env.CUBEJS_DB_NAME || config && config.database || 'default'
       },

--- a/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
+++ b/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
@@ -17,7 +17,7 @@ class ClickHouseDriver extends BaseDriver {
       },
       ...config
     };
-    this.readOnlyMode = Boolean(process.env.CUBEJS_DB_CLICKHOUSE_READONLY);
+    this.readOnlyMode = process.env.CUBEJS_DB_CLICKHOUSE_READONLY === 'true';
     this.pool = genericPool.createPool({
       create: async () => new ClickHouse({
         ...this.config,

--- a/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
+++ b/packages/cubejs-clickhouse-driver/driver/ClickHouseDriver.js
@@ -12,12 +12,12 @@ class ClickHouseDriver extends BaseDriver {
       port: process.env.CUBEJS_DB_PORT,
       auth: process.env.CUBEJS_DB_USER || process.env.CUBEJS_DB_PASS ? `${process.env.CUBEJS_DB_USER}:${process.env.CUBEJS_DB_PASS}` : '',
       protocol: process.env.CUBEJS_DB_SSL ? 'https:' : 'http:',
-      readonly: Boolean(process.env.CUBEJS_DB_CLICKHOUSE_READONLY),
       queryOptions: {
         database: process.env.CUBEJS_DB_NAME || config && config.database || 'default'
       },
       ...config
     };
+    this.readOnlyMode = Boolean(process.env.CUBEJS_DB_CLICKHOUSE_READONLY);
     this.pool = genericPool.createPool({
       create: async () => new ClickHouse({
         ...this.config,
@@ -29,7 +29,7 @@ class ClickHouseDriver extends BaseDriver {
           // can not be changed
           //
           //
-          ...(this.config.readonly ? {} : { join_use_nulls: 1 }),
+          ...(this.readOnlyMode ? {} : { join_use_nulls: 1 }),
           session_id: uuid(),
           ...this.config.queryOptions,
         }
@@ -95,7 +95,7 @@ class ClickHouseDriver extends BaseDriver {
         // can not be changed
         //
         //
-        ...(this.config.readonly ? {} : { join_use_nulls: 1 }),
+        ...(this.readOnlyMode ? {} : { join_use_nulls: 1 }),
       }
     }).then(res => this.normaliseResponse(res)));
   }


### PR DESCRIPTION
**Added HTTPS support to ClickHouse driver.**

Now it's possible to connect to a HTTPS-enabled ClickHouse database when `CUBEJS_DB_SSL` is set to `true`.

See https://github.com/apla/node-clickhouse#options (the "protocol" option) for implementation details.

**Added read-only support to ClickHouse driver.**

Now it's possible to connect to a ClickHouse server when a user's permissions are restricted to read-only when new config flag `CUBEJS_DB_CLICKHOUSE_READONLY` is set to `true`.

See https://clickhouse.tech/docs/en/operations/settings/permissions-for-queries/#settings_readonly and https://github.com/apla/node-clickhouse#options (the "readonly" option) for implementation details.

---

Documentation is updated in relevant parts.