### PR TITLE
fix(@cubejs-client/core): Long Query 413 URL too large

### DIFF
--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -20,7 +20,7 @@ class HttpTransport {
 
     let url = `${this.apiUrl}/${method}${searchParams.toString().length ? `?${searchParams}` : ''}`;
 
-    let requestMethod = this.method || (url.length < 2000 ? 'GET' : 'POST');
+    const requestMethod = this.method || (url.length < 2000 ? 'GET' : 'POST');
     if (requestMethod === 'POST') {
       url = `${this.apiUrl}/${method}`;
       this.headers['Content-Type'] = 'application/json';

--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -20,8 +20,8 @@ class HttpTransport {
 
     let url = `${this.apiUrl}/${method}${searchParams.toString().length ? `?${searchParams}` : ''}`;
 
-    this.method = this.method || (url.length < 2000 ? 'GET' : 'POST');
-    if (this.method === 'POST') {
+    let requestMethod = this.method || (url.length < 2000 ? 'GET' : 'POST');
+    if (requestMethod === 'POST') {
       url = `${this.apiUrl}/${method}`;
       this.headers['Content-Type'] = 'application/json';
     }
@@ -29,14 +29,14 @@ class HttpTransport {
     // Currently, all methods make GET requests. If a method makes a request with a body payload,
     // remember to add {'Content-Type': 'application/json'} to the header.
     const runRequest = () => fetch(url, {
-      method: this.method,
+      method: requestMethod,
       headers: {
         Authorization: this.authorization,
         'x-request-id': baseRequestId && `${baseRequestId}-span-${spanCounter++}`,
         ...this.headers
       },
       credentials: this.credentials,
-      body: this.method === 'POST' ? JSON.stringify(params) : null
+      body: requestMethod === 'POST' ? JSON.stringify(params) : null
     });
 
     return {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
#1558 

**Description**
In HttpTransport, `this.method = this.method || (url.length < 2000 ? 'GET' : 'POST');` the later url length logic will only get run once if method is undefined. Any request afterwards will be taken from `this.method`. For apps that uses the client as a singleton like angular, client will never fire a `POST` request if query is too long. 