### PR TITLE
fix(cubestore): 'unsorted data in merge'

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#3ce50a3f834c30c30d7575b03171059f0e3aff25"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#2630309dee315ba00c07444b9f48219fda15b506"
 dependencies = [
  "bitflags",
  "chrono",
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#3ce50a3f834c30c30d7575b03171059f0e3aff25"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#2630309dee315ba00c07444b9f48219fda15b506"
 dependencies = [
  "arrow",
  "base64 0.13.0",
@@ -2884,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "5.0.0"
-source = "git+https://github.com/cube-js/arrow-rs?branch=cube#3ce50a3f834c30c30d7575b03171059f0e3aff25"
+source = "git+https://github.com/cube-js/arrow-rs?branch=cube#2630309dee315ba00c07444b9f48219fda15b506"
 dependencies = [
  "arrow",
  "base64 0.13.0",


### PR DESCRIPTION
And other issues caused by invalid reads from Parquet.
The actual fix is in arrow repository.