### PR TITLE
fix: Continuous refresh during Scheduled Refresh in case of both external and internal pre-aggregations are defined for the same data source

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -62,7 +62,13 @@ type VersionEntry = {
   naming_version?: number
 };
 
-const tablesToVersionEntries = (schema, tables: any[]): VersionEntry[] => R.sortBy(
+type TableCacheEntry = {
+  // eslint-disable-next-line camelcase
+  table_name?: string;
+  TABLE_NAME?: string;
+};
+
+const tablesToVersionEntries = (schema, tables: TableCacheEntry[]): VersionEntry[] => R.sortBy(
   table => -table.last_updated_at,
   tables.map(table => {
     const match = (table.table_name || table.TABLE_NAME).match(/(.+)_(.+)_(.+)_(.+)/);
@@ -118,10 +124,13 @@ class PreAggregationLoadCache {
 
   private requestId: any;
 
-  private versionEntries: any;
+  private versionEntries: { [redisKey: string]: VersionEntriesObj };
 
-  private tables: any;
+  private tables: { [redisKey: string]: TableCacheEntry[] };
 
+  // TODO this is in memory cache structure as well however it depends on
+  // data source only and load cache is per data source for now.
+  // Make it per data source key in case load cache scope is broaden.
   private queryStageState: any;
 
   private dataSource: string;
@@ -142,6 +151,8 @@ class PreAggregationLoadCache {
     this.cacheDriver = preAggregations.cacheDriver;
     this.externalDriverFactory = preAggregations.externalDriverFactory;
     this.requestId = options.requestId;
+    this.versionEntries = {};
+    this.tables = {};
   }
 
   protected async tablesFromCache(preAggregation, forceRenew?) {
@@ -182,14 +193,16 @@ class PreAggregationLoadCache {
   }
 
   protected async getTablesQuery(preAggregation) {
-    if (!this.tables) {
-      this.tables = await this.tablesFromCache(preAggregation);
+    const redisKey = this.tablesRedisKey(preAggregation);
+    if (!this.tables[redisKey]) {
+      this.tables[redisKey] = await this.tablesFromCache(preAggregation);
     }
-    return this.tables;
+    return this.tables[redisKey];
   }
 
   protected async getVersionEntries(preAggregation): Promise<VersionEntriesObj> {
-    if (!this.versionEntries) {
+    const redisKey = this.tablesRedisKey(preAggregation);
+    if (!this.versionEntries[redisKey]) {
       const entries = tablesToVersionEntries(
         preAggregation.preAggregationsSchema,
         await this.getTablesQuery(preAggregation)
@@ -223,9 +236,9 @@ class PreAggregationLoadCache {
         }
       });
 
-      this.versionEntries = { versionEntries, byContent, byStructure, byTableName };
+      this.versionEntries[redisKey] = { versionEntries, byContent, byStructure, byTableName };
     }
-    return this.versionEntries;
+    return this.versionEntries[redisKey];
   }
 
   protected async keyQueryResult(keyQuery, waitForRenew, priority, renewalThreshold) {
@@ -272,9 +285,9 @@ class PreAggregationLoadCache {
 
   protected async reset(preAggregation) {
     await this.tablesFromCache(preAggregation, true);
-    this.tables = undefined;
+    this.tables = {};
     this.queryStageState = undefined;
-    this.versionEntries = undefined;
+    this.versionEntries = {};
   }
 }
 
@@ -871,8 +884,8 @@ export class PreAggregations {
     const loadCacheByDataSource = queryBody.preAggregationsLoadCacheByDataSource || {};
 
     const getLoadCacheByDataSource = (dataSource) => {
+      dataSource = dataSource || 'default';
       if (!loadCacheByDataSource[dataSource]) {
-        dataSource = dataSource || 'default';
         loadCacheByDataSource[dataSource] =
           new PreAggregationLoadCache(this.redisPrefix, () => this.driverFactory(dataSource), this.queryCache, this, {
             requestId: queryBody.requestId,

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
@@ -608,4 +608,48 @@ describe('QueryOrchestrator', () => {
       )
     ).toBe(true);
   });
+
+  test('load cache should respect external flag', async () => {
+    const preAggregationsLoadCacheByDataSource = {};
+    const externalPreAggregation = {
+      preAggregationsLoadCacheByDataSource,
+      query: 'SELECT "orders__created_at_week" "orders__created_at_week", sum("orders__count") "orders__count" FROM (SELECT * FROM stb_pre_aggregations.orders_number_and_count20191101) as partition_union  WHERE ("orders__created_at_week" >= ($1::timestamptz::timestamptz AT TIME ZONE \'UTC\') AND "orders__created_at_week" <= ($2::timestamptz::timestamptz AT TIME ZONE \'UTC\')) GROUP BY 1 ORDER BY 1 ASC LIMIT 10000',
+      values: ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z'],
+      cacheKeyQueries: {
+        renewalThreshold: 21600,
+        queries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]]
+      },
+      preAggregations: [{
+        preAggregationsSchema: 'stb_pre_aggregations',
+        tableName: 'stb_pre_aggregations.orders_number_and_count20191101',
+        loadSql: ['CREATE TABLE stb_pre_aggregations.orders_number_and_count20191101 AS SELECT\n      date_trunc(\'week\', ("orders".created_at::timestamptz AT TIME ZONE \'UTC\')) "orders__created_at_week", count("orders".id) "orders__count", sum("orders".number) "orders__number"\n    FROM\n      public.orders AS "orders"\n  WHERE ("orders".created_at >= $1::timestamptz AND "orders".created_at <= $2::timestamptz) GROUP BY 1', ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z']],
+        invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
+        external: true,
+      }],
+      renewQuery: true,
+      requestId: 'load cache should respect external flag'
+    };
+    const internalPreAggregation = {
+      preAggregationsLoadCacheByDataSource,
+      query: 'SELECT "orders__created_at_week" "orders__created_at_week", sum("orders__count") "orders__count" FROM (SELECT * FROM stb_pre_aggregations.orders_number_and_count20191101) as partition_union  WHERE ("orders__created_at_week" >= ($1::timestamptz::timestamptz AT TIME ZONE \'UTC\') AND "orders__created_at_week" <= ($2::timestamptz::timestamptz AT TIME ZONE \'UTC\')) GROUP BY 1 ORDER BY 1 ASC LIMIT 10000',
+      values: ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z'],
+      cacheKeyQueries: {
+        renewalThreshold: 21600,
+        queries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]]
+      },
+      preAggregations: [{
+        preAggregationsSchema: 'stb_pre_aggregations',
+        tableName: 'stb_pre_aggregations.internal',
+        loadSql: ['CREATE TABLE stb_pre_aggregations.internal AS SELECT\n      date_trunc(\'week\', ("orders".created_at::timestamptz AT TIME ZONE \'UTC\')) "orders__created_at_week", count("orders".id) "orders__count", sum("orders".number) "orders__number"\n    FROM\n      public.orders AS "orders"\n  WHERE ("orders".created_at >= $1::timestamptz AND "orders".created_at <= $2::timestamptz) GROUP BY 1', ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z']],
+        invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
+      }],
+      renewQuery: true,
+      requestId: 'load cache should respect external flag'
+    };
+    await queryOrchestrator.fetchQuery(internalPreAggregation);
+    await queryOrchestrator.fetchQuery(externalPreAggregation);
+    await queryOrchestrator.fetchQuery(internalPreAggregation);
+    console.log(mockDriver.tables);
+    expect(mockDriver.tables.length).toBe(2);
+  });
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
