### PR TITLE
fix(cubestore): do not resolve aliases in having clause

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#3a32e08e7665bf0f191089912adae59420748cf3"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#c23d6d9b9bfb3cc759ff36e59b96d035da2707b0"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#3a32e08e7665bf0f191089912adae59420748cf3"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#c23d6d9b9bfb3cc759ff36e59b96d035da2707b0"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -1121,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#3a32e08e7665bf0f191089912adae59420748cf3"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#c23d6d9b9bfb3cc759ff36e59b96d035da2707b0"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#3a32e08e7665bf0f191089912adae59420748cf3"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#c23d6d9b9bfb3cc759ff36e59b96d035da2707b0"
 dependencies = [
  "arrow",
  "base64 0.12.3",


### PR DESCRIPTION
This fixes failures on queries sent by CubeJS.
