### PR TITLE
chore(cubestore): refactor `RemoteFs`

### DIFF
--- a/rust/cubestore/src/config/injection.rs
+++ b/rust/cubestore/src/config/injection.rs
@@ -192,21 +192,21 @@ macro_rules! di_service (
                 &self,
                 target: core::any::TypeId,
                 type_name: &'static str,
-                arc: Arc<dyn $crate::config::injection::DIService>,
+                arc: std::sync::Arc<dyn $crate::config::injection::DIService>,
             ) -> Result<core::raw::TraitObject, CubeError> {
                 unsafe {
-                    let ptr = Arc::into_raw(arc);
-                    let arc = Arc::<Self>::from_raw(ptr as *const Self);
+                    let ptr = std::sync::Arc::into_raw(arc);
+                    let arc = std::sync::Arc::<Self>::from_raw(ptr as *const Self);
                     $(
                     if target == core::any::TypeId::of::<dyn $trait_ty>() {
-                        let iface_arc: Arc<dyn $trait_ty> = arc;
-                        let ptr = Arc::into_raw(iface_arc);
+                        let iface_arc: std::sync::Arc<dyn $trait_ty> = arc;
+                        let ptr = std::sync::Arc::into_raw(iface_arc);
                         return Ok(std::mem::transmute(&*ptr));
                     }
                     )*
                     if target == core::any::TypeId::of::<$ty>() {
-                        let typ_arc: Arc<$ty> = arc;
-                        let ptr = Arc::into_raw(typ_arc);
+                        let typ_arc: std::sync::Arc<$ty> = arc;
+                        let ptr = std::sync::Arc::into_raw(typ_arc);
                         return Ok(core::raw::TraitObject {
                             data: ptr as *const _ as *mut (),
                             vtable: std::ptr::null_mut(),

--- a/rust/cubestore/src/remotefs/remote_storage.rs
+++ b/rust/cubestore/src/remotefs/remote_storage.rs
@@ -1,0 +1,77 @@
+use crate::config::injection::DIService;
+use crate::di_service;
+use crate::remotefs::{LocalDirRemoteStorage, RemoteFile};
+use crate::CubeError;
+use async_trait::async_trait;
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+#[async_trait]
+pub trait RemoteStorage: Debug + DIService {
+    async fn upload_file(&self, local_path: &str, remote_path: &str) -> Result<(), CubeError>;
+    async fn download_file(
+        &self,
+        local_file_path: &Path,
+        local_file: File,
+        remote_path: &str,
+    ) -> Result<(), CubeError>;
+    async fn delete_file(&self, remote_path: &str) -> Result<(), CubeError>;
+    async fn list_with_metadata(&self, remote_prefix: &str) -> Result<Vec<RemoteFile>, CubeError>;
+}
+
+pub async fn list_remote(
+    s: &dyn RemoteStorage,
+    remote_prefix: &str,
+) -> Result<Vec<String>, CubeError> {
+    Ok(s.list_with_metadata(remote_prefix)
+        .await?
+        .into_iter()
+        .map(|f| f.remote_path)
+        .collect::<Vec<_>>())
+}
+
+/// Point this into '.cubestore' to avoid creating extra copies of the data. Directory only used to
+/// implement `list`, modification operations are nops.
+#[derive(Debug)]
+pub struct NoopRemoteStorage {
+    dir: PathBuf,
+}
+
+impl NoopRemoteStorage {
+    pub fn new(dir: PathBuf) -> NoopRemoteStorage {
+        NoopRemoteStorage { dir }
+    }
+}
+
+di_service!(NoopRemoteStorage, [RemoteStorage]);
+
+#[async_trait]
+impl RemoteStorage for NoopRemoteStorage {
+    async fn upload_file(&self, _local_path: &str, _remote_path: &str) -> Result<(), CubeError> {
+        Ok(())
+    }
+
+    async fn download_file(
+        &self,
+        _local_file_path: &Path,
+        _local_file: File,
+        _remote_path: &str,
+    ) -> Result<(), CubeError> {
+        Ok(())
+    }
+
+    async fn delete_file(&self, _remote_path: &str) -> Result<(), CubeError> {
+        Ok(())
+    }
+
+    async fn list_with_metadata(&self, remote_prefix: &str) -> Result<Vec<RemoteFile>, CubeError> {
+        let result = LocalDirRemoteStorage::list_recursive(
+            self.dir.clone().clone(),
+            remote_prefix.to_string(),
+            self.dir.clone(),
+        )
+        .await?;
+        Ok(result)
+    }
+}

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -878,10 +878,10 @@ mod tests {
     use super::*;
     use crate::cluster::MockCluster;
     use crate::config::{Config, FileStoreProvider};
-    use crate::metastore::RocksMetaStore;
+    use crate::metastore::{create_test_fs, RocksMetaStore};
     use crate::queryplanner::query_executor::MockQueryExecutor;
     use crate::queryplanner::MockQueryPlanner;
-    use crate::remotefs::{LocalDirRemoteFs, RemoteFs};
+    use crate::remotefs::RemoteFs;
     use crate::store::{ChunkStore, WALStore};
     use async_compression::tokio::write::GzipEncoder;
     use futures_timer::Delay;
@@ -892,7 +892,6 @@ mod tests {
     use rocksdb::{Options, DB};
     use std::fs::File;
     use std::io::Write;
-    use std::path::PathBuf;
     use std::time::Duration;
     use std::{env, fs};
     use tokio::io::{AsyncWriteExt, BufWriter};
@@ -909,10 +908,7 @@ mod tests {
         let _ = fs::remove_dir_all(remote_store_path.clone());
 
         {
-            let remote_fs = LocalDirRemoteFs::new(
-                Some(PathBuf::from(remote_store_path.clone())),
-                PathBuf::from(store_path.clone()),
-            );
+            let remote_fs = create_test_fs(Path::new(&store_path), Path::new(&remote_store_path));
             let meta_store = RocksMetaStore::new(path, remote_fs.clone(), config.config_obj());
             let rows_per_chunk = 10;
             let query_timeout = Duration::from_secs(30);
@@ -959,10 +955,7 @@ mod tests {
         let _ = fs::remove_dir_all(store_path.clone());
         let _ = fs::remove_dir_all(remote_store_path.clone());
         {
-            let remote_fs = LocalDirRemoteFs::new(
-                Some(PathBuf::from(remote_store_path.clone())),
-                PathBuf::from(store_path.clone()),
-            );
+            let remote_fs = create_test_fs(Path::new(&store_path), Path::new(&remote_store_path));
             let meta_store = RocksMetaStore::new(path, remote_fs.clone(), config.config_obj());
             let rows_per_chunk = 10;
             let query_timeout = Duration::from_secs(30);

--- a/rust/cubestore/src/store/mod.rs
+++ b/rust/cubestore/src/store/mod.rs
@@ -421,13 +421,12 @@ impl ChunkDataStore for ChunkStore {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::metastore::RocksMetaStore;
-    use crate::remotefs::LocalDirRemoteFs;
+    use crate::metastore::{create_test_fs, RocksMetaStore};
     use crate::table::data::MutRows;
     use crate::{metastore::ColumnType, table::TableValue};
     use rocksdb::{Options, DB};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::Path;
 
     #[tokio::test]
     async fn create_wal_test() {
@@ -440,10 +439,7 @@ mod tests {
         let _ = fs::remove_dir_all(remote_store_path.clone());
 
         {
-            let remote_fs = LocalDirRemoteFs::new(
-                Some(PathBuf::from(remote_store_path.clone())),
-                PathBuf::from(store_path.clone()),
-            );
+            let remote_fs = create_test_fs(Path::new(&store_path), Path::new(&remote_store_path));
             let store = WALStore::new(
                 RocksMetaStore::new(path, remote_fs.clone(), config.config_obj()),
                 remote_fs.clone(),
@@ -520,9 +516,9 @@ mod tests {
         let _ = fs::remove_dir_all(chunk_store_path.clone());
         let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
         {
-            let remote_fs = LocalDirRemoteFs::new(
-                Some(PathBuf::from(chunk_remote_store_path.clone())),
-                PathBuf::from(chunk_store_path.clone()),
+            let remote_fs = create_test_fs(
+                Path::new(&chunk_store_path),
+                Path::new(&chunk_remote_store_path),
             );
             let meta_store = RocksMetaStore::new(path, remote_fs.clone(), config.config_obj());
             let wal_store = WALStore::new(meta_store.clone(), remote_fs.clone(), 10);

--- a/rust/cubestore/src/util/mod.rs
+++ b/rust/cubestore/src/util/mod.rs
@@ -3,6 +3,8 @@ mod malloc_trim_loop;
 pub mod maybe_owned;
 pub mod ordfloat;
 pub mod time_span;
+pub mod ufs;
+
 pub use malloc_trim_loop::spawn_malloc_trim_loop;
 
 use crate::CubeError;

--- a/rust/cubestore/src/util/ufs.rs
+++ b/rust/cubestore/src/util/ufs.rs
@@ -1,0 +1,48 @@
+//! Wraps some fs operations to get more detailed logs.
+//! The name of the module is deliberately short and different from `fs` to keep clients readable.
+use crate::CubeError;
+use std::path::Path;
+
+pub async fn create_dir_all(path: impl AsRef<Path>) -> Result<(), CubeError> {
+    tokio::fs::create_dir_all(path.as_ref()).await.map_err(|e| {
+        CubeError::internal(format!("create_dir_all({:?}) failed: {}", path.as_ref(), e))
+    })
+}
+
+pub async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64, CubeError> {
+    tokio::fs::copy(from.as_ref(), to.as_ref())
+        .await
+        .map_err(|e| {
+            CubeError::internal(format!(
+                "copy({:?}, {:?}) failed: {}",
+                from.as_ref(),
+                to.as_ref(),
+                e
+            ))
+        })
+}
+
+pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), CubeError> {
+    tokio::fs::rename(from.as_ref(), to.as_ref())
+        .await
+        .map_err(|e| {
+            CubeError::internal(format!(
+                "rename({:?}, {:?}) failed: {}",
+                from.as_ref(),
+                to.as_ref(),
+                e
+            ))
+        })
+}
+
+pub async fn remove_file(path: impl AsRef<Path>) -> Result<(), CubeError> {
+    tokio::fs::remove_file(path.as_ref())
+        .await
+        .map_err(|e| CubeError::internal(format!("remove_file({:?}) failed: {}", path.as_ref(), e)))
+}
+
+pub async fn remove_dir(path: impl AsRef<Path>) -> Result<(), CubeError> {
+    tokio::fs::remove_dir(path.as_ref())
+        .await
+        .map_err(|e| CubeError::internal(format!("remove_dir({:?}) failed: {}", path.as_ref(), e)))
+}


### PR DESCRIPTION
The goal is to reduce code duplication and separate local files
management from the cloud storage API wrappers.

We now have `RemoteStorage` for the latter.