### PR TITLE
@cubejs-client/core: update uuid package 3.4.0 -> 8.3.2

### DIFF
--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -20,7 +20,7 @@
     "moment-range": "^4.0.1",
     "ramda": "^0.27.0",
     "url-search-params-polyfill": "^7.0.0",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "test": "npm run unit",

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -1,4 +1,4 @@
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import ResultSet from './ResultSet';
 import SqlQuery from './SqlQuery';
 import Meta from './Meta';


### PR DESCRIPTION
**Check List**
- [x] Linter has been run for changed code

**Description of Changes Made**

`@cubejs-client/core` depends on `uuid@3.4.0`, which uses the older `browser` fields instead of the new `exports` field in its `package.json`, which causes issues for newer bundlers that don't support the `browser` field.  By updating to `uuid@8.3.2`, `@cubejs-client/core` can be used in projects that use modern bundlers like Vite/esbuild.
