### PR TITLE
chore(cubestore): temporarily disable top-k

### DIFF
--- a/rust/cubestore/src/queryplanner/planning.rs
+++ b/rust/cubestore/src/queryplanner/planning.rs
@@ -258,7 +258,8 @@ impl PlanRewriter for ChooseIndex<'_> {
     ) -> Result<LogicalPlan, DataFusionError> {
         let p = self.choose_table_index(n)?;
         let p = pull_up_cluster_send(p)?;
-        let p = materialize_topk(p)?;
+        // TODO: fix and re-enable.
+        // let p = materialize_topk(p)?;
         Ok(p)
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
