### PR TITLE
feat: Support every for refreshKey with SQL

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -69,7 +69,10 @@ const BaseMeasure = {
 const BasePreAggregationWithoutPartitionGranularity = {
   refreshKey: Joi.alternatives().try(
     Joi.object().keys({
-      sql: Joi.func().required()
+      sql: Joi.func().required(),
+      // We dont support timezone for this, because it's useless
+      // We cannot support cron interval
+      every: Joi.alternatives().try(everyInterval),
     }),
     Joi.object().keys({
       every: Joi.alternatives().try(everyInterval, everyCronInterval),
@@ -116,7 +119,10 @@ const cubeSchema = Joi.object().keys({
   sql: Joi.func().required(),
   refreshKey: Joi.alternatives().try(
     Joi.object().keys({
-      sql: Joi.func().required()
+      sql: Joi.func().required(),
+      // We dont support timezone for this, because it's useless
+      // We cannot support cron interval
+      every: Joi.alternatives().try(everyInterval),
     }),
     Joi.object().keys({
       immutable: Joi.boolean().required()


### PR DESCRIPTION
Hello!

## Motiviation

Some users can define `refreshKey` with `sql`, and cube.js will check this SQL every 10 seconds, which is too often and it can be useless for performance & cost reasons (example, `SELECT MAX(created) FROM table`). In this PR I've introduced support for every in refresh key that declares SQL.

Thanks