### PR TITLE
fix(postgres-driver): Use correct encoding for HLL_POSTGRES

### DIFF
--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -40,7 +40,11 @@ const timestampDataTypes = [
   1184
 ];
 const timestampTypeParser = (val: string) => moment.utc(val).format(moment.HTML5_FMT.DATETIME_LOCAL_MS);
-const hllTypeParser = (val: string) => Buffer.from(val).toString('base64');
+const hllTypeParser = (val: string) => Buffer.from(
+  // Postgres uses prefix as \x for encoding
+  val.substr(2),
+  'hex'
+).toString('base64');
 
 export type PostgresDriverConfiguration = Partial<PoolConfig> & {
   storeTimezone?: string,


### PR DESCRIPTION
Hello!

Proof, External pre-aggregation in Cube Store with HLL sketch:

![image](https://user-images.githubusercontent.com/572096/133426400-d1523867-a77f-4adf-b738-c8446db6f8a0.png)

Thanks