### PR TITLE
fix: RefreshWorker not working with refreshKey with FILTER_PARAMS

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
@@ -132,10 +132,7 @@ export class CubeEvaluator extends CubeSymbols {
                 refreshRangeEnd: refreshRangeEnd && refreshRangeEnd.sql && { sql: refreshRangeEnd.sql() }
               },
               refreshKeyReferences: {
-                refreshKey: refreshKey && {
-                  ...refreshKey,
-                  sql: refreshKey && refreshKey.sql && refreshKey.sql()
-                }
+                refreshKey
               },
               indexesReferences: indexes && Object.keys(indexes).reduce((obj, indexName) => {
                 obj[indexName] = {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Could solve #2955

**Description of Changes Made (if issue reference is not provided)**

When having a `preAggregation` with `FILTER_PARAMS` in the `refreshKey`, the RefreshWorker won't be able to run it. Following is a sample configuration:
```js
    preAggregations: {
      main: {
        external: true,
        measures: [CUBE.count],
        dimensions: [CUBE.organisationId],
        timeDimension: CUBE.createdAt,
        granularity: `day`,
        partitionGranularity: `year`,
        scheduledRefresh: true,
        refreshKey: {
          every: `1 minute`,
          sql: `select MAX(modified_at) from orders WHERE ${FILTER_PARAMS.Order.createdAt.filter('from_iso8601_timestamp(created_at)')}`
        }
      }
    },
```
And the error would be like:
```
cube_refresh_worker_1  | Refresh Scheduler Error: scheduler-cd43cacf-1410-4c00-9cff-69bea85f19af 
cube_refresh_worker_1  | {
cube_refresh_worker_1  |   "securityContext": {}
cube_refresh_worker_1  | } 
cube_refresh_worker_1  | TypeError: Cannot read property 'Order' of undefined
cube_refresh_worker_1  |     at Object.sql (Order.js:19:133)
cube_refresh_worker_1  |     at /cube/node_modules/@cubejs-backend/schema-compiler/src/compiler/CubeEvaluator.js:137:67
cube_refresh_worker_1  |     at Array.map (<anonymous>)
cube_refresh_worker_1  |     at /cube/node_modules/@cubejs-backend/schema-compiler/src/compiler/CubeEvaluator.js:122:12
cube_refresh_worker_1  |     at Array.map (<anonymous>)
cube_refresh_worker_1  |     at CubeEvaluator.preAggregations (/cube/node_modules/@cubejs-backend/schema-compiler/src/compiler/CubeEvaluator.js:115:8)
cube_refresh_worker_1  |     at CubeEvaluator.scheduledPreAggregations (/cube/node_modules/@cubejs-backend/schema-compiler/src/compiler/CubeEvaluator.js:157:17)
cube_refresh_worker_1  |     at CompilerApi.scheduledPreAggregations (/cube/node_modules/@cubejs-backend/server-core/src/core/CompilerApi.js:118:26)
cube_refresh_worker_1  |     at RefreshScheduler.roundRobinRefreshPreAggregationsQueryIterator (/cube/node_modules/@cubejs-backend/server-core/src/core/RefreshScheduler.ts:262:38)
cube_refresh_worker_1  |     at /cube/node_modules/@cubejs-backend/server-core/src/core/RefreshScheduler.ts:374:12
```
The reason is when loading the preAggregation, `preAggregations()` tries to evaluate `refresh.sql()` which `FILTER_PARAMS` is not available. Instead, it should be evaluated later.