### PR TITLE
Picking up allowUngroupedWithoutPrimaryKey from env

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -170,8 +170,8 @@ const variables: Record<string, (...args: any) => any> = {
     .default('false')
     .asBoolStrict(),
   allowUngroupedWithoutPrimaryKey: () => get('CUBEJS_ALLOW_UNGROUPED_WITHOUT_PRIMARY_KEY')
-  .default('false')
-  .asBoolStrict(),
+    .default('false')
+    .asBoolStrict(),
   redisPassword: () => {
     const redisPassword = get('CUBEJS_REDIS_PASSWORD')
       .asString();

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -169,6 +169,9 @@ const variables: Record<string, (...args: any) => any> = {
   redisUseIORedis: () => get('CUBEJS_REDIS_USE_IOREDIS')
     .default('false')
     .asBoolStrict(),
+  allowUngroupedWithoutPrimaryKey: () => get('CUBEJS_ALLOW_UNGROUPED_WITHOUT_PRIMARY_KEY')
+  .default('false')
+  .asBoolStrict(),
   redisPassword: () => {
     const redisPassword = get('CUBEJS_REDIS_PASSWORD')
       .asString();

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -730,7 +730,9 @@ export class CubejsServerCore {
       logger: this.logger,
       externalDbType: options.externalDbType,
       preAggregationsSchema: options.preAggregationsSchema,
-      allowUngroupedWithoutPrimaryKey: this.options.allowUngroupedWithoutPrimaryKey || getEnv('allowUngroupedWithoutPrimaryKey'),
+      allowUngroupedWithoutPrimaryKey:
+        this.options.allowUngroupedWithoutPrimaryKey ||
+        getEnv("allowUngroupedWithoutPrimaryKey"),
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -730,7 +730,7 @@ export class CubejsServerCore {
       logger: this.logger,
       externalDbType: options.externalDbType,
       preAggregationsSchema: options.preAggregationsSchema,
-      allowUngroupedWithoutPrimaryKey: this.options.allowUngroupedWithoutPrimaryKey || process.env.CUBEJS_ALLOW_UNGROUPED_WITHOUT_PRIMARY_KEY,
+      allowUngroupedWithoutPrimaryKey: this.options.allowUngroupedWithoutPrimaryKey || getEnv('allowUngroupedWithoutPrimaryKey'),
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -730,7 +730,7 @@ export class CubejsServerCore {
       logger: this.logger,
       externalDbType: options.externalDbType,
       preAggregationsSchema: options.preAggregationsSchema,
-      allowUngroupedWithoutPrimaryKey: this.options.allowUngroupedWithoutPrimaryKey,
+      allowUngroupedWithoutPrimaryKey: this.options.allowUngroupedWithoutPrimaryKey || process.env.CUBEJS_ALLOW_UNGROUPED_WITHOUT_PRIMARY_KEY,
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -731,8 +731,8 @@ export class CubejsServerCore {
       externalDbType: options.externalDbType,
       preAggregationsSchema: options.preAggregationsSchema,
       allowUngroupedWithoutPrimaryKey:
-        this.options.allowUngroupedWithoutPrimaryKey ||
-        getEnv("allowUngroupedWithoutPrimaryKey"),
+          this.options.allowUngroupedWithoutPrimaryKey ||
+          getEnv("allowUngroupedWithoutPrimaryKey"),
       compileContext: options.context,
       dialectClass: options.dialectClass,
       externalDialectClass: options.externalDialectClass,


### PR DESCRIPTION
allowUngroupedWithoutPrimaryKey is an option that is not available to set over the environment variables
I am trying to run the service as a docker and this will help with that
If this name is fine, I can also update the environment variables doc