### PR TITLE
examples(helm-charts): Default values for cube store and redis

### DIFF
--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -63,17 +63,17 @@
 {{- end }}
 
 
-{{- /*
-  If global.redis.enabled = true,
-  we set the default value for CUBEJS_REDIS_URL
-  and CUBEJS_REDIS_PASSWORD to the default value
-  provided by bitnami/redis if these values
-  are not set explicitly.
+{{/*
+If global.redis.enabled = true,
+we set the default value for CUBEJS_REDIS_URL
+and CUBEJS_REDIS_PASSWORD to the default value
+provided by bitnami/redis if these values
+are not set explicitly.
 
-  Otherwise, when global.cubestore.enabled = false,
-  we require you to set the cubestore.host and
-  cubestore.port.
-*/ -}}
+Otherwise, when global.redis.enabled = false,
+we require you to set the CUBEJS_REDIS_URL and
+CUBEJS_REDIS_PASSWORD.
+*/}}
 
 {{- if .Values.global.redis.enabled }}
 {{- if .Values.redis.url }}
@@ -379,17 +379,17 @@
 {{- end }}
 {{- end }}
 
-{{- /*
-  If global.cubestore.enabled = true,
-  we set the default value for cubestore.host
-  and cubestore.port to the default value
-  defined in the Cube Store Chart if these values
-  are not set explicitly.
+{{/*
+If global.cubestore.enabled = true,
+we set the default value for cubestore.host
+and cubestore.port to the default value
+defined in the Cube Store Chart if these values
+are not set explicitly.
 
-  Otherwise, when global.cubestore.enabled = false,
-  we require you to set the cubestore.host and
-  cubestore.port.
-*/ -}}
+Otherwise, when global.cubestore.enabled = false,
+we require you to set the cubestore.host and
+cubestore.port.
+*/}}
 
 {{- if .Values.global.cubestore.enabled }}
 {{- if .Values.cubestore.host }}

--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -61,15 +61,45 @@
 - name: CUBEJS_TOPIC_NAME
   value: {{ .Values.config.topicName | quote }}
 {{- end }}
+
+
+{{- /*
+  If global.redis.enabled = true,
+  we set the default value for CUBEJS_REDIS_URL
+  and CUBEJS_REDIS_PASSWORD to the default value
+  provided by bitnami/redis if these values
+  are not set explicitly.
+
+  Otherwise, when global.cubestore.enabled = false,
+  we require you to set the cubestore.host and
+  cubestore.port.
+*/ -}}
+
 {{- if .Values.global.redis.enabled }}
+{{- if .Values.redis.url }}
+- name: CUBEJS_REDIS_URL
+  value: {{ .Values.redis.url | quote }}
+{{- else }}
 - name: CUBEJS_REDIS_URL
   value: {{ printf "redis://%s-redis-master:6379" .Release.Name }}
+{{- end }}
+{{- if .Values.redis.password }}
+- name: CUBEJS_REDIS_PASSWORD
+  value: {{ .Values.redis.password | quote }}
+{{- else if .Values.redis.passwordFromSecret }}
+- name: CUBEJS_REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.redis.passwordFromSecret.name | required "redis.passwordFromSecret.name is required" }}
+      key: {{ .Values.redis.passwordFromSecret.key | required "redis.passwordFromSecret.key is required" }}
+{{- else }}
 - name: CUBEJS_REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s-redis" .Release.Name }}
       key: {{ printf "redis-password" }}
 {{- end }}
+{{- else }}
 {{- if .Values.redis.url }}
 - name: CUBEJS_REDIS_URL
   value: {{ .Values.redis.url | quote }}
@@ -84,6 +114,8 @@
       name: {{ .Values.redis.passwordFromSecret.name | required "redis.passwordFromSecret.name is required" }}
       key: {{ .Values.redis.passwordFromSecret.key | required "redis.passwordFromSecret.key is required" }}
 {{- end }}
+{{- end }}
+
 {{- if .Values.redis.tls }}
 - name: CUBEJS_REDIS_TLS
   value: {{ .Values.redis.tls | quote }}

--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -81,7 +81,7 @@
   value: {{ .Values.redis.url | quote }}
 {{- else }}
 - name: CUBEJS_REDIS_URL
-  value: {{ printf "redis://%s-redis-master:6379" .Release.Name }}
+  value: {{ printf "redis://%s-redis-master:6379" .Release.Name | quote }}
 {{- end }}
 {{- if .Values.redis.password }}
 - name: CUBEJS_REDIS_PASSWORD
@@ -97,7 +97,7 @@
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s-redis" .Release.Name }}
-      key: {{ printf "redis-password" }}
+      key: "redis-password"
 {{- end }}
 {{- else }}
 {{- if .Values.redis.url }}

--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -346,14 +346,45 @@
   value: {{ .Value.database.ssl.passPhrase | quote }}
 {{- end }}
 {{- end }}
