### PR TITLE
feat(cubestore): top-k query planning and execution

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#057b74836e97e1850b70f1c043693b22da160145"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e1c3abba6872ba96ab5ff87b3a3d70ea1f09ce3d"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#057b74836e97e1850b70f1c043693b22da160145"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e1c3abba6872ba96ab5ff87b3a3d70ea1f09ce3d"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#057b74836e97e1850b70f1c043693b22da160145"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e1c3abba6872ba96ab5ff87b3a3d70ea1f09ce3d"
 dependencies = [
  "ahash 0.6.3",
  "arrow",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#057b74836e97e1850b70f1c043693b22da160145"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-01-27#e1c3abba6872ba96ab5ff87b3a3d70ea1f09ce3d"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -8,6 +8,8 @@
 #![feature(raw)]
 #![feature(total_cmp)]
 #![feature(vec_into_raw_parts)]
+#![feature(hash_set_entry)]
+#![feature(map_first_last)]
 // #![feature(trace_macros)]
 
 // trace_macros!(true);

--- a/rust/cubestore/src/queryplanner/mod.rs
+++ b/rust/cubestore/src/queryplanner/mod.rs
@@ -5,6 +5,7 @@ mod planning;
 pub mod pretty_printers;
 pub mod query_executor;
 pub mod serialized_plan;
+mod topk;
 pub mod udfs;
 
 use crate::config::injection::DIService;

--- a/rust/cubestore/src/queryplanner/optimizations/mod.rs
+++ b/rust/cubestore/src/queryplanner/optimizations/mod.rs
@@ -1,7 +1,7 @@
 use crate::cluster::Cluster;
 use crate::queryplanner::optimizations::distributed_partial_aggregate::push_aggregate_to_workers;
 use crate::queryplanner::optimizations::prefer_inplace_aggregates::try_switch_to_inplace_aggregates;
-use crate::queryplanner::planning::ClusterSendPlanner;
+use crate::queryplanner::planning::CubeExtensionPlanner;
 use crate::queryplanner::serialized_plan::SerializedPlan;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::{ExecutionContextState, QueryPlanner};
@@ -45,7 +45,7 @@ impl QueryPlanner for CubeQueryPlanner {
         logical_plan: &LogicalPlan,
         ctx_state: &ExecutionContextState,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let p = DefaultPhysicalPlanner::with_extension_planner(Arc::new(ClusterSendPlanner {
+        let p = DefaultPhysicalPlanner::with_extension_planner(Arc::new(CubeExtensionPlanner {
             cluster: self.cluster.clone(),
             serialized_plan: self.serialized_plan.clone(),
         }))

--- a/rust/cubestore/src/queryplanner/topk/execute.rs
+++ b/rust/cubestore/src/queryplanner/topk/execute.rs
@@ -1,0 +1,1218 @@
+use crate::queryplanner::topk::SortColumn;
+use arrow::array::ArrayRef;
+use arrow::compute::SortOptions;
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::error::DataFusionError;
+use datafusion::logical_plan::DFSchemaRef;
+use datafusion::physical_plan::aggregates::AggregateFunction;
+use datafusion::physical_plan::group_scalar::GroupByScalar;
+use datafusion::physical_plan::hash_aggregate::{
+    create_accumulators, create_group_by_values, write_group_result_row, AccumulatorSet,
+    AggregateMode,
+};
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::{
+    AggregateExpr, ExecutionPlan, OptimizerHints, Partitioning, SendableRecordBatchStream,
+};
+use datafusion::scalar::ScalarValue;
+use flatbuffers::bitflags::_core::cmp::Ordering;
+use futures::StreamExt;
+use itertools::Itertools;
+use smallvec::smallvec;
+use smallvec::SmallVec;
+use std::any::Any;
+use std::collections::BTreeSet;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct AggregateTopKExec {
+    pub limit: usize,
+    pub key_len: usize,
+    pub agg_expr: Vec<Arc<dyn AggregateExpr>>,
+    pub agg_descr: Vec<AggDescr>,
+    pub order_by: Vec<SortColumn>,
+    /// Always an instance of ClusterSendExec or WorkerExec.
+    pub cluster: Arc<dyn ExecutionPlan>,
+    pub schema: DFSchemaRef,
+}
+
+/// Third item is the neutral value for the corresponding aggregate function.
+type AggDescr = (AggregateFunction, SortOptions, ScalarValue);
+
+impl AggregateTopKExec {
+    pub fn new(
+        limit: usize,
+        key_len: usize,
+        agg_expr: Vec<Arc<dyn AggregateExpr>>,
+        agg_fun: &[AggregateFunction],
+        order_by: Vec<SortColumn>,
+        cluster: Arc<dyn ExecutionPlan>,
+        schema: DFSchemaRef,
+    ) -> AggregateTopKExec {
+        assert_eq!(schema.fields().len(), agg_expr.len() + key_len);
+        assert_eq!(agg_fun.len(), agg_expr.len());
+        let agg_descr = Self::compute_descr(&agg_expr, agg_fun, &order_by);
+
+        AggregateTopKExec {
+            limit,
+            key_len,
+            agg_expr,
+            agg_descr,
+            order_by,
+            cluster,
+            schema,
+        }
+    }
+
+    fn compute_descr(
+        agg_expr: &[Arc<dyn AggregateExpr>],
+        agg_fun: &[AggregateFunction],
+        order_by: &[SortColumn],
+    ) -> Vec<AggDescr> {
+        let mut agg_descr = Vec::with_capacity(agg_expr.len());
+        for i in 0..agg_expr.len() {
+            agg_descr.push((
+                agg_fun[i].clone(),
+                SortOptions::default(),
+                ScalarValue::Int64(None),
+            ));
+        }
+        for o in order_by {
+            agg_descr[o.agg_index].1 = o.sort_options();
+        }
+        agg_descr
+    }
+
+    #[cfg(test)]
+    fn change_order(&mut self, order_by: Vec<SortColumn>) {
+        self.agg_descr = Self::compute_descr(
+            &self.agg_expr,
+            &self
+                .agg_descr
+                .iter()
+                .map(|(f, _, _)| f.clone())
+                .collect_vec(),
+            &order_by,
+        );
+        self.order_by = order_by;
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for AggregateTopKExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> DFSchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.cluster.clone()]
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        assert_eq!(children.len(), 1);
+        let cluster = children.into_iter().next().unwrap();
+        Ok(Arc::new(AggregateTopKExec {
+            limit: self.limit,
+            key_len: self.key_len,
+            agg_expr: self.agg_expr.clone(),
+            agg_descr: self.agg_descr.clone(),
+            order_by: self.order_by.clone(),
+            cluster,
+            schema: self.schema.clone(),
+        }))
+    }
+
+    fn output_hints(&self) -> OptimizerHints {
+        // It's a top-level plan most of the time, so the results should not matter.
+        OptimizerHints::default()
+    }
+
+    async fn execute(
+        &self,
+        partition: usize,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        assert_eq!(partition, 0);
+        let nodes = self.cluster.output_partitioning().partition_count();
+        let mut tasks = Vec::with_capacity(nodes);
+        for p in 0..nodes {
+            // TODO: actual streaming of results.
+            let cluster = self.cluster.clone();
+            tasks.push(tokio::spawn(async move {
+                // fuse the streams to simplify further code.
+                cluster.execute(p).await.map(|s| s.fuse())
+            }));
+        }
+        let mut streams = Vec::with_capacity(nodes);
+        for t in tasks {
+            streams.push(
+                t.await.map_err(|_| {
+                    DataFusionError::Internal("could not join threads".to_string())
+                })??,
+            );
+        }
+
+        let mut buffer = TopKBuffer::default();
+        let mut state = TopKState::new(
+            self.limit,
+            nodes,
+            self.key_len,
+            &self.order_by,
+            &self.agg_expr,
+            &self.agg_descr,
+            &mut buffer,
+        )?;
+        let mut batches = Vec::with_capacity(nodes);
+        'processing: loop {
+            assert!(batches.is_empty());
+            for s in &mut streams {
+                let batch;
+                loop {
+                    if let Some(b) = s.next().await {
+                        let b = b?;
+                        if b.num_rows() == 0 {
+                            continue;
+                        }
+                        batch = Some(b);
+                    } else {
+                        batch = None;
+                    }
+                    break;
+                }
+                batches.push(batch);
+            }
+
+            if state.update(&mut batches)? {
+                batches.clear();
+                break 'processing;
+            }
+            batches.clear();
+        }
+
+        let batch = state.finish(self.schema.to_schema_ref())?;
+        let schema = batch.schema();
+        // TODO: don't clone batch.
+        MemoryExec::try_new(&vec![vec![batch]], schema, None)?
+            .execute(0)
+            .await
+    }
+}
+
+// Mutex is to provide interior mutability inside async function, no actual waiting ever happens.
+// TODO: remove mutex with careful use of unsafe.
+type TopKBuffer = std::sync::Mutex<Vec<Group>>;
+
+struct TopKState<'a> {
+    limit: usize,
+    buffer: &'a TopKBuffer,
+    key_len: usize,
+    order_by: &'a [SortColumn],
+    agg_expr: &'a Vec<Arc<dyn AggregateExpr>>,
+    agg_descr: &'a [AggDescr],
+    /// Holds the maximum value seen in each node, used to estimate unseen scores.
+    node_estimates: Vec<AccumulatorSet>,
+    finished_nodes: Vec<bool>,
+    sorted: BTreeSet<SortKey<'a>>,
+    groups: HashSet<GroupKey<'a>>,
+    /// Final output.
+    top: Vec<usize>,
+}
+
+struct Group {
+    pub group_key: SmallVec<[GroupByScalar; 2]>,
+    /// The real value based on all nodes seen so far.
+    pub accumulators: AccumulatorSet,
+    /// The estimated value. Provides correct answer after the group was visited in all nodes.
+    pub estimates: AccumulatorSet,
+    /// Tracks nodes that have already reported this group.
+    pub nodes: Vec<bool>,
+}
+
+impl Group {
+    fn estimate(&self) -> Result<SmallVec<[ScalarValue; 1]>, DataFusionError> {
+        self.estimates.iter().map(|e| e.evaluate()).collect()
+    }
+
+    fn estimate_correct(&self) -> bool {
+        self.nodes.iter().all(|b| *b)
+    }
+}
+
+struct SortKey<'a> {
+    order_by: &'a [SortColumn],
+    estimate: SmallVec<[ScalarValue; 1]>,
+    index: usize,
+    /// Informative, not used in the [cmp] implementation.
+    estimate_correct: bool,
+}
+
+impl PartialEq for SortKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+impl Eq for SortKey<'_> {}
+impl PartialOrd for SortKey<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SortKey<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.index == other.index {
+            return Ordering::Equal;
+        }
+        for sc in self.order_by {
+            // Assuming `self` and `other` point to the same data.
+            let o = cmp_same_types(
+                &self.estimate[sc.agg_index],
+                &other.estimate[sc.agg_index],
+                sc.nulls_first,
+                sc.asc,
+            );
+            if o != Ordering::Equal {
+                return o;
+            }
+        }
+        // Distinguish items with the same scores for removals/updates.
+        self.index.cmp(&other.index)
+    }
+}
+
+struct GroupKey<'a> {
+    data: &'a TopKBuffer,
+    index: usize,
+}
+
+impl PartialEq for GroupKey<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        let data = self.data.lock().unwrap();
+        data[self.index].group_key == data[other.index].group_key
+    }
+}
+impl Eq for GroupKey<'_> {}
+impl Hash for GroupKey<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.data.lock().unwrap()[self.index].group_key.hash(state)
+    }
+}
+
+impl TopKState<'_> {
+    pub fn new(
+        limit: usize,
+        num_nodes: usize,
+        key_len: usize,
+        order_by: &'a [SortColumn],
+        agg_expr: &'a Vec<Arc<dyn AggregateExpr>>,
+        agg_descr: &'a [AggDescr],
+        buffer: &'a mut TopKBuffer,
+    ) -> Result<TopKState<'a>, DataFusionError> {
+        Ok(TopKState {
+            limit,
+            buffer,
+            key_len,
+            order_by,
+            agg_expr,
+            agg_descr,
+            finished_nodes: vec![false; num_nodes],
+            // initialized with the first record batches, see [update].
+            node_estimates: Vec::with_capacity(num_nodes),
+            sorted: BTreeSet::new(),
+            groups: HashSet::new(),
+            top: Vec::new(),
+        })
+    }
+
+    pub fn update(&mut self, batches: &mut [Option<RecordBatch>]) -> Result<bool, DataFusionError> {
+        let num_nodes = batches.len();
+        assert_eq!(num_nodes, self.finished_nodes.len());
+
+        // We need correct estimates for further processing.
+        if self.node_estimates.is_empty() {
+            for node in 0..num_nodes {
+                let mut estimates = create_accumulators(self.agg_expr)?;
+                if let Some(batch) = &batches[node] {
+                    assert_ne!(batch.num_rows(), 0, "empty batch passed to `update`");
+                    Self::update_node_estimates(
+                        self.key_len,
+                        self.agg_descr,
+                        &mut estimates,
+                        batch.columns(),
+                        0,
+                    )?;
+                }
+                self.node_estimates.push(estimates);
+            }
+        }
+
+        for node in 0..num_nodes {
+            if batches[node].is_none() && !self.finished_nodes[node] {
+                self.finished_nodes[node] = true;
+            }
+        }
+
+        let mut num_rows = batches
+            .iter()
+            .map(|b| b.as_ref().map(|b| b.num_rows()).unwrap_or(0))
+            .collect_vec();
+        num_rows.sort_unstable();
+
+        let mut row_i = 0;
+        let mut pop_top_counter = self.limit;
+        for row_limit in num_rows {
+            while row_i < row_limit {
+                // row_i updated at the end of the loop.
+                for node in 0..num_nodes {
+                    let batch;
+                    if let Some(b) = &batches[node] {
+                        batch = b;
+                    } else {
+                        continue;
+                    }
+
+                    let mut key = smallvec![GroupByScalar::Int8(0); self.key_len];
+                    create_group_by_values(&batch.columns()[0..self.key_len], row_i, &mut key)?;
+                    let temp_index = self.buffer.lock().unwrap().len();
+                    self.buffer.lock().unwrap().push(Group {
+                        group_key: key,
+                        accumulators: AccumulatorSet::new(),
+                        estimates: AccumulatorSet::new(),
+                        nodes: Vec::new(),
+                    });
+
+                    let existing = self
+                        .groups
+                        .get_or_insert(GroupKey {
+                            data: self.buffer,
+                            index: temp_index,
+                        })
+                        .index;
+                    if existing != temp_index {
+                        // Found existing, remove the temporary value from the buffer.
+                        let mut data = self.buffer.lock().unwrap();
+                        data.pop();
+
+                        // Prepare to update the estimates, will re-add when done.
+                        let estimate = data[existing].estimate()?;
+                        self.sorted.remove(&SortKey {
+                            order_by: self.order_by,
+                            estimate,
+                            index: existing,
+                            // Does not affect comparison.
+                            estimate_correct: false,
+                        });
+                    } else {
+                        let mut data = self.buffer.lock().unwrap();
+                        let g = &mut data[temp_index];
+                        g.accumulators = create_accumulators(self.agg_expr).unwrap();
+                        g.estimates = create_accumulators(self.agg_expr).unwrap();
+                        g.nodes = self.finished_nodes.clone();
+                    }
+
+                    // Update the group.
+                    let key;
+                    {
+                        let mut data = self.buffer.lock().unwrap();
+                        let group = &mut data[existing];
+                        group.nodes[node] = true;
+                        for i in 0..group.accumulators.len() {
+                            group.accumulators[i].update_batch(&vec![batch
+                                .column(self.key_len + i)
+                                .slice(row_i, 1)])?;
+                        }
+                        self.update_group_estimates(group)?;
+                        key = SortKey {
+                            order_by: self.order_by,
+                            estimate: group.estimate()?,
+                            estimate_correct: group.estimate_correct(),
+                            index: existing,
+                        }
+                    }
+                    let inserted = self.sorted.insert(key);
+                    assert!(inserted);
+
+                    Self::update_node_estimates(
+                        self.key_len,
+                        self.agg_descr,
+                        &mut self.node_estimates[node],
+                        batch.columns(),
+                        row_i,
+                    )?;
+                }
+
+                row_i += 1;
+
+                pop_top_counter -= 1;
+                if pop_top_counter == 0 {
+                    if self.pop_top_elements()? {
+                        return Ok(true);
+                    }
+                    pop_top_counter = self.limit;
+                }
+            }
+
+            for node in 0..num_nodes {
+                if let Some(b) = &batches[node] {
+                    if b.num_rows() == row_limit {
+                        batches[node] = None;
+                    }
+                }
+            }
+        }
+
+        self.pop_top_elements()
+    }
+
+    /// Moves groups with known top scores into the [top].
+    /// Returns true iff [top] contains the correct answer to the top-k query.
+    fn pop_top_elements(&mut self) -> Result<bool, DataFusionError> {
+        while self.top.len() < self.limit && !self.sorted.is_empty() {
+            let mut candidate = self.sorted.pop_first().unwrap();
+            while !candidate.estimate_correct {
+                // The estimate might be stale. Update and re-insert.
+                let updated;
+                {
+                    let mut data = self.buffer.lock().unwrap();
+                    self.update_group_estimates(&mut data[candidate.index])?;
+                    updated = SortKey {
+                        order_by: self.order_by,
+                        estimate: data[candidate.index].estimate()?,
+                        estimate_correct: data[candidate.index].estimate_correct(),
+                        index: candidate.index,
+                    };
+                }
+                self.sorted.insert(updated);
+
+                let next_candidate = self.sorted.first().unwrap();
+                if candidate.index == next_candidate.index && !next_candidate.estimate_correct {
+                    // Same group with top estimate, need to wait until we see it on all nodes.
+                    return Ok(false);
+                } else {
+                    candidate = self.sorted.pop_first().unwrap();
+                }
+            }
+
+            self.top.push(candidate.index);
+        }
+        return Ok(self.top.len() == self.limit || self.finished_nodes.iter().all(|f| *f));
+    }
+
+    fn finish(self, schema: SchemaRef) -> Result<RecordBatch, DataFusionError> {
+        log::trace!(
+            "aggregate top-k processed {} groups to return {} rows",
+            self.top.len() + self.sorted.len(),
+            self.limit
+        );
+        let mut key_columns = Vec::with_capacity(self.key_len);
+        let mut value_columns = Vec::with_capacity(self.agg_expr.len());
+
+        let mut data = self.buffer.lock().unwrap();
+        for group in self.top {
+            let g = &mut data[group];
+            write_group_result_row(
+                AggregateMode::Final,
+                &g.group_key,
+                &g.accumulators,
+                &mut key_columns,
+                &mut value_columns,
+            )?
+        }
+
+        let columns = key_columns
+            .into_iter()
+            .chain(value_columns)
+            .map(|mut c| c.finish())
+            .collect_vec();
+        if columns.is_empty() {
+            Ok(RecordBatch::new_empty(schema))
+        } else {
+            Ok(RecordBatch::try_new(schema, columns)?)
+        }
+    }
+
+    /// Returns true iff the estimate matches the correct score.
+    fn update_group_estimates(&self, group: &mut Group) -> Result<(), DataFusionError> {
+        for i in 0..group.estimates.len() {
+            group.estimates[i].reset();
+            group.estimates[i].merge(&group.accumulators[i].state()?.to_vec())?;
+            // Node estimate might contain a neutral value (e.g. '0' for sum), but we must avoid
+            // giving invalid estimates for NULL values.
+            let use_node_estimates =
+                !self.agg_descr[i].1.nulls_first || !group.estimates[i].evaluate()?.is_null();
+            for node in 0..group.nodes.len() {
+                if !group.nodes[node] {
+                    if self.finished_nodes[node] {
+                        group.nodes[node] = true;
+                        continue;
+                    }
+                    if use_node_estimates {
+                        group.estimates[i]
+                            .merge(&self.node_estimates[node][i].state()?.to_vec())?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn update_node_estimates(
+        key_len: usize,
+        agg_descr: &[AggDescr],
+        estimates: &mut AccumulatorSet,
+        columns: &[ArrayRef],
+        row_i: usize,
+    ) -> Result<(), DataFusionError> {
+        for (i, acc) in estimates.iter_mut().enumerate() {
+            acc.reset();
+
+            // evaluate() gives us a scalar value of the required type.
+            let mut neutral = acc.evaluate()?;
+            to_neutral_value(&mut neutral, &agg_descr[i].0);
+
+            acc.update_batch(&vec![columns[key_len + i].slice(row_i, 1)])?;
+
+            // Neutral value (i.e. missing on the node) might be the right estimate.
+            // E.g. `0` is better than `-10` on `SUM(x) ORDER BY SUM(x) DESC`.
+            // We have to provide correct estimates.
+            let o = cmp_same_types(
+                &neutral,
+                &acc.evaluate()?,
+                agg_descr[i].1.nulls_first,
+                !agg_descr[i].1.descending,
+            );
+            if o < Ordering::Equal {
+                acc.reset();
+            }
+        }
+        Ok(())
+    }
+}
+
+fn cmp_same_types(l: &ScalarValue, r: &ScalarValue, nulls_first: bool, asc: bool) -> Ordering {
+    match (l.is_null(), r.is_null()) {
+        (true, true) => return Ordering::Equal,
+        (true, false) => {
+            return if nulls_first {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            }
+        }
+        (false, true) => {
+            return if nulls_first {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            }
+        }
+        (false, false) => {} // fallthrough.
+    }
+
+    let o = match (l, r) {
+        (ScalarValue::Boolean(Some(l)), ScalarValue::Boolean(Some(r))) => l.cmp(r),
+        (ScalarValue::Float32(Some(l)), ScalarValue::Float32(Some(r))) => l.total_cmp(r),
+        (ScalarValue::Float64(Some(l)), ScalarValue::Float64(Some(r))) => l.total_cmp(r),
+        (ScalarValue::Int8(Some(l)), ScalarValue::Int8(Some(r))) => l.cmp(r),
+        (ScalarValue::Int16(Some(l)), ScalarValue::Int16(Some(r))) => l.cmp(r),
+        (ScalarValue::Int32(Some(l)), ScalarValue::Int32(Some(r))) => l.cmp(r),
+        (ScalarValue::Int64(Some(l)), ScalarValue::Int64(Some(r))) => l.cmp(r),
+        (
+            ScalarValue::Int64Decimal(Some(l), lscale),
+            ScalarValue::Int64Decimal(Some(r), rscale),
+        ) => {
+            assert_eq!(lscale, rscale);
+            l.cmp(r)
+        }
+        (ScalarValue::UInt8(Some(l)), ScalarValue::UInt8(Some(r))) => l.cmp(r),
+        (ScalarValue::UInt16(Some(l)), ScalarValue::UInt16(Some(r))) => l.cmp(r),
+        (ScalarValue::UInt32(Some(l)), ScalarValue::UInt32(Some(r))) => l.cmp(r),
+        (ScalarValue::UInt64(Some(l)), ScalarValue::UInt64(Some(r))) => l.cmp(r),
+        (ScalarValue::Binary(Some(l)), ScalarValue::Binary(Some(r))) => l.cmp(r),
+        (ScalarValue::Utf8(Some(l)), ScalarValue::Utf8(Some(r))) => l.cmp(r),
+        (ScalarValue::LargeUtf8(Some(l)), ScalarValue::LargeUtf8(Some(r))) => l.cmp(r),
+        (ScalarValue::Date32(Some(l)), ScalarValue::Date32(Some(r))) => l.cmp(r),
+        (ScalarValue::TimeMicrosecond(Some(l)), ScalarValue::TimeMicrosecond(Some(r))) => l.cmp(r),
+        (ScalarValue::TimeNanosecond(Some(l)), ScalarValue::TimeNanosecond(Some(r))) => l.cmp(r),
+        (ScalarValue::List(_, _), ScalarValue::List(_, _)) => {
+            panic!("list as accumulator result is not supported")
+        }
+        (_, _) => panic!("unhandled types in comparison"),
+    };
+    if asc {
+        o
+    } else {
+        o.reverse()
+    }
+}
+
+fn to_neutral_value(s: &mut ScalarValue, f: &AggregateFunction) {
+    match f {
+        AggregateFunction::Sum => to_zero(s),
+        AggregateFunction::Min => to_max_value(s),
+        AggregateFunction::Max => to_min_value(s),
+        _ => panic!("unsupported aggregate function"),
+    }
+}
+
+fn to_zero(s: &mut ScalarValue) {
+    match s {
+        ScalarValue::Boolean(v) => *v = Some(false),
+        // Note that -0.0, not 0.0, is the neutral value for floats, at least in IEEE 754.
+        ScalarValue::Float32(v) => *v = Some(-0.0),
+        ScalarValue::Float64(v) => *v = Some(-0.0),
+        ScalarValue::Int8(v) => *v = Some(0),
+        ScalarValue::Int16(v) => *v = Some(0),
+        ScalarValue::Int32(v) => *v = Some(0),
+        ScalarValue::Int64(v) => *v = Some(0),
+        ScalarValue::Int64Decimal(v, _) => *v = Some(0),
+        ScalarValue::UInt8(v) => *v = Some(0),
+        ScalarValue::UInt16(v) => *v = Some(0),
+        ScalarValue::UInt32(v) => *v = Some(0),
+        ScalarValue::UInt64(v) => *v = Some(0),
+        // TODO: dates and times?
+        _ => panic!("unsupported data type"),
+    }
+}
+
+fn to_max_value(s: &mut ScalarValue) {
+    match s {
+        ScalarValue::Boolean(v) => *v = Some(true),
+        ScalarValue::Float32(v) => *v = Some(f32::INFINITY),
+        ScalarValue::Float64(v) => *v = Some(f64::INFINITY),
+        ScalarValue::Int8(v) => *v = Some(i8::MAX),
+        ScalarValue::Int16(v) => *v = Some(i16::MAX),
+        ScalarValue::Int32(v) => *v = Some(i32::MAX),
+        ScalarValue::Int64(v) => *v = Some(i64::MAX),
+        ScalarValue::Int64Decimal(v, _) => *v = Some(i64::MAX),
+        ScalarValue::UInt8(v) => *v = Some(u8::MAX),
+        ScalarValue::UInt16(v) => *v = Some(u16::MAX),
+        ScalarValue::UInt32(v) => *v = Some(u32::MAX),
+        ScalarValue::UInt64(v) => *v = Some(u64::MAX),
+        // TODO: dates and times?
+        _ => panic!("unsupported data type"),
+    }
+}
+
+fn to_min_value(s: &mut ScalarValue) {
+    match s {
+        ScalarValue::Boolean(v) => *v = Some(false),
+        ScalarValue::Float32(v) => *v = Some(f32::NEG_INFINITY),
+        ScalarValue::Float64(v) => *v = Some(f64::NEG_INFINITY),
+        ScalarValue::Int8(v) => *v = Some(i8::MIN),
+        ScalarValue::Int16(v) => *v = Some(i16::MIN),
+        ScalarValue::Int32(v) => *v = Some(i32::MIN),
+        ScalarValue::Int64(v) => *v = Some(i64::MIN),
+        ScalarValue::Int64Decimal(v, _) => *v = Some(i64::MIN),
+        ScalarValue::UInt8(v) => *v = Some(u8::MIN),
+        ScalarValue::UInt16(v) => *v = Some(u16::MIN),
+        ScalarValue::UInt32(v) => *v = Some(u32::MIN),
+        ScalarValue::UInt64(v) => *v = Some(u64::MIN),
+        // TODO: dates and times?
+        _ => panic!("unsupported data type"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::queryplanner::topk::{AggregateTopKExec, SortColumn};
+    use arrow::array::{Array, ArrayRef, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use arrow::error::ArrowError;
+    use arrow::record_batch::RecordBatch;
+    use datafusion::error::DataFusionError;
+    use datafusion::execution::context::{ExecutionConfig, ExecutionContextState};
+    use datafusion::logical_plan::{DFField, DFSchema, Expr};
+    use datafusion::physical_plan::aggregates::AggregateFunction;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::memory::MemoryExec;
+    use datafusion::physical_plan::planner::DefaultPhysicalPlanner;
+    use datafusion::physical_plan::ExecutionPlan;
+    use futures::StreamExt;
+    use itertools::Itertools;
+    use std::convert::TryFrom;
+    use std::iter::FromIterator;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn topk_simple() {
+        // Test sum with descending sort order.
+        let proto = mock_topk(
+            2,
+            &[DataType::Int64],
+            &[AggregateFunction::Sum],
+            vec![SortColumn {
+                agg_index: 0,
+                asc: false,
+                nulls_first: true,
+            }],
+        )
+        .unwrap();
+        let bs = proto.cluster.schema().to_schema_ref();
+
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(&bs, &[&[1, 100], &[0, 50], &[8, 11], &[6, 10]])],
+                vec![make_batch(&bs, &[&[6, 40], &[1, 20], &[0, 15], &[8, 9]])],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 120], vec![0, 65]]);
+
+        // empty batches.
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![
+                    make_batch(&bs, &[&[1, 100], &[0, 50], &[8, 11], &[6, 10]]),
+                    make_batch(&bs, &[]),
+                ],
+                vec![
+                    make_batch(&bs, &[]),
+                    make_batch(&bs, &[&[6, 40], &[1, 20], &[0, 15], &[8, 9]]),
+                ],
+                vec![
+                    make_batch(&bs, &[]),
+                    make_batch(&bs, &[]),
+                    make_batch(&bs, &[]),
+                ],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 120], vec![0, 65]]);
+
+        // batches of different sizes.
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![
+                    make_batch(&bs, &[&[1, 100]]),
+                    make_batch(&bs, &[&[0, 50], &[8, 11]]),
+                    make_batch(&bs, &[&[6, 10]]),
+                ],
+                vec![make_batch(&bs, &[&[6, 40], &[1, 20], &[0, 15], &[8, 9]])],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 120], vec![0, 65]]);
+
+        // missing groups on some nodes.
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![
+                    make_batch(&bs, &[&[1, 100], &[8, 11]]),
+                    make_batch(&bs, &[&[6, 9]]),
+                ],
+                vec![make_batch(&bs, &[&[6, 40], &[0, 15], &[8, 9]])],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 100], vec![6, 49]]);
+
+        // sort order might be affected by values that are far away in the input.
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(
+                    &bs,
+                    &[&[1, 1000], &[2, 500], &[3, 500], &[4, 500]],
+                )],
+                vec![
+                    make_batch(&bs, &[&[2, 600], &[3, 599]]),
+                    make_batch(&bs, &[&[4, 598], &[5, 500]]),
+                    make_batch(&bs, &[&[6, 500], &[7, 500]]),
+                    make_batch(&bs, &[&[8, 500], &[9, 500]]),
+                    make_batch(&bs, &[&[1, 101]]),
+                ],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 1101], vec![2, 1100]]);
+    }
+
+    #[tokio::test]
+    async fn topk_missing_elements() {
+        // Start with sum, descending order.
+        let mut proto = mock_topk(
+            2,
+            &[DataType::Int64],
+            &[AggregateFunction::Sum],
+            vec![SortColumn {
+                agg_index: 0,
+                asc: false,
+                nulls_first: true,
+            }],
+        )
+        .unwrap();
+        let bs = proto.cluster.schema().to_schema_ref();
+
+        // negative numbers must not confuse the estimates.
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(&bs, &[&[1, 100], &[2, 50]])],
+                vec![make_batch(
+                    &bs,
+                    &[&[3, 90], &[4, 80], &[5, -100], &[6, -500]],
+                )],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 100], vec![3, 90]]);
+
+        // same with positive numbers in ascending order.
+        proto.change_order(vec![SortColumn {
+            agg_index: 0,
+            asc: true,
+            nulls_first: true,
+        }]);
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(&bs, &[&[1, -100], &[2, -50]])],
+                vec![make_batch(
+                    &bs,
+                    &[&[3, -90], &[4, -80], &[5, 100], &[6, 500]],
+                )],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, -100], vec![3, -90]]);
+
+        // nulls should be taken into account in the estimates.
+        proto.change_order(vec![SortColumn {
+            agg_index: 0,
+            asc: false,
+            nulls_first: true,
+        }]);
+        let r = run_topk_opt(
+            &proto,
+            vec![
+                vec![make_batch_opt(&bs, &[&[Some(1), None], &[Some(2), None]])],
+                vec![make_batch_opt(
+                    &bs,
+                    &[&[Some(10), Some(1000)], &[Some(1), Some(900)]],
+                )],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![Some(2), None], vec![Some(10), Some(1000)]]);
+    }
+
+    #[tokio::test]
+    async fn topk_sort_orders() {
+        let mut proto = mock_topk(
+            1,
+            &[DataType::Int64],
+            &[AggregateFunction::Sum],
+            vec![SortColumn {
+                agg_index: 0,
+                asc: true,
+                nulls_first: true,
+            }],
+        )
+        .unwrap();
+        let bs = proto.cluster.schema().to_schema_ref();
+
+        // Ascending.
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(&bs, &[&[1, 0], &[0, 100]])],
+                vec![make_batch(&bs, &[&[0, -100], &[1, -5]])],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, -5]]);
+
+        // Descending.
+        proto.change_order(vec![SortColumn {
+            agg_index: 0,
+            asc: false,
+            nulls_first: true,
+        }]);
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(&bs, &[&[0, 100], &[1, 0]])],
+                vec![make_batch(&bs, &[&[1, -5], &[0, -100]])],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![0, 0]]);
+
+        // Ascending, null first.
+        proto.change_order(vec![SortColumn {
+            agg_index: 0,
+            asc: true,
+            nulls_first: true,
+        }]);
+        let r = run_topk_opt(
+            &proto,
+            vec![
+                vec![make_batch_opt(&bs, &[&[Some(3), None]])],
+                vec![make_batch_opt(
+                    &bs,
+                    &[&[Some(2), None], &[Some(3), Some(1)]],
+                )],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![Some(2), None]]);
+
+        // Ascending, null last.
+        proto.change_order(vec![SortColumn {
+            agg_index: 0,
+            asc: true,
+            nulls_first: false,
+        }]);
+        let r = run_topk_opt(
+            &proto,
+            vec![
+                vec![make_batch_opt(
+                    &bs,
+                    &[&[Some(4), Some(10)], &[Some(3), None]],
+                )],
+                vec![make_batch_opt(
+                    &bs,
+                    &[&[Some(3), Some(1)], &[Some(2), None], &[Some(4), None]],
+                )],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![Some(3), Some(1)]]);
+    }
+
+    #[tokio::test]
+    async fn topk_multi_column_sort() {
+        let proto = mock_topk(
+            10,
+            &[DataType::Int64],
+            &[AggregateFunction::Sum, AggregateFunction::Min],
+            vec![
+                SortColumn {
+                    agg_index: 0,
+                    asc: true,
+                    nulls_first: true,
+                },
+                SortColumn {
+                    agg_index: 1,
+                    asc: false,
+                    nulls_first: true,
+                },
+            ],
+        )
+        .unwrap();
+        let bs = proto.cluster.schema().to_schema_ref();
+
+        let r = run_topk(
+            &proto,
+            vec![
+                vec![make_batch(
+                    &bs,
+                    &[&[2, 50, 20], &[3, 100, 20], &[1, 100, 10]],
+                )],
+                vec![make_batch(&bs, &[&[1, 0, 10], &[3, 50, 5], &[2, 50, 5]])],
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, vec![vec![1, 100, 10], vec![2, 100, 5], vec![3, 150, 5]]);
+    }
+
+    fn make_batch(schema: &SchemaRef, rows: &[&[i64]]) -> RecordBatch {
+        if rows.is_empty() {
+            return RecordBatch::new_empty(schema.clone());
+        }
+        for r in rows {
+            assert_eq!(r.len(), schema.fields().len());
+        }
+        let mut columns: Vec<ArrayRef> = Vec::new();
+        for col_i in 0..rows[0].len() {
+            let column_data = (0..rows.len()).map(|row_i| rows[row_i][col_i]);
+            columns.push(Arc::new(Int64Array::from_iter_values(column_data)))
+        }
+        RecordBatch::try_new(schema.clone(), columns).unwrap()
+    }
+
+    fn make_batch_opt(schema: &SchemaRef, rows: &[&[Option<i64>]]) -> RecordBatch {
+        if rows.is_empty() {
+            return RecordBatch::new_empty(schema.clone());
+        }
+        for r in rows {
+            assert_eq!(r.len(), schema.fields().len());
+        }
+        let mut columns: Vec<ArrayRef> = Vec::new();
+        for col_i in 0..rows[0].len() {
+            let column_data = (0..rows.len()).map(|row_i| rows[row_i][col_i]);
+            columns.push(Arc::new(Int64Array::from_iter(column_data)))
+        }
+        RecordBatch::try_new(schema.clone(), columns).unwrap()
+    }
+
+    fn mock_topk(
+        limit: usize,
+        group_by: &[DataType],
+        aggs: &[AggregateFunction],
+        order_by: Vec<SortColumn>,
+    ) -> Result<AggregateTopKExec, DataFusionError> {
+        let key_fields = group_by
+            .iter()
+            .enumerate()
+            .map(|(i, t)| DFField::new(None, &format!("key{}", i + 1), t.clone(), false))
+            .collect_vec();
+        let key_len = key_fields.len();
+
+        let input_agg_fields = (0..aggs.len())
+            .map(|i| DFField::new(None, &format!("agg{}", i + 1), DataType::Int64, true))
+            .collect_vec();
+        let input_schema =
+            DFSchema::new(key_fields.iter().cloned().chain(input_agg_fields).collect())?;
+
+        let ctx = ExecutionContextState {
+            datasources: Default::default(),
+            scalar_functions: Default::default(),
+            var_provider: Default::default(),
+            aggregate_functions: Default::default(),
+            config: ExecutionConfig::new(),
+        };
+        let agg_exprs = aggs
+            .iter()
+            .enumerate()
+            .map(|(i, f)| Expr::AggregateFunction {
+                fun: f.clone(),
+                args: vec![Expr::Column(format!("agg{}", i + 1), None)],
+                distinct: false,
+            });
+        let physical_agg_exprs = agg_exprs
+            .map(|e| {
+                Ok(DefaultPhysicalPlanner::default().create_aggregate_expr(
+                    &e,
+                    &input_schema,
+                    &input_schema,
+                    &ctx,
+                )?)
+            })
+            .collect::<Result<Vec<_>, DataFusionError>>()?;
+
+        let output_agg_fields = physical_agg_exprs
+            .iter()
+            .map(|agg| agg.field())
+            .collect::<Result<Vec<_>, DataFusionError>>()?;
+        let output_schema = Arc::new(DFSchema::try_from(Schema::new(
+            key_fields
+                .into_iter()
+                .map(|k| Field::new(k.name().as_ref(), k.data_type().clone(), k.is_nullable()))
+                .chain(output_agg_fields)
+                .collect(),
+        ))?);
+
+        Ok(AggregateTopKExec::new(
+            limit,
+            key_len,
+            physical_agg_exprs,
+            aggs,
+            order_by,
+            Arc::new(EmptyExec::new(false, input_schema.to_schema_ref())),
+            output_schema,
+        ))
+    }
+
+    async fn run_topk_as_batch(
+        proto: &AggregateTopKExec,
+        inputs: Vec<Vec<RecordBatch>>,
+    ) -> Result<RecordBatch, DataFusionError> {
+        let input = Arc::new(MemoryExec::try_new(
+            &inputs,
+            proto.cluster.schema().to_schema_ref(),
+            None,
+        )?);
+        let results = proto
+            .with_new_children(vec![input])?
+            .execute(0)
+            .await?
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, ArrowError>>()?;
+        assert_eq!(results.len(), 1);
+        Ok(results.into_iter().next().unwrap())
+    }
+
+    async fn run_topk(
+        proto: &AggregateTopKExec,
+        inputs: Vec<Vec<RecordBatch>>,
+    ) -> Result<Vec<Vec<i64>>, DataFusionError> {
+        return Ok(to_vec(&run_topk_as_batch(proto, inputs).await?));
+    }
+
+    async fn run_topk_opt(
+        proto: &AggregateTopKExec,
+        inputs: Vec<Vec<RecordBatch>>,
+    ) -> Result<Vec<Vec<Option<i64>>>, DataFusionError> {
+        return Ok(to_opt_vec(&run_topk_as_batch(proto, inputs).await?));
+    }
+
+    fn to_opt_vec(b: &RecordBatch) -> Vec<Vec<Option<i64>>> {
+        let mut rows = vec![vec![None; b.num_columns()]; b.num_rows()];
+        for col_i in 0..b.num_columns() {
+            let col = b
+                .column(col_i)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            for row_i in 0..b.num_rows() {
+                if col.is_null(row_i) {
+                    continue;
+                }
+                rows[row_i][col_i] = Some(col.value(row_i));
+            }
+        }
+        rows
+    }
+
+    fn to_vec(b: &RecordBatch) -> Vec<Vec<i64>> {
+        let mut rows = vec![vec![0; b.num_columns()]; b.num_rows()];
+        for col_i in 0..b.num_columns() {
+            let col = b
+                .column(col_i)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            assert_eq!(col.null_count(), 0);
+            let col = col.values();
+            for row_i in 0..b.num_rows() {
+                rows[row_i][col_i] = col[row_i]
+            }
+        }
+        rows
+    }
+}

