### PR TITLE
feat(cubestore): readiness and liveness probes 

### DIFF
--- a/rust/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/src/bin/cubestored.rs
@@ -1,5 +1,6 @@
 use cubestore::app_metrics;
 use cubestore::config::{Config, CubeServices};
+use cubestore::http::status::serve_status_probes;
 use cubestore::telemetry::track_event;
 use cubestore::util::logger::init_cube_logger;
 use cubestore::util::metrics::init_metrics;
@@ -38,9 +39,12 @@ fn main() {
     cubestore::util::respawn::init();
 
     let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
-
     runtime.block_on(async move {
-        let services = config.configure().await;
+        config.configure_injector().await;
+
+        serve_status_probes(&config);
+
+        let services = config.cube_services().await;
 
         track_event("Cube Store Start".to_string(), HashMap::new()).await;
 

--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -11,6 +11,7 @@ use crate::ack_error;
 use crate::cluster::message::NetworkMessage;
 use crate::cluster::transport::{ClusterTransport, MetaStoreTransport, WorkerConnection};
 use crate::config::injection::DIService;
+use crate::config::is_router;
 #[allow(unused_imports)]
 use crate::config::{Config, ConfigObj};
 use crate::import::ImportService;
@@ -654,7 +655,7 @@ impl ClusterImpl {
     }
 
     pub fn is_select_worker(&self) -> bool {
-        self.config_obj.worker_bind_address().is_some()
+        !is_router(self.config_obj.as_ref())
     }
 
     pub async fn wait_for_worker_to_close(&self) {

--- a/rust/cubestore/src/config/mod.rs
+++ b/rust/cubestore/src/config/mod.rs
@@ -6,7 +6,7 @@ use crate::cluster::transport::{
     ClusterTransport, ClusterTransportImpl, MetaStoreTransport, MetaStoreTransportImpl,
 };
 use crate::cluster::{Cluster, ClusterImpl, ClusterMetaStoreClient};
-use crate::config::injection::{get_service, get_service_typed, DIService, Injector, InjectorRef};
+use crate::config::injection::{DIService, Injector};
 use crate::config::processing_loop::ProcessingLoop;
 use crate::http::HttpServer;
 use crate::import::limits::ConcurrencyLimits;
@@ -747,8 +747,8 @@ impl Config {
                         let meta_store = RocksMetaStore::load_from_remote(
                             &path,
                             // TODO metastore works with non queue remote fs as it requires loops to be started prior to load_from_remote call
-                            get_service(&i, "original_remote_fs").await,
-                            get_service_typed::<dyn ConfigObj>(&i).await,
+                            i.get_service("original_remote_fs").await,
+                            i.get_service_typed::<dyn ConfigObj>().await,
                         )
                         .await
                         .unwrap();
@@ -864,9 +864,7 @@ impl Config {
                     i.get_service_typed().await,
                     i.get_service_typed().await,
                     i.get_service_typed().await,
-                    i.get_service_typed::<dyn ConfigObj>()
-                        .await
-                        .wal_split_threshold() as usize,
+                    c.wal_split_threshold() as usize,
                     Duration::from_secs(c.query_timeout()),
                     c.max_cached_queries(),
                 )

--- a/rust/cubestore/src/http/mod.rs
+++ b/rust/cubestore/src/http/mod.rs
@@ -1,3 +1,5 @@
+pub mod status;
+
 use std::sync::Arc;
 
 use warp::{Filter, Rejection, Reply};

--- a/rust/cubestore/src/http/status.rs
+++ b/rust/cubestore/src/http/status.rs
@@ -1,0 +1,96 @@
+use crate::config::injection::Injector;
+use crate::config::{is_router, uses_remote_metastore, Config};
+use crate::metastore::MetaStore;
+use crate::sql::SqlService;
+use crate::CubeError;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use warp::http::StatusCode;
+use warp::Filter;
+
+pub fn serve_status_probes(c: &Config) {
+    let addr = match c.config_obj().status_bind_address() {
+        Some(a) => a.clone(),
+        None => return,
+    };
+
+    let p = match RouterProbes::try_new(c) {
+        Some(p) => p,
+        None => return,
+    };
+
+    let pc = p.clone();
+    let l = warp::path!("livez").and_then(move || {
+        let pc = pc.clone();
+        async move { status_probe_reply("liveness", pc.is_live().await) }
+    });
+    let r = warp::path!("readyz").and_then(move || {
+        let p = p.clone();
+        async move { status_probe_reply("readiness", p.is_ready().await) }
+    });
+
+    let addr: SocketAddr = addr.parse().expect("cannot parse status probe address");
+    match warp::serve(l.or(r)).try_bind_ephemeral(addr) {
+        Ok((addr, f)) => {
+            log::info!("Serving status probes at {}", addr);
+            tokio::spawn(f);
+        }
+        Err(e) => {
+            log::error!("Failed to serve status probes at {}: {}", addr, e);
+        }
+    }
+}
+
+pub fn status_probe_reply(probe: &str, r: Result<(), CubeError>) -> Result<StatusCode, Infallible> {
+    match r {
+        Ok(()) => Ok(StatusCode::OK),
+        Err(e) => {
+            log::warn!("{} probe failed: {}", probe, e.display_with_backtrace());
+            Ok(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RouterProbes {
+    services: Arc<Injector>,
+}
+
+impl RouterProbes {
+    pub fn try_new(config: &Config) -> Option<RouterProbes> {
+        if !is_router(config.config_obj().as_ref()) {
+            return None;
+        }
+        Some(RouterProbes {
+            services: config.injector(),
+        })
+    }
+
+    pub async fn is_live(&self) -> Result<(), CubeError> {
+        if let Some(s) = self
+            .services
+            .try_get_service_typed::<dyn SqlService>()
+            .await
+        {
+            s.exec_query("SELECT 1").await?;
+        }
+        Ok(())
+    }
+
+    pub async fn is_ready(&self) -> Result<(), CubeError> {
+        if uses_remote_metastore(&self.services).await {
+            return Ok(());
+        }
+        let m = match self.services.try_get_service_typed::<dyn MetaStore>().await {
+            None => return Err(CubeError::internal("metastore is not ready".to_string())),
+            Some(m) => m,
+        };
+        // Check metastore is not stalled.
+        m.get_schemas().await?;
+        // It is tempting to check worker connectivity on the router, but we cannot do this now.
+        // Workers connect to the router for warmup, so router must be ready before workers are up.
+        // TODO: warmup explicitly with router request instead?
+        Ok(())
+    }
+}

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -408,6 +408,12 @@ impl From<tokio::sync::AcquireError> for CubeError {
     }
 }
 
+impl From<warp::Error> for CubeError {
+    fn from(v: warp::Error) -> Self {
+        return CubeError::from_error(v);
+    }
+}
+
 impl Into<ArrowError> for CubeError {
     fn into(self) -> ArrowError {
         ArrowError::ExternalError(Box::new(self))


### PR DESCRIPTION
Available only on router nodes via `/livez` and `/readyz`.
Use `CUBESTORE_STATUS_BIND_ADDR` or `CUBESTORE_STATUS_PORT` for
endpoint configuration. Default is `0.0.0.0:3031`.

Runs as a separate HTTP server to simplify implementation. Main HTTP
server does waits for metastore from remote before it starts listening
on a socket.

The checks are very basic. Liveness check tries to execute a trivial
query. Readiness check after metastore got loaded from remote and
can serve another trivial query.