### PR TITLE
Change MssqlQuery dateTimeCast to DATETIME2

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.js
@@ -62,7 +62,7 @@ export class MssqlQuery extends BaseQuery {
   }
 
   dateTimeCast(value) {
-    return `CAST(${value} AS DATETIME)`;
+    return `CAST(${value} AS DATETIME2)`;
   }
 
   timeGroupedColumn(granularity, dimension) {


### PR DESCRIPTION
Addresses a bug with casting to DATETIME in MSSQL

**Issue Reference this PR resolves**

#2729 
