### PR TITLE
React client TypeScript fixes, QueryBuilder improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ yarn-error.log
 **/coverage
 lerna-debug.log
 tsconfig.tsbuildinfo
+**/*.swo
+**/*.swp

--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -641,6 +641,7 @@ declare module '@cubejs-client/core' {
      */
     tableColumns(pivotConfig?: PivotConfig): TableColumn[];
 
+    totalRow(): ChartPivotRow;
     query(): Query;
     rawData(): T[];
     annotation(): QueryAnnotations;

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -13,10 +13,10 @@ import {
   TDryRunResponse,
   TOrderMember,
   QueryOrder,
-  TQueryOrderArray,
   TSourceAxis,
   TimeDimensionComparison,
   TimeDimensionRanged,
+  Meta,
 } from '@cubejs-client/core';
 
 /**
@@ -188,6 +188,10 @@ declare module '@cubejs-client/react' {
     resultSet?: ResultSet | null;
     error?: Error | null;
     loadingState?: TLoadingState;
+
+    meta: Meta;
+    metaError?: Error | null;
+    isFetchingMeta: boolean;
 
     /**
      * Indicates whether the query is ready to be displayed or not

--- a/packages/cubejs-client-react/package.json
+++ b/packages/cubejs-client-react/package.json
@@ -12,6 +12,7 @@
     "@babel/runtime": "^7.1.2",
     "@cubejs-client/core": "^0.26.19",
     "core-js": "^3.6.5",
+    "prop-types": "^15.7.2",
     "ramda": "^0.27.0"
   },
   "peerDependencies": {

--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -542,7 +542,7 @@ export default class QueryBuilder extends React.Component {
   }
 
   render() {
-    const { query, meta } = this.state;
+    const { query } = this.state;
     const { cubejsApi, render, wrapWithQueryRenderer } = this.props;
 
     if (wrapWithQueryRenderer) {

--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -296,7 +296,9 @@ export default class QueryBuilder extends React.Component {
           nextPivotConfig[sourceAxis].splice(sourceIndex, 1);
           nextPivotConfig[destinationAxis].splice(destinationIndex, 0, id);
 
-          this.updateVizState({ pivotConfig: nextPivotConfig });
+          this.updateVizState({
+            pivotConfig: nextPivotConfig
+          });
         },
         update: (config) => {
           const { limit } = config;
@@ -319,13 +321,12 @@ export default class QueryBuilder extends React.Component {
 
   updateQuery(queryUpdate) {
     const { query } = this.state;
-    const newQuery = {
-      ...query,
-      ...queryUpdate
-    };
 
     this.updateVizState({
-      query: newQuery
+      query: {
+        ...query,
+        ...queryUpdate,
+      },
     });
   }
 
@@ -336,7 +337,7 @@ export default class QueryBuilder extends React.Component {
     state = pick(['query', 'pivotConfig', 'chartType'], state);
 
     const finalState = this.applyStateChangeHeuristics(state);
-    if (!finalState.query) finalState.query = stateQuery;
+    if (!finalState.query) finalState.query = { ...stateQuery };
 
     if (finalState.shouldApplyHeuristicOrder) {
       finalState.query.order = defaultOrder(finalState.query);
@@ -383,7 +384,7 @@ export default class QueryBuilder extends React.Component {
 
     return {
       ...query,
-      filters: (query.filters || []).filter(f => f.operator),
+      filters: (query.filters || []).filter((f) => f.operator),
     };
   }
 


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

### TypeScript type updates

I tried using cube.js react client in a typescript project, and found a number of issues with the provided typescript types.  In many cases, the types were not specific enough to be used in a strict typescript project, but in others the types were simply incorrect.  The included changes were necessary for me to use it in my project, where I use a I have created QueryBuilder wrapper similar to that in the playground, but strongly typed.  I have also modified the types to support the QueryBuilder changes I made, as described below.

### QueryBuilder Improvements

#### Convert to uncontrolled

I ran into some issues while making other improvements, and realized that it was because the QueryBuilder was neither fully controller nor uncontrolled, and was using the React anti-pattern of [unconditionally copying props to state](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-unconditionally-copying-props-to-state).  Following the recommendations in that article and based on my experience as a React developer, I decided to make QueryBuilder uncontrolled.  This means that QueryBuilder controls it's own state, and can't be modified from the outside save for in specific ways that are allowed through props.

This involved removing the `query`, `setQuery`, `vizState`, and `setVizState` props, and adding the `initialVizState` and `onVizStateChanged` props.  From my analysis, the most common use case for accessing the `vizState` outside of the query editor is to save the editor state in persistent storage.  These two new props allow for setting up a QueryBuilder component from a saved state and then listening for changes to save back.  I'm using this in my app to save the `vizState` to a database so I can persist the QueryBuilder state across reloads.

I also added the `defaultQuery` and `defaultChartType` props, so that if `initialVizState` is empty, it will pick up the default values for those. `defaultChartType` was listed in the documentation before, but wasn't actually implemented until now.

#### Refactor `orderMembers`

Another issue I ran into was the interop between `query.order` and `orderMembers`.  Whenever the query changed, `orderMembers` potentially needed to be updated, and every time `orderMembers` changed, the query might need to be updated.  This relationship made reasoning about the various state changes difficult, and especially saving/restoring state and reloads.

I refactored the QueryBuilder so that `orderMembers` is calculated on demand in then `render` method based on the `availableDimensions`, `availableMeasures`, and `query.order`.  Then, I changed `updateOrder` so that it just modified the `query.order` and sent it through the normal query update path.  This makes `query.order` the single source of truth, and removes any difficulties with maintaining the relationship between `query.order` and `orderMembers`.

#### Add `error` render prop

I noticed that if `dryRun` failed, the error was logged to the console but not shown to the user.  Instead of ignoring and letting the `query` call report the same error, I changed it so that `dryRun` errors are reported to the rendered function in the `error` prop.  This is mostly useful when `wrapWithQueryRenderer` is false, as when it is true, the QueryRenderer will produce the same error and overwrite with it's own `error` prop (by design).

#### Add PropTypes

I added PropTypes so that non-typescript users can enjoy the benefit of prop type checking as well.  This should be a lot safer and prevent unexpected props from being passed in.'

### Summary

I know this is a lot, but I believe it makes the QueryBuilder a lot simpler to reason about, easier for fluent React developers like myself to pick it up and use it, and easier for future open source contributors to understand and add to the code.

I did not update the example React dashboard app and other docs yet with these changes, as I wanted to get approval and resolve all issues before I spent the time updating those.  Once this is approved, I will go through and update the docs and examples to support these new props, and make sure the example react dashboard app still works.

As always, I'm hoping for good discussions and will readily make changes to address all concerns.  I look forward to working with the cube.js development team on these changes, and if it goes well, would most likely invest more time into the project in the future.