### PR TITLE
fix(client-core): keep order of elements within tableColumns

### DIFF
--- a/packages/cubejs-client-core/src/ResultSet.js
+++ b/packages/cubejs-client-core/src/ResultSet.js
@@ -537,15 +537,15 @@ class ResultSet {
         let currentItem = schema;
 
         yValues.forEach((value, index) => {
-          currentItem[value] = {
+          currentItem[`_${value}`] = {
             key: value,
             memberId: normalizedPivotConfig.y[index] === 'measures'
               ? value
               : normalizedPivotConfig.y[index],
-            children: (currentItem[value] && currentItem[value].children) || {}
+            children: (currentItem[`_${value}`] && currentItem[`_${value}`].children) || {}
           };
 
-          currentItem = currentItem[value].children;
+          currentItem = currentItem[`_${value}`].children;
         });
       }
     });

--- a/packages/cubejs-client-core/src/tests/table.test.js
+++ b/packages/cubejs-client-core/src/tests/table.test.js
@@ -693,4 +693,99 @@ describe('resultSet tablePivot and tableColumns', () => {
       ]);
     });
   });
+
+  test('order of values is preserved', () => {
+    const resultSet = new ResultSet({
+      query: {
+        measures:  [
+          'Branch.count'
+        ],
+        dimensions: [
+          'Tenant.number'
+        ],
+        'order': [
+          {
+            'id': 'Tenant.number',
+            'desc': true
+          }
+        ],
+        filters: [],
+        timezone: 'UTC'
+      },
+      data: [
+        {
+          'Tenant.number': '6',
+          'Branch.count': '2'
+        },
+        {
+          'Tenant.number': '1',
+          'Branch.count': '2'
+        },
+      ],
+      annotation: {
+        measures: {
+          'Branch.count': {
+            type: 'number'
+          }
+        },
+        dimensions: {
+          'Tenant.number': {
+            title: 'Tenant Number',
+            shortTitle: 'Number',
+            type: 'string'
+          }
+        },
+        segments: {},
+        timeDimensions: {}
+      }
+    });
+
+    expect(resultSet.tableColumns({
+      'x': [],
+      'y': [
+        'Tenant.number'
+      ]
+    })).toEqual(
+        [
+          {
+            'key': '6',
+            'type': 'string',
+            'title': 'Tenant Number 6',
+            'shortTitle': '6',
+            'format': undefined,
+            'meta': undefined,
+            'children': [
+              {
+                'key': 'Branch.count',
+                'type': 'number',
+                'dataIndex': '6,Branch.count',
+                'title': 'Branch.count',
+                'shortTitle': 'Branch.count',
+                'format': undefined,
+                'meta': undefined,
+              }
+            ]
+          },
+          {
+            'key': '1',
+            'type': 'string',
+            'title': 'Tenant Number 1',
+            'shortTitle': '1',
+            'format': undefined,
+            'meta': undefined,
+            'children': [
+              {
+                'key': 'Branch.count',
+                'type': 'number',
+                'dataIndex': '1,Branch.count',
+                'title': 'Branch.count',
+                'shortTitle': 'Branch.count',
+                'format': undefined,
+                "meta": undefined,
+              }
+            ]
+          }
+        ]
+    );
+  });
 });


### PR DESCRIPTION
Prefix the key used to build the schema with an underscore to ensure the key is treated as a string and not as a numeric and thus as an array index.

**Check List**
- [X] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

https://github.com/cube-js/cube.js/issues/3367

