### PR TITLE
feat(cubestore): debug data dumps for select queries

### DIFF
--- a/rust/cubestore/src/util/mod.rs
+++ b/rust/cubestore/src/util/mod.rs
@@ -6,6 +6,7 @@ mod malloc_trim_loop;
 pub mod maybe_owned;
 pub mod metrics;
 pub mod ordfloat;
+pub mod strings;
 pub mod time_span;
 
 pub use malloc_trim_loop::spawn_malloc_trim_loop;

--- a/rust/cubestore/src/util/strings.rs
+++ b/rust/cubestore/src/util/strings.rs
@@ -1,0 +1,17 @@
+use crate::CubeError;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub fn path_to_string(p: PathBuf) -> Result<String, CubeError> {
+    os_to_string(p.into_os_string())
+}
+
+pub fn os_to_string(s: OsString) -> Result<String, CubeError> {
+    match s.into_string() {
+        Ok(s) => Ok(s),
+        Err(s) => Err(CubeError::internal(format!(
+            "Cannot convert string to UTF8: {:?}",
+            s
+        ))),
+    }
+}


### PR DESCRIPTION
The dump contains enough information to allow reproducing the same query
on another machine. Intended only for debugging CubeStore and not designed
for heavy use in production.

To use, prefix select queries with `dump`, e.g.
```sql
DUMP SELECT customer_id, SUM(total) FROM s.orders GROUP BY 1
```

The above SQL returns the dump directory. Inside there are parquet files,
metastore backup and the SQL query.

To reproduce the same query, first restore the metastore backup:
```sh
ldb --db=$DUMP/metastore restore --backup_dir=$DUMP/metastore-backup
```

Then run CubeStore inside the dump:
```sh
CUBESTORE_DATA_DIR=$DUMP ./cubestored
```