### PR TITLE
fix(cubestore): do not keep zombie child processes 

### DIFF
--- a/rust/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore-sql-tests/src/tests.rs
@@ -784,7 +784,10 @@ async fn numbers_to_bool(service: Box<dyn SqlClient>) {
     );
 
     // Other types work fine.
-    let r = service.exec_query("SELECT 1 = 1, '1' = 1, 'foo' = 'foo'").await.unwrap();
+    let r = service
+        .exec_query("SELECT 1 = 1, '1' = 1, 'foo' = 'foo'")
+        .await
+        .unwrap();
     assert_eq!(to_rows(&r), rows(&[(true, true, true)]))
 }
 

--- a/rust/cubestore/src/sys/process.rs
+++ b/rust/cubestore/src/sys/process.rs
@@ -1,4 +1,28 @@
 #[cfg(feature = "process-cleanup")]
+pub fn avoid_child_zombies() {
+    unsafe {
+        let mut a = libc::sigaction {
+            sa_sigaction: libc::SIG_DFL,
+            sa_mask: std::mem::zeroed(),
+            sa_flags: libc::SA_NOCLDWAIT,
+            sa_restorer: None,
+        };
+        if libc::sigemptyset(&mut a.sa_mask) != 0 {
+            log::error!("failed to fill empty signal mask, cannot set SA_NOCLDWAIT");
+            return;
+        }
+        if libc::sigaction(libc::SIGCHLD, &a, std::ptr::null_mut()) != 0 {
+            log::error!("Failed to set SA_NOCLDWAIT flag");
+        }
+    }
+}
+
+#[cfg(not(feature = "process-cleanup"))]
+pub fn avoid_child_zombies() {
+    // nop
+}
+
+#[cfg(feature = "process-cleanup")]
 pub fn die_with_parent(parent_pid: u64) {
     unsafe {
         if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGHUP) != 0 {

--- a/rust/cubestore/src/util/respawn.rs
+++ b/rust/cubestore/src/util/respawn.rs
@@ -5,7 +5,7 @@ use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
 use mysql_common::serde::de::DeserializeOwned;
 use mysql_common::serde::Serialize;
 
-use crate::sys::process::die_with_parent;
+use crate::sys::process::{avoid_child_zombies, die_with_parent};
 use crate::CubeError;
 use std::any::type_name;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -64,6 +64,8 @@ pub fn register_handler<Args: Serialize + DeserializeOwned + 'static>(f: fn(Args
 }
 
 pub fn init() {
+    avoid_child_zombies();
+
     let handler_name = match std::env::var(HANDLER_ENV) {
         Ok(h) => h,
         Err(_) => return, // we're the main process.


### PR DESCRIPTION
Enabled only with `process-cleanup` feature.