### PR TITLE
docs: fix "jumping" sidebar when switching between OSS and Cube Cloud docs

### DIFF
--- a/docs/static/styles/_layout.scss
+++ b/docs/static/styles/_layout.scss
@@ -384,7 +384,7 @@ span.group-header {
   width: inherit;
   background: $sidebar-bg;
   padding: 16px 24px;
-  overflow-y: auto;
+  overflow-y: scroll;
   overflow-x: hidden;
   position: fixed;
   //padding-left: calc(9999px + 24px);


### PR DESCRIPTION
Story details: https://app.clubhouse.io/cube-dev/story/228

Thanks @cainaleaouk!