### PR TITLE
feat(bigquery-driver): Use INFORMATION_SCHEMA.COLUMNS for introspection

### DIFF
--- a/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
+++ b/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
@@ -11,8 +11,6 @@ import { Table } from '@google-cloud/bigquery/build/src/table';
 import { Query } from '@google-cloud/bigquery/build/src/bigquery';
 import { HydrationStream } from './HydrationStream';
 
-const suffixTableRegex = /^(.*?)([0-9_]+)$/;
-
 interface BigQueryDriverOptions extends BigQueryOptions {
   readOnly?: boolean
   projectId?: string,
@@ -60,13 +58,6 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
       this.storage = new Storage(this.options);
       this.bucket = this.storage.bucket(this.options.exportBucket);
     }
-
-    this.mapFieldsRecursive = this.mapFieldsRecursive.bind(this);
-    this.tablesSchema = this.tablesSchema.bind(this);
-    this.parseDataset = this.parseDataset.bind(this);
-    this.parseTableData = this.parseTableData.bind(this);
-    this.flatten = this.flatten.bind(this);
-    this.toObjectFromId = this.toObjectFromId.bind(this);
   }
 
   public static driverEnvVariables() {
@@ -98,57 +89,26 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
     );
   }
 
-  protected toObjectFromId(accumulator: any, currentElement: any) {
-    accumulator[currentElement.id] = currentElement.data;
-    return accumulator;
-  }
-
-  protected reduceSuffixTables(accumulator: any, currentElement: any) {
-    const suffixMatch = currentElement.id.toString().match(suffixTableRegex);
-    if (suffixMatch) {
-      accumulator.__suffixMatched = accumulator.__suffixMatched || {};
-      accumulator.__suffixMatched[suffixMatch[1]] = accumulator.__suffixMatched[suffixMatch[1]] || [];
-      accumulator.__suffixMatched[suffixMatch[1]].push(currentElement);
-    } else {
-      accumulator[currentElement.id] = currentElement.data;
-    }
-    return accumulator;
-  }
-
-  protected addSuffixTables(accumulator: any) {
-    // eslint-disable-next-line no-restricted-syntax,guard-for-in
-    for (const prefix in accumulator.__suffixMatched) {
-      const suffixMatched = accumulator.__suffixMatched[prefix];
-      const sorted = suffixMatched.sort((a: any, b: any) => b.toString().localeCompare(a.toString()));
-      for (let i = 0; i < Math.min(10, sorted.length); i++) {
-        accumulator[sorted[i].id] = sorted[i].data;
-      }
-    }
-    delete accumulator.__suffixMatched;
-    return accumulator;
-  }
-
-  protected flatten(list: any) {
-    return list.reduce(
-      (a: any, b: any) => a.concat(Array.isArray(b) ? this.flatten(b) : b), []
-    );
-  }
-
-  protected mapFieldsRecursive(field: any) {
-    if (field.type === 'RECORD') {
-      return this.flatten(field.fields.map(this.mapFieldsRecursive)).map(
-        (nestedField: any) => ({ name: `${field.name}.${nestedField.name}`, type: nestedField.type })
-      );
-    }
-    return field;
-  }
-
-  protected async parseDataset(dataset: Dataset) {
+  protected async loadTablesForDataset(dataset: Dataset) {
     try {
-      return await dataset.getTables().then(
-        (data) => Promise.all(data[0].map(this.parseTableData))
-          .then(tables => ({ id: dataset.id, data: this.addSuffixTables(tables.reduce(this.reduceSuffixTables, {})) }))
-      );
+      const result = await dataset.query({
+        query: `
+        SELECT
+          columns.column_name as ${this.quoteIdentifier('column_name')},
+          columns.table_name as ${this.quoteIdentifier('table_name')},
+          columns.table_schema as ${this.quoteIdentifier('table_schema')},
+          columns.data_type as ${this.quoteIdentifier('data_type')}
+        FROM INFORMATION_SCHEMA.COLUMNS
+      `
+      });
+
+      if (result.length) {
+        return R.reduce(
+          this.informationColumnsSchemaReducer, {}, result[0]
+        );
+      }
+
+      return [];
     } catch (e) {
       if (e.message.includes('Permission bigquery.tables.get denied on table')) {
         return {};
@@ -158,18 +118,13 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
     }
   }
 
-  protected parseTableData(table: Table) {
-    return table.getMetadata().then(
-      (data) => ({
-        id: table.id,
-        data: this.flatten(((data[0].schema && data[0].schema.fields) || []).map(this.mapFieldsRecursive))
-      })
+  public async tablesSchema() {
+    const dataSets = await this.bigquery.getDatasets();
+    const dataSetsColumns = await Promise.all(
+      dataSets[0].map((dataSet) => this.loadTablesForDataset(dataSet))
     );
-  }
 
-  public tablesSchema() {
-    return this.bigquery.getDatasets().then((data) => Promise.all(data[0].map(this.parseDataset))
-      .then(innerData => innerData.reduce(this.toObjectFromId, {})));
+    return dataSetsColumns.reduce((prev, current) => Object.assign(prev, current), {});
   }
 
   public async getTablesQuery(schemaName: string) {

--- a/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
+++ b/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
@@ -223,24 +223,27 @@ export class BaseDriver {
     return false;
   }
 
+  /**
+   * @protected
+   */
+  informationColumnsSchemaReducer(result, i) {
+    let schema = (result[i.table_schema] || {});
+    const tables = (schema[i.table_name] || []);
+
+    tables.push({ name: i.column_name, type: i.data_type, attributes: i.key_type ? ['primaryKey'] : [] });
+
+    tables.sort();
+    schema[i.table_name] = tables;
+    schema = sortByKeys(schema);
+    result[i.table_schema] = schema;
+
+    return sortByKeys(result);
+  }
+
   tablesSchema() {
     const query = this.informationSchemaQuery();
 
-    const reduceCb = (result, i) => {
-      let schema = (result[i.table_schema] || {});
-      const tables = (schema[i.table_name] || []);
-
-      tables.push({ name: i.column_name, type: i.data_type, attributes: i.key_type ? ['primaryKey'] : [] });
-
-      tables.sort();
-      schema[i.table_name] = tables;
-      schema = sortByKeys(schema);
-      result[i.table_schema] = schema;
-
-      return sortByKeys(result);
-    };
-
-    return this.query(query).then(data => reduce(reduceCb, {}, data));
+    return this.query(query).then(data => reduce(this.informationColumnsSchemaReducer, {}, data));
   }
 
   /**


### PR DESCRIPTION
Hello!

There was a problem before this PR that we use an additional call for each table to introspect columns.

1. list of datasets
2. list of tables
3. list of columns for each table

In this PR we started to use INFORMATION_SCHEMA.COLUMNS for each dataset, it will reduce the number of calls that we send to API.

Thanks