### PR TITLE
feat(cubestore): cleanup local copies of files removed remotely

### DIFF
--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -710,7 +710,9 @@ impl ClusterImpl {
             .trim_start_matches("/")
             .to_string();
 
-        self.remote_fs.upload_file(&to_upload).await?;
+        self.remote_fs
+            .upload_file(heart_beat_path.to_str().unwrap(), &to_upload)
+            .await?;
 
         let heart_beats = self
             .remote_fs


### PR DESCRIPTION
The goal is to free up disks on the worker machines.

This is done via a background process that periodically lists files on
remotes and removes any extra files we have locally. This process runs
every 10 minutes.

The cleanup only affects the direct siblings (i.e. the `.parquet` files)
and not subdirectories. E.g. the exceptions to the cleanup are
`metastore-*` and `node-heart-beats`. The underlying subsystems manage
their local copies directly.

Uploads are now prepared in a separate subdirectory of `.cubestore` to
avoid accidental removals by the cleanup process. The `RemoteFS` APIs
are updated accordingly.