### PR TITLE
Prevent calling onVizStateChanged twice unless needed

### DIFF
--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { prop, uniqBy, equals, pick } from 'ramda';
+import { prop, uniqBy, equals, pick, clone } from 'ramda';
 import { ResultSet, moveItemInArray, defaultOrder, flattenFilters, getQueryMembers } from '@cubejs-client/core';
 import QueryRenderer from './QueryRenderer.jsx';
 import CubeContext from './CubeContext';
@@ -379,10 +379,16 @@ export default class QueryBuilder extends React.Component {
       finalState.query = { ...stateQuery };
     }
 
+    let vizStateSent = null;
     const handleVizStateChange = (currentState) => {
       const { onVizStateChanged } = this.props;
       if (onVizStateChanged) {
-        onVizStateChanged(pick(['chartType', 'pivotConfig', 'query'], currentState));
+        const newVizState = pick(['chartType', 'pivotConfig', 'query'], currentState);
+        // Don't run callbacks more than once unless the viz state has changed since last time
+        if (!vizStateSent || !equals(vizStateSent, newVizState)) {
+          onVizStateChanged(newVizState);
+          vizStateSent = clone(newVizState); // use clone to make sure we don't save object references
+        }
       }
     };
 


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required

Related to #2303 

Prevents `onVizStateChanged` from being called twice unnecessarily by doing an `equals` object comparison before calling the second time.

After this change, in all my testing, it was only called once.  I was unable to find a test case where the query or pivotConfig was changed after `dry-run`.  I'd be happy to test more if you can identify a sequence of actions that could lead to that.  Looking at the code, it _should_ run twice if changed, but I have not proven that.
