### PR TITLE
fix(cubestore): do not call `malloc_trim` on selects

### DIFF
--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -677,7 +677,6 @@ impl ClusterImpl {
         &self,
         plan_node: SerializedPlan,
     ) -> Result<SerializedRecordBatchStream, CubeError> {
-        scopeguard::defer!(trim_allocs());
         let start = SystemTime::now();
         debug!("Running select: {:?}", plan_node);
         let to_download = plan_node.files_to_download();

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -444,7 +444,6 @@ impl SqlService for SqlServiceImpl {
                 Ok(DataFrame::new(vec![], vec![]))
             }
             CubeStoreStatement::Statement(Statement::Query(q)) => {
-                scopeguard::defer!(trim_allocs());
                 let logical_plan = self
                     .query_planner
                     .logical_plan(DFStatement::Statement(Statement::Query(q)))


### PR DESCRIPTION
`malloc_trim` is expensive, we do not want to call it unless we allocate
a lot of memory.

Assuming most selects are cheap, `malloc_trim` happens to be too expensive,
especially when serving multiple cheap requests in a row.