### PR TITLE
fix(@cubejs-client/react): QueryBuilder incorrectly deduplicates filt…

### DIFF
--- a/packages/cubejs-client-react/src/QueryBuilder.jsx
+++ b/packages/cubejs-client-react/src/QueryBuilder.jsx
@@ -250,13 +250,11 @@ export default class QueryBuilder extends React.Component {
       dryRunResponse,
     } = this.state;
 
-    const flatFilters = uniqBy(
-      prop('member'),
+    const flatFilters = uniqBy((filter) => `${prop('member', filter)}${prop('operator', filter)}`,
       flattenFilters((meta && query.filters) || []).map((filter) => ({
         ...filter,
         member: filter.member || filter.dimension,
-      }))
-    );
+      })));
 
     const filters = flatFilters.map((m, i) => ({
       ...m,


### PR DESCRIPTION
fix(@cubejs-client/react): QueryBuilder incorrectly deduplicates filters based only on member instead of member+operator (#2948)

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
#2948 

**Description of Changes Made (if issue reference is not provided)**
fixes QueryBuilder's deduplication of filters to deduplicate based on member+operator instead of just member
