### PR TITLE
 fix(cubestore): only pick index with exact column order 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#93f32cc91a525b7a645ae3e8d784db8dd44536f9"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#93f32cc91a525b7a645ae3e8d784db8dd44536f9"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#93f32cc91a525b7a645ae3e8d784db8dd44536f9"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#93f32cc91a525b7a645ae3e8d784db8dd44536f9"
+source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/rust/cubestore-sql-tests/src/lib.rs
+++ b/rust/cubestore-sql-tests/src/lib.rs
@@ -16,6 +16,8 @@ use tests::sql_tests;
 
 #[cfg(not(target_os = "windows"))]
 pub mod multiproc;
+#[allow(unused_parens, non_snake_case)]
+mod rows;
 mod tests;
 
 #[async_trait]

--- a/rust/cubestore-sql-tests/src/rows.rs
+++ b/rust/cubestore-sql-tests/src/rows.rs
@@ -1,0 +1,79 @@
+//! Helpers to match on returned rows in tests.
+use cubestore::table::{TableValue, TimestampValue};
+use cubestore::util::decimal::Decimal;
+
+pub fn rows(i: &[impl ToRow]) -> Vec<Vec<TableValue>> {
+    i.iter().map(ToRow::to_row).collect()
+}
+
+pub trait ToRow {
+    fn to_row(&self) -> Vec<TableValue>;
+}
+
+macro_rules! impl_to_row {
+    ( $($ts:ident),* ) => {
+        impl <$( $ts: ToValue ),*> ToRow for ($( $ts ),*) {
+            fn to_row(&self) -> Vec<TableValue> {
+                let ( $( $ts ),* ) = self;
+                vec![ $( $ts.to_val() ),* ]
+            }
+        }
+    }
+}
+
+impl_to_row!(T);
+impl_to_row!(T1, T2);
+impl_to_row!(T1, T2, T3);
+impl_to_row!(T1, T2, T3, T4);
+
+pub trait ToValue {
+    fn to_val(&self) -> TableValue;
+}
+
+impl ToValue for () {
+    fn to_val(&self) -> TableValue {
+        TableValue::Null
+    }
+}
+
+impl ToValue for &str {
+    fn to_val(&self) -> TableValue {
+        TableValue::String(self.to_string())
+    }
+}
+
+impl ToValue for i64 {
+    fn to_val(&self) -> TableValue {
+        TableValue::Int(*self)
+    }
+}
+
+impl ToValue for Decimal {
+    fn to_val(&self) -> TableValue {
+        TableValue::Decimal(*self)
+    }
+}
+
+impl ToValue for f64 {
+    fn to_val(&self) -> TableValue {
+        TableValue::Float(self.clone().into())
+    }
+}
+
+impl ToValue for &[u8] {
+    fn to_val(&self) -> TableValue {
+        TableValue::Bytes(self.to_vec())
+    }
+}
+
+impl ToValue for TimestampValue {
+    fn to_val(&self) -> TableValue {
+        TableValue::Timestamp(*self)
+    }
+}
+
+impl ToValue for bool {
+    fn to_val(&self) -> TableValue {
+        TableValue::Boolean(*self)
+    }
+}

--- a/rust/cubestore/src/queryplanner/optimizations/prefer_inplace_aggregates.rs
+++ b/rust/cubestore/src/queryplanner/optimizations/prefer_inplace_aggregates.rs
@@ -29,13 +29,13 @@ pub fn try_switch_to_inplace_aggregates(
     // Try to cheaply rearrange the plan so that it produces sorted inputs.
     let new_input = try_regroup_columns(agg.input().clone())?;
 
-    if compute_aggregation_strategy(new_input.as_ref(), agg.group_expr())
-        != AggregateStrategy::InplaceSorted
-    {
+    let (strategy, order) = compute_aggregation_strategy(new_input.as_ref(), agg.group_expr());
+    if strategy != AggregateStrategy::InplaceSorted {
         return Ok(p);
     }
     Ok(Arc::new(HashAggregateExec::try_new(
         AggregateStrategy::InplaceSorted,
+        order,
         *agg.mode(),
         agg.group_expr().into(),
         agg.aggr_expr().into(),

--- a/rust/cubestore/src/queryplanner/topk/plan.rs
+++ b/rust/cubestore/src/queryplanner/topk/plan.rs
@@ -267,9 +267,10 @@ pub fn plan_topk(
             planner.create_aggregate_expr(e, &logical_input_schema, &physical_input_schema, ctx)
         })
         .collect::<Result<Vec<_>, DataFusionError>>()?;
-    let strategy = compute_aggregation_strategy(input.as_ref(), &group_expr);
+    let (strategy, order) = compute_aggregation_strategy(input.as_ref(), &group_expr);
     let aggregate = Arc::new(HashAggregateExec::try_new(
         strategy,
+        order,
         AggregateMode::Full,
         group_expr,
         initial_aggregate_expr.clone(),


### PR DESCRIPTION
This fixes another instance of the "unmerged data" error.

Order of columns is propagated to the `MergeSortExec` nodes and it must
match the actual data order.

Also land the arrow fix for `HashAggregateExec`.

Both are required for the added test to work.