### PR TITLE
fix(cubestore): proper support for nulls in group by

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
+source = "git+https://github.com/cube-js/arrow?branch=cube-main#725a3d03f1392bbe6c59753850850cb7a6df5e4d"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
+source = "git+https://github.com/cube-js/arrow?branch=cube-main#725a3d03f1392bbe6c59753850850cb7a6df5e4d"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
+source = "git+https://github.com/cube-js/arrow?branch=cube-main#725a3d03f1392bbe6c59753850850cb7a6df5e4d"
 dependencies = [
  "ahash 0.7.2",
  "arrow",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow?branch=cubestore-2021-05-17#b14f5d35ab32c8ed662cf6828507b3ed75573a7b"
+source = "git+https://github.com/cube-js/arrow?branch=cube-main#725a3d03f1392bbe6c59753850850cb7a6df5e4d"
 dependencies = [
  "arrow",
  "base64 0.12.3",

--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -25,10 +25,10 @@ serde_bytes = "0.11.5"
 cubehll = { path = "../cubehll" }
 cubezetasketch = { path = "../cubezetasketch" }
 cuberpc = { path = "../cuberpc" }
-parquet = { git = 'https://github.com/cube-js/arrow', branch = 'cubestore-2021-05-17', version = "5.0.0-SNAPSHOT" }
-arrow = { git = 'https://github.com/cube-js/arrow', branch = 'cubestore-2021-05-17', version = "5.0.0-SNAPSHOT" }
-arrow-flight = { git = 'https://github.com/cube-js/arrow', branch = 'cubestore-2021-05-17', version = "5.0.0-SNAPSHOT" }
-datafusion = { git = 'https://github.com/cube-js/arrow', branch = 'cubestore-2021-05-17', version = "5.0.0-SNAPSHOT" }
+parquet = { git = "https://github.com/cube-js/arrow", branch = "cube-main" }
+arrow = { git = "https://github.com/cube-js/arrow", branch = "cube-main" }
+arrow-flight = { git = "https://github.com/cube-js/arrow", branch = "cube-main" }
+datafusion = { git = "https://github.com/cube-js/arrow", branch = "cube-main" }
 csv = "1.1.3"
 bytes = "0.5.4"
 serde_json = "1.0.56"

--- a/rust/cubestore/src/queryplanner/topk/execute.rs
+++ b/rust/cubestore/src/queryplanner/topk/execute.rs
@@ -543,6 +543,7 @@ impl TopKState<'_> {
                 AggregateMode::Final,
                 &g.group_key,
                 &g.accumulators,
+                &schema.fields()[..self.key_len],
                 &mut key_columns,
                 &mut value_columns,
             )?

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -1322,7 +1322,7 @@ mod tests {
                             join_results.push(Row::new(vec![TableValue::String(email.clone()), TableValue::String(uuid), TableValue::Int(i)]))
                         }
                     } else {
-                        join_results.push(Row::new(vec![TableValue::String(email.clone()), TableValue::String("".to_string()), TableValue::Int(i)]))
+                        join_results.push(Row::new(vec![TableValue::String(email.clone()), TableValue::Null, TableValue::Int(i)]))
                     }
                 }
 


### PR DESCRIPTION
The actual fix is in DataFusion.
In addition to the correct semantics, also fixes an infinite loop.