### PR TITLE
chore(cubestore): add option to build docker image without AVX2

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -23,10 +23,14 @@ COPY cubestore-sql-tests cubestore-sql-tests
 COPY cubestore/Cargo.toml cubestore/Cargo.toml
 RUN mkdir -p cubestore/src/bin && \
     echo "fn main() {print!(\"Dummy main\");} // dummy file" > cubestore/src/bin/cubestored.rs
-RUN RUSTFLAGS="-C target-feature=+avx2" cargo build --release -p cubestore
+
+ARG WITH_AVX2=1
+RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
+	 cargo build --release -p cubestore
 
 COPY cubestore cubestore
-RUN RUSTFLAGS="-C target-feature=+avx2" cargo build --release -p cubestore
+RUN [ "$WITH_AVX2" -eq "1" ] && export RUSTFLAGS="-C target-feature=+avx2"; \
+	cargo build --release -p cubestore
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
By default, we still build with AVX2.
Use `docker --build-arg WITH_AVX2=0` to build without AVX2.