### PR TITLE
Support multi-value filtering on same column through FILTER_PARAMS

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2223,26 +2223,32 @@ export class BaseQuery {
         const cubeName = this.cubeEvaluator.cubeNameFromPath(name);
         return new Proxy({ cube: cubeName }, {
           get: (cubeNameObj, propertyName) => {
-            const filter =
-              allFilters.find(f => f.dimension === this.cubeEvaluator.pathFromArray([cubeNameObj.cube, propertyName]));
+            const filters =
+              allFilters.filter(f => f.dimension === this.cubeEvaluator.pathFromArray([cubeNameObj.cube, propertyName]));
             return {
               filter: (column) => {
-                const filterParams = filter && filter.filterParams();
-                if (
-                  filterParams && filterParams.length
-                ) {
-                  if (typeof column === 'function') {
-                    // eslint-disable-next-line prefer-spread
-                    return column.apply(
-                      null,
-                      filterParams.map(this.paramAllocator.allocateParam.bind(this.paramAllocator))
-                    );
-                  } else {
-                    return filter.conditionSql(column);
-                  }
-                } else {
+                if (!filters.length > 0) {
                   return '1 = 1';
                 }
+
+                return filters.map(filter => {
+                  const filterParams = filter && filter.filterParams();
+                  if (
+                    filterParams && filterParams.length
+                  ) {
+                    if (typeof column === 'function') {
+                      // eslint-disable-next-line prefer-spread
+                      return column.apply(
+                        null,
+                        filterParams.map(this.paramAllocator.allocateParam.bind(this.paramAllocator))
+                      );
+                    } else {
+                      return filter.conditionSql(column);
+                    }
+                  } else {
+                    return '1 = 1';
+                  }
+                }).join(' AND ');
               }
             };
           }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2227,7 +2227,7 @@ export class BaseQuery {
               allFilters.filter(f => f.dimension === this.cubeEvaluator.pathFromArray([cubeNameObj.cube, propertyName]));
             return {
               filter: (column) => {
-                if (!filters.length > 0) {
+                if (!filters.length) {
                   return '1 = 1';
                 }
 

--- a/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
@@ -240,6 +240,33 @@ describe('SQL Generation', () => {
       }
     })
 
+    cube('visitor_checkins_sources', {
+      sql: \`
+      select id, source from visitor_checkins WHERE \${FILTER_PARAMS.visitor_checkins_sources.source.filter('source')}
+      \`,
+
+      rewriteQueries: true,
+
+      joins: {
+        cards: {
+          relationship: 'hasMany',
+          sql: \`\${CUBE}.id = \${cards}.visitor_checkin_id\`
+        }
+      },
+
+      dimensions: {
+        id: {
+          type: 'number',
+          sql: 'id',
+          primaryKey: true
+        },
+        source: {
+          type: 'string',
+          sql: 'source'
+        }
+      }
+    })
+
     cube('cards', {
       sql: \`
       select * from cards
@@ -1337,6 +1364,32 @@ describe('SQL Generation', () => {
       }]
     }, [
       { visitors__source: 'some' }
+    ])
+  );
+
+  it(
+    'contains multiple value filter',
+    () => runQueryTest({
+      measures: [],
+      dimensions: [
+        'visitor_checkins_sources.source'
+      ],
+      timeDimensions: [],
+      timezone: 'America/Los_Angeles',
+      filters: [{
+        dimension: 'visitor_checkins_sources.source',
+        operator: 'contains',
+        values: ['goo']
+      }, {
+        dimension: 'visitor_checkins_sources.source',
+        operator: 'contains',
+        values: ['gle']
+      }],
+      order: [{
+        id: 'visitor_checkins_sources.source'
+      }]
+    }, [
+      { visitor_checkins_sources__source: 'google' }
     ])
   );
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

No related issue.

**Description of Changes Made (if issue reference is not provided)**

This PR adds support to properly process multiple filters over the same dimension when accessing them through `FILTER_PARAMS` context variable, this becomes particularly handy when the expression involved is an `ILIKE` operator (or similar).

With this change it's possible to define SQLs like:

```js
cube('Foo', {
  sql: `SELECT id, name FROM foo WHERE ${FILTER_PARAMS.Foo.name.filter('name')}`,
  dimensions: {
    id: {
      type: 'number',
      sql: 'id',
      primaryKey: true
    },
    name: {
      type: 'string',
      sql: 'name'
    }
  }
}
```

and if the filter passed are in the form:

```js
filters: [
  {
    dimension: 'Foo.name',
    operator: 'contains',
    values: ['Foo']
  }, {
    dimension: 'Foo.name',
    operator: 'contains',
    values: ['Bar']
  }
]
```

Will result in an SQL query like:

```sql
SELECT id, name FROM foo WHERE name ILIKE '%Foo%' AND name ILIKE '%Bar%';
```