### PR TITLE
fix(cubestore): use merge sort exec when aggregations are required

### DIFF
--- a/rust/cubestore/src/queryplanner/mod.rs
+++ b/rust/cubestore/src/queryplanner/mod.rs
@@ -1,4 +1,5 @@
 pub mod hll;
+mod optimizations;
 mod partition_filter;
 pub mod query_executor;
 pub mod serialized_plan;

--- a/rust/cubestore/src/queryplanner/optimizations/mod.rs
+++ b/rust/cubestore/src/queryplanner/optimizations/mod.rs
@@ -1,0 +1,21 @@
+use crate::queryplanner::optimizations::prefer_inplace_aggregates::try_switch_to_inplace_aggregates;
+use datafusion::execution::context::{ExecutionContextState, QueryPlanner};
+use datafusion::logical_plan::LogicalPlan;
+use datafusion::physical_plan::planner::DefaultPhysicalPlanner;
+use datafusion::physical_plan::{ExecutionPlan, PhysicalPlanner};
+use std::sync::Arc;
+
+pub mod prefer_inplace_aggregates;
+
+pub struct CubeQueryPlanner {}
+
+impl QueryPlanner for CubeQueryPlanner {
+    fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        ctx_state: &ExecutionContextState,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let p = DefaultPhysicalPlanner::default().create_physical_plan(logical_plan, ctx_state)?;
+        try_switch_to_inplace_aggregates(p.as_ref())
+    }
+}

--- a/rust/cubestore/src/queryplanner/optimizations/prefer_inplace_aggregates.rs
+++ b/rust/cubestore/src/queryplanner/optimizations/prefer_inplace_aggregates.rs
@@ -1,0 +1,89 @@
+use datafusion::physical_plan::expressions::AliasedSchemaExec;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::hash_aggregate::{AggregateStrategy, HashAggregateExec};
+use datafusion::physical_plan::merge::MergeExec;
+use datafusion::physical_plan::merge_sort::MergeSortExec;
+use datafusion::physical_plan::planner::compute_aggregation_strategy;
+use datafusion::physical_plan::ExecutionPlan;
+use std::sync::Arc;
+
+pub fn try_switch_to_inplace_aggregates(
+    p: &dyn ExecutionPlan,
+) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+    let delegate_to_children = || {
+        let children: datafusion::error::Result<Vec<_>> = p
+            .children()
+            .into_iter()
+            .map(|c| try_switch_to_inplace_aggregates(c.as_ref()))
+            .collect();
+        p.with_new_children(children?)
+    };
+
+    let agg;
+    if let Some(a) = p.as_any().downcast_ref::<HashAggregateExec>() {
+        agg = a;
+    } else {
+        return delegate_to_children();
+    }
+    if agg.strategy() != AggregateStrategy::Hash || agg.group_expr().len() == 0 {
+        return delegate_to_children();
+    }
+
+    // Try to cheaply rearrange the plan so that it produces sorted inputs.
+    let new_input = try_regroup_columns(agg.input().clone())?;
+
+    if compute_aggregation_strategy(new_input.as_ref(), agg.group_expr())
+        != AggregateStrategy::InplaceSorted
+    {
+        return delegate_to_children();
+    }
+    Ok(Arc::new(HashAggregateExec::try_new(
+        AggregateStrategy::InplaceSorted,
+        *agg.mode(),
+        agg.group_expr().into(),
+        agg.aggr_expr().into(),
+        new_input,
+    )?))
+}
+
+/// Attempts to provide **some** grouping in the results, but no particular one is guaranteed.
+fn try_regroup_columns(
+    p: Arc<dyn ExecutionPlan>,
+) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+    if p.as_any().is::<HashAggregateExec>() {
+        return try_switch_to_inplace_aggregates(p.as_ref());
+    }
+    if p.as_any().is::<AliasedSchemaExec>() || p.as_any().is::<FilterExec>() {
+        let children: datafusion::error::Result<Vec<_>> = p
+            .children()
+            .into_iter()
+            .map(|c| try_regroup_columns(c))
+            .collect();
+        return p.with_new_children(children?);
+    }
+    let merge;
+    if let Some(m) = p.as_any().downcast_ref::<MergeExec>() {
+        merge = m;
+    } else {
+        return Ok(p);
+    }
+
+    // Try to replace `MergeExec` with `MergeSortExec`.
+    let sort_order;
+    if let Some(o) = merge.input().output_hints().sort_order {
+        sort_order = o;
+    } else {
+        return Ok(p);
+    }
+    if sort_order.is_empty() {
+        return Ok(p);
+    }
+    let sort_columns = sort_order
+        .into_iter()
+        .map(|i| merge.input().schema().field(i).qualified_name())
+        .collect();
+    Ok(Arc::new(MergeSortExec::try_new(
+        merge.input().clone(),
+        sort_columns,
+    )?))
+}

--- a/rust/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/src/queryplanner/query_executor.rs
@@ -2,6 +2,7 @@ use crate::cluster::Cluster;
 use crate::config::injection::DIService;
 use crate::metastore::table::Table;
 use crate::metastore::{Column, ColumnType, IdRow, Index, Partition};
+use crate::queryplanner::optimizations::CubeQueryPlanner;
 use crate::queryplanner::serialized_plan::{IndexSnapshot, SerializedPlan};
 use crate::store::DataFrame;
 use crate::table::{Row, TableValue, TimestampValue};
@@ -184,7 +185,8 @@ impl QueryExecutorImpl {
         let ctx = ExecutionContext::with_config(
             ExecutionConfig::new()
                 .with_batch_size(4096)
-                .with_concurrency(1),
+                .with_concurrency(1)
+                .with_query_planner(Arc::new(CubeQueryPlanner {})),
         );
         Ok(Arc::new(ctx))
     }


### PR DESCRIPTION
The new physical plan optimization aims to change the consumer of
`CubeTableExec` from `MergeExec` to `MergeSortExec`, but only if
results get consumed by aggregations.

This lets us use more efficient inplace aggregations in more cases.