### PR TITLE
fix(server-core): Re-create agent transport after reject WS connection on retries

### DIFF
--- a/packages/cubejs-server-core/src/core/agentCollect.ts
+++ b/packages/cubejs-server-core/src/core/agentCollect.ts
@@ -139,13 +139,13 @@ export default async (event: Record<string, any>, endpointUrl: string, logger: a
   });
   lastEvent = new Date();
 
-  if (!transport) {
-    transport = /^http/.test(endpointUrl) ?
-      new HttpTransport(endpointUrl) :
-      new WebSocketTransport(endpointUrl, logger, clearTransport);
-  }
-
   const flush = async (toFlush?: any[], retries?: number) => {
+    if (!transport) {
+      transport = /^http/.test(endpointUrl) ?
+        new HttpTransport(endpointUrl) :
+        new WebSocketTransport(endpointUrl, logger, clearTransport);
+    }
+
     if (!toFlush) toFlush = trackEvents.splice(0, getEnv('agentFrameSize'));
     if (!toFlush.length) return false;
     if (retries == null) retries = 3;


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Re-create agent transport after reject WS connection on retries
