### PR TITLE
fix(cubestore): simplify `trim_alloc` handling

### DIFF
--- a/rust/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/src/bin/cubestored.rs
@@ -1,10 +1,12 @@
 use cubestore::config::{Config, CubeServices};
 use cubestore::telemetry::{track_event, ReportingLogger};
+use cubestore::util::spawn_malloc_trim_loop;
 use log::debug;
 use log::Level;
 use simple_logger::SimpleLogger;
 use std::collections::HashMap;
 use std::env;
+use std::time::Duration;
 use tokio::runtime::Builder;
 
 fn main() {
@@ -29,6 +31,11 @@ fn main() {
     let config = Config::default();
 
     Config::configure_worker_services();
+
+    let trim_every = config.config_obj().malloc_trim_every_secs();
+    if trim_every != 0 {
+        spawn_malloc_trim_loop(Duration::from_secs(trim_every));
+    }
 
     debug!("New process started");
 

--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -26,7 +26,6 @@ use crate::queryplanner::serialized_plan::SerializedPlan;
 use crate::remotefs::RemoteFs;
 use crate::store::compaction::CompactionService;
 use crate::store::ChunkDataStore;
-use crate::sys::malloc::trim_allocs;
 use crate::CubeError;
 use arrow::datatypes::SchemaRef;
 use arrow::error::ArrowError;
@@ -806,7 +805,6 @@ impl ClusterImpl {
         &self,
         plan_node: SerializedPlan,
     ) -> Result<(SchemaRef, Vec<SerializedRecordBatchStream>), CubeError> {
-        scopeguard::defer!(trim_allocs());
         let start = SystemTime::now();
         debug!("Running select: {:?}", plan_node);
         let to_download = plan_node.files_to_download();

--- a/rust/cubestore/src/cluster/worker_pool.rs
+++ b/rust/cubestore/src/cluster/worker_pool.rs
@@ -1,4 +1,3 @@
-use crate::sys::malloc::trim_allocs;
 use crate::CubeError;
 use async_trait::async_trait;
 use deadqueue::unlimited;
@@ -239,7 +238,6 @@ impl<
                 let res = rx.recv();
                 match res {
                     Ok(args) => {
-                        scopeguard::defer!(trim_allocs());
                         let send_res = tx.send(runtime.block_on(P::process(args)));
                         if let Err(e) = send_res {
                             error!("Worker message send error: {:?}", e);

--- a/rust/cubestore/src/import/mod.rs
+++ b/rust/cubestore/src/import/mod.rs
@@ -9,7 +9,6 @@ use crate::metastore::{Column, ColumnType, ImportFormat, MetaStore};
 use crate::remotefs::RemoteFs;
 use crate::sql::timestamp_from_string;
 use crate::store::ChunkDataStore;
-use crate::sys::malloc::trim_allocs;
 use crate::table::data::{MutRows, Rows};
 use crate::table::{Row, TableValue};
 use crate::util::maybe_owned::MaybeOwnedStr;
@@ -27,7 +26,6 @@ use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use mockall::automock;
 use pin_project_lite::pin_project;
-use scopeguard::defer;
 use std::fs;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -443,8 +441,6 @@ impl ImportService for ImportServiceImpl {
                     table.get_row().get_columns().clone(),
                 )
                 .await?;
-
-            defer!(trim_allocs());
 
             let mut ingestion = Ingestion::new(
                 self.meta_store.clone(),

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -30,7 +30,6 @@ use crate::queryplanner::query_executor::QueryExecutor;
 use crate::remotefs::RemoteFs;
 use crate::sql::parser::CubeStoreParser;
 use crate::store::ChunkDataStore;
-use crate::sys::malloc::trim_allocs;
 use crate::table::data::{MutRows, Rows, TableValueR};
 use chrono::format::Fixed::Nanosecond3;
 use chrono::format::Item::{Fixed, Literal, Numeric, Space};
@@ -449,8 +448,6 @@ impl SqlService for SqlServiceImpl {
                 columns,
                 source,
             }) => {
-                scopeguard::defer!(trim_allocs());
-
                 let data = if let SetExpr::Values(Values(data_series)) = &source.body {
                     data_series
                 } else {
@@ -472,7 +469,6 @@ impl SqlService for SqlServiceImpl {
                 Ok(DataFrame::new(vec![], vec![]))
             }
             CubeStoreStatement::Statement(Statement::Query(q)) => {
-                scopeguard::defer!(trim_allocs());
                 let logical_plan = self
                     .query_planner
                     .logical_plan(DFStatement::Statement(Statement::Query(q)))
@@ -506,7 +502,6 @@ impl SqlService for SqlServiceImpl {
         };
         match ast {
             CubeStoreStatement::Statement(Statement::Query(q)) => {
-                scopeguard::defer!(trim_allocs());
                 let logical_plan = self
                     .query_planner
                     .logical_plan(DFStatement::Statement(Statement::Query(q)))

--- a/rust/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/src/store/compaction.rs
@@ -3,7 +3,6 @@ use crate::config::ConfigObj;
 use crate::metastore::MetaStore;
 use crate::remotefs::RemoteFs;
 use crate::store::ChunkDataStore;
-use crate::sys::malloc::trim_allocs;
 use crate::table::data::{cmp_row_key, RowsView, TableValueR};
 use crate::table::parquet::ParquetTableStore;
 use crate::table::TableStore;
@@ -11,7 +10,6 @@ use crate::CubeError;
 use async_trait::async_trait;
 use itertools::{EitherOrBoth, Itertools};
 use num::integer::div_ceil;
-use scopeguard::defer;
 use std::mem::swap;
 use std::sync::Arc;
 
@@ -48,7 +46,6 @@ impl CompactionServiceImpl {
 #[async_trait]
 impl CompactionService for CompactionServiceImpl {
     async fn compact(&self, partition_id: u64) -> Result<(), CubeError> {
-        defer!(trim_allocs());
         let mut chunks = self
             .meta_store
             .get_chunks_by_partition(partition_id, false)

--- a/rust/cubestore/src/store/mod.rs
+++ b/rust/cubestore/src/store/mod.rs
@@ -22,7 +22,6 @@ use std::{
 };
 
 use crate::config::injection::DIService;
-use crate::sys::malloc::trim_allocs;
 use crate::table::data::{cmp_row_key, cmp_row_key_heap, MutRows, Rows};
 use crate::table::parquet::ParquetTableStore;
 use arrow::array::{Array, Int64Builder, StringBuilder};
@@ -31,7 +30,6 @@ use futures::future::join_all;
 use itertools::Itertools;
 use log::trace;
 use mockall::automock;
-use scopeguard::defer;
 use std::cmp::Ordering;
 use tokio::task::JoinHandle;
 
@@ -329,8 +327,6 @@ impl ChunkDataStore for ChunkStore {
     }
 
     async fn repartition(&self, partition_id: u64) -> Result<(), CubeError> {
-        defer!(trim_allocs());
-
         let partition = self.meta_store.get_partition(partition_id).await?;
         if partition.get_row().is_active() {
             return Err(CubeError::internal(format!(
@@ -722,7 +718,6 @@ impl ChunkStore {
         mut rows: Rows,
         columns: &[Column],
     ) -> Result<Vec<ChunkUploadJob>, CubeError> {
-        defer!(trim_allocs());
         let mut new_chunks = Vec::new();
         for index in indexes.iter() {
             let index_columns = index.get_row().columns();

--- a/rust/cubestore/src/util/malloc_trim_loop.rs
+++ b/rust/cubestore/src/util/malloc_trim_loop.rs
@@ -1,0 +1,15 @@
+use crate::sys::malloc::{trim_allocs, HAS_TRIM_ALLOC};
+use std::time::Duration;
+
+/// See the comment on [trim_alloc] on discussion on why we need it.
+pub fn spawn_malloc_trim_loop(period: Duration) {
+    if !HAS_TRIM_ALLOC {
+        return;
+    }
+
+    // We detach the thread, so have to be prepared it gets killed at any point.
+    std::thread::spawn(move || loop {
+        std::thread::sleep(period);
+        trim_allocs()
+    });
+}

--- a/rust/cubestore/src/util/mod.rs
+++ b/rust/cubestore/src/util/mod.rs
@@ -1,7 +1,9 @@
 pub mod lock;
+mod malloc_trim_loop;
 pub mod maybe_owned;
 pub mod ordfloat;
 pub mod time_span;
+pub use malloc_trim_loop::spawn_malloc_trim_loop;
 
 use crate::CubeError;
 use log::error;


### PR DESCRIPTION
Remove on-demand calls and spawn a separate thread that
periodically calls `trim_alloc`.

The period is configurable via `CUBESTORE_MALLOC_TRIM_EVERY_SECS`
environment variable.

The advantages are:
  - No need to annonate memory-allocating code.
  - Less calls to `trim_alloc` on a lot of simple requests.

A slight disadvantage is that calls to `trim_alloc` are now slightly
less predictable. Although in practice we normally have concurrent
requests that were calling `trim_allocs` at unpredictable times too.