### PR TITLE
fix(cubestore): allow decimal and float type in index keys 

### DIFF
--- a/rust/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore-sql-tests/src/tests.rs
@@ -5,6 +5,7 @@ use cubestore::queryplanner::MIN_TOPK_STREAM_ROWS;
 use cubestore::sql::timestamp_from_string;
 use cubestore::store::DataFrame;
 use cubestore::table::{Row, TableValue, TimestampValue};
+use cubestore::util::decimal::Decimal;
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
 use std::env;
@@ -285,11 +286,11 @@ async fn group_by_decimal(service: Box<dyn SqlClient>) {
         result.get_rows(),
         &vec![
             Row::new(vec![
-                TableValue::Decimal("100".to_string()),
+                TableValue::Decimal(Decimal::new(100 * 100_000)),
                 TableValue::Int(3)
             ]),
             Row::new(vec![
-                TableValue::Decimal("200".to_string()),
+                TableValue::Decimal(Decimal::new(200 * 100_000)),
                 TableValue::Int(2)
             ])
         ]
@@ -2108,7 +2109,7 @@ async fn topk_decimals(service: Box<dyn SqlClient>) {
             .map(|(s, i)| {
                 vec![
                     TableValue::String(s.to_string()),
-                    TableValue::Decimal(i.to_string()),
+                    TableValue::Decimal(Decimal::new(*i * 100_000)),
                 ]
             })
             .collect_vec()

--- a/rust/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore-sql-tests/src/tests.rs
@@ -76,6 +76,8 @@ pub fn sql_tests() -> Vec<(&'static str, TestFn)> {
         t("offset", offset),
         t("having", having),
         t("rolling_window_join", rolling_window_join),
+        t("decimal_index", decimal_index),
+        t("float_index", float_index),
     ];
 
     fn t<F>(name: &'static str, f: fn(Box<dyn SqlClient>) -> F) -> (&'static str, TestFn)
@@ -2345,6 +2347,84 @@ async fn rolling_window_join(service: Box<dyn SqlClient>) {
                     TableValue::Timestamp(*t),
                     TableValue::String(s.to_string()),
                     TableValue::Int(*n),
+                ]
+            })
+            .collect_vec()
+    }
+}
+
+async fn decimal_index(service: Box<dyn SqlClient>) {
+    service.exec_query("CREATE SCHEMA s").await.unwrap();
+    service
+        .exec_query("CREATE TABLE s.Data(x decimal, y decimal)")
+        .await
+        .unwrap();
+    service
+        .exec_query("CREATE INDEX reverse on s.Data(y, x)")
+        .await
+        .unwrap();
+    service
+        .exec_query("INSERT INTO s.Data(x,y) VALUES (1, 2), (2, 3), (3, 4)")
+        .await
+        .unwrap();
+
+    let r = service
+        .exec_query("SELECT * FROM s.Data ORDER BY x")
+        .await
+        .unwrap();
+    assert_eq!(to_rows(&r), rows(&[(1, 2), (2, 3), (3, 4)]));
+
+    let r = service
+        .exec_query("SELECT * FROM s.Data ORDER BY y DESC")
+        .await
+        .unwrap();
+    assert_eq!(to_rows(&r), rows(&[(3, 4), (2, 3), (1, 2)]));
+
+    fn rows(a: &[(i64, i64)]) -> Vec<Vec<TableValue>> {
+        a.iter()
+            .map(|(x, y)| {
+                vec![
+                    TableValue::Decimal(Decimal::new(x * 100000)),
+                    TableValue::Decimal(Decimal::new(y * 100000)),
+                ]
+            })
+            .collect_vec()
+    }
+}
+
+async fn float_index(service: Box<dyn SqlClient>) {
+    service.exec_query("CREATE SCHEMA s").await.unwrap();
+    service
+        .exec_query("CREATE TABLE s.Data(x float, y float)")
+        .await
+        .unwrap();
+    service
+        .exec_query("CREATE INDEX reverse on s.Data(y, x)")
+        .await
+        .unwrap();
+    service
+        .exec_query("INSERT INTO s.Data(x,y) VALUES (1, 2), (2, 3), (3, 4)")
+        .await
+        .unwrap();
+
+    let r = service
+        .exec_query("SELECT * FROM s.Data ORDER BY x")
+        .await
+        .unwrap();
+    assert_eq!(to_rows(&r), rows(&[(1., 2.), (2., 3.), (3., 4.)]));
+
+    let r = service
+        .exec_query("SELECT * FROM s.Data ORDER BY y DESC")
+        .await
+        .unwrap();
+    assert_eq!(to_rows(&r), rows(&[(3., 4.), (2., 3.), (1., 2.)]));
+
+    fn rows(a: &[(f64, f64)]) -> Vec<Vec<TableValue>> {
+        a.iter()
+            .map(|(x, y)| {
+                vec![
+                    TableValue::Float((*x).into()),
+                    TableValue::Float((*y).into()),
                 ]
             })
             .collect_vec()

--- a/rust/cubestore/src/http/mod.rs
+++ b/rust/cubestore/src/http/mod.rs
@@ -22,6 +22,7 @@ use log::info;
 use log::trace;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::net::SocketAddr;
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc;
@@ -388,7 +389,7 @@ impl HttpMessage {
                     let mut row_offsets = Vec::with_capacity(data_frame.get_rows().len());
                     for row in data_frame.get_rows().iter() {
                         let mut value_offsets = Vec::with_capacity(row.values().len());
-                        for value in row.values().iter() {
+                        for (i, value) in row.values().iter().enumerate() {
                             let value = match value {
                                 TableValue::Null => HttpColumnValue::create(
                                     &mut builder,
@@ -409,7 +410,14 @@ impl HttpMessage {
                                     )
                                 }
                                 TableValue::Decimal(v) => {
-                                    let string_value = Some(builder.create_string(&v.to_string()));
+                                    let scale = u8::try_from(
+                                        data_frame.get_columns()[i]
+                                            .get_column_type()
+                                            .target_scale(),
+                                    )
+                                    .unwrap();
+                                    let string_value =
+                                        Some(builder.create_string(&v.to_string(scale)));
                                     HttpColumnValue::create(
                                         &mut builder,
                                         &HttpColumnValueArgs { string_value },

--- a/rust/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/src/metastore/mod.rs
@@ -284,7 +284,7 @@ impl DataFrameValue<String> for Option<Row> {
                             TableValue::Timestamp(t) => format!("{:?}", t),
                             TableValue::Bytes(b) => format!("{:?}", b),
                             TableValue::Boolean(b) => format!("{:?}", b),
-                            TableValue::Decimal(v) => format!("{}", v),
+                            TableValue::Decimal(v) => format!("{}", v.raw_value()),
                             TableValue::Float(v) => format!("{}", v),
                         })
                         .join(", ")

--- a/rust/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/src/metastore/mod.rs
@@ -2294,7 +2294,7 @@ impl MetaStore for RocksMetaStore {
             let (mut sorted, mut unsorted) =
                 index_cols.clone().into_iter().partition::<Vec<_>, _>(|c| {
                     match c.get_column_type() {
-                        ColumnType::Decimal { .. } | ColumnType::Bytes | ColumnType::Float => false,
+                        ColumnType::Bytes => false,
                         _ => true,
                     }
                 });
@@ -3386,6 +3386,7 @@ mod tests {
                 },
                 2,
             ));
+            columns.push(Column::new("col4".to_string(), ColumnType::Bytes, 3));
 
             let table1 = meta_store
                 .create_table(

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -33,6 +33,7 @@ use crate::sql::cache::SqlResultCache;
 use crate::sql::parser::CubeStoreParser;
 use crate::store::ChunkDataStore;
 use crate::table::data::{MutRows, Rows, TableValueR};
+use crate::util::decimal::Decimal;
 use chrono::format::Fixed::Nanosecond3;
 use chrono::format::Item::{Fixed, Literal, Numeric, Space};
 use chrono::format::Numeric::{Day, Hour, Minute, Month, Second, Year};
@@ -48,9 +49,8 @@ use itertools::Itertools;
 use parser::Statement as CubeStoreStatement;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Write;
+use std::convert::TryFrom;
 use std::path::Path;
-use std::str::from_utf8_unchecked;
 use std::time::Duration;
 use tokio::time::timeout;
 use tracing::instrument;
@@ -792,11 +792,9 @@ fn extract_data<'a>(
                 }
                 TableValueR::Int(val_int.unwrap())
             }
-            ColumnType::Decimal { .. } => {
-                let decimal_val = parse_decimal(cell)?;
-                buffer.clear();
-                buffer.write_fmt(format_args!("{}", decimal_val)).unwrap();
-                TableValueR::Decimal(unsafe { from_utf8_unchecked(buffer) })
+            t @ ColumnType::Decimal { .. } => {
+                let d = parse_decimal(cell, u8::try_from(t.target_scale()).unwrap())?;
+                TableValueR::Decimal(d)
             }
             ColumnType::Bytes => {
                 let val;
@@ -839,10 +837,7 @@ fn extract_data<'a>(
                     )))
                 }
             },
-            ColumnType::Float => {
-                let decimal_val = parse_decimal(cell)?;
-                TableValueR::Float(decimal_val.into())
-            }
+            ColumnType::Float => TableValueR::Float(parse_float(cell)?.into()),
         }
     };
     Ok(res)
@@ -873,38 +868,35 @@ fn parse_time(s: &str, format: &[chrono::format::Item]) -> ParseResult<Parsed> {
     Ok(p)
 }
 
-fn parse_decimal(cell: &Expr) -> Result<f64, CubeError> {
-    let decimal_val = match cell {
+fn parse_float(cell: &Expr) -> Result<f64, CubeError> {
+    match cell {
         Expr::Value(Value::Number(v, _)) | Expr::Value(Value::SingleQuotedString(v)) => {
-            v.parse::<f64>()
+            Ok(v.parse::<f64>()?)
         }
         Expr::UnaryOp {
             op: UnaryOperator::Minus,
-            expr,
-        } => {
-            if let Expr::Value(Value::Number(v, _)) = expr.as_ref() {
-                v.parse::<f64>().map(|v| v * -1.0)
-            } else {
-                return Err(CubeError::user(format!(
-                    "Can't parse decimal from, {:?}",
-                    cell
-                )));
-            }
-        }
-        _ => {
-            return Err(CubeError::user(format!(
-                "Can't parse decimal from, {:?}",
-                cell
-            )))
-        }
-    };
-    if let Err(e) = decimal_val {
-        return Err(CubeError::user(format!(
-            "Can't parse decimal from, {:?}: {}",
-            cell, e
-        )));
+            expr: box Expr::Value(Value::Number(v, _)),
+        } => Ok(-v.parse::<f64>()?),
+        _ => Err(CubeError::user(format!(
+            "Can't parse float from, {:?}",
+            cell
+        ))),
     }
-    Ok(decimal_val?)
+}
+fn parse_decimal(cell: &Expr, scale: u8) -> Result<Decimal, CubeError> {
+    match cell {
+        Expr::Value(Value::Number(v, _)) | Expr::Value(Value::SingleQuotedString(v)) => {
+            crate::import::parse_decimal(v, scale)
+        }
+        Expr::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr: box Expr::Value(Value::Number(v, _)),
+        } => Ok(crate::import::parse_decimal(v, scale)?.negate()),
+        _ => Err(CubeError::user(format!(
+            "Can't parse decimal from, {:?}",
+            cell
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -1077,35 +1069,35 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal("7.61".to_string()), TableValue::Decimal("59.92".to_string())]));
+            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal(Decimal::new(761000)), TableValue::Decimal(Decimal::new(5992))]));
 
             let result = service
                 .exec_query("SELECT sum(dec_value), sum(dec_value_1) from foo.values where dec_value > 10")
                 .await
                 .unwrap();
 
