### PR TITLE
fix: CUBEJS_REFRESH_WORKER shouldn't enabled externalRefresh

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -358,6 +358,7 @@ class PreAggregationLoader {
     this.requestId = options.requestId;
     this.structureVersionPersistTime = preAggregations.structureVersionPersistTime;
     this.externalRefresh = options.externalRefresh;
+
     if (this.externalRefresh && this.waitForRenew) {
       const message = 'Invalid configuration - when externalRefresh is true, it will not perform a renew, therefore you cannot wait for it using waitForRenew.';
       if (['production', 'test'].includes(getEnv('nodeEnv'))) {

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -645,9 +645,9 @@ export class CubejsServerCore {
     const refreshWorkerMode = getEnv('refreshWorkerMode');
     const rollupOnlyMode = getEnv('rollupOnlyMode');
 
-    // External refresh is enabled for refreshWorkerMode or rollupOnlyMode, but it's disabled
+    // External refresh is enabled for rollupOnlyMode, but it's disabled
     // when it's both refreshWorkerMode & rollupOnlyMode
-    const externalRefresh: boolean = (!refreshWorkerMode !== !rollupOnlyMode);
+    const externalRefresh: boolean = rollupOnlyMode && !refreshWorkerMode;
 
     const orchestratorApi = this.createOrchestratorApi(
       async (dataSource = 'default') => {

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -384,7 +384,7 @@ describe('index.test', () => {
   };
 
   testRefreshWorkerAndRollupModes(true, false, (options) => {
-    expect(options.preAggregationsOptions.externalRefresh).toEqual(true);
+    expect(options.preAggregationsOptions.externalRefresh).toEqual(false);
     expect(options.rollupOnlyMode).toEqual(false);
   });
 
@@ -395,7 +395,8 @@ describe('index.test', () => {
 
   testRefreshWorkerAndRollupModes(true, true, (options) => {
     expect(options.rollupOnlyMode).toEqual(true);
-    // externalRefresh is false when both refreshWorkerMode & rollupOnlyMode are enabled
+    // External refresh is enabled for rollupOnlyMode, but it's disabled
+    // when it's both refreshWorkerMode & rollupOnlyMode
     expect(options.preAggregationsOptions.externalRefresh).toEqual(false);
   });
 


### PR DESCRIPTION
Hello!

# Issue

Few versions ago we introduced CUBEJS_REFRESH_WORKER, but it will not work with Refresh Scheduler.

Thanks