### PR TITLE
Fix client hangs when loading big responses (node)

### DIFF
--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -109,11 +109,12 @@ class CubejsApi {
       }
 
       let body = {};
-
+      let text = '';
       try {
-        body = await response.clone().json();
+        text = await response.text();
+        body = JSON.parse(text);
       } catch (_) {
-        body.error = await response.text();
+        body.error = text;
       }
 
       if (body.error === 'Continue wait') {


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet (no new code paths added)
- [X] Docs have been added / updated if required (no docs changes required)

**Description of Changes Made (if issue reference is not provided)**

The cloned response stream and the original stream have to be resolved in parallel, otherwise if the response is bigger than the `highWaterMark` (16kB in Node.js) the text stream will hang.

In theory, this can also affect browsers but the `highWaterMark` is usually much bigger there.

See https://github.com/node-fetch/node-fetch/issues/151 and [node-fetch and `highWaterMark`](https://github.com/node-fetch/node-fetch#custom-highwatermark).
