### PR TITLE
docs(cloud): move Cube IDE to Developer Tools to match OSS docs

### DIFF
--- a/docs/content/Cube-Cloud/Developer-Tools/Cube-IDE.md
+++ b/docs/content/Cube-Cloud/Developer-Tools/Cube-IDE.md
@@ -1,7 +1,7 @@
 ---
 title: Cube IDE
 permalink: /cloud/cube-ide
-category: Cube IDE
+category: Developer Tools
 menuOrder: 1
 ---
 

--- a/docs/src/components/Layout/MainMenu.tsx
+++ b/docs/src/components/Layout/MainMenu.tsx
@@ -19,7 +19,7 @@ import { layout } from '../../theme';
 const menuOrderCloud = [
   'Cube Cloud Getting Started',
   'Configuration',
-  'Cube IDE',
+  'Developer Tools',
   'Deploys',
   'Inspecting Queries'
 ];


### PR DESCRIPTION
Story details: https://app.clubhouse.io/cube-dev/story/574