### PR TITLE
docs: change code of boolean logical operators section example

### DIFF
--- a/docs/content/Cube.js-Backend/Query-Format.md
+++ b/docs/content/Cube.js-Backend/Query-Format.md
@@ -335,7 +335,7 @@ Logical operators have only one of the following properties:
         {
           member: 'visitors.source',
           operator: 'equals',
-          values: ['some']
+          values: ['other']
         },
         {
           member: 'visitor_checkins.cardsCount',


### PR DESCRIPTION
**Description of Changes Made**

A code example of Boolean logical operators doesn't work.
This PR makes the first condition from "and" logical operator different than the first condition from "or" logical operator. I only changed the value inside the "values" array, but it could be something else. I don't think it must be more descriptive than that, though.
