### PR TITLE
fix(@cubejs-api-gateway): fix end date when current month has less days than previous month

### DIFF
--- a/packages/cubejs-api-gateway/src/dateParser.js
+++ b/packages/cubejs-api-gateway/src/dateParser.js
@@ -36,7 +36,7 @@ export function dateParser(dateString, timezone, now = new Date()) {
     const span = match[2] === 'week' ? 'isoWeek' : match[2];
     momentRange = [
       moment.tz(timezone).startOf(span).add(-parseInt(match[1], 10), match[2]),
-      moment.tz(timezone).endOf(span).add(-1, match[2])
+      moment.tz(timezone).add(-1, match[2]).endOf(span)
     ];
   } else if (dateString.match(/today/)) {
     momentRange = [moment.tz(timezone).startOf('day'), moment.tz(timezone).endOf('day')];

--- a/packages/cubejs-api-gateway/test/dateParser.test.js
+++ b/packages/cubejs-api-gateway/test/dateParser.test.js
@@ -1,4 +1,4 @@
-/* globals describe,test,expect */
+/* globals describe,test,expect,jest */
 
 import { dateParser } from '../src/dateParser';
 
@@ -67,5 +67,27 @@ describe('dateParser', () => {
     expect(() => dateParser('unexpected date', 'UTC')).toThrowError(
       'Can\'t parse date: \'unexpected date\'',
     );
+  });
+
+  test('last 6 months from month with less days than previous month', () => {
+    Date.now = jest.fn().mockReturnValue(new Date(2021, 1, 15, 13, 0, 0, 0));
+
+    expect(dateParser('last 6 months', 'UTC', new Date(2021, 1, 15, 13, 0, 0, 0))).toStrictEqual([
+      '2020-08-01T00:00:00.000',
+      '2021-01-31T23:59:59.999',
+    ]);
+
+    Date.now.mockRestore();
+  });
+
+  test('last 6 months from month with more days than previous month', () => {
+    Date.now = jest.fn().mockReturnValue(new Date(2021, 2, 15, 13, 0, 0, 0));
+
+    expect(dateParser('last 6 months', 'UTC', new Date(2021, 1, 15, 13, 0, 0, 0))).toStrictEqual([
+      '2020-09-01T00:00:00.000',
+      '2021-02-28T23:59:59.999',
+    ]);
+
+    Date.now.mockRestore();
   });
 });


### PR DESCRIPTION
… days than previous month

**Check List**
- [x ] Tests has been run in packages where changes made if available
- [x ] Linter has been run for changed code
- [x ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#2141 

Order of operations on moment were reversed when dateParser evaluated 'last X months' dateStrings.
