### PR TITLE
misc: migrate testcontainers to ^7.5

### DIFF
--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -48,7 +48,6 @@
     "@types/mysql": "^2.15.17",
     "@types/ws": "^7.4.0",
     "jest": "^26.6.3",
-    "testcontainers": "^6.4.2",
     "typescript": "~4.1.5"
   },
   "license": "Apache-2.0",

--- a/packages/cubejs-dremio-driver/package.json
+++ b/packages/cubejs-dremio-driver/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.27.0",
     "jest": "^26.6.3",
-    "testcontainers": "^2.4.0"
+    "testcontainers": "^7.9.0"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cubejs-elasticsearch-driver/test/ElasticSearchOpenDistro.integration.js
+++ b/packages/cubejs-elasticsearch-driver/test/ElasticSearchOpenDistro.integration.js
@@ -6,7 +6,7 @@ describe('ElasticSearchDriver OpenDistro', () => {
   let container;
   let elasticSearchDriver;
 
-  jest.setTimeout(50000);
+  jest.setTimeout(60 * 2 * 1000);
 
   const version = process.env.TEST_ELASTIC_OPENDISTRO_VERSION || '1.13.1';
 

--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -32,7 +32,7 @@
     "@cubejs-backend/linter": "^0.27.0",
     "mocha": "^8.1.3",
     "should": "^13.2.3",
-    "testcontainers": "^4.0.9"
+    "testcontainers": "^7.6.2"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-prestodb-driver/test/PrestoDriverTest.js
+++ b/packages/cubejs-prestodb-driver/test/PrestoDriverTest.js
@@ -1,8 +1,6 @@
 /* globals describe, before, after, it */
 const path = require('path');
 const { DockerComposeEnvironment, Wait } = require('testcontainers');
-// eslint-disable-next-line import/no-extraneous-dependencies
-const { Duration, TemporalUnit } = require('node-duration');
 
 const PrestoDriver = require('../driver/PrestoDriver');
 
@@ -39,14 +37,14 @@ describe('PrestoHouseDriver', () => {
     );
 
     env = await dc
-      .withStartupTimeout(new Duration(90, TemporalUnit.SECONDS))
+      .withStartupTimeout(90 * 1000)
       .withWaitStrategy('coordinator', Wait.forHealthCheck())
       .withWaitStrategy('worker0', Wait.forLogMessage('Added catalog postgresql'))
       .withWaitStrategy('postgres', Wait.forHealthCheck())
       .up();
 
     config = {
-      host: env.getContainer('coordinator').getContainerIpAddress(),
+      host: env.getContainer('coordinator').getHost(),
       port: env.getContainer('coordinator').getMappedPort(8080),
       catalog: 'postgresql',
       schema: 'default'

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -81,7 +81,7 @@
     "request-promise": "^4.2.4",
     "source-map-support": "^0.5.19",
     "sqlstring": "^2.3.1",
-    "testcontainers": "^6.4.2",
+    "testcontainers": "^7.6.2",
     "typescript": "~4.1.5",
     "uuid": "^3.3.2"
   },

--- a/packages/cubejs-schema-compiler/test/integration/clickhouse/ClickHouseDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/clickhouse/ClickHouseDbRunner.js
@@ -70,7 +70,7 @@ export class ClickHouseDbRunner {
     if (!this.container && !process.env.TEST_CLICKHOUSE_HOST) {
       const version = process.env.TEST_CLICKHOUSE_VERSION || '21.1.2';
 
-      this.container = await new GenericContainer(`yandex/clickhouse-server`, version)
+      this.container = await new GenericContainer(`yandex/clickhouse-server:${version}`)
         .withExposedPorts(8123)
         .start();
     }

--- a/packages/cubejs-schema-compiler/test/integration/mssql/MSSqlDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/mssql/MSSqlDbRunner.js
@@ -88,7 +88,7 @@ export class MSSqlDbRunner extends BaseDbRunner {
   async containerLazyInit() {
     const version = process.env.TEST_MSSQL_VERSION || '2017-latest';
 
-    return new GenericContainer('mcr.microsoft.com/mssql/server', version)
+    return new GenericContainer(`mcr.microsoft.com/mssql/server:${version}`)
       .withEnv('ACCEPT_EULA', 'Y')
       .withEnv('MSSQL_PID', 'Developer')
       .withEnv('MSSQL_SA_PASSWORD', this.password())

--- a/packages/cubejs-schema-compiler/test/integration/mysql/MySqlDbRunner.js
+++ b/packages/cubejs-schema-compiler/test/integration/mysql/MySqlDbRunner.js
@@ -78,7 +78,7 @@ export class MySqlDbRunner extends BaseDbRunner {
   async containerLazyInit() {
     const version = process.env.TEST_MYSQL_VERSION || '5.7';
 
-    return new GenericContainer('mysql', version)
+    return new GenericContainer(`mysql:${version}`)
       .withEnv('MYSQL_ROOT_PASSWORD', this.password())
       .withExposedPorts(this.port())
       // workaround for MySQL 8 unsupported auth

--- a/packages/cubejs-sqlite-driver/package.json
+++ b/packages/cubejs-sqlite-driver/package.json
@@ -24,8 +24,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.27.0",
     "mocha": "^8.0.1",
-    "should": "^13.2.3",
-    "testcontainers": "^2.4.0"
+    "should": "^13.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,9 +2830,9 @@
     xdg-basedir "^4.0.0"
 
 "@grpc/grpc-js@~1.3.0":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.3.tgz#479764be3044f44c9fe38702643f59ea1a5374cb"
-  integrity sha512-KkKZrX3fVTBYCtUk8I+Y4xWaauEEOIR1mIGoPFUK8C+a9TTub5dmjowJpFGz0dqYj//wJcgVR9fqpoNhSYFfHQ==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.3.4.tgz#5c4f5df717cd10cc5ebbc7523504008d1ff7b322"
+  integrity sha512-AxtZcm0mArQhY9z8T3TynCYVEaSKxNCa9mVhVwBCUnsuUEe8Zn94bPYYKVQSLt+hJJ1y0ukr3mUvtWfcATL/IQ==
   dependencies:
     "@types/node" ">=12.12.47"
 
@@ -4447,10 +4447,10 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-7.3.4.tgz#9f075e263d1d3c1ba7a789e0085a5ed75d6daad1"
-  integrity sha512-binmLrMQWBG0CvUE/jS3/XXrZbX3oN/6gF7ocSsb/ZJ0xfox2isJN4ZhGeL91SDJVzFK7XuUYBm2mlIDedkxsg==
+"@octokit/openapi-types@^7.3.5":
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-7.3.5.tgz#ffd195472f345b32fb29ba3c86a1ee68c09f24b3"
+  integrity sha512-6bm5lzGDOeSnWHM5W8OZ86RD2KpchynU+/Qlm5hNEFjfLDhwfAY2lSe68YRUEYFGlxSHe0HmakyhvmtWoD3Zog==
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
@@ -4537,11 +4537,11 @@
     "@types/node" ">= 8"
 
 "@octokit/types@^6.0.3", "@octokit/types@^6.16.1":
-  version "6.16.6"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.16.6.tgz#c113a0408a799ccb93c8749806733ad5d3edd142"
-  integrity sha512-PrEGjMnEhLlNttsuLadEWqXdMYJX3icHHaRs/ChJebRT79VDh/cNkk8bURx05BEEwr7QvaLsRzjt3hNxUJZfXA==
+  version "6.16.7"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.16.7.tgz#f27e87daf7ed87bde3e67b2e71956468fa4d02a7"
+  integrity sha512-OuQELiwIKeDySgNID52vm33wDRc2aaX8lKYgAw9Hmw939ITow1HspT8/AH3M3jgGFUMDmHlMNBNEmH7xV7ggXQ==
   dependencies:
-    "@octokit/openapi-types" "^7.3.4"
+    "@octokit/openapi-types" "^7.3.5"
 
 "@oozcitak/dom@1.15.8":
   version "1.15.8"
@@ -4573,9 +4573,9 @@
   integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
 
 "@opentelemetry/api@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.0.tgz#cc7712009095697f8a9492ee375daa08588ba263"
-  integrity sha512-TcdhrGy+ehLIFs79/TcWiHiPujishrhSgQ7wxvWvk8WY2YT8Np/pYXmRP94voG3N8GJ/5nIVyzacfViwhN50AQ==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.1.tgz#03c72f548431da5820a0c8864d1401e348e7e79f"
+  integrity sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==
 
 "@opentelemetry/semantic-conventions@^0.22.0":
   version "0.22.0"
@@ -4995,9 +4995,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6", "@types/babel__traverse@^7.11.0":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.11.1.tgz#654f6c4f67568e24c23b367e947098c6206fa639"
-  integrity sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.0.tgz#a34277cf8acbd3185ea74129e1f100491eb1da7f"
+  integrity sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -5075,13 +5075,6 @@
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"
   integrity sha512-W24e3Ycz1UZPgr1ZEDHlK4XnvOr+CpJH3qNsFeqXwwlW/9END9gxn3oJSsp7gYdiQxrXUHwUUd3xuzVz37MrZQ==
-  dependencies:
-    "@types/node" "*"
-
-"@types/dockerode@^2.5.34":
-  version "2.5.34"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-2.5.34.tgz#9adb884f7cc6c012a6eb4b2ad794cc5d01439959"
-  integrity sha512-LcbLGcvcBwBAvjH9UrUI+4qotY+A5WCer5r43DR5XHv2ZIEByNXFdPLo1XxR+v/BjkGjlggW8qUiXuVEhqfkpA==
   dependencies:
     "@types/node" "*"
 
@@ -5339,9 +5332,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "15.12.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
-  integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
+  version "15.12.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
+  integrity sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==
 
 "@types/node@12.12.50":
   version "12.12.50"
@@ -7306,9 +7299,9 @@ autoprefixer@^9.6.1, autoprefixer@^9.6.5, autoprefixer@^9.8.6:
     postcss-value-parser "^4.1.0"
 
 aws-sdk@^2.403.0, aws-sdk@^2.404.0, aws-sdk@^2.787.0, aws-sdk@^2.819.0:
-  version "2.934.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.934.0.tgz#1c26bd8ded15d2f6b2aa3301d35fc5daf1a61d68"
-  integrity sha512-k7p08ewrKcbs0ikCLFi9OI98Iv9dMND5244xPxUIjK5BLtuT/9Gr6eSCHfN70eCQyM5Y2xG1VJP6zhpkihu9Ew==
+  version "2.935.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.935.0.tgz#f122667a4b004d6cf5761e754d42f507b1fc36f7"
+  integrity sha512-OeoqkZ0fXPC1xjumoFQmPccASXmGBBNBsI3l9vs/NCQk3WyBfiYh07H6RO5owtCmp0a8hAjKSZAHjnRe2JlmEA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -8510,9 +8503,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001032, caniuse-lite@^1.0.30001061, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
+  version "1.0.30001240"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz#ec15d125b590602c8731545c5351ff054ad2d52f"
+  integrity sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==
 
 canonical-path@1.0.0:
   version "1.0.0"
@@ -10703,7 +10696,7 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-docker-compose@^0.23.10, docker-compose@^0.23.5:
+docker-compose@^0.23.10:
   version "0.23.12"
   resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.12.tgz#fa883b98be08f6926143d06bf9e522ef7ed3210c"
   integrity sha512-KFbSMqQBuHjTGZGmYDOCO0L4SaML3BsWTId5oSUyaBa22vALuFHNv+UdDWs3HcMylHWKsxCbLB7hnM/nCosWZw==
@@ -10720,7 +10713,7 @@ docker-modem@^3.0.0:
     split-ca "^1.0.1"
     ssh2 "^0.8.7"
 
-dockerode@^3.2.0, dockerode@^3.2.1:
+dockerode@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.3.0.tgz#bedaf48ef9fa9124275a54a9881a92374c51008e"
   integrity sha512-St08lfOjpYCOXEM8XA0VLu3B3hRjtddODphNW5GFoA0AS3JHgoPQKOz0Qmdzg3P+hUPxhb02g1o1Cu1G+U3lRg==
@@ -10974,9 +10967,9 @@ ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.723:
-  version "1.3.758"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.758.tgz#0baeb8f0a89d1850cc65f92da5f669343e4f6241"
-  integrity sha512-StYtiDbgZdjcck3OLwsVVVif7QDuD5m5v2gF+XpETp5lHa7X0y3129YBlYaHRPyj1fep1oAaC6i//gAdp+rhbw==
+  version "1.3.759"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.759.tgz#b0d652d376831470a4c230ba721da2427bfb996a"
+  integrity sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -17820,11 +17813,6 @@ node-dijkstra@^2.5.0:
   resolved "https://registry.yarnpkg.com/node-dijkstra/-/node-dijkstra-2.5.0.tgz#0feb76c5a05f35b56e786de6df4d3364af28d4e8"
   integrity sha1-D+t2xaBfNbVueG3m300zZK8o1Og=
 
-node-duration@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/node-duration/-/node-duration-1.0.4.tgz#3e94ecc0e473691c89c4560074503362071cecac"
-  integrity sha512-eUXYNSY7DL53vqfTosggWkvyIW3bhAcqBDIlolgNYlZhianXTrCL50rlUJWD1eRqkIxMppXTfiFbp+9SjpPrgA==
-
 node-fetch-npm@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz#6507d0e17a9ec0be3bec516958a497cec54bf5a4"
@@ -20266,9 +20254,9 @@ prettier@^1.16.4, prettier@^1.18.2, prettier@^1.19.1:
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 prettier@^2.0.5:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
-  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
@@ -23897,7 +23885,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar-fs@^2.0.0, tar-fs@^2.1.0, tar-fs@^2.1.1:
+tar-fs@^2.0.0, tar-fs@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
@@ -24173,57 +24161,7 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-testcontainers@^2.4.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-2.20.0.tgz#1d3977346e5724fc6f88e543774101d8529001a6"
-  integrity sha512-kq3oOf/ayA8qo9aqChcmBNB/Yjd5LBH17FsiD7zqlpXktXCQMrWJfM3qD82RwpHrPDobhLiopwTcBhIkJuMXJg==
-  dependencies:
-    "@types/dockerode" "^2.5.34"
-    byline "^5.0.0"
-    debug "^4.1.1"
-    docker-compose "^0.23.5"
-    dockerode "^3.2.0"
-    get-port "^5.1.1"
-    glob "^7.1.6"
-    node-duration "^1.0.4"
-    stream-to-array "^2.3.0"
-    tar-fs "^2.1.0"
-
-testcontainers@^4.0.9:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-4.7.0.tgz#5a9a864b1b0cc86984086dcc737c2f5e73490cf3"
-  integrity sha512-5SrG9RMfDRRZig34fDZeMcGD5i3lHCOJzn0kjouyK4TiEWjZB3h7kCk8524lwNRHROFE1j6DGjceonv/5hl5ag==
-  dependencies:
-    "@types/dockerode" "^2.5.34"
-    byline "^5.0.0"
-    debug "^4.1.1"
-    docker-compose "^0.23.5"
-    dockerode "^3.2.1"
-    get-port "^5.1.1"
-    glob "^7.1.6"
-    node-duration "^1.0.4"
-    slash "^3.0.0"
-    stream-to-array "^2.3.0"
-    tar-fs "^2.1.0"
-
-testcontainers@^6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-6.4.2.tgz#abce8cd7850973d6fbc4666aaf237e2fdc55e659"
-  integrity sha512-816Phx5lClxD9N/uchqX8G7eC6OtsKgVNW9HVgxWofnAth25bZ6Rlx0EohZ9P3NOPAni3KDGDGQwfega+BhDew==
-  dependencies:
-    "@types/dockerode" "^3.2.1"
-    byline "^5.0.0"
-    debug "^4.3.1"
-    docker-compose "^0.23.5"
-    dockerode "^3.2.1"
-    get-port "^5.1.1"
-    glob "^7.1.6"
-    slash "^3.0.0"
-    ssh-remote-port-forward "^1.0.3"
-    stream-to-array "^2.3.0"
-    tar-fs "^2.1.1"
-
-testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2:
+testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2, testcontainers@^7.9.0:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-7.11.1.tgz#b3810badf79433ba02f210683eec1a1c488c107d"
   integrity sha512-lfZeys5bLkADjOaoXfQy0V0+G8sGKr8ESANz7MhSVBwC+OTTxkP3+FVwP48bW4mwRcQ4Hojwbfw10OYT80QZmQ==
@@ -25750,9 +25688,9 @@ whatwg-url@^7.0.0:
     webidl-conversions "^4.0.2"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.6.0.tgz#27c0205a4902084b872aecb97cf0f2a7a3011f4c"
-  integrity sha512-os0KkeeqUOl7ccdDT1qqUcS4KH4tcBTSKK5Nl5WKb2lyxInIZ/CpjkqKa1Ss12mjfdcRX9mHmPPs7/SxG1Hbdw==
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
+  integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
   dependencies:
     lodash "^4.7.0"
     tr46 "^2.1.0"


### PR DESCRIPTION
Hello!

We use yarn workspaces to reduce disk usage with transitive dependencies, let's align all versions of test containers to one major version.

Thanks