### PR TITLE
Skip `refreshCubesRefreshKey` If A Cube Has No Pre-Aggregations

### DIFF
--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -137,7 +137,8 @@ export class RefreshScheduler {
       const cubeFromPath = queryForEvaluation.cubeEvaluator.cubeFromPath(cube);
       const measuresCount = Object.keys(cubeFromPath.measures || {}).length;
       const dimensionsCount = Object.keys(cubeFromPath.dimensions || {}).length;
-      if (measuresCount === 0 && dimensionsCount === 0) {
+      const preAggregationsCount = Object.keys(cubeFromPath.preAggregations || {}).length;
+      if (preAggregationsCount || (measuresCount === 0 && dimensionsCount === 0)) {
         return;
       }
       await Promise.all(queryingOptions.timezones.map(async timezone => {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Skip `refreshCubesRefreshKey` if a Cube has no pre-aggregations defined for it.

# Background

- I'm trying to trigger a scheduled refresh using the `/v1/run-scheduled-refresh` API endpoint
- I have two Cubes: one named `X` with `preAggregations` and one named `Y` without `preAggregations`
- I have a Big Query data source that requires a partition filter on all queries, so I reference that partition column `X.p` in the `timeDimensions` part of the API call's query options
- The Cube server emits an error `Error: Can't find join path to join 'Y', 'X'`, presumably because of the query option referencing a column from `X`

I am proposing this change to skip `refreshCubesRefreshKey` if a Cube's `preAggregations` field is empty. Thanks!