### PR TITLE
docs: Remove mentions of non-existent autorollup feature

### DIFF
--- a/docs/content/Guides/Incremental-Pre-Aggregations.md
+++ b/docs/content/Guides/Incremental-Pre-Aggregations.md
@@ -28,7 +28,7 @@ export const immutablePartitionRollupRefreshKey = (filterFn) =>
 ```
 
 Here we use Standard BigQuery SQL dialect.
-To use this `refreshKey` with for example `Events` table you can define `autoRollup` like this:
+To use this `refreshKey` with for example `Events` table you can define `rollup` like this:
 
 ```javascript
 import { immutablePartitionRollupRefreshKey } from './RefreshKeyHelper';
@@ -37,9 +37,12 @@ cube(`Events`, {
   // ...
 
   preAggregations: {
-    auto: {
-      type: `autoRollup`,
+    main: {
+      type: `rollup`,
       partitionGranularity: `month`,
+      
+      // ...
+      
       refreshKey: {
         sql: immutablePartitionRollupRefreshKey(
           FILTER_PARAMS.FirebaseEvents.time.filter

--- a/docs/content/Schema/pre-aggregations.md
+++ b/docs/content/Schema/pre-aggregations.md
@@ -395,12 +395,12 @@ up a custom refresh check strategy by using `refreshKey`:
 
 ```javascript
 cube(`Orders`, {
-  sql: `select * from orders`,
+  sql: `SELECT * FROM orders`,
 
   preAggregations: {
     main: {
-      type: `autoRollup`,
-      maxPreAggregations: 20,
+      type: `rollup`,
+      measureReferences: [Orders.count],
       refreshKey: {
         sql: `SELECT MAX(created_at) FROM orders`,
       },


### PR DESCRIPTION
We're getting questions about `autorollup` pre-aggregations. However, this feature is not supported. Let's remove mentions of this feature from docs so we don't confuse Cube.js users.