### PR TITLE
Support reading AWS config and credentials files

### DIFF
--- a/packages/cubejs-athena-driver/driver/AthenaDriver.js
+++ b/packages/cubejs-athena-driver/driver/AthenaDriver.js
@@ -8,19 +8,20 @@ const applyParams = (query, params) => SqlString.format(query, params);
 class AthenaDriver extends BaseDriver {
   constructor(config = {}) {
     super();
-
     this.config = {
-      credentials: {
-        accessKeyId: config.accessKeyId || process.env.CUBEJS_AWS_KEY,
-        secretAccessKey: config.secretAccessKey || process.env.CUBEJS_AWS_SECRET,
-      },
       region: process.env.CUBEJS_AWS_REGION,
       S3OutputLocation: process.env.CUBEJS_AWS_S3_OUTPUT_LOCATION,
+      WorkGroup: config.WorkGroup || 'primary',
       ...config,
       pollTimeout: (config.pollTimeout || getEnv('dbPollTimeout')) * 1000,
       pollMaxInterval: (config.pollMaxInterval || getEnv('dbPollMaxInterval')) * 1000,
     };
-
+    if (!process.env.AWS_SDK_LOAD_CONFIG) {
+      this.config.credentials = {
+        accessKeyId: config.accessKeyId || process.env.CUBEJS_AWS_KEY,
+        secretAccessKey: config.secretAccessKey || process.env.CUBEJS_AWS_SECRET,
+      };
+    }
     this.athena = new AWS.Athena(this.config);
   }
 
@@ -92,7 +93,8 @@ class AthenaDriver extends BaseDriver {
       QueryString: queryString,
       ResultConfiguration: {
         OutputLocation: this.config.S3OutputLocation
-      }
+      },
+      WorkGroup: this.config.WorkGroup,
     });
 
     const startedTime = Date.now();
@@ -116,7 +118,6 @@ class AthenaDriver extends BaseDriver {
   async tablesSchema() {
     const tablesSchema = await super.tablesSchema();
     const viewsSchema = await this.viewsSchema(tablesSchema);
-
     return this.mergeSchemas([tablesSchema, viewsSchema]);
   }
 
@@ -141,7 +142,6 @@ class AthenaDriver extends BaseDriver {
       FROM information_schema.tables
       WHERE tables.table_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
     `);
-
     return data;
   }
 


### PR DESCRIPTION
Modified Athena drive config to not override aws-sdk reading config/creds from ~/.aws directory

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
