### PR TITLE
feat: add minio support

### DIFF
--- a/rust/cubestore/src/config/mod.rs
+++ b/rust/cubestore/src/config/mod.rs
@@ -158,9 +158,9 @@ pub enum FileStoreProvider {
     },
     S3 {
         region: String,
-        endpoint:Option<String>,
+        endpoint: Option<String>,
         bucket_name: String,
-        path_style:bool,
+        path_style: bool,
         sub_path: Option<String>,
     },
     GCS {
@@ -410,10 +410,10 @@ impl Config {
                 store_provider: {
                     if let Ok(bucket_name) = env::var("CUBESTORE_S3_BUCKET") {
                         FileStoreProvider::S3 {
-                            bucket_name:bucket_name,
+                            bucket_name: bucket_name,
                             region: env::var("CUBESTORE_S3_REGION").unwrap(),
                             endpoint: env::var("CUBESTORE_S3_ENDPOINT").ok(),
-                            path_style:env_bool("CURBSTONE_S3_PATH_STYLE",false),
+                            path_style: env_bool("CURBSTONE_S3_PATH_STYLE", false),
                             sub_path: env::var("CUBESTORE_S3_SUB_PATH").ok(),
                         }
                     } else if let Ok(bucket_name) = env::var("CUBESTORE_GCS_BUCKET") {
@@ -660,8 +660,15 @@ impl Config {
                 let sub_path = sub_path.clone();
                 self.injector
                     .register("original_remote_fs", async move |_| {
-                        let arc: Arc<dyn DIService> =
-                            S3RemoteFs::new(data_dir, region,path_style,endpoint, bucket_name, sub_path).unwrap();
+                        let arc: Arc<dyn DIService> = S3RemoteFs::new(
+                            data_dir,
+                            region,
+                            path_style,
+                            endpoint,
+                            bucket_name,
+                            sub_path,
+                        )
+                        .unwrap();
                         arc
                     })
                     .await;

--- a/rust/cubestore/src/config/mod.rs
+++ b/rust/cubestore/src/config/mod.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 use std::{env, fs};
 use tokio::sync::broadcast;
 use tokio::time::{timeout_at, Duration, Instant};
-use std::env::VarError;
 
 #[derive(Clone)]
 pub struct CubeServices {

--- a/rust/cubestore/src/config/mod.rs
+++ b/rust/cubestore/src/config/mod.rs
@@ -413,7 +413,7 @@ impl Config {
                             bucket_name: bucket_name,
                             region: env::var("CUBESTORE_S3_REGION").unwrap(),
                             endpoint: env::var("CUBESTORE_S3_ENDPOINT").ok(),
-                            path_style: env_bool("CURBSTONE_S3_PATH_STYLE", false),
+                            path_style: env_bool("CUBESTORE_S3_PATH_STYLE", false),
                             sub_path: env::var("CUBESTORE_S3_SUB_PATH").ok(),
                         }
                     } else if let Ok(bucket_name) = env::var("CUBESTORE_GCS_BUCKET") {
@@ -656,7 +656,7 @@ impl Config {
                 let region = region.to_string();
                 let bucket_name = bucket_name.to_string();
                 let endpoint = endpoint.clone();
-                let path_style = path_style.to_owned();
+                let path_style = path_style.clone();
                 let sub_path = sub_path.clone();
                 self.injector
                     .register("original_remote_fs", async move |_| {

--- a/rust/cubestore/src/remotefs/s3.rs
+++ b/rust/cubestore/src/remotefs/s3.rs
@@ -29,7 +29,7 @@ impl S3RemoteFs {
     pub fn new(
         dir: PathBuf,
         region: String,
-        path_style:bool,
+        path_style: bool,
         endpoint: Option<String>,
         bucket_name: String,
         sub_path: Option<String>,
@@ -41,16 +41,16 @@ impl S3RemoteFs {
             None,
             None,
         )?;
-        let bucket = if path_style==true {
+        let bucket = if path_style == true {
             Bucket::new_with_path_style(
                 &bucket_name,
                 Region::Custom {
-                    endpoint:endpoint.unwrap(),
+                    endpoint: endpoint.unwrap(),
                     region,
                 },
-                credentials
+                credentials,
             )?
-        } else{
+        } else {
             Bucket::new(&bucket_name, region.parse()?, credentials)?
         };
         Ok(Arc::new(Self {

--- a/rust/cubestore/src/remotefs/s3.rs
+++ b/rust/cubestore/src/remotefs/s3.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use log::{debug, info};
 use regex::{NoExpand, Regex};
 use s3::creds::Credentials;
-use s3::Bucket;
+use s3::{Bucket, Region};
 use std::env;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -29,6 +29,8 @@ impl S3RemoteFs {
     pub fn new(
         dir: PathBuf,
         region: String,
+        path_style:bool,
+        endpoint: Option<String>,
         bucket_name: String,
         sub_path: Option<String>,
     ) -> Result<Arc<Self>, CubeError> {
@@ -39,7 +41,18 @@ impl S3RemoteFs {
             None,
             None,
         )?;
-        let bucket = Bucket::new(&bucket_name, region.parse()?, credentials)?;
+        let bucket = if path_style==true {
+            Bucket::new_with_path_style(
+                &bucket_name,
+                Region::Custom {
+                    endpoint:endpoint.unwrap(),
+                    region,
+                },
+                credentials
+            )?
+        } else{
+            Bucket::new(&bucket_name, region.parse()?, credentials)?
+        };
         Ok(Arc::new(Self {
             dir,
             bucket,

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -1241,6 +1241,8 @@ mod tests {
                 c.compaction_chunks_count_threshold = 100;
                 c.store_provider = FileStoreProvider::S3 {
                     region: "us-west-2".to_string(),
+                    endpoint:None,
+                    path_style:false,
                     bucket_name: "cube-store-ci-test".to_string(),
                     sub_path: Some("high_frequency_inserts_s3".to_string()),
                 };
@@ -1256,6 +1258,8 @@ mod tests {
                         c.server_name = "127.0.0.1:4306".to_string();
                         c.store_provider = FileStoreProvider::S3 {
                             region: "us-west-2".to_string(),
+                            endpoint:None,
+                            path_style:false,
                             bucket_name: "cube-store-ci-test".to_string(),
                             sub_path: Some("high_frequency_inserts_s3".to_string()),
                         };
@@ -1558,6 +1562,8 @@ mod tests {
                 c.compaction_chunks_count_threshold = 100;
                 c.store_provider = FileStoreProvider::S3 {
                     region: "us-west-2".to_string(),
+                    path_style:false,
+                    endpoint:None,
                     bucket_name: "cube-store-ci-test".to_string(),
                     sub_path: Some("create_table_with_location_cluster".to_string()),
                 };
@@ -1574,6 +1580,8 @@ mod tests {
                         c.server_name = "127.0.0.1:24306".to_string();
                         c.store_provider = FileStoreProvider::S3 {
                             region: "us-west-2".to_string(),
+                            endpoint:None,
+                            path_style:false,
                             bucket_name: "cube-store-ci-test".to_string(),
                             sub_path: Some("create_table_with_location_cluster".to_string()),
                         };

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -1241,8 +1241,8 @@ mod tests {
                 c.compaction_chunks_count_threshold = 100;
                 c.store_provider = FileStoreProvider::S3 {
                     region: "us-west-2".to_string(),
-                    endpoint:None,
-                    path_style:false,
+                    endpoint: None,
+                    path_style: false,
                     bucket_name: "cube-store-ci-test".to_string(),
                     sub_path: Some("high_frequency_inserts_s3".to_string()),
                 };
@@ -1258,8 +1258,8 @@ mod tests {
                         c.server_name = "127.0.0.1:4306".to_string();
                         c.store_provider = FileStoreProvider::S3 {
                             region: "us-west-2".to_string(),
-                            endpoint:None,
-                            path_style:false,
+                            endpoint: None,
+                            path_style: false,
                             bucket_name: "cube-store-ci-test".to_string(),
                             sub_path: Some("high_frequency_inserts_s3".to_string()),
                         };


### PR DESCRIPTION
**Issue Reference this PR resolves**

Add minio S3-Compatible storage   https://github.com/cube-js/cube.js/issues/2642 

env config 

```code
CUBESTORE_SERVER_NAME=localhost:9999
CUBESTORE_META_PORT=9999
CUBESTORE_S3_BUCKET=<bucket>
CUBESTORE_S3_ENDPOINT=<minio endpoint>
CUBESTORE_S3_REGION=<minio default region us-east-1>
CUBESTORE_S3_PATH_STYLE=1 // this  need pass  for support path style access 
CUBESTORE_AWS_ACCESS_KEY_ID=<>
CUBESTORE_AWS_SECRET_ACCESS_KEY=<>
```
