### PR TITLE
docs(caching): Mention CUBESTORE_WORKERS needs to be set on workers

### DIFF
--- a/docs/content/Caching/Running-in-Production.md
+++ b/docs/content/Caching/Running-in-Production.md
@@ -105,7 +105,7 @@ reference][ref-config-env].
 | ----------------------- | ------------------ | ------------------ |
 | `CUBESTORE_SERVER_NAME` | Yes                | Yes                |
 | `CUBESTORE_META_PORT`   | Yes                | -                  |
-| `CUBESTORE_WORKERS`     | Yes                | -                  |
+| `CUBESTORE_WORKERS`     | Yes                | Yes                |
 | `CUBESTORE_WORKER_PORT` | -                  | Yes                |
 | `CUBESTORE_META_ADDR`   | -                  | Yes                |
 
@@ -141,6 +141,7 @@ services:
       - CUBESTORE_SERVER_NAME=cubestore_worker_1:9001
       - CUBESTORE_WORKER_PORT=9001
       - CUBESTORE_META_ADDR=cubestore_router:9999
+      - CUBESTORE_WORKERS=cubestore_worker_1:9001,cubestore_worker_2:9001
       - CUBESTORE_REMOTE_DIR=/cube/data
     depends_on:
       - cubestore_router
@@ -155,6 +156,7 @@ services:
       - CUBESTORE_SERVER_NAME=cubestore_worker_2:9001
       - CUBESTORE_WORKER_PORT=9001
       - CUBESTORE_META_ADDR=cubestore_router:9999
+      - CUBESTORE_WORKERS=cubestore_worker_1:9001,cubestore_worker_2:9001
       - CUBESTORE_REMOTE_DIR=/cube/data
     depends_on:
       - cubestore_router
@@ -208,6 +210,7 @@ services:
       - CUBESTORE_SERVER_NAME=cubestore_worker_1:9001
       - CUBESTORE_WORKER_PORT=9001
       - CUBESTORE_META_ADDR=cubestore_router:9999
+      - CUBESTORE_WORKERS=cubestore_worker_1:9001
       - CUBESTORE_S3_BUCKET=<BUCKET_NAME_IN_S3>
       - CUBESTORE_S3_REGION=<BUCKET_REGION_IN_S3>
       - CUBESTORE_AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID>


### PR DESCRIPTION
We do not communicate between workers. However, we may rely on the
exact struct of the whole cluster to perform some operations.