### PR TITLE
fix(cubestore): fix Docker Hub repository name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -282,7 +282,7 @@ jobs:
         env:
           GITHUB_SHA: ${{ github.sha }}
         run: |
-          DOCKER_IMAGE=cubejs/cube
+          DOCKER_IMAGE=cubejs/cubestore
           VERSION=noop
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly


### PR DESCRIPTION
We used to publish CubeStore image into the CubeJS repository.