### PR TITLE
Refactoring React QueryBuilder to be uncontrolled

### DIFF
--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -157,14 +157,21 @@ declare module '@cubejs-client/react' {
      */
     cubejsApi: CubejsApi;
     /**
-     * Default query
+     * State for the QueryBuilder to start with. Pass in the value previously saved from onVizStateChanged to restore a session.
      */
-    query?: Query;
-    vizState?: VizState;
+    initialVizState?: VizState;
     /**
-     * @default defaultChartType line
+     * Called by the `QueryBuilder` when the viz state has changed. Use it to save state outside of the `QueryBuilder` component.
+     */
+    onVizStateChanged?: (vizState: VizState) => void;
+    /**
+     * @default defaultChartType line (used when initialVizState is not set or does not contain chartType)
      */
     defaultChartType?: ChartType;
+    /**
+     * Default query (used when initialVizState is not set or does not contain query)
+     */
+    defaultQuery?: Query;
     /**
      * Defaults to `false`. This means that the default heuristics will be applied. For example: when the query is empty and you select a measure that has a default time dimension it will be pushed to the query.
      * @default disableHeuristics false
@@ -177,9 +184,20 @@ declare module '@cubejs-client/react' {
      */
     stateChangeHeuristics?: (state: QueryBuilderState) => QueryBuilderState;
     /**
-     * Called by the `QueryBuilder` when the query state has changed. Use it when state is maintained outside of the `QueryBuilder` component.
+     * @ignore @deprecated Controlled query
+     */
+    query?: Query;
+    /**
+     * @ignore @deprecated Controlled query setter
      */
     setQuery?: (query: Query) => void;
+    /**
+     * @ignore @deprecated Controlled vizState
+     */
+    vizState?: VizState;
+    /**
+     * @ignore @deprecated Controlled vizState setter
+     */
     setVizState?: (vizState: VizState) => void;
   };
 
@@ -526,7 +544,7 @@ declare module '@cubejs-client/react' {
   type FilterUpdateFields = {
     member?: string;
     operator: BinaryOperator | UnaryOperator;
-    values: string[];
+    values?: string[];
     dimension: TCubeDimension | TCubeMeasure
   }
   type FilterUpdater = MemberUpdater<FilterUpdateFields>;
@@ -543,9 +561,11 @@ declare module '@cubejs-client/react' {
     sourceAxis: TSourceAxis;
     destinationAxis: TSourceAxis;
   };
-
+  type PivotConfigExtraUpdateFields = {
+    limit?: number;
+  };
   type PivotConfigUpdater = {
     moveItem: (args: PivotConfigUpdaterArgs) => void;
-    update: (pivotConfig: PivotConfig & { limit: number }) => void;
+    update: (pivotConfig: PivotConfig & PivotConfigExtraUpdateFields) => void;
   };
 }