-            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal("160.61".to_string()), TableValue::Decimal("58.92".to_string())]));
+            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal(Decimal::new(16061000)), TableValue::Decimal(Decimal::new(5892))]));
 
             let result = service
                 .exec_query("SELECT sum(dec_value), sum(dec_value_1) / 10 from foo.values where dec_value > 10")
                 .await
                 .unwrap();
 
-            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal("160.61".to_string()), TableValue::Float(5.892.into())]));
+            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal(Decimal::new(16061000)), TableValue::Float(5.892.into())]));
 
             let result = service
                 .exec_query("SELECT sum(dec_value), sum(dec_value_1) / 10 from foo.values where dec_value_1 < 10")
                 .await
                 .unwrap();
 
-            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal("-132.99".to_string()), TableValue::Float(0.45.into())]));
+            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal(Decimal::new(-13299000)), TableValue::Float(0.45.into())]));
 
             let result = service
                 .exec_query("SELECT sum(dec_value), sum(dec_value_1) / 10 from foo.values where dec_value_1 < '10'")
                 .await
                 .unwrap();
 
-            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal("-132.99".to_string()), TableValue::Float(0.45.into())]));
+            assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Decimal(Decimal::new(-13299000)), TableValue::Float(0.45.into())]));
         })
             .await;
     }

