### PR TITLE
fix: Pre-aggregations should have default refreshKey of every 1 hour if it doesn't set for Cube

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2251,7 +2251,6 @@ export class BaseQuery {
         }
 
         if (
-          preAggregation.partitionGranularity &&
           !preAggregationQueryForSql.allCubeNames.find(c => {
             const fromPath = this.cubeEvaluator.cubeFromPath(c);
             return fromPath.refreshKey && fromPath.refreshKey.sql;
@@ -2261,25 +2260,7 @@ export class BaseQuery {
           return preAggregationQueryForSql.evaluateSymbolSqlWithContext(
             () => preAggregationQueryForSql.cacheKeyQueries(
               (refreshKeyCube, [refreshKeySQL, refreshKeyQueryOptions, refreshKeyQuery]) => {
-                if (cubeFromPath.refreshKey && cubeFromPath.refreshKey.immutable) {
-                  /**
-                   * It's not supported in Cube Store, because it doesnt support Sub Query
-                   * There is a PR with fix for that https://github.com/cube-js/cube.js/pull/3098
-                   * But probably we will remove immutable refreshKeys in the future
-                   */
-                  return [
-                    this.refreshKeySelect(
-                      this.incrementalRefreshKey(preAggregationQueryForSql, `(${refreshKeySQL})`, {
-                        refreshKeyQuery
-                      })
-                    ),
-                    {
-                      external: refreshKeyQueryOptions.external,
-                      renewalThreshold: this.defaultRefreshKeyRenewalThreshold(),
-                    },
-                    refreshKeyQuery
-                  ];
-                } else if (!cubeFromPath.refreshKey) {
+                if (!cubeFromPath.refreshKey) {
                   const [sql, external, query] = this.everyRefreshKeySql({
                     every: '1 hour'
                   });

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -1035,6 +1035,8 @@ describe('PreAggregations', () => {
 
     const queries = dbRunner.tempTablePreAggregations(preAggregationsDescription);
 
+    expect(queries.filter(([q]) => !!q.match(/3600/)).length).toBeGreaterThanOrEqual(1);
+
     console.log(JSON.stringify(queries.concat(queryAndParams)));
 
     return dbRunner.evaluateQueryWithPreAggregations(query).then(res => {
@@ -1265,6 +1267,8 @@ describe('PreAggregations', () => {
     console.log(preAggregationsDescription);
 
     const queries = dbRunner.tempTablePreAggregations(preAggregationsDescription);
+
+    expect(queries.filter(([q]) => !!q.match(/3600/)).length).toBeGreaterThanOrEqual(1);
 
     console.log(JSON.stringify(queries.concat(queryAndParams)));
 

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -383,39 +383,6 @@ describe('SQL Generation', () => {
         `
       })
     );
-
-    it('refreshKey from cube immutable (external)', async () => {
-      await compiler.compile();
-
-      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
-        measures: [
-          'cards.count'
-        ],
-        timeDimensions: [{
-          dimension: 'cards.createdAt',
-          granularity: 'day',
-          dateRange: ['2016-12-30', '2017-01-05']
-        }],
-        filters: [],
-        timezone: 'America/Los_Angeles',
-        externalQueryClass: MssqlQuery
-      });
-
-      const preAggregations: any = query.newPreAggregations().preAggregationsDescription();
-      expect(preAggregations.length).toEqual(1);
-      expect(preAggregations[0].invalidateKeyQueries).toEqual([
-        [
-          'SELECT CASE\n    WHEN CURRENT_TIMESTAMP < CAST($1 AS DATETIME2) THEN (SELECT FLOOR((DATEDIFF(SECOND,\'1970-01-01\', GETUTCDATE())) / 10) as refresh_key) END as refresh_key',
-          [
-            '__TO_PARTITION_RANGE'
-          ],
-          {
-            external: true,
-            renewalThreshold: 10,
-          }
-        ]
-      ]);
-    });
   });
 
   describe('refreshKey only cube (every)', () => {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