--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -375,7 +375,16 @@ export default class QueryBuilder extends React.Component {
     const { query: stateQuery, pivotConfig: statePivotConfig, meta } = this.state;
 
     const finalState = this.applyStateChangeHeuristics(state);
-    if (!finalState.query) finalState.query = { ...stateQuery };
+    if (!finalState.query) {
+      finalState.query = { ...stateQuery };
+    }
+
+    const handleVizStateChange = (currentState) => {
+      const { onVizStateChanged } = this.props;
+      if (onVizStateChanged) {
+        onVizStateChanged(pick(['chartType', 'pivotConfig', 'query'], currentState));
+      }
+    };
 
     // deprecated, setters replaced by onVizStateChanged
     const runSetters = (currentState) => {
@@ -411,6 +420,8 @@ export default class QueryBuilder extends React.Component {
       queryError: null,
     });
 
+    handleVizStateChange(finalState);
+
     if (QueryRenderer.isQueryPresent(finalState.query) && finalState.missingMembers.length === 0) {
       try {
         const response = await this.cubejsApi().dryRun(finalState.query, {
@@ -439,12 +450,7 @@ export default class QueryBuilder extends React.Component {
       }
     }
 
-    this.setState(finalState, () => {
-      const { onVizStateChanged } = this.props;
-      if (onVizStateChanged) {
-        onVizStateChanged(pick(['chartType', 'pivotConfig', 'query'], this.state));
-      }
-    });
+    this.setState(finalState, () => handleVizStateChange(this.state));
   }
 
   validatedQuery(state) {

--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { prop, uniqBy, equals } from 'ramda';
+import { prop, uniqBy, equals, pick } from 'ramda';
 import { ResultSet, moveItemInArray, defaultOrder, flattenFilters, getQueryMembers } from '@cubejs-client/core';
 import QueryRenderer from './QueryRenderer.jsx';
 import CubeContext from './CubeContext';
@@ -16,23 +16,28 @@ const granularities = [
 ];
 
 export default class QueryBuilder extends React.Component {
+  // This is an anti-pattern, only kept for backward compatibility
+  // https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-unconditionally-copying-props-to-state
   static getDerivedStateFromProps(props, state) {
-    const nextState = {
-      ...state,
-      ...(props.vizState || {}),
-    };
+    if (props.query || props.vizState) {
+      const nextState = {
+        ...state,
+        ...(props.vizState || {}),
+      };
 
-    if (Array.isArray(props.query)) {
-      throw new Error('Array of queries is not supported.');
+      if (Array.isArray(props.query)) {
+        throw new Error('Array of queries is not supported.');
+      }
+
+      return {
+        ...nextState,
+        query: {
+          ...nextState.query,
+          ...(props.query || {}),
+        },
+      };
     }
-
-    return {
-      ...nextState,
-      query: {
-        ...nextState.query,
-        ...(props.query || {}),
-      },
-    };
+    return null;
   }
 
   static resolveMember(type, { meta, query }) {
@@ -68,13 +73,13 @@ export default class QueryBuilder extends React.Component {
     super(props);
 
     this.state = {
-      query: props.query,
-      chartType: 'line',
-      pivotConfig: null,
-      validatedQuery: props.query,
+      query: props.defaultQuery || props.query,
+      chartType: props.defaultChartType,
+      validatedQuery: props.query, // deprecated, validatedQuery should not be set until after dry-run for safety
       missingMembers: [],
       isFetchingMeta: false,
-      ...props.vizState,
+      ...props.vizState, // deprecated
+      ...props.initialVizState
     };
 
     this.mutexObj = {};
@@ -107,9 +112,6 @@ export default class QueryBuilder extends React.Component {
   }
 
   fetchMeta = async () => {
-    const { query, pivotConfig } = this.state;
-    let dryRunResponse;
-    let missingMembers = [];
     let meta;
     let metaError = null;
 
@@ -120,20 +122,14 @@ export default class QueryBuilder extends React.Component {
       metaError = error;
     }
 
-    if (this.isQueryPresent()) {
-      missingMembers = this.getMissingMembers(query, meta);
-
-      if (missingMembers.length === 0) {
-        dryRunResponse = this.cubejsApi().dryRun(query);
-      }
-    }
-
     this.setState({
       meta,
       metaError,
-      pivotConfig: ResultSet.getNormalizedPivotConfig(dryRunResponse?.pivotQuery || {}, pivotConfig),
-      missingMembers,
       isFetchingMeta: false
+    }, () => {
+      // Run update query to force viz state update
+      // This will catch any new missing members, and also validate the query against the new meta
+      this.updateQuery({});
     });
   }
 
@@ -347,16 +343,13 @@ export default class QueryBuilder extends React.Component {
         update: (config) => {
           const { limit } = config;
 
-          if (limit == null) {
-            this.updateVizState({
-              pivotConfig: {
-                ...pivotConfig,
-                ...config,
-              },
-            });
-          } else {
-            this.updateQuery({ limit });
-          }
+          this.updateVizState({
+            pivotConfig: {
+              ...pivotConfig,
+              ...config,
+            },
+            ...(limit ? { query: { ...query, limit } } : null)
+          });
         },
       },
       missingMembers,
@@ -381,9 +374,10 @@ export default class QueryBuilder extends React.Component {
     const { setQuery, setVizState } = this.props;
     const { query: stateQuery, pivotConfig: statePivotConfig, meta } = this.state;
 
-    let finalState = this.applyStateChangeHeuristics(state);
-    const query = { ...(finalState.query || stateQuery) };
+    const finalState = this.applyStateChangeHeuristics(state);
+    if (!finalState.query) finalState.query = { ...stateQuery };
 
+    // deprecated, setters replaced by onVizStateChanged
     const runSetters = (currentState) => {
       if (setVizState) {
         const { meta: _, validatedQuery, ...toSet } = currentState;
@@ -395,55 +389,43 @@ export default class QueryBuilder extends React.Component {
     };
 
     if (finalState.shouldApplyHeuristicOrder) {
-      query.order = defaultOrder(query);
+      finalState.query.order = defaultOrder(finalState.query);
     }
 
-    const nextQuery = {
-      ...query,
-    };
-
     finalState.pivotConfig = ResultSet.getNormalizedPivotConfig(
-      nextQuery,
+      finalState.query,
       finalState.pivotConfig !== undefined ? finalState.pivotConfig : statePivotConfig
     );
 
-    const missingMembers = this.getMissingMembers(nextQuery, meta);
+    finalState.missingMembers = this.getMissingMembers(finalState.query, meta);
 
+    // deprecated
     runSetters({
       ...state,
-      query: nextQuery,
+      query: finalState.query,
     });
 
+    // Update optimistically so that UI does not stutter
     this.setState({
       ...finalState,
-      query: nextQuery,
-      missingMembers,
       queryError: null,
     });
 
-    let pivotQuery = {};
-    if (QueryRenderer.isQueryPresent(query) && missingMembers.length === 0) {
+    if (QueryRenderer.isQueryPresent(finalState.query) && finalState.missingMembers.length === 0) {
       try {
-        const response = await this.cubejsApi().dryRun(query, {
+        const response = await this.cubejsApi().dryRun(finalState.query, {
           mutexObj: this.mutexObj,
         });
-        pivotQuery = response.pivotQuery;
 
         if (finalState.shouldApplyHeuristicOrder) {
-          nextQuery.order = (response.queryOrder || []).reduce((memo, current) => ({ ...memo, ...current }), {});
+          finalState.query.order = (response.queryOrder || []).reduce((memo, current) => ({ ...memo, ...current }), {});
         }
 
-        if (QueryRenderer.isQueryPresent(stateQuery)) {
-          finalState = {
-            ...finalState,
-            query: nextQuery,
-            pivotConfig: ResultSet.getNormalizedPivotConfig(pivotQuery, finalState.pivotConfig),
-          };
+        finalState.pivotConfig = ResultSet.getNormalizedPivotConfig(response.pivotQuery, finalState.pivotConfig);
+        finalState.validatedQuery = this.validatedQuery(finalState);
 
-          this.setState({
-            ...finalState,
-            validatedQuery: this.validatedQuery(finalState),
-          });
+        // deprecated
+        if (QueryRenderer.isQueryPresent(stateQuery)) {
           runSetters({
             ...this.state,
             ...finalState,
@@ -456,6 +438,13 @@ export default class QueryBuilder extends React.Component {
         });
       }
     }
+
+    this.setState(finalState, () => {
+      const { onVizStateChanged } = this.props;
+      if (onVizStateChanged) {
+        onVizStateChanged(pick(['chartType', 'pivotConfig', 'query'], this.state));
+      }
+    });
   }
 
   validatedQuery(state) {
@@ -468,7 +457,7 @@ export default class QueryBuilder extends React.Component {
   }
 
   defaultHeuristics(newState) {
-    const { query, sessionGranularity } = this.state;
+    const { query, sessionGranularity, meta } = this.state;
     const defaultGranularity = sessionGranularity || 'day';
 
     if (Array.isArray(query)) {
@@ -478,8 +467,6 @@ export default class QueryBuilder extends React.Component {
     if (newState.query) {
       const oldQuery = query;
       let newQuery = newState.query;
-
-      const { meta } = this.state;
 
       if (
         (oldQuery.timeDimensions || []).length === 1
@@ -654,12 +641,18 @@ QueryBuilder.contextType = CubeContext;
 
 QueryBuilder.defaultProps = {
   cubejsApi: null,
-  query: {},
-  setQuery: null,
-  setVizState: null,
   stateChangeHeuristics: null,
   disableHeuristics: false,
   render: null,
   wrapWithQueryRenderer: true,
-  vizState: {},
+  defaultChartType: 'line',
+  defaultQuery: {},
+  initialVizState: null,
+  onVizStateChanged: null,
+
+  // deprecated
+  query: null,
+  setQuery: null,
+  vizState: null,
+  setVizState: null,
 };


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required

Broken off from #2196 

I ran into some issues while making other changes to the React QueryBuilder, and realized that it was because the QueryBuilder was neither fully controller nor uncontrolled, and was using the React anti-pattern of [unconditionally copying props to state](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-unconditionally-copying-props-to-state).  Following the recommendations in that article and based on my experience as a React developer, I decided to make QueryBuilder uncontrolled.  This means that QueryBuilder controls it's own state, and can't be modified from the outside save for in specific ways that are allowed through props.

This involved deprecating the `query`, `setQuery`, `vizState`, and `setVizState` props, and adding the `initialVizState` and `onVizStateChanged` props.  From my analysis, the most common use case for accessing the `vizState` outside of the query editor is to save the editor state in persistent storage.  These two new props allow for setting up a QueryBuilder component from a saved state and then listening for changes to save back.  I'm using this in my app to save the `vizState` to a database so I can persist the QueryBuilder state across reloads.

I also added the `defaultQuery` and `defaultChartType` props, so that if `initialVizState` is empty, it will pick up the default values for those. `defaultChartType` was listed in the documentation before, but wasn't actually implemented until now.
