### PR TITLE
docs(getting-started): fix link format typo

### DIFF
--- a/docs/content/Getting-Started/Getting-Started-Nodejs.md
+++ b/docs/content/Getting-Started/Getting-Started-Nodejs.md
@@ -85,8 +85,7 @@ cube(`Users`, {
 The Cube.js client provides set of methods to access Cube.js API and to work
 with query result. The client itself doesn't provide any visualizations and is
 designed to work with existing chart libraries. You can find more information
-about [the Cube.js client as well as our frontend integrations here]
-[ref-frontend-intro].
+about [the Cube.js client as well as our frontend integrations here][ref-frontend-intro].
 
 As a shortcut you can run your dev server first:
 


### PR DESCRIPTION
**Before**
<img width="1037" alt="изображение" src="https://user-images.githubusercontent.com/18264667/123513714-087a1380-d6a8-11eb-9866-46d94fc8c6f9.png">

**After**
<img width="1037" alt="изображение" src="https://user-images.githubusercontent.com/18264667/123513738-30697700-d6a8-11eb-951b-dbc6ac9b13e0.png">
