### PR TITLE
fix(cubestore): 'unsorted data' assertion with high-precision timestamps

### DIFF
--- a/rust/cubestore/src/table/mod.rs
+++ b/rust/cubestore/src/table/mod.rs
@@ -29,7 +29,10 @@ pub struct TimestampValue {
 }
 
 impl TimestampValue {
-    pub fn new(unix_nano: i64) -> TimestampValue {
+    pub fn new(mut unix_nano: i64) -> TimestampValue {
+        // This is a hack to workaround a mismatch between on-disk and in-memory representations.
+        // We use millisecond precision on-disk.
+        unix_nano -= unix_nano % 1000;
         TimestampValue { unix_nano }
     }
 


### PR DESCRIPTION
CubeStore used to truncate timestamps to millisecond precision when
writing to parquet, but sort the data with nanosecond precision.

This led to 'unsorted data in merge' assertions.

Ensure we truncate before we sort the data.
Increasing the storage precision is another option, but that involves
backward and forward compatibility issues and requires more planning.
So stick with the current behavior for now.

If you see 'unmerged data' assertion in the logs, you have to manually
drop the tables where this happens, e.g. by rebuilding the rollups in
CubeJS.