### PR TITLE
fix(bigquery-driver): Ignore dataSets with wrong permissions

### DIFF
--- a/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
+++ b/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
@@ -143,11 +143,19 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
     return field;
   }
 
-  protected parseDataset(dataset: Dataset) {
-    return dataset.getTables().then(
-      (data) => Promise.all(data[0].map(this.parseTableData))
-        .then(tables => ({ id: dataset.id, data: this.addSuffixTables(tables.reduce(this.reduceSuffixTables, {})) }))
-    );
+  protected async parseDataset(dataset: Dataset) {
+    try {
+      return await dataset.getTables().then(
+        (data) => Promise.all(data[0].map(this.parseTableData))
+          .then(tables => ({ id: dataset.id, data: this.addSuffixTables(tables.reduce(this.reduceSuffixTables, {})) }))
+      );
+    } catch (e) {
+      if (e.message.includes('Permission bigquery.tables.get denied on table')) {
+        return {};
+      }
+
+      throw e;
+    }
   }
 
   protected parseTableData(table: Table) {


### PR DESCRIPTION
Hello!

There are two different permissions in BigQuery to get tables from INFORMATION_SCHEMA & get list of dataSets. Right now, we load the list of dataSets and load tables for each dataSet, but if the user didn't specify `tables.get` permission for dataSet we are not able to get a list of tables. There is no way to get permissions, let's ignore dataSets with wrong permissions from introspection.

Thanks