### PR TITLE
feat: Make scheduledRefresh true by default (preview period)

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -260,6 +260,9 @@ const variables: Record<string, (...args: any) => any> = {
   externalDefault: () => get('CUBEJS_EXTERNAL_DEFAULT')
     .default('false')
     .asBoolStrict(),
+  scheduledRefreshDefault: () => get('CUBEJS_SCHEDULED_REFRESH_DEFAULT')
+    .default('false')
+    .asBoolStrict(),
 };
 
 type Vars = typeof variables;

--- a/packages/cubejs-cli/src/templates.ts
+++ b/packages/cubejs-cli/src/templates.ts
@@ -32,7 +32,8 @@ const handlerJs = `module.exports = require('@cubejs-backend/serverless');
 const sharedDotEnvVars = env => `CUBEJS_DEV_MODE=true
 CUBEJS_DB_TYPE=${env.dbType}
 CUBEJS_API_SECRET=${env.apiSecret}
-CUBEJS_EXTERNAL_DEFAULT=true`;
+CUBEJS_EXTERNAL_DEFAULT=true
+CUBEJS_SCHEDULED_REFRESH_DEFAULT=true`;
 
 const defaultDotEnvVars = env => `# Cube.js environment variables: https://cube.dev/docs/reference/environment-variables
 CUBEJS_DB_HOST=<YOUR_DB_HOST_HERE>

--- a/packages/cubejs-cli/test/templates.test.ts
+++ b/packages/cubejs-cli/test/templates.test.ts
@@ -22,7 +22,8 @@ CUBEJS_WEB_SOCKETS=true
 CUBEJS_DEV_MODE=true
 CUBEJS_DB_TYPE=${dbType}
 CUBEJS_API_SECRET=${secret}
-CUBEJS_EXTERNAL_DEFAULT=true`;
+CUBEJS_EXTERNAL_DEFAULT=true
+CUBEJS_SCHEDULED_REFRESH_DEFAULT=true`;
 
   expect(dotEnv(generateTestEnv(secret, dbType))).toBe(expectedDotEnvVars);
 });
@@ -38,7 +39,8 @@ CUBEJS_WEB_SOCKETS=true
 CUBEJS_DEV_MODE=true
 CUBEJS_DB_TYPE=${dbType}
 CUBEJS_API_SECRET=${secret}
-CUBEJS_EXTERNAL_DEFAULT=true`;
+CUBEJS_EXTERNAL_DEFAULT=true
+CUBEJS_SCHEDULED_REFRESH_DEFAULT=true`;
 
   expect(dotEnv(generateTestEnv(secret, dbType))).toBe(expectedDotEnvVars);
 });
@@ -55,7 +57,8 @@ CUBEJS_JDBC_DRIVER=athena
 CUBEJS_DEV_MODE=true
 CUBEJS_DB_TYPE=${dbType}
 CUBEJS_API_SECRET=${secret}
-CUBEJS_EXTERNAL_DEFAULT=true`;
+CUBEJS_EXTERNAL_DEFAULT=true
+CUBEJS_SCHEDULED_REFRESH_DEFAULT=true`;
 
   expect(dotEnv(generateTestEnv(secret, dbType))).toBe(expectedDotEnvVars);
 });

--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.js
@@ -1,5 +1,4 @@
 import R from 'ramda';
-import { getEnv } from '@cubejs-backend/shared';
 
 import { UserError } from '../compiler/UserError';
 
@@ -115,18 +114,11 @@ export class PreAggregations {
     const tableName = this.preAggregationTableName(cube, preAggregationName, preAggregation);
     const refreshKeyQueries = this.query.preAggregationInvalidateKeyQueries(cube, preAggregation);
 
-    // eslint-disable-next-line prefer-destructuring
-    let external = preAggregation.external;
-
-    if (external === undefined) {
-      external = ['rollup', 'rollupJoin'].includes(preAggregation.type) && getEnv('externalDefault');
-    }
-
     return {
       preAggregationId: `${cube}.${preAggregationName}`,
       timezone: this.query.options && this.query.options.timezone,
       tableName,
-      external,
+      external: preAggregation.external,
       preAggregationsSchema: this.query.preAggregationSchema(),
       loadSql: this.query.preAggregationLoadSql(cube, preAggregation, tableName),
       sql: this.query.preAggregationSql(cube, preAggregation),

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -1,7 +1,7 @@
 import { prepareCompiler } from './PrepareCompiler';
 
 describe('Schema Testing', () => {
-  it('valid schemas', async () => {
+  const schemaCompile = async () => {
     const { compiler, cubeEvaluator } = prepareCompiler(` 
       cube('CubeA', {
         sql: \`select * from test\`,
@@ -27,7 +27,6 @@ describe('Schema Testing', () => {
         preAggregations: {
             // Pre-aggregation without type, rollup is used by default
             countCreatedAt: {
-                external: true,
                 measureReferences: [count],
                 timeDimensionReference: createdAt,
                 granularity: \`day\`,
@@ -38,9 +37,39 @@ describe('Schema Testing', () => {
     `);
     await compiler.compile();
 
+    return { compiler, cubeEvaluator };
+  };
+
+  it('valid schemas', async () => {
+    const { cubeEvaluator } = await schemaCompile();
+
     expect(cubeEvaluator.preAggregationsForCube('CubeA')).toEqual({
       countCreatedAt: {
+        external: false,
+        scheduledRefresh: false,
+        granularity: 'day',
+        measureReferences: expect.any(Function),
+        timeDimensionReference: expect.any(Function),
+        partitionGranularity: 'month',
+        type: 'rollup',
+      }
+    });
+  });
+
+  it('valid schemas (preview flags)', async () => {
+    process.env.CUBEJS_EXTERNAL_DEFAULT = 'true';
+    process.env.CUBEJS_SCHEDULED_REFRESH_DEFAULT = 'true';
+
+    const { cubeEvaluator } = await schemaCompile();
+
+    delete process.env.CUBEJS_EXTERNAL_DEFAULT;
+    delete process.env.CUBEJS_SCHEDULED_REFRESH_DEFAULT;
+
+    expect(cubeEvaluator.preAggregationsForCube('CubeA')).toEqual({
+      countCreatedAt: {
+        // because preview
         external: true,
+        scheduledRefresh: true,
         granularity: 'day',
         measureReferences: expect.any(Function),
         timeDimensionReference: expect.any(Function),

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -410,6 +410,7 @@ export class DevServer {
 
       // CUBEJS_EXTERNAL_DEFAULT will be default in next major version, let's test it with docker too
       variables.CUBEJS_EXTERNAL_DEFAULT = 'true';
+      variables.CUBEJS_SCHEDULED_REFRESH_DEFAULT = 'true';
       variables = Object.entries(variables).map(([key, value]) => ([key, value].join('=')));
 
       const repositoryPath = path.join(process.cwd(), options.schemaPath);


### PR DESCRIPTION
Hello!

In the next major version, We are going to make `scheduledRefresh: true` by default for any pre-aggregations, but before We are going to make an preview period for new projects to verify that everything works without errors.
 
Thanks