--- a/rust/cubestore/src/queryplanner/topk/mod.rs
+++ b/rust/cubestore/src/queryplanner/topk/mod.rs
@@ -1,0 +1,118 @@
+mod execute;
+mod plan;
+
+pub use execute::AggregateTopKExec;
+pub use plan::materialize_topk;
+pub use plan::plan_topk;
+
+use crate::queryplanner::serialized_plan::IndexSnapshot;
+use arrow::compute::SortOptions;
+use datafusion::logical_plan::{DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode};
+use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
+use std::any::Any;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+/// Aggregates input by [group_expr], sorts with [order_by] and returns [limit] first elements.
+/// The output schema must have exactly columns for results of [group_expr] followed by results
+/// of [aggregate_expr].
+#[derive(Debug)]
+pub struct ClusterAggregateTopK {
+    pub limit: usize,
+    pub input: Arc<LogicalPlan>,
+    pub group_expr: Vec<Expr>,
+    pub aggregate_expr: Vec<Expr>,
+    pub order_by: Vec<SortColumn>,
+    pub schema: DFSchemaRef,
+    pub snapshots: Vec<Vec<IndexSnapshot>>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct SortColumn {
+    /// Index of the column in the output schema.
+    pub agg_index: usize,
+    pub asc: bool,
+    pub nulls_first: bool,
+}
+
+impl SortColumn {
+    fn sort_options(&self) -> SortOptions {
+        SortOptions {
+            descending: !self.asc,
+            nulls_first: self.nulls_first,
+        }
+    }
+}
+
+impl Display for SortColumn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.agg_index.fmt(f)?;
+        if !self.asc {
+            f.write_str(" desc")?;
+        }
+        if !self.nulls_first {
+            f.write_str(" nulls last")?;
+        }
+        Ok(())
+    }
+}
+
+impl ClusterAggregateTopK {
+    pub fn into_plan(self) -> LogicalPlan {
+        LogicalPlan::Extension {
+            node: Arc::new(self),
+        }
+    }
+}
+
+impl UserDefinedLogicalNode for ClusterAggregateTopK {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        self.group_expr
+            .iter()
+            .chain(&self.aggregate_expr)
+            .cloned()
+            .collect_vec()
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter<'a>) -> std::fmt::Result {
+        write!(
+            f,
+            "ClusterAggregateTopK, limit = {}, groupBy = {:?}, aggr = {:?}, sortBy = {:?}",
+            self.limit, self.group_expr, self.aggregate_expr, self.order_by
+        )
+    }
+
+    fn from_template(
+        &self,
+        exprs: &Vec<Expr>,
+        inputs: &Vec<LogicalPlan>,
+    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        let num_groups = self.group_expr.len();
+        let num_aggs = self.aggregate_expr.len();
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(exprs.len(), num_groups + num_aggs);
+        Arc::new(ClusterAggregateTopK {
+            limit: self.limit,
+            input: Arc::new(inputs[0].clone()),
+            group_expr: Vec::from(&exprs[0..num_groups]),
+            aggregate_expr: Vec::from(&exprs[num_groups..num_groups + num_aggs]),
+            order_by: self.order_by.clone(),
+            schema: self.schema.clone(),
+            snapshots: self.snapshots.clone(),
+        })
+    }
+}

