### PR TITLE
fix(@cubejs-client/vue): catch `dryRun` errors on `query-builder` mount

### DIFF
--- a/packages/cubejs-client-vue/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue/src/QueryBuilder.js
@@ -392,17 +392,16 @@ export default {
     this.copyQueryFromProps();
 
     if (isQueryPresent(this.initialQuery)) {
-      await this.cubejsApi
-        .dryRun(this.initialQuery)
-        .then((dryRunResponse) => {
-          this.pivotConfig = ResultSet.getNormalizedPivotConfig(
+      try {
+        const dryRunResponse = await this.cubejsApi.dryRun(this.initialQuery);
+
+        this.pivotConfig = ResultSet.getNormalizedPivotConfig(
             dryRunResponse?.pivotQuery || {},
             this.pivotConfig
-          );
-        })
-        .catch((error) => {
-          console.error(error);
-        });
+        );
+      } catch (error) {
+          console.error(error)
+      }
     }
   },
 

--- a/packages/cubejs-client-vue/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue/src/QueryBuilder.js
@@ -392,11 +392,17 @@ export default {
     this.copyQueryFromProps();
 
     if (isQueryPresent(this.initialQuery)) {
-      const dryRunResponse = await this.cubejsApi.dryRun(this.initialQuery);
-      this.pivotConfig = ResultSet.getNormalizedPivotConfig(
-        dryRunResponse?.pivotQuery || {},
-        this.pivotConfig
-      );
+      await this.cubejsApi
+        .dryRun(this.initialQuery)
+        .then((dryRunResponse) => {
+          this.pivotConfig = ResultSet.getNormalizedPivotConfig(
+            dryRunResponse?.pivotQuery || {},
+            this.pivotConfig
+          );
+        })
+        .catch((error) => {
+          console.error(error);
+        });
     }
   },
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
#3449

**Description of Changes Made (if issue reference is not provided)**
Added a `catch` promise to contain errors returned when executing the following `dryRun`: 
* https://github.com/cube-js/cube.js/blob/master/packages/cubejs-client-vue/src/QueryBuilder.js#L395
