### PR TITLE
fix: Original SQL table is not found when `useOriginalSqlPreAggregations` used together with `CUBE.sql()` reference

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
@@ -39,11 +39,8 @@ export class PreAggregations {
       isInPreAggregationQuery && this.query.options.useOriginalSqlPreAggregationsInPreAggregation) {
       return R.pipe(
         R.map(cube => {
-          const foundPreAggregation = this.findPreAggregationToUseForCube(cube);
-          if (foundPreAggregation) {
-            return this.preAggregationDescriptionsFor(foundPreAggregation);
-          }
-          return null;
+          const { preAggregations } = this.collectOriginalSqlPreAggregations(() => this.query.cubeSql(cube));
+          return R.unnest(preAggregations.map(p => this.preAggregationDescriptionsFor(p)));
         }),
         R.filter(R.identity),
         R.unnest


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
