### PR TITLE
fix(cubestore-driver): Map UUID to VARCHAR(64)

### DIFF
--- a/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
@@ -20,7 +20,8 @@ import { WebSocketConnection } from './WebSocketConnection';
 
 const GenericTypeToCubeStore: Record<string, string> = {
   string: 'varchar(255)',
-  text: 'varchar(255)'
+  text: 'varchar(255)',
+  uuid: 'varchar(64)'
 };
 
 type Column = {


### PR DESCRIPTION
Hello!

refs https://github.com/cube-js/cube.js/issues/3100

Right now, Cube Store supports UUID, but it's mapping it to Bytes internally, it's why it's expected to use hex encoding in CSV parsing, but it's impossibly hard to do it on the Cube.js side (because it requires a lot of refactoring in each driver). As I quick solution I am going to use varchar(64) for UUID type.

Thanks