### PR TITLE
fix: dimensionColumns only fetch string  column

### DIFF
--- a/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingSchema.js
+++ b/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingSchema.js
@@ -141,7 +141,7 @@ export class ScaffoldingSchema {
 
   dimensionColumns(tableDefinition) {
     const dimensionColumns = tableDefinition.filter(
-      column => !column.name.startsWith('_')  ||
+      column => !column.name.startsWith('_') ||
         column.attributes && column.attributes.indexOf('primaryKey') !== -1 ||
         column.name.toLowerCase() === 'id'
     );

--- a/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingSchema.js
+++ b/packages/cubejs-schema-compiler/src/scaffolding/ScaffoldingSchema.js
@@ -141,7 +141,7 @@ export class ScaffoldingSchema {
 
   dimensionColumns(tableDefinition) {
     const dimensionColumns = tableDefinition.filter(
-      column => !column.name.startsWith('_') && this.columnType(column) === 'string' ||
+      column => !column.name.startsWith('_')  ||
         column.attributes && column.attributes.indexOf('primaryKey') !== -1 ||
         column.name.toLowerCase() === 'id'
     );


### PR DESCRIPTION
dimensionColumns  method delete `&& this.columnType(column) === 'string'`  otherwise cube.js  playground with schema generater will  always only fetch string type column
