### PR TITLE
feat(@cubejs-client/vue): support all pivotConfig props

### DIFF
--- a/packages/cubejs-client-vue/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue/src/QueryBuilder.js
@@ -170,10 +170,7 @@ export default {
             );
           },
           update: (pivotConfig) => {
-            this.pivotConfig = {
-              x: pivotConfig.x || this.pivotConfig.x,
-              y: pivotConfig.y || this.pivotConfig.y,
-            };
+            this.pivotConfig = Object.assign({}, this.pivotConfig, pivotConfig)
           },
         },
       };

--- a/packages/cubejs-client-vue/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue/src/QueryBuilder.js
@@ -170,7 +170,10 @@ export default {
             );
           },
           update: (pivotConfig) => {
-            this.pivotConfig = Object.assign({}, this.pivotConfig, pivotConfig)
+            this.pivotConfig = {
+              ...this.pivotConfig,
+              ...pivotConfig,
+            }
           },
         },
       };

--- a/packages/cubejs-client-vue/tests/unit/QueryBuilder.spec.js
+++ b/packages/cubejs-client-vue/tests/unit/QueryBuilder.spec.js
@@ -645,4 +645,46 @@ describe('QueryBuilder.vue', () => {
     //   expect(wrapper.vm.filters[0].values).toContain('1');
     // });
   });
+
+  describe('builder slot updatePivotConfig.update', () => {
+     it.each([
+       { x: [ 'Orders.status' ] },
+       { y: [ 'measures' ] },
+       { x: [ 'Orders.status', 'measures' ], y: [] },
+       { aliasSeries: [ 'one' ] },
+       { fillMissingDates: true },
+       { fillMissingDates: false }
+     ])('sets pivotConfig', async (pivotConfig) => {
+      const cube = createCubejsApi();
+      jest
+        .spyOn(cube, 'request')
+        .mockImplementation(fetchMock(load))
+        .mockImplementationOnce(fetchMock(meta));
+
+      const wrapper = mount(QueryBuilder, {
+        propsData: {
+          cubejsApi: cube,
+          query: {
+            measures: ['Orders.count'],
+            dimensions: ['Orders.status'],
+          },
+        },
+        scopedSlots: {
+          builder: function({ updatePivotConfig }) {
+            return this.$createElement(
+              'input',
+              {
+                on: { change: () => updatePivotConfig.update(pivotConfig) }
+              }
+            )
+          }
+        }
+      });
+
+      await flushPromises();
+
+      wrapper.find('input').trigger('change')
+      expect(wrapper.vm.pivotConfig).toMatchObject(pivotConfig);
+    });
+  })
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR ensures all PivotConfig properties are assigned when updated via builder slot props' `updatePivotConfig.update`. Previously only `x` and `y` were assigned. 