--- a/rust/cubestore/src/table/data.rs
+++ b/rust/cubestore/src/table/data.rs
@@ -429,6 +429,7 @@ pub fn cmp_same_types(l: &TableValueR, r: &TableValueR) -> Ordering {
         (TableValueR::String(a), TableValueR::String(b)) => a.cmp(b),
         (TableValueR::Int(a), TableValueR::Int(b)) => a.cmp(b),
         (TableValueR::Decimal(a), TableValueR::Decimal(b)) => a.cmp(b),
+        (TableValueR::Float(a), TableValueR::Float(b)) => a.cmp(b),
         (TableValueR::Bytes(a), TableValueR::Bytes(b)) => a.cmp(b),
         (TableValueR::Timestamp(a), TableValueR::Timestamp(b)) => a.cmp(b),
         (TableValueR::Boolean(a), TableValueR::Boolean(b)) => a.cmp(b),

--- a/rust/cubestore/src/table/data.rs
+++ b/rust/cubestore/src/table/data.rs
@@ -18,6 +18,7 @@
 //!
 //! To iterate over produced rows use [RowsView], also see [`Rows::view`].
 use crate::table::{Row, TableValue, TimestampValue};
+use crate::util::decimal::Decimal;
 use crate::util::ordfloat::OrdF64;
 use bumpalo::Bump;
 use itertools::Itertools;
@@ -31,7 +32,7 @@ pub enum TableValueR<'a> {
     Null,
     String(&'a str),
     Int(i64),
-    Decimal(&'a str), // TODO bincode is incompatible with BigDecimal
+    Decimal(Decimal),
     Float(OrdF64),
     Bytes(&'a [u8]),
     Timestamp(TimestampValue),
@@ -44,7 +45,7 @@ impl TableValueR<'_> {
             TableValue::Null => TableValueR::Null,
             TableValue::String(s) => TableValueR::String(&s),
             TableValue::Int(i) => TableValueR::Int(*i),
-            TableValue::Decimal(d) => TableValueR::Decimal(&d),
+            TableValue::Decimal(d) => TableValueR::Decimal(*d),
             TableValue::Float(f) => TableValueR::Float(*f),
             TableValue::Bytes(b) => TableValueR::Bytes(&b),
             TableValue::Timestamp(v) => TableValueR::Timestamp(v.clone()),
@@ -366,7 +367,7 @@ impl<'a> InsertedRow<'a> {
         *target = match source {
             TableValueR::Boolean(v) => TableValueR::Boolean(v),
             TableValueR::Bytes(s) => TableValueR::Bytes(arena.alloc_slice_copy(s)),
-            TableValueR::Decimal(s) => TableValueR::Decimal(arena.alloc_str(s)),
+            TableValueR::Decimal(d) => TableValueR::Decimal(d),
             TableValueR::Float(v) => TableValueR::Float(v),
             TableValueR::Int(v) => TableValueR::Int(v),
             TableValueR::Null => TableValueR::Null,
@@ -442,7 +443,7 @@ pub fn convert_row_to_heap_allocated(r: &RowR) -> Row {
                 TableValueR::Null => TableValue::Null,
                 TableValueR::String(s) => TableValue::String(s.to_string()),
                 TableValueR::Int(i) => TableValue::Int(*i),
-                TableValueR::Decimal(d) => TableValue::Decimal(d.to_string()),
+                TableValueR::Decimal(d) => TableValue::Decimal(*d),
                 TableValueR::Float(f) => TableValue::Float(*f),
                 TableValueR::Bytes(b) => TableValue::Bytes(b.to_vec()),
                 TableValueR::Timestamp(v) => TableValue::Timestamp(v.clone()),

--- a/rust/cubestore/src/table/mod.rs
+++ b/rust/cubestore/src/table/mod.rs
@@ -1,4 +1,5 @@
 use crate::table::data::{Rows, RowsView};
+use crate::util::decimal::Decimal;
 use crate::util::ordfloat::OrdF64;
 use crate::CubeError;
 use chrono::{SecondsFormat, TimeZone, Utc};
@@ -13,7 +14,7 @@ pub enum TableValue {
     Null,
     String(String),
     Int(i64),
-    Decimal(String), // TODO bincode is incompatible with BigDecimal
+    Decimal(Decimal),
     Float(OrdF64),
     Bytes(Vec<u8>),
     Timestamp(TimestampValue),

--- a/rust/cubestore/src/table/mod.rs
+++ b/rust/cubestore/src/table/mod.rs
@@ -117,6 +117,7 @@ pub fn cmp_same_types(l: &TableValue, r: &TableValue) -> Ordering {
         (TableValue::String(a), TableValue::String(b)) => a.cmp(b),
         (TableValue::Int(a), TableValue::Int(b)) => a.cmp(b),
         (TableValue::Decimal(a), TableValue::Decimal(b)) => a.cmp(b),
+        (TableValue::Float(a), TableValue::Float(b)) => a.cmp(b),
         (TableValue::Bytes(a), TableValue::Bytes(b)) => a.cmp(b),
         (TableValue::Timestamp(a), TableValue::Timestamp(b)) => a.cmp(b),
         (TableValue::Boolean(a), TableValue::Boolean(b)) => a.cmp(b),

--- a/rust/cubestore/src/util/decimal.rs
+++ b/rust/cubestore/src/util/decimal.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+/// This it not a general-purpose decimal implementation. We use it inside [TableValue] to cement
+/// data format of decimals in CubeStore.
+pub struct Decimal {
+    // Users see only i64, we keep i128 so serialization does not change when we switch to i128.
+    raw_value: i128,
+}
+
+impl Decimal {
+    pub fn new(raw_value: i64) -> Decimal {
+        Decimal {
+            raw_value: raw_value as i128,
+        }
+    }
+
+    pub fn raw_value(&self) -> i64 {
+        self.raw_value as i64
+    }
+
+    pub fn negate(&self) -> Decimal {
+        Decimal::new(-self.raw_value())
+    }
+
+    pub fn to_string(&self, scale: u8) -> String {
+        let n = 10_i64.pow(scale as u32);
+        let v = self.raw_value();
+        let integral = v / n;
+        let fractional = (v % n).abs();
+        format!("{}.{}", integral, fractional)
+    }
+}

--- a/rust/cubestore/src/util/mod.rs
+++ b/rust/cubestore/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod decimal;
 pub mod error;
 pub mod lock;
 mod malloc_trim_loop;


### PR DESCRIPTION
There is a caveat with this change. It can break existing cubestore instances that have non-default indexes on decimal columns.
I believe this is the only case where CubeStore actually wrote decimal columns into metastore.

There is not easy fix: users will probably have to recreate the database in that case.
We did not write decimals into the default index, though, so most users should be unaffected.