### PR TITLE
fix(cubestore): temporarily disable streaming in top-k

### DIFF
--- a/rust/cubestore/src/queryplanner/topk/plan.rs
+++ b/rust/cubestore/src/queryplanner/topk/plan.rs
@@ -307,7 +307,7 @@ pub fn plan_topk(
         sort,
         &node.snapshots,
         schema.clone(),
-        /*use_streaming*/ true,
+        /*use_streaming*/ false, // TODO: enable streaming.
         /*max_batch_rows*/ max(2 * node.limit, MIN_TOPK_STREAM_ROWS),
     )?;
     let agg_fun = node


### PR DESCRIPTION
This causes performance problems in some operation modes.
Will re-enable when fixed.