### PR TITLE
fix(@cubejs-backend/mssql-driver): add column type mappings for MSSQL external pre-aggregations

### DIFF
--- a/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
+++ b/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
@@ -4,8 +4,7 @@ const { BaseDriver } = require('@cubejs-backend/query-orchestrator');
 const GenericTypeToMSSql = {
   string: 'nvarchar(max)',
   text: 'nvarchar(max)',
-  // should this be timezone aware? use datetimeoffset
-  timestamp: 'datetime',
+  timestamp: 'datetime2',
 };
 
 class MSSqlDriver extends BaseDriver {

--- a/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
+++ b/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
@@ -1,6 +1,13 @@
 const sql = require('mssql');
 const { BaseDriver } = require('@cubejs-backend/query-orchestrator');
 
+const GenericTypeToMSSql = {
+  string: 'nvarchar(max)',
+  text: 'nvarchar(max)',
+  // should this be timezone aware? use datetimeoffset
+  timestamp: 'datetime',
+};
+
 class MSSqlDriver extends BaseDriver {
   constructor(config) {
     super();
@@ -96,6 +103,10 @@ class MSSqlDriver extends BaseDriver {
       rows: result,
       types,
     };
+  }
+
+  fromGenericType(columnType) {
+    return GenericTypeToMSSql[columnType] || super.fromGenericType(columnType);
   }
 
   readOnly() {


### PR DESCRIPTION
Hi, this PR provides type mappings from generic types to MSSQL data types. Fixes bugs when creating external pre-aggregation tables in a MSSQL database.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#2831