+
+{{- /*
+  If global.cubestore.enabled = true,
+  we set the default value for cubestore.host
+  and cubestore.port to the default value
+  defined in the Cube Store Chart if these values
+  are not set explicitly.
+
+  Otherwise, when global.cubestore.enabled = false,
+  we require you to set the cubestore.host and
+  cubestore.port.
+*/ -}}
+
+{{- if .Values.global.cubestore.enabled }}
 {{- if .Values.cubestore.host }}
 - name: CUBEJS_CUBESTORE_HOST
-  value: {{ .Values.cubestore.host | quote }}
+  value: {{ .Values.cubestore.host | quote | required "cubestore.host is required" }}
+{{- else }}
+- name: CUBEJS_CUBESTORE_HOST
+  value: {{ printf "%s-cubestore-router" .Release.Name | quote }}
 {{- end }}
 {{- if .Values.cubestore.port }}
 - name: CUBEJS_CUBESTORE_PORT
-  value: {{ .Values.cubestore.port | quote }}
+  value: {{ .Values.cubestore.port | quote | required "cubestore.port is required, this port is the HTTP PORT" }}
+{{- else }}
+- name: CUBEJS_CUBESTORE_PORT
+  value: {{ printf "3030" | quote }}
 {{- end }}
+{{- else }}
+{{- if .Values.cubestore.host }}
+- name: CUBEJS_CUBESTORE_HOST
+  value: {{ .Values.cubestore.host | quote | required "cubestore.host is required" }}
+{{- end }}
+{{- if .Values.cubestore.port }}
+- name: CUBEJS_CUBESTORE_PORT
+  value: {{ .Values.cubestore.port | quote | required "cubestore.port is required" }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.externalDatabase.type }}
 - name: CUBEJS_EXT_DB_TYPE
   value: {{ .Values.externalDatabase.type | quote }}

--- a/examples/helm-charts/cubestore/templates/workers/statefulset.yaml
+++ b/examples/helm-charts/cubestore/templates/workers/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: CUBESTORE_SERVER_NAME
-              value: {{ printf "$(MY_POD_NAME).%s:%d" $headlessServiceName $workerPort}}
+              value: {{ printf "$(MY_POD_NAME).%s:%d" $headlessServiceName $workerPort | quote }}
             - name: CUBESTORE_WORKER_PORT
               value: {{ .Values.workers.port | quote }}
             {{- $workers := list }}

--- a/examples/kubernetes/cluster/cube-api-deployment.yaml
+++ b/examples/kubernetes/cluster/cube-api-deployment.yaml
@@ -21,7 +21,7 @@ spec:
             - name: CUBEJS_API_SECRET
               value: <API_SECRET>
             - name: CUBEJS_CUBESTORE_HOST
-              value: "cubestore-router" # USING THIS CUBESTPRE HOST BECAUSE THE CUBESTORE ROUTER SERVICE IS NAMED "CUBESTORE-ROUTER"
+              value: "cubestore-router" # USING THIS CUBESTORE HOST BECAUSE THE CUBESTORE ROUTER SERVICE IS NAMED "CUBESTORE-ROUTER"
             - name: CUBEJS_DB_HOST
               value: <DB_HOST>
             - name: CUBEJS_DB_NAME

--- a/examples/kubernetes/cluster/cube-api-schema-configmap.yaml
+++ b/examples/kubernetes/cluster/cube-api-schema-configmap.yaml
@@ -283,6 +283,25 @@ data:
           timeDimension: CUBE.createdAt,
           granularity: `day`,
           partitionGranularity: `month`,
+          refreshKey: {
+            every: `1 minute`,
+            incremental: true,
+            updateWindow: `3 day`,
+          },
+          buildRangeEnd: {
+            sql: `SELECT NOW()`,
+          }
+        },
+
+        second: {
+          measures: [CUBE.count],
+          dimensions: [CUBE.status],
+          timeDimension: CUBE.completedAt,
+          granularity: `day`,
+          partitionGranularity: `month`,
+          refreshKey: {
+            every: `1 minute`,
+          },
         },
       },
       joins: {

--- a/examples/kubernetes/cluster/cube-refresh-worker-deployment.yaml
+++ b/examples/kubernetes/cluster/cube-refresh-worker-deployment.yaml
@@ -21,8 +21,8 @@ spec:
             - name: CUBEJS_API_SECRET
               value: <API_SECRET>
             - name: CUBEJS_CUBESTORE_HOST
-              value: "cubestore-router"
-              - name: CUBEJS_DB_HOST
+              value: "cubestore-router" # USING THIS CUBESTORE HOST BECAUSE THE CUBESTORE ROUTER SERVICE IS NAMED "CUBESTORE-ROUTER"
+            - name: CUBEJS_DB_HOST
               value: <DB_HOST>
             - name: CUBEJS_DB_NAME
               value: <DB_NAME>


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Running the default setup of cube-stack did not connect cubejs to cubestore automatically. This PR adds a default setup to connect cubejs to cubestore without specifying values.