--- a/rust/cubestore/src/queryplanner/topk/plan.rs
+++ b/rust/cubestore/src/queryplanner/topk/plan.rs
@@ -1,0 +1,324 @@
+use crate::queryplanner::planning::{ClusterSendNode, CubeExtensionPlanner};
+use crate::queryplanner::topk::execute::AggregateTopKExec;
+use crate::queryplanner::topk::{ClusterAggregateTopK, SortColumn};
+use arrow::datatypes::DataType;
+use datafusion::error::DataFusionError;
+use datafusion::execution::context::ExecutionContextState;
+use datafusion::logical_plan::{DFField, DFSchema, DFSchemaRef, Expr, LogicalPlan};
+use datafusion::physical_plan::aggregates::AggregateFunction;
+use datafusion::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
+use datafusion::physical_plan::planner::{compute_aggregation_strategy, DefaultPhysicalPlanner};
+use datafusion::physical_plan::sort::{SortExec, SortOptions};
+use datafusion::physical_plan::ExecutionPlan;
+use itertools::Itertools;
+use std::sync::Arc;
+
+/// Replaces `Limit(Sort(Aggregate(ClusterSend)))` with [ClusterAggregateTopK] when possible.
+pub fn materialize_topk(p: LogicalPlan) -> Result<LogicalPlan, DataFusionError> {
+    match &p {
+        LogicalPlan::Limit {
+            n: limit,
+            input: sort,
+        } => match sort.as_ref() {
+            LogicalPlan::Sort {
+                expr: sort_expr,
+                input: sort_input,
+            } => {
+                let projection = extract_column_projection(&sort_input);
+                let aggregate = projection.as_ref().map(|p| p.input).unwrap_or(sort_input);
+                match aggregate.as_ref() {
+                    LogicalPlan::Aggregate {
+                        input: cluster_send,
+                        group_expr,
+                        aggr_expr,
+                        schema: aggregate_schema,
+                    } => {
+                        assert_eq!(
+                            aggregate_schema.fields().len(),
+                            group_expr.len() + aggr_expr.len()
+                        );
+                        if group_expr.len() == 0
+                            || aggr_expr.len() == 0
+                            || !aggr_exprs_allow_topk(aggr_expr)
+                            || !aggr_schema_allows_topk(aggregate_schema.as_ref(), group_expr.len())
+                        {
+                            return Ok(p);
+                        }
+                        let sort_columns;
+                        if let Some(sc) = extract_sort_columns(
+                            group_expr.len(),
+                            &sort_expr,
+                            sort_input.schema(),
+                            projection.as_ref().map(|c| c.input_columns.as_slice()),
+                        ) {
+                            sort_columns = sc;
+                        } else {
+                            return Ok(p);
+                        }
+                        match cluster_send.as_ref() {
+                            LogicalPlan::Extension { node } => {
+                                let cs;
+                                if let Some(c) = node.as_any().downcast_ref::<ClusterSendNode>() {
+                                    cs = c;
+                                } else {
+                                    return Ok(p);
+                                }
+                                let topk = LogicalPlan::Extension {
+                                    node: Arc::new(ClusterAggregateTopK {
+                                        limit: *limit,
+                                        input: cs.input.clone(),
+                                        group_expr: group_expr.clone(),
+                                        aggregate_expr: aggr_expr.clone(),
+                                        order_by: sort_columns,
+                                        schema: aggregate_schema.clone(),
+                                        snapshots: cs.snapshots.clone(),
+                                    }),
+                                };
+                                if let Some(p) = projection {
+                                    let in_schema = topk.schema();
+                                    let out_schema = p.schema;
+                                    let mut expr = Vec::with_capacity(p.input_columns.len());
+                                    for out_i in 0..p.input_columns.len() {
+                                        let in_field = in_schema.field(p.input_columns[out_i]);
+                                        let out_name = out_schema.field(out_i).name();
+
+                                        let mut e = field_reference(in_field);
+                                        if out_name != in_field.name() {
+                                            e = Expr::Alias(Box::new(e), out_name.clone())
+                                        }
+                                        expr.push(e);
+                                    }
+                                    return Ok(LogicalPlan::Projection {
+                                        expr,
+                                        input: Arc::new(topk),
+                                        schema: p.schema.clone(),
+                                    });
+                                } else {
+                                    return Ok(topk);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        },
+        _ => {}
+    }
+
+    Ok(p)
+}
+
+fn aggr_exprs_allow_topk(agg_exprs: &[Expr]) -> bool {
+    for a in agg_exprs {
+        match a {
+            Expr::AggregateFunction { fun, distinct, .. } => {
+                if *distinct || !fun_allows_topk(fun.clone()) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    return true;
+}
+
+fn aggr_schema_allows_topk(schema: &DFSchema, group_expr_len: usize) -> bool {
+    for agg_field in &schema.fields()[group_expr_len..] {
+        match agg_field.data_type() {
+            DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Int64Decimal(_) => {} // ok, continue.
+            _ => return false,
+        }
+    }
+    return true;
+}
+
+fn fun_allows_topk(f: AggregateFunction) -> bool {
+    // Only monotone functions are allowed in principle.
+    // Implementation also requires accumulator state and final value to be the same.
+    // TODO: lift the restriction and add support for Avg.
+    match f {
+        AggregateFunction::Sum | AggregateFunction::Min | AggregateFunction::Max => true,
+        AggregateFunction::Count | AggregateFunction::Avg => false,
+    }
+}
+
+fn extract_aggregate_fun(e: &Expr) -> Option<AggregateFunction> {
+    match e {
+        Expr::AggregateFunction { fun, .. } => Some(fun.clone()),
+        _ => None,
+    }
+}
+
+struct ColumnProjection<'a> {
+    input_columns: Vec<usize>,
+    input: &'a Arc<LogicalPlan>,
+    schema: &'a DFSchemaRef,
+}
+
+fn extract_column_projection(p: &LogicalPlan) -> Option<ColumnProjection> {
+    match p {
+        LogicalPlan::Projection {
+            expr,
+            input,
+            schema,
+        } => {
+            let in_schema = input.schema();
+            let mut input_columns = Vec::with_capacity(expr.len());
+            for e in expr {
+                match e {
+                    Expr::Alias(box Expr::Column(n, q), _) | Expr::Column(n, q) => {
+                        input_columns.push(field_index(in_schema, q.as_deref(), n)?)
+                    }
+                    _ => return None,
+                }
+            }
+            Some(ColumnProjection {
+                input_columns,
+                input,
+                schema,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn extract_sort_columns(
+    group_key_len: usize,
+    sort_expr: &[Expr],
+    schema: &DFSchema,
+    projection: Option<&[usize]>,
+) -> Option<Vec<SortColumn>> {
+    let mut sort_columns = Vec::with_capacity(sort_expr.len());
+    for e in sort_expr {
+        match e {
+            Expr::Sort {
+                expr: box Expr::Column(n, q),
+                asc,
+                nulls_first,
+            } => {
+                let mut index = field_index(schema, q.as_deref(), n)?;
+                if let Some(p) = projection {
+                    index = p[index];
+                }
+                if index < group_key_len {
+                    return None;
+                }
+                sort_columns.push(SortColumn {
+                    agg_index: index - group_key_len,
+                    asc: *asc,
+                    nulls_first: *nulls_first,
+                })
+            }
+            _ => return None,
+        }
+    }
+    Some(sort_columns)
+}
+
+fn field_index(schema: &DFSchema, qualifier: Option<&str>, name: &str) -> Option<usize> {
+    schema
+        .fields()
+        .iter()
+        .position(|f| f.qualifier().map(|s| s.as_str()) == qualifier && f.name() == name)
+}
+
+pub fn plan_topk(
+    ext_planner: &CubeExtensionPlanner,
+    node: &ClusterAggregateTopK,
+    input: Arc<dyn ExecutionPlan>,
+    ctx: &ExecutionContextState,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let planner = DefaultPhysicalPlanner::default();
+
+    // Partial aggregate on workers. Mimics corresponding planning code from DataFusion.
+    let physical_input_schema = input.schema();
+    let logical_input_schema = node.input.schema();
+    let group_expr = node
+        .group_expr
+        .iter()
+        .map(|e| {
+            Ok((
+                planner.create_physical_expr(e, &physical_input_schema, ctx)?,
+                e.name(&logical_input_schema)?,
+            ))
+        })
+        .collect::<Result<Vec<_>, DataFusionError>>()?;
+    let group_expr_len = group_expr.len();
+    let initial_aggregate_expr = node
+        .aggregate_expr
+        .iter()
+        .map(|e| {
+            planner.create_aggregate_expr(e, &logical_input_schema, &physical_input_schema, ctx)
+        })
+        .collect::<Result<Vec<_>, DataFusionError>>()?;
+    let strategy = compute_aggregation_strategy(input.as_ref(), &group_expr);
+    let aggregate = Arc::new(HashAggregateExec::try_new(
+        strategy,
+        AggregateMode::Full,
+        group_expr,
+        initial_aggregate_expr.clone(),
+        input,
+    )?);
+
+    let aggregate_schema = aggregate.as_ref().schema();
+
+    // Sort on workers.
+    let sort_expr = node
+        .order_by
+        .iter()
+        .map(|c| {
+            planner.create_physical_sort_expr(
+                &field_reference(aggregate_schema.field(group_expr_len + c.agg_index)),
+                &aggregate_schema,
+                SortOptions {
+                    descending: !c.asc,
+                    nulls_first: c.nulls_first,
+                },
+                ctx,
+            )
+        })
+        .collect::<Result<Vec<_>, DataFusionError>>()?;
+    let sort = Arc::new(SortExec::try_new(
+        sort_expr,
+        aggregate,
+        ctx.config.concurrency,
+    )?);
+    let sort_schema = sort.schema();
+
+    // Send results to router.
+    let schema = sort_schema.clone();
+    let cluster = ext_planner.plan_cluster_send(sort, &node.snapshots, schema.clone())?;
+    let agg_fun = node
+        .aggregate_expr
+        .iter()
+        .map(|e| extract_aggregate_fun(e).unwrap())
+        .collect_vec();
+    Ok(Arc::new(AggregateTopKExec::new(
+        node.limit,
+        group_expr_len,
+        initial_aggregate_expr,
+        &agg_fun,
+        node.order_by.clone(),
+        cluster,
+        schema,
+    )))
+}
+
+fn field_reference(f: &DFField) -> Expr {
+    Expr::Column(f.name().clone(), f.qualifier().cloned())
+}


### PR DESCRIPTION
This allows to more efficiently execute queries like:

```
SELECT group_key, SUM(agg) FROM … GROUP BY 1 ORDER BY 2 LIMIT 10
```

Previously, we would:
    1. pre-aggregate results on the workers,
    2. send pre-aggregated results from each worker to the router,
    3. do the final aggregation on the router for the full data,
    4. sort full results,
    5. return top 10 rows.

When the dataset is large and the limit is small, we clearly do a
lot more work than needed, both on the workers and on the router.

After this change, we:
    1. pre-aggregate and sort on the workers,
    2. send results to the router,
    3. process only the required number of rows from each worker to get
       the 10 result rows.

After this change, we do much less work on the router.
More improvements are on the way:
  - stream only the required number of rows from each worker,
  - allow to replace the 'sort and pre-aggregate' step on the workers
    with table scan from an index if possible.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
