### PR TITLE
feat: change 403 to UserError's status

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -957,7 +957,7 @@ export class ApiGateway {
       }
     } catch (e) {
       if (e instanceof UserError) {
-        res.status(403).json({ error: e.message });
+        res.status(e.status).json({ error: e.message });
       } else {
         this.log({
           type: 'Auth Error',


### PR DESCRIPTION
change 403 to  UserError's status for better  set http statu code 
for example 
```code
// Cube.js configuration options: https://cube.dev/docs/config
const {UserError} = require("@cubejs-backend/api-gateway")
class MyUserError extends UserError {
    constructor(message){
       super(message)
       this.status=401
    }
}
module.exports = {
    checkAuth: (ob) => {
        // we can set  http statu code 
        throw new MyUserError('Could not authenticate user from LDAP');
    }
};
```