### PR TITLE
chore(cubestore): add context information to logs

### DIFF
--- a/rust/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/src/bin/cubestored.rs
@@ -1,35 +1,16 @@
 use cubestore::config::{Config, CubeServices};
-use cubestore::telemetry::{track_event, ReportingLogger};
+use cubestore::telemetry::track_event;
+use cubestore::util::logger::init_cube_logger;
 use cubestore::util::spawn_malloc_trim_loop;
 use log::debug;
-use log::Level;
-use simple_logger::SimpleLogger;
 use std::collections::HashMap;
-use std::env;
 use std::time::Duration;
 use tokio::runtime::Builder;
 
 fn main() {
-    let log_level = match env::var("CUBESTORE_LOG_LEVEL")
-        .unwrap_or("info".to_string())
-        .to_lowercase()
-        .as_str()
-    {
-        "error" => Level::Error,
-        "warn" => Level::Warn,
-        "info" => Level::Info,
-        "debug" => Level::Debug,
-        "trace" => Level::Trace,
-        x => panic!("Unrecognized log level: {}", x),
-    };
-
-    let logger = SimpleLogger::new()
-        .with_level(Level::Error.to_level_filter())
-        .with_module_level("cubestore", log_level.to_level_filter());
-    ReportingLogger::init(Box::new(logger), log_level.to_level_filter()).unwrap();
+    init_cube_logger(true);
 
     let config = Config::default();
-
     Config::configure_worker_services();
 
     let trim_every = config.config_obj().malloc_trim_every_secs();

--- a/rust/cubestore/src/telemetry/mod.rs
+++ b/rust/cubestore/src/telemetry/mod.rs
@@ -1,7 +1,7 @@
 use crate::CubeError;
 use chrono::{SecondsFormat, Utc};
 use core::mem;
-use log::{Level, LevelFilter, Log, Metadata, Record};
+use log::{Level, Log, Metadata, Record};
 use nanoid::nanoid;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -121,11 +121,8 @@ pub struct ReportingLogger {
 }
 
 impl ReportingLogger {
-    pub fn init(logger: Box<dyn Log>, max_level: LevelFilter) -> Result<(), CubeError> {
-        let reporting_logger = Self { logger };
-        log::set_boxed_logger(Box::new(reporting_logger))?;
-        log::set_max_level(max_level);
-        Ok(())
+    pub fn new(logger: Box<dyn Log>) -> Self {
+        Self { logger }
     }
 }
 

--- a/rust/cubestore/src/util/logger.rs
+++ b/rust/cubestore/src/util/logger.rs
@@ -1,0 +1,73 @@
+use crate::telemetry::ReportingLogger;
+use log::{Level, Log, Metadata, Record};
+use simple_logger::SimpleLogger;
+use std::env;
+
+/// Logger will add 'CUBESTORE_LOG_CONTEXT' to all messages.
+/// Set it during `procspawn` to help distinguish processes in the logs.
+pub fn init_cube_logger(enable_telemetry: bool) {
+    let log_level = match env::var("CUBESTORE_LOG_LEVEL")
+        .unwrap_or("info".to_string())
+        .to_lowercase()
+        .as_str()
+    {
+        "error" => Level::Error,
+        "warn" => Level::Warn,
+        "info" => Level::Info,
+        "debug" => Level::Debug,
+        "trace" => Level::Trace,
+        x => panic!("Unrecognized log level: {}", x),
+    };
+
+    let logger = SimpleLogger::new()
+        .with_level(Level::Error.to_level_filter())
+        .with_module_level("cubestore", log_level.to_level_filter());
+
+    let mut ctx = format!("pid:{}", std::process::id());
+    if let Ok(extra) = env::var("CUBESTORE_LOG_CONTEXT") {
+        ctx += " ";
+        ctx += &extra;
+    }
+    let mut logger: Box<dyn Log> = Box::new(ContextLogger::new(ctx, logger));
+    if enable_telemetry {
+        logger = Box::new(ReportingLogger::new(logger))
+    }
+
+    log::set_boxed_logger(logger).expect("Failed to initialize logger");
+    log::set_max_level(log_level.to_level_filter());
+}
+
+/// Adds the same 'context' string to all log messages.
+pub struct ContextLogger<Logger> {
+    context: String,
+    inner: Logger,
+}
+
+impl<Logger: Log> ContextLogger<Logger> {
+    pub fn new(context: String, inner: Logger) -> Self {
+        Self { context, inner }
+    }
+}
+
+impl<Logger: Log> Log for ContextLogger<Logger> {
+    fn enabled(&self, metadata: &Metadata<'a>) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record<'a>) {
+        if !self.enabled(record.metadata()) {
+            // Assume inner logger is not interested.
+            return;
+        }
+        self.inner.log(
+            &record
+                .to_builder()
+                .args(format_args!("<{}> {}", self.context, record.args()))
+                .build(),
+        )
+    }
+
+    fn flush(&self) {
+        self.inner.flush()
+    }
+}

--- a/rust/cubestore/src/util/mod.rs
+++ b/rust/cubestore/src/util/mod.rs
@@ -1,6 +1,7 @@
 pub mod decimal;
 pub mod error;
 pub mod lock;
+pub mod logger;
 mod malloc_trim_loop;
 pub mod maybe_owned;
 pub mod ordfloat;


### PR DESCRIPTION
Logs now show pid and name of the logging process.
The latter only shows for select worker subprocesses.