### PR TITLE
docs(deployment): fix incorrect URL for GCP deployments

### DIFF
--- a/docs/content/Deployment/Overview.md
+++ b/docs/content/Deployment/Overview.md
@@ -339,6 +339,6 @@ If you want to run Cube.js in production without Redis, you can use
 [ref-deploy-cubecloud]: /deployment/platforms/cube-cloud
 [ref-deploy-docker]: /deployment/platforms/docker
 [ref-deploy-sls-aws]: /deployment/platforms/serverless/aws
-[ref-deploy-sls-gcp]: /deployment/platforms/serverless/gcp
+[ref-deploy-sls-gcp]: /deployment/platforms/serverless/google-cloud
 [ref-config-env]: /reference/environment-variables
 [ref-config-js]: /config


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**
link to deployment guidelines to GCP (GCP Serverless) is 404

![Screenshot from 2021-07-21 10-21-44](https://user-images.githubusercontent.com/5369329/126425679-b2ecffb0-f9f4-446d-a094-e5cff69cd677.png)

![Screenshot from 2021-07-21 10-21-37](https://user-images.githubusercontent.com/5369329/126425676-c9c323f2-4d6d-4ad1-a904-0c200a6fa8dc.png)

