### PR TITLE
Exporting CubejsApi class

### DIFF
--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -235,7 +235,7 @@ class CubejsApi {
 
 export default (apiToken, options) => new CubejsApi(apiToken, options);
 
-export { HttpTransport, ResultSet };
+export { CubejsApi, HttpTransport, ResultSet };
 export {
   areQueriesEqual,
   defaultHeuristics,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

I have a specific authorization use case that I would like to add to the CubejsApi class. Without access to the class I have to modify the instantiated object which doesn't feel as clean or scalable.

This change just adds the `CubejsApi` class to the named exports so that more experienced developers can extend the API.
