### PR TITLE
fix(cubestore): reduce serialization time for record batches

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "rust-s3",
  "scopeguard",
  "serde",
+ "serde_bytes",
  "serde_derive",
  "serde_json",
  "simple_logger",
@@ -3824,6 +3825,15 @@ dependencies = [
  "serde",
  "thiserror",
  "xml-rs",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -21,6 +21,7 @@ warp = { git = 'https://github.com/seanmonstar/warp', version = "0.3.0" }
 sqlparser = "0.7.0"
 serde_derive = "1.0.115"
 serde = "1.0.115"
+serde_bytes = "0.11.5"
 cubehll = { path = "../cubehll" }
 cubezetasketch = { path = "../cubezetasketch" }
 cuberpc = { path = "../cuberpc" }

--- a/rust/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/src/queryplanner/query_executor.rs
@@ -909,6 +909,7 @@ pub fn arrow_to_column_type(arrow_type: DataType) -> Result<ColumnType, CubeErro
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SerializedRecordBatchStream {
+    #[serde(with = "serde_bytes")] // serde_bytes makes serialization efficient.
     record_batch_file: Vec<u8>,
 }
 


### PR DESCRIPTION
Sending large result sets via IPC or network is much cheaper now.