### PR TITLE
docs(deployment): prevent dev dependencies leaking in Docker Compose startup

### DIFF
--- a/docs/content/Deployment/Platform-Docker.mdx
+++ b/docs/content/Deployment/Platform-Docker.mdx
@@ -345,6 +345,7 @@ services:
       - CUBEJS_API_SECRET=secret
     volumes:
       - .:/cube/conf
+      # Prevent dev dependencies leaking
       - .empty:/cube/conf/node_modules/@cubejs-backend/
     depends_on:
       - cubestore_router

--- a/docs/content/Deployment/Platform-Docker.mdx
+++ b/docs/content/Deployment/Platform-Docker.mdx
@@ -345,6 +345,7 @@ services:
       - CUBEJS_API_SECRET=secret
     volumes:
       - .:/cube/conf
+      - .empty:/cube/conf/node_modules/@cubejs-backend/
     depends_on:
       - cubestore_router
       - cube_refresh_worker

--- a/docs/content/Getting-Started/Getting-Started-Docker-Compose.mdx
+++ b/docs/content/Getting-Started/Getting-Started-Docker-Compose.mdx
@@ -31,6 +31,7 @@ services:
       - CUBEJS_DEV_MODE=true
     volumes:
       - .:/cube/conf
+      # Prevent dev dependencies leaking
       - .empty:/cube/conf/node_modules/@cubejs-backend/
 ```
 

--- a/docs/content/Getting-Started/Getting-Started-Docker-Compose.mdx
+++ b/docs/content/Getting-Started/Getting-Started-Docker-Compose.mdx
@@ -31,6 +31,7 @@ services:
       - CUBEJS_DEV_MODE=true
     volumes:
       - .:/cube/conf
+      - .empty:/cube/conf/node_modules/@cubejs-backend/
 ```
 
 ## 2. Run Cube.js


### PR DESCRIPTION
When starting up cube.js locally with `docker-compose up` it is possible for the dev dependencies to leak into container.
This fix demonstrates in documentation how to prevent this.

No code has been changed.