### PR TITLE
fix(cubestore): make get active partitions a read operation

### DIFF
--- a/rust/cubestore/src/config/mod.rs
+++ b/rust/cubestore/src/config/mod.rs
@@ -85,9 +85,8 @@ impl CubeServices {
                 ClusterImpl::listen_on_metastore_port(cluster).await
             }));
             let scheduler = self.scheduler.clone();
-            futures.push(tokio::spawn(async move {
-                SchedulerImpl::run_scheduler(scheduler).await
-            }));
+            futures.extend(SchedulerImpl::spawn_processing_loops(scheduler));
+
             if self.injector.has_service_typed::<MySqlServer>().await {
                 let mysql_server = self.injector.get_service_typed::<MySqlServer>().await;
                 futures.push(tokio::spawn(
@@ -226,6 +225,8 @@ pub struct ConfigObjImpl {
     pub bind_address: Option<String>,
     pub http_bind_address: Option<String>,
     pub query_timeout: u64,
+    /// Must be set to 2*query_timeout in prod, only for overrides in tests.
+    pub not_used_timeout: u64,
     pub select_workers: Vec<String>,
     pub worker_bind_address: Option<String>,
     pub metastore_bind_address: Option<String>,
@@ -279,7 +280,7 @@ impl ConfigObj for ConfigObjImpl {
     }
 
     fn not_used_timeout(&self) -> u64 {
-        self.query_timeout * 2
+        self.not_used_timeout
     }
 
     fn select_workers(&self) -> &Vec<String> {
@@ -339,6 +340,10 @@ lazy_static! {
 
 impl Config {
     pub fn default() -> Config {
+        let query_timeout = env::var("CUBESTORE_QUERY_TIMEOUT")
+            .ok()
+            .map(|v| v.parse::<u64>().unwrap())
+            .unwrap_or(120);
         Config {
             injector: Injector::new(),
             config_obj: Arc::new(ConfigObjImpl {
@@ -385,10 +390,8 @@ impl Config {
                         .map(|v| v.parse::<u16>().unwrap())
                         .unwrap_or(3030u16)),
                 )),
-                query_timeout: env::var("CUBESTORE_QUERY_TIMEOUT")
-                    .ok()
-                    .map(|v| v.parse::<u64>().unwrap())
-                    .unwrap_or(120),
+                query_timeout,
+                not_used_timeout: 2 * query_timeout,
                 select_workers: env::var("CUBESTORE_WORKERS")
                     .ok()
                     .map(|v| v.split(",").map(|s| s.to_string()).collect())
@@ -424,6 +427,7 @@ impl Config {
     }
 
     pub fn test(name: &str) -> Config {
+        let query_timeout = 15;
         Config {
             injector: Injector::new(),
             config_obj: Arc::new(ConfigObjImpl {
@@ -444,7 +448,8 @@ impl Config {
                 job_runners_count: 4,
                 bind_address: None,
                 http_bind_address: None,
-                query_timeout: 15,
+                query_timeout,
+                not_used_timeout: 2 * query_timeout,
                 select_workers: Vec::new(),
                 worker_bind_address: None,
                 metastore_bind_address: None,

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -141,8 +141,11 @@ impl From<tokio::task::JoinError> for CubeError {
     }
 }
 
-impl From<SendError<metastore::MetaStoreEvent>> for CubeError {
-    fn from(v: SendError<metastore::MetaStoreEvent>) -> Self {
+impl<T> From<SendError<T>> for CubeError
+where
+    T: Debug,
+{
+    fn from(v: SendError<T>) -> Self {
         CubeError::internal(format!("{:?}\n{}", v, Backtrace::capture()))
     }
 }

--- a/rust/cubestore/src/metastore/chunks.rs
+++ b/rust/cubestore/src/metastore/chunks.rs
@@ -3,11 +3,9 @@ use crate::base_rocks_secondary_index;
 use crate::metastore::{IdRow, MetaStoreEvent};
 use crate::rocks_table_impl;
 use byteorder::{BigEndian, WriteBytesExt};
-use chrono::Utc;
 use rocksdb::DB;
 use serde::{Deserialize, Deserializer};
 use std::io::Cursor;
-use std::ops::Sub;
 
 impl Chunk {
     pub fn new(partition_id: u64, row_count: usize) -> Chunk {
@@ -52,24 +50,12 @@ impl Chunk {
         }
     }
 
-    pub fn update_last_used(&self) -> Self {
-        let mut new = self.clone();
-        new.last_used = Some(Utc::now());
-        new
-    }
-
     pub fn uploaded(&self) -> bool {
         self.uploaded
     }
 
     pub fn active(&self) -> bool {
         self.active
-    }
-
-    pub fn is_used(&self, timeout: u64) -> bool {
-        self.last_used
-            .map(|time| Utc::now().sub(time.clone()).num_seconds() < timeout as i64)
-            .unwrap_or(false)
     }
 }
 

--- a/rust/cubestore/src/metastore/partition.rs
+++ b/rust/cubestore/src/metastore/partition.rs
@@ -6,10 +6,8 @@ use crate::metastore::{IdRow, MetaStoreEvent};
 use crate::rocks_table_impl;
 use crate::table::Row;
 use byteorder::{BigEndian, WriteBytesExt};
-use chrono::Utc;
 use rocksdb::DB;
 use serde::{Deserialize, Deserializer};
-use std::ops::Sub;
 
 impl Partition {
     pub fn new(index_id: u64, min_value: Option<Row>, max_value: Option<Row>) -> Partition {
@@ -76,12 +74,6 @@ impl Partition {
         p
     }
 
-    pub fn update_last_used(&self) -> Self {
-        let mut new = self.clone();
-        new.last_used = Some(Utc::now());
-        new
-    }
-
     pub fn get_index_id(&self) -> u64 {
         self.index_id
     }
@@ -100,12 +92,6 @@ impl Partition {
 
     pub fn main_table_row_count(&self) -> u64 {
         self.main_table_row_count
-    }
-
-    pub fn is_used(&self, timeout: u64) -> bool {
-        self.last_used
-            .map(|time| Utc::now().sub(time.clone()).num_seconds() < timeout as i64)
-            .unwrap_or(false)
     }
 }
 

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -171,7 +171,6 @@ impl SqlServiceImpl {
 
             let mut futures = Vec::new();
             let indexes = self.db.get_table_indexes(table.get_id()).await?;
-            // TODO it may be too much to mark those as last used in a light of it can be still compacted
             let partitions = self
                 .db
                 .get_active_partitions_and_chunks_by_index_id_for_select(
@@ -1576,6 +1575,7 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 1000000;
                 c.compaction_chunks_count_threshold = 0;
+                c.not_used_timeout = 0;
                 c
             })
             .start_test(async move |services| {


### PR DESCRIPTION
To reduce write contention on metastore.

We still need to avoid removing partitions used by queries.
In order to do so, we now run the cleanup only after the corresponding timeout.