### PR TITLE
fix(cubestore): allow to disable top-k with env var

### DIFF
--- a/rust/cubestore/src/queryplanner/topk/execute.rs
+++ b/rust/cubestore/src/queryplanner/topk/execute.rs
@@ -650,7 +650,11 @@ fn cmp_same_types(l: &ScalarValue, r: &ScalarValue, nulls_first: bool, asc: bool
         (ScalarValue::List(_, _), ScalarValue::List(_, _)) => {
             panic!("list as accumulator result is not supported")
         }
-        (_, _) => panic!("unhandled types in comparison"),
+        (l, r) => panic!(
+            "unhandled types in comparison: {} and {}",
+            l.get_datatype(),
+            r.get_datatype()
+        ),
     };
     if asc {
         o

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -3000,7 +3000,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn planning_inplace_aggregate2() {
         Config::run_test("planning_inplace_aggregate2", async move |services| {
             let service = services.sql_service;


### PR DESCRIPTION
Also adds more verbose logs for a panic that we hit in practice.
This also reverts commits:
  - ca668ea24dde6a9e6fa1663bdca9f7cdee8eb8e5: Revert "chore(cubestore): temporarily disable top-k (#2559)"
  - eebb2facd8491d3a2ac0ff9f2ffcec89c76073e9: Revert "chore(cubestore): revert streaming once again: ignore topk tests"