### PR TITLE
Update server start messages for consistency

### DIFF
--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -40,11 +40,13 @@ export class DevServer {
     const cubejsToken = jwt.sign({}, options.apiSecret || 'secret', { expiresIn: '1d' });
 
     if (process.env.NODE_ENV !== 'production') {
-      console.log('🔓 Authentication checks are disabled in developer mode. Please use NODE_ENV=production to enable it.');
+      console.log('Cube.js is running in development mode: https://cube.dev/docs/configuration/overview#development-mode');
+      console.log('🔓 Authentication checks are disabled. Unset CUBEJS_DEV_MODE=true to enable.');
     } else {
-      console.log(`🔒 Your temporary cube.js token: ${cubejsToken}`);
+      console.log('Cube.js is running in production mode.');
+      console.log(`🔒 Your temporary API token: ${cubejsToken}`);
     }
-    console.log(`🦅 Dev environment available at ${apiUrl}`);
+    console.log(`🦅 Developer Playground is available at ${apiUrl}`);
     this.cubejsServer.event('Dev Server Start');
     const serveStatic = require('serve-static');
 


### PR DESCRIPTION
I've update Cube.js server start messages printed to console for consistency with docs and the current state of Cube.js.
* `developer mode` → `development mode` (https://cube.dev/docs/configuration/overview#development-mode)
* `NODE_ENV=production` → `CUBEJS_DEV_MODE=true`
* `Dev environment` → `Developer Playground` (https://cube.dev/docs/dev-tools/dev-playground)

I've also provided a link to docs where the details of the development mode are explained.