### PR TITLE
fix(api-gateway): Debug API, allow subscribe to pre-aggregations queue events only by playground JWT

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -868,7 +868,14 @@ export class ApiGateway {
     }
   }
 
-  public subscribeQueueEvents({ context, connectionId, res }) {
+  public subscribeQueueEvents({ context, signedWithPlaygroundAuthSecret, connectionId, res }) {
+    if (this.enforceSecurityChecks && !signedWithPlaygroundAuthSecret) {
+      throw new CubejsHandlerError(
+        403,
+        'Forbidden',
+        'Only for signed with playground auth secret'
+      );
+    }
     return this.getAdapterApi(context).subscribeQueueEvents(connectionId, res);
   }
 


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Debug API, allow subscribe to pre-aggregations queue events only by playground JWT

