### PR TITLE
feat(cubestore): cubestore-specific env vars for GCS configuration

### DIFF
--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -1362,7 +1362,9 @@ mod tests {
 
     #[tokio::test]
     async fn high_frequency_inserts_gcs() {
-        if env::var("SERVICE_ACCOUNT_JSON").is_err() {
+        if env::var("SERVICE_ACCOUNT_JSON").is_err()
+            && env::var("CUBESTORE_GCP_SERVICE_ACCOUNT_JSON").is_err()
+        {
             return;
         }
         Config::test("high_frequency_inserts_gcs")


### PR DESCRIPTION
The new env vars are:
    - `CUBESTORE_GCP_SERVICE_ACCOUNT`
    - `CUBESTORE_GCP_SERVICE_ACCOUNT_JSON`
    - `CUBESTORE_GCP_GOOGLE_APPLICATION_CREDENTIALS`
    - `CUBESTORE_GCP_GOOGLE_APPLICATION_CREDENTIALS_JSON`

Eventually we want to disallow `SERVICE_ACCOUNT` for consistency with
AWS configuration. To allow gradual transition, CubeStore warns
when it sees the old variants.

