### PR TITLE
fix(bigquery-driver): Encode buffer as base64 for CSV (streaming)

### DIFF
--- a/packages/cubejs-bigquery-driver/src/HydrationStream.ts
+++ b/packages/cubejs-bigquery-driver/src/HydrationStream.ts
@@ -6,7 +6,20 @@ export class HydrationStream extends stream.Transform {
     super({
       objectMode: true,
       transform(row: any, encoding: BufferEncoding, callback: TransformCallback) {
-        const transformed = R.map(value => (value && value.value && typeof value.value === 'string' ? value.value : value), row);
+        const transformed = R.map(
+          (value) => {
+            if (value && value.value && typeof value.value === 'string') {
+              return value.value;
+            }
+
+            if (Buffer.isBuffer(value)) {
+              return value.toString('base64');
+            }
+
+            return value;
+          },
+          row
+        );
 
         this.push(transformed);
 


### PR DESCRIPTION
Hello!

BigQuery SDK uses Buffer for HLL in streaming, which causes a problem with CSV reading on the Cube Store side.

Thanks