### PR TITLE
fix schemaVersion type

### DIFF
--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -117,7 +117,7 @@ export interface CreateOptions {
   queryTransformer?: QueryRewriteFn;
   queryRewrite?: QueryRewriteFn;
   preAggregationsSchema?: string | PreAggregationsSchemaFn;
-  schemaVersion?: (context: RequestContext) => string;
+  schemaVersion?: (context: RequestContext) => string | Promise<string>;
   extendContext?: ExtendContextFn;
   scheduledRefreshTimer?: boolean | number;
   scheduledRefreshTimeZones?: string[];


### PR DESCRIPTION
Following https://github.com/cube-js/cube.js/pull/557, the `schemaVersion` option also supports an async function.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

I'm afraid that for a type change, I don't have time to checkout the repo, install the build tools and run these tasks :(. I'm assuming the CI will do it anyway?

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Following https://github.com/cube-js/cube.js/pull/557, the `schemaVersion` option also supports an async function. This is also what the docs describe.
