### PR TITLE
fix(cubestore): remove backtraces from error messages

### DIFF
--- a/rust/cubestore/src/http/mod.rs
+++ b/rust/cubestore/src/http/mod.rs
@@ -200,12 +200,18 @@ impl HttpServer {
                             message_id,
                             command,
                         },
-                        Err(e) => HttpMessage {
-                            message_id,
-                            command: HttpCommand::Error {
-                                error: e.to_string(),
-                            },
-                        },
+                        Err(e) => {
+                            log::error!(
+                                "Error processing HTTP command: {}\n",
+                                e.display_with_backtrace()
+                            );
+                            HttpMessage {
+                                message_id,
+                                command: HttpCommand::Error {
+                                    error: e.to_string(),
+                                },
+                            }
+                        }
                     };
                     if let Err(e) = sender.send(message).await {
                         error!("Send result channel error: {:?}", e);

--- a/rust/cubestore/src/mysql/mod.rs
+++ b/rust/cubestore/src/mysql/mod.rs
@@ -64,7 +64,11 @@ impl<W: io::Write + Send> AsyncMysqlShim<W> for Backend {
             )
             .await;
         if let Err(e) = res {
-            error!("Error during processing {}: {}", query, e.message);
+            error!(
+                "Error during processing {}: {}",
+                query,
+                e.display_with_backtrace()
+            );
             results.error(ErrorKind::ER_INTERNAL_ERROR, e.message.as_bytes())?;
             return Ok(());
         }


### PR DESCRIPTION
Show them in the logs, but send only the message back to the user.