### PR TITLE
fix(@cubejs-backend/query-orchestrator): rollup only mode error message update

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -450,7 +450,7 @@ export class PreAggregationLoader {
       const versionEntryByStructureVersion = byStructure[`${this.preAggregation.tableName}_${structureVersion}`];
       if (this.externalRefresh) {
         if (!versionEntryByStructureVersion) {
-          throw new Error('One or more pre-aggregation tables could not be found to satisfy that query');
+          throw new Error('Your configuration restricts query requests to only be served from pre-aggregations, and no pre-aggregation was found matching this query. Either update your pre-aggregations or disable rollup only mode in your Cube.js configuration.');
         }
 
         // the rollups are being maintained independently of this instance of cube.js,

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
@@ -232,7 +232,7 @@ describe('PreAggregations', () => {
 
     test('fail if rollup doesn\'t already exist', async () => {
       await expect(preAggregations.loadAllPreAggregationsIfNeeded(basicQuery))
-        .rejects.toThrowError(/One or more pre-aggregation tables could not be found to satisfy that query/);
+        .rejects.toThrowError(/Your configuration restricts query requests to only be served from pre-aggregations/);
     });
   });
 


### PR DESCRIPTION

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

554e6e014f684792b20147bd2fd2f3cb

**Description of Changes Made (if issue reference is not provided)**

From "One or more pre-aggregation tables could not be found to satisfy that query"

To 

"Your configuration restricts query requests to only be served from pre-aggregations, and no pre-aggregation was found matching this query. Either update your pre-aggregations or disable rollup only mode in your Cube.js configuration."