### PR TITLE
fix: Reduce Redis traffic while querying immutable pre-aggregation partitions by introducing LRU in memory cache for refresh keys

### DIFF
--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -34,6 +34,7 @@
     "@cubejs-backend/shared": "^0.26.74",
     "generic-pool": "^3.7.1",
     "ioredis": "^4.19.4",
+    "lru-cache": "^6.0.0",
     "ramda": "^0.27.0",
     "redis": "^3.0.2"
   },

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -244,7 +244,8 @@ class PreAggregationLoadCache {
           waitForRenew,
           priority,
           requestId: this.requestId,
-          dataSource: this.dataSource
+          dataSource: this.dataSource,
+          useInMemory: true
         }
       );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4308,7 +4308,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
-"@types/ramda@0.27.34", "@types/ramda@^0.27.32", "@types/ramda@^0.27.34":
+"@types/ramda@^0.27.32", "@types/ramda@^0.27.34":
   version "0.27.34"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.34.tgz#08505be193a1ac9d9de0411fbf5aa0d9e817fd9a"
   integrity sha512-8pJBMViQ4v88ebcNkDMDf59vZ4/EMTgvN/pKCAgp70XUjEPgs+U40DWhpIzcgOgDmXV2OMew2tqed5tqKwPWZg==


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

