### PR TITLE
feat(cubejs-api-gateway): Add `next` keyword for relative date ranges

### DIFF
--- a/docs/content/Cube.js-Backend/Query-Format.md
+++ b/docs/content/Cube.js-Backend/Query-Format.md
@@ -412,8 +412,8 @@ provides a convenient shortcut to pass a dimension and a filter as a
   padded to the start and end of the day if used in start and end of date range
   interval accordingly. If only one date is specified it's equivalent to passing
   two of the same dates as a date range. You can also pass a string instead of
-  array with relative date range, for example: `last quarter` or
-  `last 360 days`.
+  array with relative date range, for example: `last quarter`, `last 360 days`,
+  or `next 2 months`.
 - `compareDateRange`: An array of date ranges to compare a measure change over
   previous period
 - `granularity`: A granularity for a time dimension. It supports the following
@@ -452,8 +452,8 @@ const resultSet = cubejsApi.load({
 // ...
 ```
 
-You can also set a relative `dateRange`, e.g. `today`, `yesterday`, `last year`,
-or `last 6 months`.
+You can also set a relative `dateRange`, e.g. `today`, `yesterday`, `tomorrow`, `last year`,
+`next month`, or `last 6 months`.
 
 ```js
 {
@@ -466,8 +466,8 @@ or `last 6 months`.
 }
 ```
 
-Be aware that e.g. `Last 7 days` does not include the current date. If you need
-the current date also you can use `from N days ago to now`.
+Be aware that e.g. `Last 7 days` or `Next 2 weeks` do not include the current
+date. If you need the current date also you can use `from N days ago to now` or `from now to N days from now`.
 
 ```js
 {

--- a/packages/cubejs-api-gateway/src/dateParser.js
+++ b/packages/cubejs-api-gateway/src/dateParser.js
@@ -21,29 +21,48 @@ export function dateParser(dateString, timezone, now = new Date()) {
   let momentRange;
   dateString = dateString.toLowerCase();
 
-  if (dateString.match(/(this|last)\s+(day|week|month|year|quarter|hour|minute|second)/)) {
-    const match = dateString.match(/(this|last)\s+(day|week|month|year|quarter|hour|minute|second)/);
+  if (dateString.match(/(this|last|next)\s+(day|week|month|year|quarter|hour|minute|second)/)) {
+    const match = dateString.match(/(this|last|next)\s+(day|week|month|year|quarter|hour|minute|second)/);
     let start = moment.tz(timezone);
     let end = moment.tz(timezone);
     if (match[1] === 'last') {
       start = start.add(-1, match[2]);
       end = end.add(-1, match[2]);
     }
+    if (match[1] === 'next') {
+      start = start.add(1, match[2]);
+      end = end.add(1, match[2]);
+    }
+
     const span = match[2] === 'week' ? 'isoWeek' : match[2];
     momentRange = [start.startOf(span), end.endOf(span)];
-  } else if (dateString.match(/last\s+(\d+)\s+(day|week|month|year|quarter|hour|minute|second)/)) {
-    const match = dateString.match(/last\s+(\d+)\s+(day|week|month|year|quarter|hour|minute|second)/);
-    const span = match[2] === 'week' ? 'isoWeek' : match[2];
-    momentRange = [
-      moment.tz(timezone).startOf(span).add(-parseInt(match[1], 10), match[2]),
-      moment.tz(timezone).add(-1, match[2]).endOf(span)
-    ];
+  } else if (dateString.match(/(last|next)\s+(\d+)\s+(day|week|month|year|quarter|hour|minute|second)/)) {
+    const match = dateString.match(/(last|next)\s+(\d+)\s+(day|week|month|year|quarter|hour|minute|second)/);
+
+    let start = moment.tz(timezone);
+    let end = moment.tz(timezone);
+    if (match[1] === 'last') {
+      start = start.add(-parseInt(match[2], 10), match[3]);
+      end = end.add(-1, match[3]);
+    }
+    if (match[1] === 'next') {
+      start = start.add(parseInt(1, 10), match[3]);
+      end = end.add(parseInt(match[2], 10), match[3]);
+    }
+
+    const span = match[3] === 'week' ? 'isoWeek' : match[3];
+    momentRange = [start.startOf(span), end.endOf(span)];
   } else if (dateString.match(/today/)) {
     momentRange = [moment.tz(timezone).startOf('day'), moment.tz(timezone).endOf('day')];
   } else if (dateString.match(/yesterday/)) {
     momentRange = [
       moment.tz(timezone).startOf('day').add(-1, 'day'),
       moment.tz(timezone).endOf('day').add(-1, 'day')
+    ];
+  } else if (dateString.match(/tomorrow/)) {
+    momentRange = [
+      moment.tz(timezone).startOf('day').add(1, 'day'),
+      moment.tz(timezone).endOf('day').add(1, 'day')
     ];
   } else if (dateString.match(/^from (.*) to (.*)$/)) {
     // eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars

--- a/packages/cubejs-api-gateway/test/dateParser.test.js
+++ b/packages/cubejs-api-gateway/test/dateParser.test.js
@@ -15,6 +15,12 @@ describe('dateParser', () => {
     );
   });
 
+  test('next 1 day', () => {
+    expect(dateParser('next 1 day', 'UTC')).toStrictEqual(
+      [dateParser('tomorrow', 'UTC')[0], dateParser('tomorrow', 'UTC')[1]]
+    );
+  });
+
   test('today', () => {
     const start = new Date();
     const end = new Date();
@@ -43,6 +49,15 @@ describe('dateParser', () => {
     );
   });
 
+  test('from now to 23 hours from now', () => {
+    expect(dateParser('from now to 23 hours from now', 'UTC')).toStrictEqual(
+      [
+        new Date((Math.floor(new Date().getTime() / (1000 * 60 * 60))) * (1000 * 60 * 60)).toISOString().replace('Z', ''),
+        new Date((Math.ceil(new Date().getTime() / (1000 * 60 * 60)) + 23) * (1000 * 60 * 60) - 1).toISOString().replace('Z', '')
+      ]
+    );
+  });
+
   test('from 1 hour ago to now LA', () => {
     // 'Z' stands for Zulu time, which is also GMT and UTC.
     const now = '2020-09-22T13:03:20.518Z';
@@ -61,6 +76,12 @@ describe('dateParser', () => {
     expect(dateParser('from 7 days ago to now', 'UTC')).toStrictEqual(
       [dateParser('last 7 days', 'UTC')[0], dateParser('today', 'UTC')[1]]
     );
+  });
+
+  test('from 7 days ago to 7 days from now', () => {
+    expect(dateParser('from 7 days ago to 7 days from now', 'UTC')).toStrictEqual([
+      dateParser('last 7 days', 'UTC')[0], dateParser('next 7 days', 'UTC')[1]
+    ]);
   });
 
   test('unexpected date', () => {
@@ -87,6 +108,40 @@ describe('dateParser', () => {
       '2020-09-01T00:00:00.000',
       '2021-02-28T23:59:59.999',
     ]);
+
+    Date.now.mockRestore();
+  });
+
+  test('next 6 months', () => {
+    Date.now = jest.fn().mockReturnValue(new Date(2021, 1, 20, 13, 0, 0, 0));
+    expect(dateParser('next 6 months', 'UTC', new Date(2021, 1, 20, 13, 0, 0, 0))).toStrictEqual([
+      '2021-03-01T00:00:00.000',
+      '2021-08-31T23:59:59.999',
+    ]);
+
+    Date.now.mockRestore();
+  });
+
+  test('next month', () => {
+    Date.now = jest.fn().mockReturnValue(new Date(2021, 2, 5, 13, 0, 0, 0));
+    expect(dateParser('next month', 'UTC', new Date(2021, 2, 5, 13, 0, 0, 0))).toStrictEqual(
+      [
+        '2021-04-01T00:00:00.000',
+        '2021-04-30T23:59:59.999'
+      ]
+    );
+
+    Date.now.mockRestore();
+  });
+
+  test('next 5 days', () => {
+    Date.now = jest.fn().mockReturnValue(new Date(2021, 2, 5, 13, 0, 0, 0));
+    expect(dateParser('next 5 days', 'UTC', new Date(2021, 2, 5, 13, 0, 0, 0))).toStrictEqual(
+      [
+        '2021-03-06T00:00:00.000',
+        '2021-03-10T23:59:59.999'
+      ]
+    );
 
     Date.now.mockRestore();
   });


### PR DESCRIPTION
**Check List**
- [X] Tests has been run in packages where changes made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [X] Docs have been added / updated if required

**Issue Reference this PR resolves**
#2866 

**Description of Changes Made (if issue reference is not provided)**

