### PR TITLE
fix(cubestore): respond to warmup without waiting for download

### DIFF
--- a/rust/cubestore/src/cluster/message.rs
+++ b/rust/cubestore/src/cluster/message.rs
@@ -12,7 +12,7 @@ pub enum NetworkMessage {
     SelectResult(Result<SerializedRecordBatchStream, CubeError>),
 
     WarmupDownload(/*remote_path*/ String),
-    WarmupDownloadResult(Result<(), CubeError>),
+    WarmupDownloadResult,
 
     MetaStoreCall(MetaStoreRpcMethodCall),
     MetaStoreCallResult(MetaStoreRpcMethodResult),


### PR DESCRIPTION
To let the worker do more work in parallel to the download.