### PR TITLE
feat(server-core): add support for async `dbType()`

### DIFF
--- a/packages/cubejs-server-core/src/core/CompilerApi.js
+++ b/packages/cubejs-server-core/src/core/CompilerApi.js
@@ -119,13 +119,13 @@ export class CompilerApi {
     return createQuery(
       compilers,
       dbType, {
-      ...query,
-      dialectClass,
-      externalDialectClass: this.options.externalDialectClass,
-      externalDbType: this.options.externalDbType,
-      preAggregationsSchema: this.preAggregationsSchema,
-      allowUngroupedWithoutPrimaryKey: this.allowUngroupedWithoutPrimaryKey
-    }
+        ...query,
+        dialectClass,
+        externalDialectClass: this.options.externalDialectClass,
+        externalDbType: this.options.externalDbType,
+        preAggregationsSchema: this.preAggregationsSchema,
+        allowUngroupedWithoutPrimaryKey: this.allowUngroupedWithoutPrimaryKey
+      }
     );
   }
 

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -20,16 +20,16 @@ export class RefreshScheduler {
       const orchestratorApi = this.serverCore.getOrchestratorApi(context);
       const queryWithDataSource = await compilerApi.createQueryByDataSource(compilers, queryingOptions, dataSource);
       const [startDate, endDate] =
-        await Promise.all(queryWithDataSource.preAggregationStartEndQueries(preAggregation.cube, preAggregation.preAggregation)
-            .map(sql => orchestratorApi.executeQuery({
-              query: sql[0],
-              values: sql[1],
-              continueWait: true,
-              cacheKeyQueries: [],
-              dataSource,
-              scheduledRefresh: true,
-            }))
-        );
+        await Promise.all(queryWithDataSource
+          .preAggregationStartEndQueries(preAggregation.cube, preAggregation.preAggregation)
+          .map(sql => orchestratorApi.executeQuery({
+            query: sql[0],
+            values: sql[1],
+            continueWait: true,
+            cacheKeyQueries: [],
+            dataSource,
+            scheduledRefresh: true,
+          })));
 
       const extractDate = ({ data }: any) => {
         // TODO some backends return dates as objects here. Use ApiGateway data transformation ?

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -93,7 +93,7 @@ export type ExternalDriverFactoryFn = (context: RequestContext) => Promise<BaseD
 
 export type ExternalDialectFactoryFn = (context: RequestContext) => BaseQuery;
 
-export type DbTypeFn = (context: RequestContext) => DatabaseType;
+export type DbTypeFn = (context: RequestContext) => Promise<DatabaseType>|DatabaseType;
 
 export type LoggerFn = (msg: string, params: any) => void;
 

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -30,6 +30,13 @@ describe('index.test', () => {
       .toBeInstanceOf(CubejsServerCore);
   });
 
+  test('Should create instance of CubejsServerCore, dbType as async func', async () => {
+    const options = { dbType: async () => <DatabaseType>'postgres' };
+
+    expect(new CubejsServerCore(options))
+      .toBeInstanceOf(CubejsServerCore);
+  });
+
   test('Should throw error, unknown dbType', () => {
     const options = { dbType: <any>'unknown-db' };
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet

The current type for the `dbType` option in cube config is `string | sync function` and as per [documentation](https://cube.dev/docs/config#options-reference-db-type), it is used to dynamically select a database type depending on the user's context. but due to its sync type, we cant make any async call (eg. Network call) in it.

The `driverFactory` is already async type so it will be better to change `dbType` to async function.
