### PR TITLE
chore(cubestore): replace procspawn with custom implementation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -472,7 +472,6 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "serde",
 ]
 
 [[package]]
@@ -982,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
@@ -1037,6 +1036,7 @@ dependencies = [
  "chrono",
  "cloud-storage",
  "csv",
+ "ctor",
  "cubehll",
  "cuberpc",
  "cubezetasketch",
@@ -1052,6 +1052,7 @@ dependencies = [
  "ipc-channel",
  "itertools 0.9.0",
  "lazy_static",
+ "libc",
  "log",
  "lru",
  "mockall",
@@ -1064,7 +1065,6 @@ dependencies = [
  "paste",
  "pin-project-lite 0.2.6",
  "pretty_assertions",
- "procspawn",
  "rand 0.8.3",
  "regex",
  "reqwest 0.11.2",
@@ -1099,9 +1099,9 @@ dependencies = [
  "futures 0.3.13",
  "ipc-channel",
  "itertools 0.9.0",
+ "lazy_static",
  "log",
  "pretty_assertions",
- "procspawn",
  "scopeguard",
  "serde",
  "serde_derive",
@@ -1357,16 +1357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "findshlibs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1260d61e4fe2a6ab845ffdc426a0bd68ffb240b91cf0ec5a8d1170cec535bd8"
-dependencies = [
- "lazy_static",
- "libc",
 ]
 
 [[package]]
@@ -2164,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libloading"
@@ -3098,20 +3088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procspawn"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22d4628f0f2a777c58aa7b64654ffc577c4057a50e611c4d69cbe9fe207bf9b6"
-dependencies = [
- "backtrace",
- "ctor",
- "findshlibs",
- "ipc-channel",
- "libc",
- "serde",
-]
-
-[[package]]
 name = "prost"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,9 +3967,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/cubestore-sql-tests/Cargo.toml
+++ b/rust/cubestore-sql-tests/Cargo.toml
@@ -28,7 +28,6 @@ path = "tests/cluster.rs"
 harness = false
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-procspawn = { version = "0.9.0", features = ["test-support"] }
 ipc-channel = { version = "0.14.1" }
 
 [dependencies]
@@ -37,6 +36,7 @@ async-trait = "0.1.36"
 cubestore = { path = "../cubestore" }
 futures = "0.3.5"
 itertools = "0.9.0"
+lazy_static = "1.4.0"
 log = "0.4.11"
 pretty_assertions = "0.7.1"
 scopeguard = "1.1.0"

--- a/rust/cubestore-sql-tests/tests/cluster.rs
+++ b/rust/cubestore-sql-tests/tests/cluster.rs
@@ -1,21 +1,26 @@
 //! Runs the SQL tests with a cluster that consists of 1 router and 2 select workers.
 //! Note that each worker will also spawns 2 subprocesses for actual processing.
+
 use async_trait::async_trait;
+use serde_derive::{Deserialize, Serialize};
+
 use cubestore::config::Config;
+use cubestore::util::respawn;
 use cubestore_sql_tests::multiproc::{
-    run_multiproc_test, MultiProcTest, SignalInit, WaitCompletion, WorkerProc,
+    multiproc_child_main, run_multiproc_test, MultiProcTest, SignalInit, WaitCompletion, WorkerProc,
 };
 use cubestore_sql_tests::{run_sql_tests, TestFn};
-use serde_derive::{Deserialize, Serialize};
+
+const METASTORE_PORT: u16 = 51336;
+const WORKER_PORTS: [u16; 2] = [51337, 51338];
 
 #[cfg(not(target_os = "windows"))]
 fn main() {
     // Prepare workers.
     Config::configure_worker_services();
-    procspawn::init(); // TODO: logs in worker processes.
 
-    const METASTORE_PORT: u16 = 51336;
-    const WORKER_PORTS: [u16; 2] = [51337, 51338];
+    respawn::register_handler(multiproc_child_main::<ClusterSqlTest>);
+    respawn::init(); // TODO: logs in worker processes.
 
     // We run only 1 test in parallel to avoid using the ports concurrently.
     // We skip `planning_inplace_aggregate2` as planning results differ on cluster with 2 nodes.
@@ -33,83 +38,82 @@ fn main() {
                 test_name: test_name.to_owned() + "-cluster",
                 test_fn,
             });
-
-            #[derive(Serialize, Deserialize)]
-            struct WorkerArgs {
-                id: usize,
-                test_name: String,
-            }
-
-            struct ClusterSqlTest {
-                test_name: String,
-                test_fn: TestFn,
-            }
-
-            #[async_trait]
-            impl MultiProcTest for ClusterSqlTest {
-                type WorkerArgs = WorkerArgs;
-                type WorkerProc = WorkerFn;
-
-                fn worker_arguments(&self) -> Vec<WorkerArgs> {
-                    (0..=1)
-                        .map(|i| WorkerArgs {
-                            test_name: self.test_name.clone(),
-                            id: i,
-                        })
-                        .collect()
-                }
-
-                async fn drive(self) {
-                    Config::test(&self.test_name)
-                        .update_config(|mut c| {
-                            c.server_name = format!("localhost:{}", METASTORE_PORT);
-                            c.metastore_bind_address = Some(c.server_name.clone());
-                            c.select_workers = WORKER_PORTS
-                                .iter()
-                                .map(|p| format!("localhost:{}", p))
-                                .collect();
-                            c
-                        })
-                        .start_test(|services| async move {
-                            (self.test_fn)(Box::new(services.sql_service)).await;
-                        })
-                        .await;
-                }
-            }
-
-            #[derive(Default)]
-            struct WorkerFn;
-            #[async_trait]
-            impl WorkerProc<WorkerArgs> for WorkerFn {
-                async fn run(
-                    self,
-                    WorkerArgs { id, test_name }: WorkerArgs,
-                    init: SignalInit,
-                    done: WaitCompletion,
-                ) {
-                    // Note that Rust's libtest does not consume output in subprocesses.
-                    // Disable logs to keep output compact.
-                    if !std::env::var("CUBESTORE_TEST_LOG_WORKER").is_ok() {
-                        *cubestore::config::TEST_LOGGING_INITIALIZED.write().await = true;
-                    }
-                    Config::test(&test_name)
-                        .update_config(|mut c| {
-                            c.select_worker_pool_size = 2;
-                            c.server_name = format!("localhost:{}", WORKER_PORTS[id]);
-                            c.worker_bind_address = Some(c.server_name.clone());
-                            c.metastore_remote_address =
-                                Some(format!("localhost:{}", METASTORE_PORT));
-                            c
-                        })
-                        .start_test_worker(|_| async move {
-                            init.signal().await;
-                            done.wait_completion().await;
-                        })
-                        .await
-                }
-            }
         },
     );
+}
+
+struct ClusterSqlTest {
+    test_name: String,
+    test_fn: TestFn,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WorkerArgs {
+    id: usize,
+    test_name: String,
+}
+
+#[async_trait]
+impl MultiProcTest for ClusterSqlTest {
+    type WorkerArgs = WorkerArgs;
+    type WorkerProc = WorkerFn;
+
+    fn worker_arguments(&self) -> Vec<WorkerArgs> {
+        (0..=1)
+            .map(|i| WorkerArgs {
+                test_name: self.test_name.clone(),
+                id: i,
+            })
+            .collect()
+    }
+
+    async fn drive(self) {
+        Config::test(&self.test_name)
+            .update_config(|mut c| {
+                c.server_name = format!("localhost:{}", METASTORE_PORT);
+                c.metastore_bind_address = Some(c.server_name.clone());
+                c.select_workers = WORKER_PORTS
+                    .iter()
+                    .map(|p| format!("localhost:{}", p))
+                    .collect();
+                c
+            })
+            .start_test(|services| async move {
+                (self.test_fn)(Box::new(services.sql_service)).await;
+            })
+            .await;
+    }
+}
+
+#[derive(Default)]
+struct WorkerFn;
+#[async_trait]
+impl WorkerProc<WorkerArgs> for WorkerFn {
+    async fn run(
+        self,
+        WorkerArgs { id, test_name }: WorkerArgs,
+        init: SignalInit,
+        done: WaitCompletion,
+    ) {
+        // Note that Rust's libtest does not consume output in subprocesses.
+        // Disable logs to keep output compact.
+        if !std::env::var("CUBESTORE_TEST_LOG_WORKER").is_ok() {
+            *cubestore::config::TEST_LOGGING_INITIALIZED.write().await = true;
+        }
+        Config::test(&test_name)
+            .update_config(|mut c| {
+                c.select_worker_pool_size = 2;
+                c.server_name = format!("localhost:{}", WORKER_PORTS[id]);
+                c.worker_bind_address = Some(c.server_name.clone());
+                c.metastore_remote_address = Some(format!("localhost:{}", METASTORE_PORT));
+                c
+            })
+            .start_test_worker(|_| async move {
+                init.signal().await;
+                done.wait_completion().await;
+            })
+            .await
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/rust/cubestore-sql-tests/tests/multi_process.rs
+++ b/rust/cubestore-sql-tests/tests/multi_process.rs
@@ -1,5 +1,6 @@
 //! Runs the SQL tests with 2 select worker processes.
 use cubestore::config::Config;
+use cubestore::util::respawn;
 use cubestore_sql_tests::run_sql_tests;
 use tokio::runtime::Builder;
 
@@ -7,7 +8,7 @@ use tokio::runtime::Builder;
 fn main() {
     // Prepare workers.
     Config::configure_worker_services();
-    procspawn::init(); // TODO: logs on workers.
+    respawn::init(); // TODO: logs on workers.
 
     run_sql_tests("multi_process", vec![], |test_name, test_fn| {
         let r = Builder::new_current_thread().enable_all().build().unwrap();

--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://cube.dev"
 repository = "https://github.com/cube-js/cube.js"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-procspawn = { version = "0.9.0", features = ["test-support"] }
 ipc-channel = { version = "0.14.1" }
+libc = { version = "0.2.97", optional = true }
 
 [dependencies]
 base64 = "0.13.0"
@@ -78,6 +78,12 @@ http-auth-basic = "0.1.2"
 tracing = "0.1.25"
 tracing-futures = { version = "0.2.5", features = ["tokio", "tokio-executor"] }
 lru = "0.6.5"
+ctor = "0.1.20"
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"
+
+[features]
+# When enabled, child processes will die whenever parent process exits.
+# Highly recomended for production, available only on Linux with prctl system call.
+process-cleanup = ["libc"]

--- a/rust/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/src/bin/cubestored.rs
@@ -34,7 +34,7 @@ fn main() {
     app_metrics::STARTUPS.increment();
 
     #[cfg(not(target_os = "windows"))]
-    procspawn::init();
+    cubestore::util::respawn::init();
 
     let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
 

--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -5,7 +5,7 @@ pub mod transport;
 pub mod worker_pool;
 
 #[cfg(not(target_os = "windows"))]
-use crate::cluster::worker_pool::{MessageProcessor, WorkerPool};
+use crate::cluster::worker_pool::{worker_main, MessageProcessor, WorkerPool};
 
 use crate::ack_error;
 use crate::cluster::message::NetworkMessage;
@@ -192,6 +192,14 @@ impl MessageProcessor<WorkerMessage, (SchemaRef, Vec<SerializedRecordBatchStream
             }
         }
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[ctor::ctor]
+fn proc_handler() {
+    crate::util::respawn::register_handler(
+        worker_main::<WorkerMessage, (SchemaRef, Vec<SerializedRecordBatchStream>), WorkerProcessor>,
+    );
 }
 
 struct JobRunner {

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -271,13 +271,6 @@ impl From<std::string::FromUtf8Error> for CubeError {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
-impl From<procspawn::SpawnError> for CubeError {
-    fn from(v: procspawn::SpawnError) -> Self {
-        CubeError::from_error(v)
-    }
-}
-
 impl From<tokio::sync::oneshot::error::RecvError> for CubeError {
     fn from(v: tokio::sync::oneshot::error::RecvError) -> Self {
         CubeError::from_error(v)

--- a/rust/cubestore/src/sys/mod.rs
+++ b/rust/cubestore/src/sys/mod.rs
@@ -1,1 +1,2 @@
 pub mod malloc;
+pub mod process;

--- a/rust/cubestore/src/sys/process.rs
+++ b/rust/cubestore/src/sys/process.rs
@@ -1,0 +1,19 @@
+#[cfg(feature = "process-cleanup")]
+pub fn die_with_parent(parent_pid: u64) {
+    unsafe {
+        if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGHUP) != 0 {
+            log::error!("Failed to call PR_SET_DEATHSIG");
+            return;
+        }
+        // Handle parent process exit to finish as early as possible.
+        if libc::getppid() as u64 != parent_pid {
+            log::error!("parent process died, exiting");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(not(feature = "process-cleanup"))]
+pub fn die_with_parent(_parent_pid: u64) {
+    // nop
+}

--- a/rust/cubestore/src/util/mod.rs
+++ b/rust/cubestore/src/util/mod.rs
@@ -6,6 +6,8 @@ mod malloc_trim_loop;
 pub mod maybe_owned;
 pub mod metrics;
 pub mod ordfloat;
+#[cfg(not(target_os = "windows"))]
+pub mod respawn;
 pub mod strings;
 pub mod time_span;
 

--- a/rust/cubestore/src/util/respawn.rs
+++ b/rust/cubestore/src/util/respawn.rs
@@ -1,0 +1,126 @@
+use std::collections::HashMap;
+use std::process::{exit, Child};
+
+use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
+use mysql_common::serde::de::DeserializeOwned;
+use mysql_common::serde::Serialize;
+
+use crate::sys::process::die_with_parent;
+use crate::CubeError;
+use std::any::type_name;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::RwLock;
+
+/// Handler for [Args] must be registered prior to this call, both in main and child processes.
+pub fn respawn<Args: Serialize + DeserializeOwned>(
+    args: Args,
+    cmd_args: &[String],
+    envs: &[(String, String)],
+) -> Result<Child, CubeError> {
+    let handler = type_name::<Args>();
+    assert!(
+        HANDLERS.read().unwrap().contains_key(handler),
+        "respawn handler not registered for {}",
+        handler
+    );
+
+    let (server, ipc_name) = IpcOneShotServer::<IpcSender<Args>>::new()?;
+
+    let argv0 = std::env::args_os().next().unwrap();
+    let mut cmd = std::process::Command::new(argv0);
+    if !USE_TEST_CMD_ARGS.load(Ordering::Acquire) {
+        cmd.args(cmd_args);
+    } else {
+        cmd.args(&[
+            "--exact",
+            "-q",
+            "--test-threads=1",
+            "util::respawn::test_init",
+        ]);
+    }
+    cmd.envs(envs.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+    cmd.env(HANDLER_ENV, handler);
+    cmd.env(PARENT_PID_ENV, std::process::id().to_string());
+    cmd.env(IPC_ENV, ipc_name);
+
+    let c = cmd.spawn()?;
+    let (_, tx) = server.accept()?;
+    tx.send(args)?;
+    Ok(c)
+}
+
+pub fn register_handler<Args: Serialize + DeserializeOwned + 'static>(f: fn(Args) -> i32) {
+    let mut handlers = HANDLERS.write().unwrap();
+    // We use type_name to simplify usage, although they are not guaranteed to be unique.
+    // Hope this does not happen in practice.
+    let key = type_name::<Args>();
+    let had_duplicate = handlers
+        .insert(
+            key,
+            Box::new(move |ipc_sender| deserialize_and_run(ipc_sender, f)),
+        )
+        .is_some();
+    assert!(!had_duplicate, "duplicate handler registered for {}", key);
+}
+
+pub fn init() {
+    let handler_name = match std::env::var(HANDLER_ENV) {
+        Ok(h) => h,
+        Err(_) => return, // we're the main process.
+    };
+    let handlers = HANDLERS.read().unwrap();
+    let handler = match handlers.get(handler_name.as_str()) {
+        Some(f) => f,
+        None => panic!("no respawn handler for '{}'", handler_name),
+    };
+
+    let ppid = match std::env::var(PARENT_PID_ENV) {
+        Ok(id) => id
+            .parse::<u64>()
+            .expect("could not parse parent pid in child process"),
+        Err(_) => panic!("could not get parent pid in child process"),
+    };
+    die_with_parent(ppid);
+
+    let ipc_server = std::env::var(IPC_ENV).expect("could not get IPC channel name");
+    exit(handler(ipc_server))
+}
+
+const HANDLER_ENV: &'static str = "__CUBESTORE_RESPAWN_PROC";
+const PARENT_PID_ENV: &'static str = "__CUBESTORE_RESPAWN_PPID";
+const IPC_ENV: &'static str = "__CUBESTORE_IPC_NAME";
+
+static USE_TEST_CMD_ARGS: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+pub fn replace_cmd_args_in_tests() {
+    USE_TEST_CMD_ARGS.store(true, Ordering::Release);
+}
+#[cfg(test)]
+#[test]
+fn test_init() {
+    init();
+}
+
+lazy_static!(
+static ref HANDLERS: RwLock<
+    HashMap<
+        /*ArgsType*/ &'static str,
+        Box<dyn Fn(/*ipc_sender*/ String) -> i32 + Send + Sync>,
+    >,
+> = RwLock::new(HashMap::new());
+);
+
+fn deserialize_and_run<Args: Serialize + DeserializeOwned>(
+    ipc_sender: String,
+    f: fn(Args) -> i32,
+) -> i32 {
+    let (args_tx, args_rx) = ipc_channel::ipc::channel().unwrap();
+    IpcSender::connect(ipc_sender)
+        .unwrap()
+        .send(args_tx)
+        .unwrap();
+    let args = args_rx
+        .recv()
+        .expect("failed to deserialize process arguments");
+    f(args)
+}


### PR DESCRIPTION
procspawn now only used as a dev dependency for test support code.
  - The child process now stars with `argv[0]`. Command line arguments are
    passed by the callers instead of being replicated. Theses should
    produce better UX and more context in process monitoring tools.
    CubeStore itself ignores all command-line arguments.
  - Implementation is simpler, although the idea is the same.
  - The API usage is a bit more complicated, requires registering main
    functions separately. This allows to simplify implementation by avoiding
    the mapping of function addresses across processes.