### PR TITLE
chore(cubestore): rewrite compaction using arrow primitives 

### DIFF
--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -25,7 +25,7 @@ serde_bytes = "0.11.5"
 cubehll = { path = "../cubehll" }
 cubezetasketch = { path = "../cubezetasketch" }
 cuberpc = { path = "../cuberpc" }
-parquet = { git = "https://github.com/cube-js/arrow-rs", branch = "cube" }
+parquet = { git = "https://github.com/cube-js/arrow-rs", branch = "cube", features = ["arrow"] }
 arrow = { git = "https://github.com/cube-js/arrow-rs", branch = "cube" }
 arrow-flight = { git = "https://github.com/cube-js/arrow-rs", branch = "cube" }
 datafusion = { git = "https://github.com/cube-js/arrow-datafusion", branch = "cube" }

--- a/rust/cubestore/src/config/mod.rs
+++ b/rust/cubestore/src/config/mod.rs
@@ -851,7 +851,6 @@ impl Config {
                 ChunkStore::new(
                     i.get_service_typed().await,
                     i.get_service_typed().await,
-                    i.get_service_typed().await,
                     i.get_service_typed::<dyn ConfigObj>()
                         .await
                         .wal_split_threshold() as usize,

--- a/rust/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/src/metastore/mod.rs
@@ -413,6 +413,12 @@ pub struct Column {
 
 impl Into<Field> for Column {
     fn into(self) -> Field {
+        (&self).into()
+    }
+}
+
+impl<'a> Into<Field> for &'a Column {
+    fn into(self) -> Field {
         Field::new(
             self.name.as_str(),
             match self.column_type {
@@ -427,7 +433,7 @@ impl Into<Field> for Column {
                 ColumnType::HyperLogLog(_) => DataType::Binary,
                 ColumnType::Float => DataType::Float64,
             },
-            false,
+            true,
         )
     }
 }

--- a/rust/cubestore/src/table/data.rs
+++ b/rust/cubestore/src/table/data.rs
@@ -1,37 +1,11 @@
-//! CubeStore needs to store large chunks of data in memory sometimes. We want to do this
-//! efficiently and minimize the overhead of memory allocations and
-//!
-//! There are two flavours of data that we use throughout the program:
-//!   - heap-allocated: [TableValue] and [Row];
-//!   - arena-allocated: [TableValueR], [RowR], [Rows] and [MutRows].
-//!
-//! One should prefer arena-allocated, they will generally be more efficient. When allocating many
-//! values, using arena-allocated is a requirement to avoid overhead of heap allocations.
-//! You might need to fallback to heap-allocated if you need the `Serialize` trait, but only do so
-//! for small quantities.
-//!
-//! This module helps with creating and processing arena-allocated data. [MutRows] deals with saving
-//! all values a set of rows into the arena. Use it to create arena-allocated rows.
-//!
-//! [Rows] allows the reorder and filter rows or columns without copying the underlying data
-//! (strings and byte arrays). One can convert [MutRows] to [Rows] with [`MutRows::freeze`].
-//!
-//! To iterate over produced rows use [RowsView], also see [`Rows::view`].
-use std::cmp::Ordering;
-use std::mem::ManuallyDrop;
-use std::ops::Index;
-use std::sync::Arc;
-
-use bumpalo::Bump;
-use itertools::Itertools;
-
 use crate::metastore::{Column, ColumnType};
 use crate::table::{Row, TableValue, TimestampValue};
 use crate::util::decimal::Decimal;
 use crate::util::ordfloat::OrdF64;
 use arrow::array::{Array, ArrayBuilder, ArrayRef, StringArray};
 use arrow::record_batch::RecordBatch;
-use datafusion::cube_match_array;
+use itertools::Itertools;
+use std::cmp::Ordering;
 
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
@@ -70,347 +44,6 @@ impl Default for TableValueR<'_> {
     }
 }
 
-pub type RowR<'a> = [TableValueR<'a>];
-
-pub struct Rows {
-    num_columns: usize,
-    arena: Arc<Bump>,
-    values: TableValueVec,
-}
-
-unsafe impl Send for Rows {}
-unsafe impl Sync for Rows {}
-
-impl Rows {
-    pub fn num_columns(&self) -> usize {
-        self.num_columns
-    }
-
-    pub fn num_rows(&self) -> usize {
-        self.values.len / self.num_columns
-    }
-
-    pub fn len(&self) -> usize {
-        self.num_rows()
-    }
-
-    pub fn view(&'a self) -> RowsView<'a> {
-        let values = unsafe { self.values.as_slice() };
-        RowsView::new(values, self.num_columns)
-    }
-
-    pub fn all_values(&'a self) -> &[TableValueR<'a>] {
-        unsafe { self.values.as_slice() }
-    }
-
-    pub fn remap_columns(&self, new_columns: &[usize]) -> Rows {
-        assert!(
-            new_columns.iter().all(|c| *c < self.num_columns),
-            "invalid column number"
-        );
-        let num_rows = self.num_rows();
-        let num_columns = new_columns.len();
-
-        let rows = self.view();
-        let mut values = vec![TableValueR::default(); num_rows * num_columns];
-        for i in 0..num_rows {
-            let r = &rows[i];
-            for j in 0..num_columns {
-                values[i * num_columns + j] = r[new_columns[j]];
-            }
-        }
-
-        Rows {
-            num_columns: self.num_columns,
-            arena: self.arena.clone(),
-            values: unsafe { TableValueVec::new(values) },
-        }
-    }
-
-    pub fn copy_some_rows(&self, row_indicies: &[usize]) -> Rows {
-        let mut values = Vec::with_capacity(row_indicies.len() * self.num_columns);
-        for i in 0..row_indicies.len() {
-            values.extend_from_slice(&self.view()[row_indicies[i]])
-        }
-
-        Rows {
-            num_columns: self.num_columns,
-            arena: self.arena.clone(),
-            values: unsafe { TableValueVec::new(values) },
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct RowsView<'data> {
-    num_columns: usize,
-    values: &'data [TableValueR<'data>],
-}
-
-impl<'data> RowsView<'data> {
-    pub fn new(data: &'data [TableValueR<'data>], num_columns: usize) -> RowsView<'data> {
-        assert_eq!(data.len() % num_columns, 0);
-        RowsView {
-            num_columns,
-            values: data,
-        }
-    }
-
-    pub fn slice(&self, start: usize, end: usize) -> RowsView<'data> {
-        RowsView::new(
-            &self.values[self.num_columns * start..self.num_columns * end],
-            self.num_columns,
-        )
-    }
-
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a RowR<'data>> + 'a {
-        (0..self.len()).map(move |i| &self[i])
-    }
-
-    pub fn len(&self) -> usize {
-        // TODO: avoid division here, store row count instead.
-        self.values.len() / self.num_columns
-    }
-
-    pub fn num_rows(&self) -> usize {
-        self.len()
-    }
-
-    pub fn num_columns(&self) -> usize {
-        self.num_columns
-    }
-
-    #[cfg(test)]
-    pub fn from_heap_allocated(
-        buffer: &'a mut Vec<TableValueR<'a>>,
-        num_columns: usize,
-        rows: &'a [Row],
-    ) -> RowsView<'a> {
-        let n = rows.len();
-
-        buffer.clear();
-        buffer.resize(num_columns * n, TableValueR::default());
-
-        for i in 0..n {
-            for j in 0..num_columns {
-                buffer[i * num_columns + j] =
-                    TableValueR::from_heap_allocated(&rows[i].values()[j]);
-            }
-        }
-
-        RowsView::new(buffer, num_columns)
-    }
-
-    #[cfg(test)]
-    pub fn convert_to_heap_allocated(&self) -> Vec<Row> {
-        let mut res = Vec::new();
-        for r in self.iter() {
-            res.push(convert_row_to_heap_allocated(r));
-        }
-        res
-    }
-}
-
-impl<'a> Index<usize> for RowsView<'a> {
-    type Output = RowR<'a>;
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.values[index * self.num_columns..index * self.num_columns + self.num_columns]
-    }
-}
-
-pub struct MutRows {
-    num_columns: usize,
-    arena: Bump,
-    values: TableValueVec,
-}
-
-impl MutRows {
-    pub fn new(num_columns: usize) -> MutRows {
-        MutRows {
-            num_columns,
-            arena: Bump::new(),
-            values: unsafe { TableValueVec::new(Vec::new()) },
-        }
-    }
-
-    pub fn with_capacity(num_columns: usize, num_rows: usize) -> MutRows {
-        MutRows {
-            num_columns,
-            arena: Bump::new(),
-            values: unsafe { TableValueVec::new(Vec::with_capacity(num_columns * num_rows)) },
-        }
-    }
-
-    pub fn freeze(self) -> Rows {
-        Rows {
-            num_columns: self.num_columns,
-            arena: Arc::new(self.arena),
-            values: self.values,
-        }
-    }
-
-    pub fn num_columns(&self) -> usize {
-        self.num_columns
-    }
-
-    pub fn num_rows(&self) -> usize {
-        self.values.len / self.num_columns
-    }
-
-    pub fn len(&self) -> usize {
-        self.num_rows()
-    }
-
-    pub fn rows(&'a self) -> RowsView<'a> {
-        let values = unsafe { self.values.as_slice() };
-        RowsView::new(values, self.num_columns)
-    }
-
-    pub fn truncate(&mut self, rows: usize) {
-        unsafe {
-            let num_columns = self.num_columns;
-            self.values.on_mut_vec(|v| {
-                v.truncate(rows * num_columns);
-            });
-        }
-    }
-
-    pub fn add_row(&'a mut self) -> InsertedRow<'a> {
-        let mut start = 0;
-        let mut end = 0;
-
-        let row: &mut [TableValueR];
-        unsafe {
-            let num_columns = self.num_columns;
-            self.values.on_mut_vec(|v| {
-                start = v.len();
-                end = v.len() + num_columns;
-                v.resize(end, TableValueR::default());
-            });
-            row = &mut self.values.as_mut_slice()[start..end];
-        }
-        InsertedRow {
-            arena: &self.arena,
-            values: row,
-        }
-    }
-
-    pub fn add_row_copy(&'a mut self, r: &RowR<'b>) -> InsertedRow<'a> {
-        assert_eq!(self.num_columns, r.len());
-        let num_columns = self.num_columns;
-        let mut new = self.add_row();
-        for i in 0..num_columns {
-            new.set_interned(i, r[i]);
-        }
-        new
-    }
-
-    pub fn add_rows(&'a mut self, n: usize) -> InsertedRows<'a> {
-        let mut start = 0;
-        let mut end = 0;
-
-        let values: &mut [TableValueR];
-        unsafe {
-            let num_columns = self.num_columns;
-            self.values.on_mut_vec(|v| {
-                start = v.len();
-                end = v.len() + n * num_columns;
-                v.resize(end, TableValueR::default());
-            });
-            values = &mut self.values.as_mut_slice()[start..end];
-        }
-        InsertedRows {
-            num_columns: self.num_columns,
-            arena: &self.arena,
-            values,
-        }
-    }
-
-    pub fn add_from_slice(&'a mut self, rows: RowsView<'a>) {
-        let num_columns = self.num_columns;
-        assert_eq!(num_columns, rows.num_columns);
-        for r in rows.iter() {
-            let mut newr = self.add_row();
-            for i in 0..num_columns {
-                newr.set_interned(i, r[i]);
-            }
-        }
-    }
-
-    pub fn add_row_heap_allocated(&mut self, r: &Row) {
-        let n = self.num_columns;
-        assert_eq!(r.values.len(), n);
-        let mut newr = self.add_row();
-        for i in 0..n {
-            newr.set_interned(i, TableValueR::from_heap_allocated(&r.values()[i]));
-        }
-    }
-
-    pub fn from_heap_allocated(num_columns: usize, rows: &[Row]) -> MutRows {
-        let mut c = MutRows::with_capacity(num_columns, rows.len());
-        for r in rows {
-            c.add_row_heap_allocated(&r);
-        }
-        c
-    }
-}
-
-pub struct InsertedRow<'a> {
-    arena: &'a Bump,
-    values: &'a mut [TableValueR<'a>],
-}
-
-impl<'a> InsertedRow<'a> {
-    pub fn len(&self) -> usize {
-        self.values.len()
-    }
-
-    pub fn get(&self, i: usize) -> &TableValueR<'a> {
-        &self.values[i]
-    }
-
-    pub fn set_interned(&'b mut self, i: usize, v: TableValueR<'b>) {
-        Self::assign_interned(&mut self.values[i], v, self.arena);
-    }
-
-    fn assign_interned(target: &mut TableValueR<'a>, source: TableValueR<'b>, arena: &'a Bump) {
-        *target = match source {
-            TableValueR::Boolean(v) => TableValueR::Boolean(v),
-            TableValueR::Bytes(s) => TableValueR::Bytes(arena.alloc_slice_copy(s)),
-            TableValueR::Decimal(d) => TableValueR::Decimal(d),
-            TableValueR::Float(v) => TableValueR::Float(v),
-            TableValueR::Int(v) => TableValueR::Int(v),
-            TableValueR::Null => TableValueR::Null,
-            TableValueR::String(s) => TableValueR::String(arena.alloc_str(s)),
-            TableValueR::Timestamp(v) => TableValueR::Timestamp(v),
-        };
-    }
-}
-
-pub struct InsertedRows<'a> {
-    num_columns: usize,
-    arena: &'a Bump,
-    values: &'a mut [TableValueR<'a>],
-}
-
-impl<'a> InsertedRows<'a> {
-    pub fn len(&self) -> usize {
-        self.values.len() / self.num_columns
-    }
-
-    pub fn get(&self, i: usize, j: usize) -> TableValueR<'a> {
-        assert!(i < self.len());
-        assert!(j < self.num_columns);
-        return self.values[i * self.num_columns + j];
-    }
-
-    pub fn set_interned(&'b mut self, i: usize, j: usize, v: TableValueR<'b>) {
-        assert!(i < self.len());
-        assert!(j < self.num_columns);
-        InsertedRow::assign_interned(&mut self.values[i * self.num_columns + j], v, self.arena);
-    }
-}
-
 pub fn cmp_partition_key(key_size: usize, l: &[TableValue], r: &[ArrayRef], ri: usize) -> Ordering {
     for i in 0..key_size {
         let o = cmp_partition_column_same_type(&l[i], r[i].as_ref(), ri);
@@ -444,9 +77,22 @@ pub fn cmp_partition_column_same_type(l: &TableValue, r: &dyn Array, ri: usize) 
     )
 }
 
-pub fn cmp_row_key_heap(sort_key_size: usize, l: &[TableValue], r: &[TableValueR]) -> Ordering {
+/// Use for comparing min/max rows insied partitions.
+pub fn cmp_row_markers(key_size: usize, l: &Option<Row>, r: &Option<Row>) -> Ordering {
+    match (l, r) {
+        (None, None) => Ordering::Equal,
+        (None, _) => Ordering::Less,
+        (_, None) => Ordering::Greater,
+        (Some(a), Some(b)) => cmp_row_key_heap(key_size, &a.values(), &b.values()),
+    }
+}
+
+pub fn cmp_row_key_heap(sort_key_size: usize, l: &[TableValue], r: &[TableValue]) -> Ordering {
     for i in 0..sort_key_size {
-        let c = cmp_same_types(&TableValueR::from_heap_allocated(&l[i]), &r[i]);
+        let c = cmp_same_types(
+            &TableValueR::from_heap_allocated(&l[i]),
+            &TableValueR::from_heap_allocated(&r[i]),
+        );
         if c != Ordering::Equal {
             return c;
         }
@@ -477,77 +123,6 @@ pub fn cmp_same_types(l: &TableValueR, r: &TableValueR) -> Ordering {
         (TableValueR::Timestamp(a), TableValueR::Timestamp(b)) => a.cmp(b),
         (TableValueR::Boolean(a), TableValueR::Boolean(b)) => a.cmp(b),
         (a, b) => panic!("Can't compare {:?} to {:?}", a, b),
-    }
-}
-
-pub fn convert_row_to_heap_allocated(r: &RowR) -> Row {
-    Row::new(
-        r.iter()
-            .map(|c| match c {
-                TableValueR::Null => TableValue::Null,
-                TableValueR::String(s) => TableValue::String(s.to_string()),
-                TableValueR::Int(i) => TableValue::Int(*i),
-                TableValueR::Decimal(d) => TableValue::Decimal(*d),
-                TableValueR::Float(f) => TableValue::Float(*f),
-                TableValueR::Bytes(b) => TableValue::Bytes(b.to_vec()),
-                TableValueR::Timestamp(v) => TableValue::Timestamp(v.clone()),
-                TableValueR::Boolean(v) => TableValue::Boolean(*v),
-            })
-            .collect_vec(),
-    )
-}
-
-/// `Vec<TableValueR>` with erased lifetime. Unsafe, use with caution.
-struct TableValueVec {
-    ptr: *mut u8,
-    len: usize,
-    cap: usize,
-}
-
-unsafe impl Send for TableValueVec {}
-unsafe impl Sync for TableValueVec {}
-
-impl TableValueVec {
-    pub unsafe fn new(v: Vec<TableValueR>) -> TableValueVec {
-        let (ptr, len, cap) = v.into_raw_parts();
-        let ptr = ptr as *mut u8;
-        TableValueVec { ptr, len, cap }
-    }
-
-    /// Extremely unsafe, fabricates lifetimes. Use with caution.
-    pub unsafe fn as_slice<'data>(&self) -> &[TableValueR<'data>] {
-        std::slice::from_raw_parts(self.ptr as *const TableValueR, self.len)
-    }
-
-    /// Extremely unsafe, fabricates lifetimes. Use with caution.
-    pub unsafe fn as_mut_slice<'data>(&mut self) -> &mut [TableValueR<'data>] {
-        std::slice::from_raw_parts_mut(self.ptr as *mut TableValueR, self.len)
-    }
-
-    /// Extremely unsafe, fabricates lifetimes. Use with caution.
-    pub unsafe fn on_mut_vec<'data, F>(&mut self, op: F)
-    where
-        F: FnOnce(&mut Vec<TableValueR<'data>>),
-    {
-        let ptr = self.ptr as *mut TableValueR<'data>;
-        let mut vec = ManuallyDrop::new(Vec::from_raw_parts(ptr, self.len, self.cap));
-
-        op(&mut vec);
-
-        let (ptr, len, cap) = ManuallyDrop::into_inner(vec).into_raw_parts();
-        self.ptr = ptr as *mut u8;
-        self.len = len;
-        self.cap = cap;
-    }
-}
-
-impl Drop for TableValueVec {
-    fn drop(&'a mut self) {
-        unsafe {
-            let ptr = self.ptr as *mut TableValueR<'a>;
-            // Reconstruct the vector to clean up the used memory.
-            Vec::from_raw_parts(ptr, self.len, self.cap);
-        }
     }
 }
 
@@ -712,46 +287,4 @@ pub fn display_rows(cols: &'a [ArrayRef]) -> impl fmt::Display + 'a {
         }
     }
     D(cols)
-}
-
-pub fn eq_columns(l: &[ArrayRef], r: &[ArrayRef]) -> bool {
-    if l.len() != r.len() {
-        return false;
-    }
-    for i in 0..l.len() {
-        if !eq_arrays(l[i].as_ref(), r[i].as_ref()) {
-            return false;
-        }
-    }
-    true
-}
-
-pub fn eq_arrays(l: &dyn Array, r: &dyn Array) -> bool {
-    let t = l.data_type();
-    if r.data_type() != t {
-        return false;
-    }
-
-    macro_rules! arrays_eq {
-        ($a: expr, $array: tt, $($rest:tt)*) => {{
-            let l = l.as_any().downcast_ref::<$array>().unwrap();
-            let r = r.as_any().downcast_ref::<$array>().unwrap();
-            if l.len() != r.len() {
-                return false;
-            }
-            for i in 0..l.len() {
-                if l.is_valid(i) != r.is_valid(i) {
-                    return false;
-                }
-                if !l.is_valid(i) {
-                    continue;
-                }
-                if l.value(i) != r.value(i) {
-                    return false;
-                }
-            }
-            true
-        }};
-    }
-    cube_match_array!(l, arrays_eq)
 }

--- a/rust/cubestore/src/table/data.rs
+++ b/rust/cubestore/src/table/data.rs
@@ -17,15 +17,25 @@
 //! (strings and byte arrays). One can convert [MutRows] to [Rows] with [`MutRows::freeze`].
 //!
 //! To iterate over produced rows use [RowsView], also see [`Rows::view`].
-use crate::table::{Row, TableValue, TimestampValue};
-use crate::util::decimal::Decimal;
-use crate::util::ordfloat::OrdF64;
-use bumpalo::Bump;
-use itertools::Itertools;
 use std::cmp::Ordering;
 use std::mem::ManuallyDrop;
 use std::ops::Index;
 use std::sync::Arc;
+
+use bumpalo::Bump;
+use itertools::Itertools;
+
+use crate::metastore::{Column, ColumnType};
+use crate::table::{Row, TableValue, TimestampValue};
+use crate::util::decimal::Decimal;
+use crate::util::ordfloat::OrdF64;
+use arrow::array::{Array, ArrayBuilder, ArrayRef, StringArray};
+use arrow::record_batch::RecordBatch;
+use datafusion::cube_match_array;
+
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
+use std::fmt;
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum TableValueR<'a> {
@@ -401,6 +411,39 @@ impl<'a> InsertedRows<'a> {
     }
 }
 
+pub fn cmp_partition_key(key_size: usize, l: &[TableValue], r: &[ArrayRef], ri: usize) -> Ordering {
+    for i in 0..key_size {
+        let o = cmp_partition_column_same_type(&l[i], r[i].as_ref(), ri);
+        if o != Ordering::Equal {
+            return o;
+        }
+    }
+    return Ordering::Equal;
+}
+
+pub fn cmp_partition_column_same_type(l: &TableValue, r: &dyn Array, ri: usize) -> Ordering {
+    // Optimization to avoid memory allocations.
+    match l {
+        TableValue::Null => match r.is_valid(ri) {
+            true => return Ordering::Less,
+            false => return Ordering::Equal,
+        },
+        TableValue::String(l) => {
+            let r = r.as_any().downcast_ref::<StringArray>().unwrap();
+            if !r.is_valid(ri) {
+                return Ordering::Greater;
+            }
+            return l.as_str().cmp(r.value(ri));
+        }
+        _ => {}
+    }
+
+    cmp_same_types(
+        &TableValueR::from_heap_allocated(l),
+        &TableValueR::from_heap_allocated(&TableValue::from_array(r, ri)),
+    )
+}
+
 pub fn cmp_row_key_heap(sort_key_size: usize, l: &[TableValue], r: &[TableValueR]) -> Ordering {
     for i in 0..sort_key_size {
         let c = cmp_same_types(&TableValueR::from_heap_allocated(&l[i]), &r[i]);
@@ -506,4 +549,209 @@ impl Drop for TableValueVec {
             Vec::from_raw_parts(ptr, self.len, self.cap);
         }
     }
+}
+
+#[macro_export]
+macro_rules! match_column_type {
+    ($t: expr, $matcher: ident) => {{
+        use arrow::array::*;
+        let t = $t;
+        match t {
+            ColumnType::String => $matcher!(String, StringBuilder, String),
+            ColumnType::Int => $matcher!(Int, Int64Builder, Int),
+            ColumnType::Bytes => $matcher!(Bytes, BinaryBuilder, Bytes),
+            ColumnType::HyperLogLog(_) => $matcher!(HyperLogLog, BinaryBuilder, Bytes),
+            ColumnType::Timestamp => $matcher!(Timestamp, TimestampMicrosecondBuilder, Timestamp),
+            ColumnType::Boolean => $matcher!(Boolean, BooleanBuilder, Boolean),
+            ColumnType::Decimal { .. } => match t.target_scale() {
+                0 => $matcher!(Decimal, Int64Decimal0Builder, Decimal, 0),
+                1 => $matcher!(Decimal, Int64Decimal1Builder, Decimal, 1),
+                2 => $matcher!(Decimal, Int64Decimal2Builder, Decimal, 2),
+                3 => $matcher!(Decimal, Int64Decimal3Builder, Decimal, 3),
+                4 => $matcher!(Decimal, Int64Decimal4Builder, Decimal, 4),
+                5 => $matcher!(Decimal, Int64Decimal5Builder, Decimal, 5),
+                10 => $matcher!(Decimal, Int64Decimal10Builder, Decimal, 10),
+                n => panic!("unhandled target scale: {}", n),
+            },
+            ColumnType::Float => $matcher!(Float, Float64Builder, Float),
+        }
+    }};
+}
+
+pub fn create_array_builder(t: &ColumnType) -> Box<dyn ArrayBuilder> {
+    macro_rules! create_builder {
+        ($type: tt, $builder: tt $(,$arg: tt)*) => {
+            Box::new($builder::new(0))
+        };
+    }
+    match_column_type!(t, create_builder)
+}
+
+pub fn create_array_builders(cs: &[Column]) -> Vec<Box<dyn ArrayBuilder>> {
+    cs.iter()
+        .map(|c| create_array_builder(c.get_column_type()))
+        .collect_vec()
+}
+
+pub fn append_row(bs: &mut [Box<dyn ArrayBuilder>], cs: &[Column], r: &Row) {
+    assert_eq!(bs.len(), r.len());
+    assert_eq!(cs.len(), r.len());
+    for i in 0..r.len() {
+        append_value(bs[i].as_mut(), cs[i].get_column_type(), &r.values()[i]);
+    }
+}
+
+pub fn append_value(b: &mut dyn ArrayBuilder, c: &ColumnType, v: &TableValue) {
+    let is_null = matches!(v, TableValue::Null);
+    macro_rules! convert_value {
+        (Decimal, $v: expr) => {{
+            $v.raw_value()
+        }};
+        (Float, $v: expr) => {{
+            $v.0
+        }};
+        (Timestamp, $v: expr) => {{
+            $v.get_time_stamp() / 1000
+        }}; // Nanoseconds to microseconds.
+        (String, $v: expr) => {{
+            $v.as_str()
+        }};
+        (Bytes, $v: expr) => {{
+            $v.as_slice()
+        }};
+        ($tv_enum: tt, $v: expr) => {{
+            *$v
+        }};
+    }
+    macro_rules! append {
+        ($type: tt, $builder: tt, $tv_enum: tt $(, $arg:tt)*) => {{
+            let b = b.as_any_mut().downcast_mut::<$builder>().unwrap();
+            if is_null {
+                b.append_null().unwrap();
+                return;
+            }
+            let v = match v {
+                TableValue::$tv_enum(v) => convert_value!($tv_enum, v),
+                other => panic!("unexpected value {:?} for type {:?}", other, c),
+            };
+            b.append_value(v).unwrap();
+        }};
+    }
+    match_column_type!(c, append)
+}
+
+pub fn rows_to_columns(cols: &[Column], rows: &[Row]) -> Vec<ArrayRef> {
+    let mut builders = create_array_builders(&cols);
+    for r in rows {
+        append_row(&mut builders, &cols, r);
+    }
+    builders.into_iter().map(|mut b| b.finish()).collect_vec()
+}
+
+pub async fn to_stream(r: RecordBatch) -> SendableRecordBatchStream {
+    let schema = r.schema();
+    MemoryExec::try_new(&[vec![r]], schema, None)
+        .unwrap()
+        .execute(0)
+        .await
+        .unwrap()
+}
+
+pub fn concat_record_batches(rs: &[RecordBatch]) -> RecordBatch {
+    assert_ne!(rs.len(), 0);
+    RecordBatch::concat(&rs[0].schema(), rs).unwrap()
+}
+
+#[macro_export]
+macro_rules! assert_eq_columns {
+    ($l: expr, $r: expr) => {{
+        use crate::table::data::display_rows;
+        use pretty_assertions::Comparison;
+
+        let l = $l;
+        let r = $r;
+        assert_eq!(
+            l,
+            r,
+            "{}",
+            Comparison::new(
+                &format!("{}", display_rows(l))
+                    .split("\n")
+                    .collect::<Vec<_>>(),
+                &format!("{}", display_rows(r))
+                    .split("\n")
+                    .collect::<Vec<_>>()
+            )
+        );
+    }};
+}
+
+pub fn display_rows(cols: &'a [ArrayRef]) -> impl fmt::Display + 'a {
+    pub struct D<'a>(&'a [ArrayRef]);
+    impl fmt::Display for D<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let cols = self.0;
+            if cols.len() == 0 {
+                return write!(f, "[]");
+            }
+            write!(f, "[")?;
+            for i in 0..cols[0].len() {
+                if i != 0 {
+                    write!(f, "\n,")?
+                }
+                write!(f, "[")?;
+                for j in 0..cols.len() {
+                    if j != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{:?}", TableValue::from_array(cols[j].as_ref(), i))?;
+                }
+                write!(f, "]")?;
+            }
+            write!(f, "]")
+        }
+    }
+    D(cols)
+}
+
+pub fn eq_columns(l: &[ArrayRef], r: &[ArrayRef]) -> bool {
+    if l.len() != r.len() {
+        return false;
+    }
+    for i in 0..l.len() {
+        if !eq_arrays(l[i].as_ref(), r[i].as_ref()) {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn eq_arrays(l: &dyn Array, r: &dyn Array) -> bool {
+    let t = l.data_type();
+    if r.data_type() != t {
+        return false;
+    }
+
+    macro_rules! arrays_eq {
+        ($a: expr, $array: tt, $($rest:tt)*) => {{
+            let l = l.as_any().downcast_ref::<$array>().unwrap();
+            let r = r.as_any().downcast_ref::<$array>().unwrap();
+            if l.len() != r.len() {
+                return false;
+            }
+            for i in 0..l.len() {
+                if l.is_valid(i) != r.is_valid(i) {
+                    return false;
+                }
+                if !l.is_valid(i) {
+                    continue;
+                }
+                if l.value(i) != r.value(i) {
+                    return false;
+                }
+            }
+            true
+        }};
+    }
+    cube_match_array!(l, arrays_eq)
 }

--- a/rust/cubestore/src/table/mod.rs
+++ b/rust/cubestore/src/table/mod.rs
@@ -171,21 +171,9 @@ pub struct Row {
     values: Vec<TableValue>,
 }
 
-pub struct RowSortKey<'a> {
-    row: &'a Row,
-    sort_key_size: usize,
-}
-
 impl Row {
     pub fn new(values: Vec<TableValue>) -> Row {
         Row { values }
-    }
-
-    pub fn sort_key(&self, sort_key_size: u64) -> RowSortKey {
-        RowSortKey {
-            row: self,
-            sort_key_size: sort_key_size as usize,
-        }
     }
 
     pub fn push(&mut self, val: TableValue) {
@@ -198,37 +186,6 @@ impl Row {
 
     pub fn values(&self) -> &Vec<TableValue> {
         &self.values
-    }
-}
-
-impl<'a> PartialEq for RowSortKey<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        if self.sort_key_size != other.sort_key_size {
-            return false;
-        }
-        for i in 0..self.sort_key_size {
-            if self.row.values[i] != other.row.values[i] {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-impl<'a> Eq for RowSortKey<'a> {}
-
-impl<'a> PartialOrd for RowSortKey<'a> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.sort_key_size != other.sort_key_size {
-            return None;
-        }
-        for i in 0..self.sort_key_size {
-            let ord = cmp_same_types(&self.row.values[i], &other.row.values[i]);
-            if ord != Ordering::Equal {
-                return Some(ord);
-            }
-        }
-        Some(Ordering::Equal)
     }
 }
 
@@ -245,12 +202,6 @@ pub fn cmp_same_types(l: &TableValue, r: &TableValue) -> Ordering {
         (TableValue::Timestamp(a), TableValue::Timestamp(b)) => a.cmp(b),
         (TableValue::Boolean(a), TableValue::Boolean(b)) => a.cmp(b),
         (a, b) => panic!("Can't compare {:?} to {:?}", a, b),
-    }
-}
-
-impl<'a> Ord for RowSortKey<'a> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
     }
 }
 

--- a/rust/cubestore/src/table/parquet.rs
+++ b/rust/cubestore/src/table/parquet.rs
@@ -1,23 +1,13 @@
-use super::TimestampValue;
-use crate::metastore::{Column, ColumnType, Index};
-use crate::table::{Row, TableStore};
+use crate::metastore::Index;
 use crate::CubeError;
-use parquet::column::reader::ColumnReader;
-use parquet::column::writer::ColumnWriter;
-use parquet::data_type::*;
+use arrow::array::ArrayRef;
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::{ArrowReader, ArrowWriter, ParquetFileArrowReader};
 use parquet::file::properties::{WriterProperties, WriterVersion};
-use parquet::file::reader::{FileReader, SerializedFileReader};
-use parquet::file::writer::{FileWriter, SerializedFileWriter};
-use parquet::schema::types;
-use std::cmp::{max, min, Ordering};
+use parquet::file::reader::SerializedFileReader;
+use std::convert::TryFrom;
 use std::fs::File;
-
-use crate::table::data::{
-    cmp_row_key, cmp_row_key_heap, convert_row_to_heap_allocated, MutRows, Rows, RowsView,
-    TableValueR,
-};
-use crate::util::decimal::Decimal;
-use num::integer::div_ceil;
 use std::sync::Arc;
 
 pub struct ParquetTableStore {
@@ -25,109 +15,15 @@ pub struct ParquetTableStore {
     row_group_size: usize,
 }
 
-pub struct RowParquetWriter {
-    columns: Vec<Column>,
-    parquet_writer: SerializedFileWriter<File>,
-    buffer: MutRows,
-    row_group_size: usize,
-}
-
-enum ColumnAccessor {
-    Bytes(Vec<ByteArray>),
-    Int(Vec<i64>),
-    Boolean(Vec<bool>),
-    Float(Vec<f64>),
-}
-
-pub struct RowParquetReader<'a> {
-    pub parquet_reader: SerializedFileReader<File>,
-    column_with_buffer: Vec<(&'a Column, usize, ColumnAccessor, Option<Vec<i16>>)>,
-}
-
-impl TableStore for ParquetTableStore {
-    fn merge_rows<'a>(
-        &'a self,
-        source_file: Option<&'a str>,
-        dest_files: Vec<String>,
-        rows: RowsView<'a>,
-        sort_key_size: usize,
-    ) -> Result<Vec<(u64, (Row, Row))>, CubeError> {
-        let mut writers = Vec::new();
-        for f in dest_files.iter() {
-            writers.push(RowParquetWriter::open(&self.table, f, self.row_group_size)?);
+impl ParquetTableStore {
+    pub fn read_columns(&self, file: &str) -> Result<Vec<RecordBatch>, CubeError> {
+        let mut r = ParquetFileArrowReader::new(Arc::new(SerializedFileReader::try_from(file)?));
+        let mut batches = Vec::new();
+        for b in r.get_record_reader(self.row_group_size)? {
+            batches.push(b?)
         }
-        if source_file.is_none() {
-            let mut split_writer = SplitRowParquetWriter::new(writers, rows.len(), sort_key_size);
-            split_writer.write_rows(rows)?;
-            return Ok(split_writer.close()?);
-        }
-
-        let mut reader = RowParquetReader::open(&self.table, source_file.unwrap(), None)?;
-        let mut right_position = 0;
-        let total_row_number =
-            reader.parquet_reader.metadata().file_metadata().num_rows() as usize + rows.len();
-        let mut split_writer = SplitRowParquetWriter::new(writers, total_row_number, sort_key_size);
-
-        for row_group_index in 0..reader.parquet_reader.num_row_groups() {
-            let mut read_rows = MutRows::new(reader.column_with_buffer.len());
-            reader.read_rows(row_group_index, &mut read_rows)?;
-            let (new_pos, to_write) = ParquetTableStore::merge_sort(
-                read_rows.freeze(),
-                rows,
-                right_position,
-                sort_key_size as usize,
-            );
-            split_writer.write_rows(to_write.view())?;
-            right_position = new_pos;
-        }
-
-        if right_position < rows.len() {
-            split_writer.write_rows(rows.slice(right_position, rows.len()))?;
-        }
-
-        Ok(split_writer.close()?)
+        Ok(batches)
     }
-
-    fn read_rows(&self, file: &str) -> Result<Rows, CubeError> {
-        let mut reader = RowParquetReader::open(&self.table, file, None)?;
-        let mut result = MutRows::new(reader.column_with_buffer.len());
-        for row_group_index in 0..reader.parquet_reader.num_row_groups() {
-            reader.read_rows(row_group_index, &mut result)?;
-        }
-        Ok(result.freeze())
-    }
-
-    fn read_filtered_rows(
-        &self,
-        file: &str,
-        columns: &Vec<Column>,
-        limit: usize,
-    ) -> Result<Rows, CubeError> {
-        let mut reader = RowParquetReader::open(&self.table, file, Some(columns))?;
-        let mut result = MutRows::new(reader.column_with_buffer.len());
-        for row_group_index in 0..reader.parquet_reader.num_row_groups() {
-            reader.read_rows(row_group_index, &mut result)?;
-            if limit <= result.num_rows() {
-                result.truncate(limit);
-                break;
-            }
-        }
-        Ok(result.freeze())
-    }
-
-    // fn scan_node(
-    //     &self,
-    //     file: &str,
-    //     columns: &Vec<Column>,
-    //     row_group_filter: Option<Arc<dyn Fn(&RowGroupMetaData) -> bool + Send + Sync>>,
-    // ) -> Result<Arc<dyn ExecutionPlan + Send + Sync>, CubeError> {
-    //     Ok(Arc::new(ParquetExec::try_new_with_filter(
-    //         file,
-    //         Some(columns.iter().map(|c| c.get_index()).collect::<Vec<_>>()),
-    //         self.row_group_size,
-    //         row_group_filter,
-    //     )?))
-    // }
 }
 
 impl ParquetTableStore {
@@ -138,825 +34,56 @@ impl ParquetTableStore {
         }
     }
 
-    #[cfg(test)]
-    pub fn merge_rows_from_heap<'a>(
-        &'a self,
-        source_file: Option<&'a str>,
-        dest_files: Vec<String>,
-        rows: Vec<Row>,
-        sort_key_size: usize,
-    ) -> Result<Vec<(u64, (Row, Row))>, CubeError> {
-        let mut buffer = Vec::new();
-        self.merge_rows(
-            source_file,
-            dest_files,
-            RowsView::from_heap_allocated(&mut buffer, rows[0].len(), &rows),
-            sort_key_size,
-        )
+    pub fn key_size(&self) -> u64 {
+        self.table.sort_key_size()
     }
 
-    fn merge_sort(
-        left: Rows,
-        right: RowsView,
-        initial_right_pos: usize,
-        sort_key_size: usize,
-    ) -> (usize, Rows) {
-        let leftv = left.view();
-        if right.len() == initial_right_pos
-            || cmp_row_key(
-                sort_key_size,
-                &leftv[leftv.len() - 1],
-                &right[initial_right_pos],
-            ) <= Ordering::Equal
-        {
-            return (initial_right_pos, left);
-        }
-        let mut result = MutRows::with_capacity(left.num_columns(), left.num_rows());
-        let mut left_position = 0;
-        let mut right_position = initial_right_pos;
-        while left_position < left.num_rows() {
-            if right.len() <= right_position
-                || cmp_row_key(sort_key_size, &leftv[left_position], &right[right_position])
-                    <= Ordering::Equal
-            {
-                result.add_row_copy(&leftv[left_position]); // TODO copy
-                left_position += 1;
-            } else {
-                result.add_row_copy(&right[right_position]); // TODO copy
-                right_position += 1;
-            }
-        }
-        (right_position, result.freeze())
-    }
-}
-
-impl<'a> RowParquetReader<'a> {
-    fn open(
-        table: &'a Index,
-        file: &'a str,
-        columns_to_read: Option<&'a Vec<Column>>,
-    ) -> Result<RowParquetReader<'a>, CubeError> {
-        let file = File::open(file)?;
-        let parquet_reader = SerializedFileReader::new(file)?;
-
-        let column_with_buffer = columns_to_read
-            .unwrap_or(table.get_columns())
-            .iter()
-            .map(|c| {
-                (
-                    c,
-                    c.get_index(),
-                    match c.get_column_type() {
-                        ColumnType::String => ColumnAccessor::Bytes(vec![ByteArray::new(); 16384]),
-                        ColumnType::Bytes | ColumnType::HyperLogLog(_) => {
-                            ColumnAccessor::Bytes(vec![ByteArray::new(); 16384])
-                        }
-                        ColumnType::Int => ColumnAccessor::Int(vec![0; 16384]),
-                        ColumnType::Decimal { .. } => ColumnAccessor::Int(vec![0; 16384]),
-                        ColumnType::Timestamp => ColumnAccessor::Int(vec![0; 16384]),
-                        ColumnType::Boolean => ColumnAccessor::Boolean(vec![false; 16384]),
-                        ColumnType::Float => ColumnAccessor::Float(vec![0.0; 16384]),
-                    },
-                    Some(vec![0; 16384]),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        Ok(RowParquetReader {
-            parquet_reader,
-            column_with_buffer,
-        })
+    pub fn arrow_schema(&self) -> Schema {
+        arrow_schema(&self.table)
     }
 
-    fn load_row_group(&mut self, row_group_index: usize) -> Result<usize, CubeError> {
-        let row_group = self.parquet_reader.get_row_group(row_group_index)?;
-        let mut values_read = 0;
-        for (_, index, column_accessor, def_levels) in &mut self.column_with_buffer {
-            let mut col_reader = row_group.get_column_reader(*index).unwrap();
-            match column_accessor {
-                ColumnAccessor::Bytes(buffer) => {
-                    if let ColumnReader::ByteArrayColumnReader(ref mut reader) = col_reader {
-                        values_read = max(
-                            values_read,
-                            reader
-                                .read_batch(
-                                    buffer.len(),
-                                    def_levels.as_mut().map(|l| l.as_mut_slice()),
-                                    None,
-                                    buffer.as_mut_slice(),
-                                )?
-                                .1,
-                        );
-                    }
-                }
-                ColumnAccessor::Int(buffer) => {
-                    if let ColumnReader::Int64ColumnReader(ref mut reader) = col_reader {
-                        values_read = max(
-                            values_read,
-                            reader
-                                .read_batch(
-                                    buffer.len(),
-                                    def_levels.as_mut().map(|l| l.as_mut_slice()),
-                                    None,
-                                    buffer.as_mut_slice(),
-                                )?
-                                .1,
-                        );
-                    }
-                }
-                ColumnAccessor::Boolean(buffer) => {
-                    if let ColumnReader::BoolColumnReader(ref mut reader) = col_reader {
-                        values_read = max(
-                            values_read,
-                            reader
-                                .read_batch(
-                                    buffer.len(),
-                                    def_levels.as_mut().map(|l| l.as_mut_slice()),
-                                    None,
-                                    buffer.as_mut_slice(),
-                                )?
-                                .1,
-                        );
-                    }
-                }
-                ColumnAccessor::Float(buffer) => {
-                    if let ColumnReader::DoubleColumnReader(ref mut reader) = col_reader {
-                        values_read = max(
-                            values_read,
-                            reader
-                                .read_batch(
-                                    buffer.len(),
-                                    def_levels.as_mut().map(|l| l.as_mut_slice()),
-                                    None,
-                                    buffer.as_mut_slice(),
-                                )?
-                                .1,
-                        );
-                    }
-                }
-            };
-        }
-        Ok(values_read)
+    pub fn writer_props(&self) -> WriterProperties {
+        WriterProperties::builder()
+            .set_max_row_group_size(self.row_group_size)
+            .set_writer_version(WriterVersion::PARQUET_2_0)
+            .build()
     }
 
-    fn read_rows(&mut self, row_group_index: usize, output: &mut MutRows) -> Result<(), CubeError> {
-        assert_eq!(output.num_columns(), self.column_with_buffer.len());
+    pub fn write_data(&self, dest_file: &str, columns: Vec<ArrayRef>) -> Result<(), CubeError> {
+        let schema = Arc::new(arrow_schema(&self.table));
+        let batch = RecordBatch::try_new(schema.clone(), columns.to_vec())?;
 
-        let values_read = self.load_row_group(row_group_index)?;
-        let mut result = output.add_rows(values_read);
-        for (col_i, (col, _, column_accessor, def_levels)) in
-            self.column_with_buffer.iter().enumerate()
-        {
-            let mut cur_value_index = 0;
-            match def_levels {
-                Some(levels) => {
-                    match col.get_column_type() {
-                        ColumnType::String => {
-                            if let ColumnAccessor::Bytes(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index].as_utf8()?;
-                                        result.set_interned(i, col_i, TableValueR::String(value));
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                        ColumnType::Bytes | ColumnType::HyperLogLog(_) => {
-                            if let ColumnAccessor::Bytes(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index].as_bytes();
-                                        result.set_interned(i, col_i, TableValueR::Bytes(value));
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                        ColumnType::Int => {
-                            if let ColumnAccessor::Int(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index];
-                                        result.set_interned(i, col_i, TableValueR::Int(value));
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                        ColumnType::Decimal { .. } => {
-                            if let ColumnAccessor::Int(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index];
+        let mut w =
+            ArrowWriter::try_new(File::create(dest_file)?, schema, Some(self.writer_props()))?;
+        w.write(&batch)?;
+        w.close()?;
 
-                                        result.set_interned(
-                                            i,
-                                            col_i,
-                                            TableValueR::Decimal(Decimal::new(value)),
-                                        );
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                        ColumnType::Timestamp => {
-                            if let ColumnAccessor::Int(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index];
-
-                                        result.set_interned(
-                                            i,
-                                            col_i,
-                                            TableValueR::Timestamp(TimestampValue::new(
-                                                value * 1000 as i64,
-                                            )),
-                                        );
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                        ColumnType::Boolean => {
-                            if let ColumnAccessor::Boolean(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index];
-                                        result.set_interned(i, col_i, TableValueR::Boolean(value));
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                        ColumnType::Float => {
-                            if let ColumnAccessor::Float(buffer) = &column_accessor {
-                                for i in 0..values_read {
-                                    if levels[i] == 1 {
-                                        let value = buffer[cur_value_index];
-                                        result.set_interned(
-                                            i,
-                                            col_i,
-                                            TableValueR::Float(value.into()),
-                                        );
-                                        cur_value_index += 1;
-                                    } else {
-                                        result.set_interned(i, col_i, TableValueR::Null);
-                                    }
-                                }
-                            }
-                        }
-                    };
-                }
-                x => panic!("Unsupported value: {:?}", x),
-            }
-        }
         Ok(())
     }
 }
 
-pub struct SplitRowParquetWriter {
-    writers: Vec<RowParquetWriter>,
-    current_writer: usize,
-    rows_written: usize,
-    rows_written_current_file: u64,
-    chunk_size: usize,
-    min_max_rows: Vec<(u64, (Row, Row))>,
-    first_row: Option<Row>,
-    last_row: Option<Row>,
-    sort_key_size: usize,
-}
-
-impl SplitRowParquetWriter {
-    pub fn new(
-        writers: Vec<RowParquetWriter>,
-        total_row_number: usize,
-        sort_key_size: usize,
-    ) -> SplitRowParquetWriter {
-        let chunk_size = div_ceil(total_row_number, writers.len());
-        SplitRowParquetWriter {
-            writers,
-            current_writer: 0,
-            rows_written: 0,
-            rows_written_current_file: 0,
-            chunk_size,
-            min_max_rows: Vec::new(),
-            first_row: None,
-            last_row: None,
-            sort_key_size,
-        }
-    }
-
-    fn write_rows(&'a mut self, rows: RowsView<'a>) -> Result<(), CubeError> {
-        if rows.len() == 0 {
-            return Ok(());
-        }
-        if self.first_row.is_none() {
-            self.first_row = Some(convert_row_to_heap_allocated(&rows[0]));
-        }
-        let mut remaining_slice = rows;
-        while remaining_slice.len() + self.rows_written
-            > (self.current_writer + 1) * self.chunk_size
-        {
-            let target_split_at = (self.current_writer + 1) * self.chunk_size;
-            let mut split_at = if self.rows_written > target_split_at {
-                0
-            } else {
-                target_split_at - self.rows_written
-            };
-            // move to the last position with a matching sort_key
-            while split_at < remaining_slice.len()
-                && self.is_current_key_equal(&remaining_slice, split_at)
-            {
-                split_at += 1;
-            }
-            if split_at == remaining_slice.len() - 1 {
-                break;
-            }
-            if split_at == 0 {
-                self.min_max_rows.push((
-                    self.rows_written_current_file,
-                    (
-                        self.first_row.as_ref().unwrap().clone(),
-                        self.last_row.as_ref().unwrap().clone(),
-                    ),
-                ));
-            } else {
-                self.writers[self.current_writer].write_rows(remaining_slice.slice(0, split_at))?;
-                self.rows_written += split_at;
-                self.rows_written_current_file += split_at as u64;
-                self.min_max_rows.push((
-                    self.rows_written_current_file,
-                    (
-                        self.first_row
-                            .as_ref()
-                            .map(|r| r.clone())
-                            .unwrap_or_else(|| convert_row_to_heap_allocated(&remaining_slice[0])),
-                        convert_row_to_heap_allocated(&remaining_slice[split_at - 1]),
-                    ),
-                ));
-            }
-            self.rows_written_current_file = 0;
-            self.first_row = None;
-            self.current_writer += 1;
-            remaining_slice = remaining_slice.slice(split_at, remaining_slice.len());
-        }
-        if remaining_slice.len() > 0 {
-            if self.first_row.is_none() {
-                self.first_row = Some(convert_row_to_heap_allocated(&remaining_slice[0]));
-            }
-            self.writers[self.current_writer].write_rows(remaining_slice)?;
-            self.last_row = Some(convert_row_to_heap_allocated(
-                &remaining_slice[remaining_slice.len() - 1],
-            ));
-            self.rows_written += remaining_slice.len();
-            self.rows_written_current_file += remaining_slice.len() as u64;
-        }
-
-        Ok(())
-    }
-
-    fn is_current_key_equal<'a>(
-        &'a self,
-        remaining_slice: &'a RowsView<'a>,
-        split_at: usize,
-    ) -> bool {
-        if split_at == 0 {
-            return self.last_row.is_some()
-                && cmp_row_key_heap(
-                    self.sort_key_size,
-                    &self.last_row.as_ref().unwrap().values,
-                    &remaining_slice[split_at],
-                ) == Ordering::Equal;
-        } else {
-            return cmp_row_key(
-                self.sort_key_size,
-                &remaining_slice[split_at - 1],
-                &remaining_slice[split_at],
-            ) == Ordering::Equal;
-        }
-    }
-
-    fn close(mut self) -> Result<Vec<(u64, (Row, Row))>, CubeError> {
-        // TODO handle case if only one partition is written out of 3
-        assert!(self.current_writer == self.writers.len() - 1);
-        if self.first_row.is_some() && self.last_row.is_some() {
-            self.min_max_rows.push((
-                self.rows_written_current_file,
-                (
-                    self.first_row.as_ref().unwrap().clone(),
-                    self.last_row.as_ref().unwrap().clone(),
-                ),
-            ));
-            self.rows_written_current_file = 0;
-        }
-        for w in self.writers.into_iter() {
-            w.close()?;
-        }
-        let sort_key_size = self.sort_key_size;
-        Ok(self
-            .min_max_rows
-            .into_iter()
-            .map(|(c, (min, max))| {
-                (
-                    c,
-                    (
-                        Row::new(min.values.into_iter().take(sort_key_size).collect()),
-                        Row::new(max.values.into_iter().take(sort_key_size).collect()),
-                    ),
-                )
-            })
-            .collect())
-    }
-}
-
-impl RowParquetWriter {
-    fn open(
-        table: &'a Index,
-        file: &'a str,
-        row_group_size: usize,
-    ) -> Result<RowParquetWriter, CubeError> {
-        let file = File::create(file)?;
-
-        let mut fields = table
-            .get_columns()
-            .iter()
-            .map(|column| {
-                // TODO pass nullable columns
-                Arc::new(parquet::schema::types::Type::from(column))
-            })
-            .collect();
-
-        let schema = Arc::new(
-            types::Type::group_type_builder("schema")
-                .with_fields(&mut fields)
-                .build()
-                .unwrap(),
-        );
-
-        let props = Self::writer_props();
-        let parquet_writer = SerializedFileWriter::new(file.try_clone()?, schema, props)?;
-
-        Ok(RowParquetWriter {
-            columns: table.get_columns().clone(),
-            parquet_writer,
-            row_group_size,
-            buffer: MutRows::with_capacity(table.get_columns().len(), row_group_size as usize),
-        })
-    }
-
-    fn write_rows(&'a mut self, rows: RowsView<'a>) -> Result<(), CubeError> {
-        self.buffer.add_from_slice(rows); // TODO avoid copying data.
-
-        if self.buffer.num_rows() >= self.row_group_size {
-            self.write_buffer()?;
-        }
-
-        Ok(())
-    }
-
-    fn write_buffer(&'a mut self) -> Result<(), CubeError> {
-        let batch_size = self.row_group_size;
-        let row_group_count = div_ceil(self.buffer.num_rows(), self.row_group_size);
-        for row_batch_index in 0..row_group_count {
-            let mut row_group_writer = self.parquet_writer.next_row_group()?;
-
-            let mut column_index = 0;
-
-            let rows_in_group = min(
-                batch_size,
-                self.buffer.num_rows() - row_batch_index * batch_size,
-            );
-
-            while let Some(mut col_writer) = row_group_writer.next_column()? {
-                // TODO types
-                match col_writer {
-                    ColumnWriter::Int64ColumnWriter(ref mut typed) => {
-                        let column = &self.columns[column_index];
-                        let mut min = None;
-                        let mut max = None;
-                        let column_values = (0..rows_in_group)
-                            .filter(|row_index| {
-                                &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                    != &TableValueR::Null
-                            })
-                            .map(|row_index| -> Result<_, CubeError> {
-                                // TODO types
-                                match &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                {
-                                    TableValueR::Int(val) => Ok(*val),
-                                    TableValueR::Decimal(val) => match column.get_column_type() {
-                                        ColumnType::Decimal { .. } => Ok(val.raw_value()),
-                                        x => panic!("Unexpected type: {:?}", x),
-                                    },
-                                    TableValueR::Timestamp(t) => {
-                                        Ok(i64::from(t.clone().get_time_stamp() / 1000))
-                                    }
-                                    x => panic!("Unsupported value: {:?}", x),
-                                }
-                            })
-                            .map(|res_val| {
-                                if res_val.is_err() {
-                                    return res_val;
-                                }
-                                let v = res_val.unwrap();
-                                if min.is_none() || v < min.unwrap() {
-                                    min = Some(v)
-                                }
-                                if max.is_none() || max.unwrap() < v {
-                                    max = Some(v)
-                                }
-                                return Ok(v);
-                            })
-                            .collect::<Result<Vec<i64>, _>>()?;
-                        let def_levels = self.get_def_levels(
-                            batch_size,
-                            row_batch_index,
-                            column_index,
-                            rows_in_group,
-                            column_values.len(),
-                        );
-                        typed.write_batch_with_statistics(
-                            &column_values,
-                            def_levels.as_ref().map(|b| b.as_slice()),
-                            None,
-                            &min,
-                            &max,
-                            None,
-                            None,
-                        )?;
-                    }
-                    ColumnWriter::DoubleColumnWriter(ref mut typed) => {
-                        let column = &self.columns[column_index];
-                        let mut min = None;
-                        let mut max = None;
-                        let column_values = (0..rows_in_group)
-                            .filter(|row_index| {
-                                &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                    != &TableValueR::Null
-                            })
-                            .map(|row_index| -> Result<_, CubeError> {
-                                // TODO types
-                                match &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                {
-                                    TableValueR::Float(val) => match column.get_column_type() {
-                                        ColumnType::Float => Ok(*val),
-                                        x => panic!("Unexpected type: {:?}", x),
-                                    },
-                                    x => panic!("Unsupported value: {:?}", x),
-                                }
-                            })
-                            .map(|res_val| {
-                                if let Err(e) = res_val {
-                                    return Err(e);
-                                }
-                                // We must use OrdF64 here!
-                                let v = res_val.unwrap();
-                                if min.is_none() || v < min.unwrap() {
-                                    min = Some(v)
-                                }
-                                if max.is_none() || max.unwrap() < v {
-                                    max = Some(v)
-                                }
-                                return Ok(v.0);
-                            })
-                            .collect::<Result<Vec<f64>, _>>()?;
-                        let def_levels = self.get_def_levels(
-                            batch_size,
-                            row_batch_index,
-                            column_index,
-                            rows_in_group,
-                            column_values.len(),
-                        );
-                        typed.write_batch_with_statistics(
-                            &column_values,
-                            def_levels.as_ref().map(|b| b.as_slice()),
-                            None,
-                            &min.map(|f| f.0),
-                            &max.map(|f| f.0),
-                            None,
-                            None,
-                        )?;
-                    }
-                    ColumnWriter::ByteArrayColumnWriter(ref mut typed) => {
-                        // Both vars store indicies into the `column_values`.
-                        let mut min: Option<String> = None;
-                        let mut max: Option<String> = None;
-                        let mut use_min_max = true;
-                        let mut update_stats = |v: &TableValueR| {
-                            if !use_min_max {
-                                return;
-                            }
-                            let s;
-                            if let TableValueR::String(ss) = v {
-                                s = ss;
-                            } else {
-                                use_min_max = false;
-                                min = None;
-                                max = None;
-                                return;
-                            }
-                            if min.is_none() || s < &min.as_deref().unwrap() {
-                                min = Some(s.to_string()) // TODO: remove allocations.
-                            }
-                            if max.is_none() || &max.as_deref().unwrap() < s {
-                                max = Some(s.to_string()) // TODO: remove allocations
-                            }
-                        };
-                        let column_values = (0..rows_in_group)
-                            .filter(|row_index| {
-                                &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                    != &TableValueR::Null
-                            })
-                            .map(|row_index| {
-                                let v = &self.buffer.rows()
-                                    [row_batch_index * batch_size + row_index][column_index];
-                                update_stats(v);
-                                // TODO types
-                                match v {
-                                    TableValueR::String(str) => ByteArray::from(*str),
-                                    TableValueR::Bytes(bytes) => ByteArray::from(bytes.to_vec()),
-                                    x => panic!("Unsupported value: {:?}", x),
-                                }
-                            })
-                            .collect::<Vec<ByteArray>>();
-                        let def_levels = self.get_def_levels(
-                            batch_size,
-                            row_batch_index,
-                            column_index,
-                            rows_in_group,
-                            column_values.len(),
-                        );
-                        assert!(use_min_max || min.is_none() && max.is_none());
-                        typed.write_batch_with_statistics(
-                            &column_values,
-                            def_levels.as_ref().map(|b| b.as_slice()),
-                            None,
-                            &min.map(|s| ByteArray::from(s.into_bytes())),
-                            &max.map(|s| ByteArray::from(s.into_bytes())),
-                            None,
-                            None,
-                        )?;
-                    }
-                    ColumnWriter::BoolColumnWriter(ref mut typed) => {
-                        let mut min = None;
-                        let mut max = None;
-                        let column_values = (0..rows_in_group)
-                            .filter(|row_index| {
-                                &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                    != &TableValueR::Null
-                            })
-                            .map(|row_index| {
-                                // TODO types
-                                match &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                                    [column_index]
-                                {
-                                    TableValueR::Boolean(b) => *b,
-                                    x => panic!("Unsupported value: {:?}", x),
-                                }
-                            })
-                            .map(|res_val| {
-                                let v = res_val;
-                                if min.is_none() || v < min.unwrap() {
-                                    min = Some(v)
-                                }
-                                if max.is_none() || max.unwrap() < v {
-                                    max = Some(v)
-                                }
-                                return res_val;
-                            })
-                            .collect::<Vec<bool>>();
-                        let def_levels = self.get_def_levels(
-                            batch_size,
-                            row_batch_index,
-                            column_index,
-                            rows_in_group,
-                            column_values.len(),
-                        );
-                        typed.write_batch_with_statistics(
-                            &column_values,
-                            def_levels.as_ref().map(|b| b.as_slice()),
-                            None,
-                            &min,
-                            &max,
-                            None,
-                            None,
-                        )?;
-                    }
-                    _ => panic!("Unsupported writer"),
-                };
-
-                row_group_writer.close_column(col_writer)?;
-                column_index += 1;
-            }
-
-            self.parquet_writer.close_row_group(row_group_writer)?;
-        }
-
-        let target_size = if row_group_count * self.row_group_size > self.buffer.num_rows() {
-            0
-        } else {
-            self.buffer.num_rows() - row_group_count * self.row_group_size
-        };
-        let mut leftovers = MutRows::with_capacity(self.buffer.num_columns(), self.row_group_size);
-        leftovers.add_from_slice(
-            self.buffer
-                .rows()
-                .slice(self.buffer.num_rows() - target_size, self.buffer.num_rows()),
-        );
-        self.buffer = leftovers;
-        Ok(())
-    }
-
-    fn get_def_levels(
-        &self,
-        batch_size: usize,
-        row_batch_index: usize,
-        column_index: usize,
-        rows_in_group: usize,
-        _column_values_len: usize,
-    ) -> Option<Vec<i16>> {
-        Some(
-            (0..rows_in_group)
-                .map(|row_index| {
-                    // TODO types
-                    match &self.buffer.rows()[row_batch_index * batch_size + row_index]
-                        [column_index]
-                    {
-                        TableValueR::Null => 0,
-                        _ => 1,
-                    }
-                })
-                .collect::<Vec<i16>>(),
-        )
-    }
-
-    fn close(mut self) -> Result<(), CubeError> {
-        self.write_buffer()?;
-        self.parquet_writer.close()?;
-        Ok(())
-    }
-
-    fn writer_props() -> Arc<WriterProperties> {
-        Arc::new(
-            WriterProperties::builder()
-                // .set_key_value_metadata(Some(vec![KeyValue::new(
-                //     "key".to_string(),
-                //     "value".to_string(),
-                // )]))
-                .set_writer_version(WriterVersion::PARQUET_2_0)
-                .set_statistics_enabled(true)
-                // .set_column_dictionary_enabled(ColumnPath::new(vec!["col0".to_string()]), true)
-                // .set_column_encoding(ColumnPath::new(vec!["col1".to_string()]), Encoding::RLE)
-                .build(),
-        )
-    }
+pub fn arrow_schema(i: &Index) -> Schema {
+    Schema::new(i.columns().iter().map(|c| c.into()).collect())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::metastore::{Column, ColumnType, Index};
-    use crate::table::parquet::{
-        ColumnAccessor, ParquetTableStore, RowParquetReader, RowParquetWriter,
-    };
-    use crate::table::{Row, TableStore, TableValue};
-    use std::{fs, io};
-
     extern crate test;
 
-    use crate::table::data::{convert_row_to_heap_allocated, RowsView, TableValueR};
+    use crate::assert_eq_columns;
+    use crate::metastore::{Column, ColumnType, Index};
+    use crate::store::{compaction, ROW_GROUP_SIZE};
+    use crate::table::data::{concat_record_batches, rows_to_columns, to_stream};
+    use crate::table::parquet::{arrow_schema, ParquetTableStore};
+    use crate::table::{Row, TableValue};
     use crate::util::decimal::Decimal;
-    use csv::ReaderBuilder;
-    use itertools::Itertools;
-    use parquet::file::reader::FileReader;
-    use parquet::file::statistics::Statistics;
-    use std::fs::File;
-    use std::io::BufReader;
-    use std::mem::swap;
-    use std::time::SystemTime;
+    use arrow::array::BooleanArray;
+    use arrow::record_batch::RecordBatch;
+    use std::sync::Arc;
     use tempfile::NamedTempFile;
-    use test::Bencher;
 
-    #[test]
-    fn gutter() {
+    #[tokio::test]
+    async fn gutter() {
         let store = ParquetTableStore {
             table: Index::try_new(
                 "foo".to_string(),
@@ -975,12 +102,13 @@ mod tests {
                         4,
                     ),
                 ],
-                1,
+                3,
             )
             .unwrap(),
             row_group_size: 10,
         };
-        let file_name = "foo.parquet";
+        let file = NamedTempFile::new().unwrap();
+        let file_name = file.path().to_str().unwrap();
 
         let mut first_rows = (0..40)
             .map(|i| {
@@ -1005,141 +133,79 @@ mod tests {
                 ])
             })
             .collect::<Vec<_>>();
-        first_rows.sort_by(|a, b| a.sort_key(1).cmp(&b.sort_key(1)));
-        store
-            .merge_rows_from_heap(None, vec![file_name.to_string()], first_rows.clone(), 3)
-            .unwrap();
-        let read_rows = store.read_rows(file_name).unwrap();
-        assert_eq!(read_rows.len(), first_rows.len());
-        for (read, expected) in read_rows.view().iter().zip(first_rows.clone()) {
-            assert_eq!(&convert_row_to_heap_allocated(&read), &expected);
-        }
+        first_rows.sort_by(|a, b| a.sort_key(3).cmp(&b.sort_key(3)));
+        let first_cols = rows_to_columns(&store.table.columns(), &first_rows);
+        store.write_data(file_name, first_cols.clone()).unwrap();
 
-        let next_file = "foo-2.parquet";
-        let mut next_rows = (40..100)
-            .map(|i| {
-                Row::new(vec![
-                    TableValue::Int(i),
-                    TableValue::String(format!("Foo {}", i)),
-                    TableValue::String(format!("Boo {}", i)),
-                    TableValue::Boolean(false),
-                    TableValue::Decimal(Decimal::new(i * 10000)),
-                ])
-            })
-            .collect::<Vec<_>>();
-        next_rows.sort_by(|a, b| a.sort_key(3).cmp(&b.sort_key(3)));
-        store
-            .merge_rows_from_heap(
-                Some(file_name),
-                vec![next_file.to_string()],
-                next_rows.clone(),
-                3,
-            )
-            .unwrap();
-
-        let mut resulting = first_rows.clone();
-        resulting.append(&mut next_rows);
-        resulting.sort_by(|a, b| a.sort_key(1).cmp(&b.sort_key(1)));
-
-        let read_rows = store.read_rows(next_file).unwrap();
-        assert_eq!(read_rows.len(), resulting.len());
-        for ((read, expected), _) in read_rows.view().iter().zip(resulting.iter()).zip(0..) {
-            // println!("{}", i);
-            // println!("{:?} - {:?}", read, expected);
-
-            assert_eq!(&convert_row_to_heap_allocated(&read), expected);
-        }
+        let read_rows = concat_record_batches(&store.read_columns(file_name).unwrap());
+        assert_eq_columns!(&first_cols, read_rows.columns());
 
         // Split
+        let split_1 = NamedTempFile::new().unwrap();
+        let split_1 = split_1.path().to_str().unwrap();
 
-        let split_1 = "foo-3-1.parquet";
-        let split_2 = "foo-3-2.parquet";
-        let mut next_rows = (100..150)
-            .map(|i| {
-                Row::new(vec![
-                    TableValue::Int(i),
-                    TableValue::String(format!("Foo {}", i)),
-                    TableValue::String(format!("Boo {}", i)),
-                    TableValue::Boolean(false),
-                    TableValue::Decimal(Decimal::new(i * 10000)),
-                ])
-            })
-            .collect::<Vec<_>>();
-        next_rows.sort_by(|a, b| a.sort_key(1).cmp(&b.sort_key(1)));
-        let min_max = store
-            .merge_rows_from_heap(
-                Some(next_file),
-                vec![split_1.to_string(), split_2.to_string()],
-                next_rows.clone(),
-                3,
-            )
-            .unwrap();
+        let split_2 = NamedTempFile::new().unwrap();
+        let split_2 = split_2.path().to_str().unwrap();
 
-        resulting.append(&mut next_rows);
-        resulting.sort_by(|a, b| a.sort_key(1).cmp(&b.sort_key(1)));
-
-        let read_rows_1 = store.read_rows(split_1).unwrap();
-        let read_rows_2 = store.read_rows(split_2).unwrap();
-        assert_eq!(read_rows_1.len() + read_rows_2.len(), resulting.len());
-        let read_rows = read_rows_1
-            .view()
-            .iter()
-            .chain(read_rows_2.view().iter())
-            .map(|r| convert_row_to_heap_allocated(r))
-            .collect_vec();
-        for (read, expected) in read_rows.iter().zip(resulting.iter()) {
-            // println!("{}", i);
-            // println!("{:?} - {:?}", read, right);
-            assert_eq!(read, expected);
+        let mut to_split = first_rows;
+        for i in 40..150 {
+            to_split.push(Row::new(vec![
+                TableValue::Int(i),
+                TableValue::String(format!("Foo {}", i)),
+                TableValue::String(format!("Boo {}", i)),
+                TableValue::Boolean(false),
+                TableValue::Decimal(Decimal::new(i * 10000)),
+            ]));
         }
+        to_split.sort_by(|a, b| a.sort_key(3).cmp(&b.sort_key(3)));
+
+        let to_split_cols = rows_to_columns(&store.table.columns(), &to_split);
+        let schema = Arc::new(arrow_schema(&store.table));
+        let to_split_batch = RecordBatch::try_new(schema.clone(), to_split_cols.clone()).unwrap();
+        let count_min = compaction::write_to_files(
+            to_stream(to_split_batch).await,
+            to_split.len(),
+            ParquetTableStore::new(store.table.clone(), store.row_group_size),
+            vec![split_1.to_string(), split_2.to_string()],
+        )
+        .await
+        .unwrap();
+
+        let read_1 = concat_record_batches(&store.read_columns(split_1).unwrap());
+        let read_2 = concat_record_batches(&store.read_columns(split_2).unwrap());
+        assert_eq!(read_1.num_rows() + read_2.num_rows(), to_split.len());
+        let read = concat_record_batches(&[read_1, read_2]);
+
+        assert_eq_columns!(read.columns(), &to_split_cols);
 
         assert_eq!(
-            min_max,
+            count_min,
             vec![
                 (
                     75,
-                    (
-                        Row::new(vec![
-                            TableValue::Null,
-                            TableValue::String(format!("Foo {}", 0)),
-                            TableValue::Null,
-                        ]),
-                        Row::new(vec![
-                            TableValue::Int(74),
-                            TableValue::String(format!("Foo {}", 74)),
-                            TableValue::String(format!("Boo {}", 74)),
-                        ])
-                    )
+                    vec![
+                        TableValue::Null,
+                        TableValue::String(format!("Foo {}", 0)),
+                        TableValue::Null,
+                    ]
                 ),
                 (
                     75,
-                    (
-                        Row::new(vec![
-                            TableValue::Int(75),
-                            TableValue::String(format!("Foo {}", 75)),
-                            TableValue::String(format!("Boo {}", 75)),
-                        ]),
-                        Row::new(vec![
-                            TableValue::Int(149),
-                            TableValue::String(format!("Foo {}", 149)),
-                            TableValue::String(format!("Boo {}", 149)),
-                        ])
-                    )
+                    vec![
+                        TableValue::Int(75),
+                        TableValue::String(format!("Foo {}", 75)),
+                        TableValue::String(format!("Boo {}", 75)),
+                    ]
                 )
             ]
         );
-
-        fs::remove_file(file_name).unwrap();
-        fs::remove_file(next_file).unwrap();
-        fs::remove_file(split_1).unwrap();
-        fs::remove_file(split_2).unwrap();
     }
 
     #[test]
     fn failed_rle_run_bools() {
-        const NUM_ROWS: usize = 16384;
+        const NUM_ROWS: usize = ROW_GROUP_SIZE;
 
-        let check_bools = |bools: &[TableValueR]| {
+        let check_bools = |bools: Vec<bool>| {
             let index = Index::try_new(
                 "test".to_string(),
                 0,
@@ -1148,32 +214,35 @@ mod tests {
             )
             .unwrap();
             let tmp_file = NamedTempFile::new().unwrap();
-            let mut w = RowParquetWriter::open(&index, tmp_file.path().to_str().unwrap(), NUM_ROWS)
+            let store = ParquetTableStore::new(index.clone(), NUM_ROWS);
+            store
+                .write_data(
+                    tmp_file.path().to_str().unwrap(),
+                    vec![Arc::new(BooleanArray::from(bools))],
+                )
                 .unwrap();
-            w.write_rows(RowsView::new(&bools, 1)).unwrap();
-            w.close().unwrap()
         };
 
         // Maximize the data to write with RLE encoding.
         // First, in bit-packed encoding.
         let mut bools = Vec::with_capacity(NUM_ROWS);
         for _ in 0..NUM_ROWS / 2 {
-            bools.push(TableValueR::Boolean(true));
-            bools.push(TableValueR::Boolean(false));
+            bools.push(true);
+            bools.push(false);
         }
-        check_bools(&bools);
+        check_bools(bools);
 
         // Second, in RLE encoding.
         let mut bools = Vec::with_capacity(NUM_ROWS);
         for _ in 0..NUM_ROWS / 16 {
             for _ in 0..8 {
-                bools.push(TableValueR::Boolean(true));
+                bools.push(true);
             }
             for _ in 0..8 {
-                bools.push(TableValueR::Boolean(false));
+                bools.push(false);
             }
         }
-        check_bools(&bools);
+        check_bools(bools);
     }
 
     #[test]
@@ -1193,213 +262,17 @@ mod tests {
         let file = NamedTempFile::new().unwrap();
         let file = file.path().to_str().unwrap();
         let rows = vec![
-            TableValueR::Int(1),
-            TableValueR::Bytes(&[1, 2, 3]),
-            TableValueR::Int(2),
-            TableValueR::Bytes(&[5, 6, 7]),
+            Row::new(vec![TableValue::Int(1), TableValue::Bytes(vec![1, 2, 3])]),
+            Row::new(vec![TableValue::Int(2), TableValue::Bytes(vec![5, 6, 7])]),
         ];
 
-        let mut w = RowParquetWriter::open(&index, file, NUM_ROWS).unwrap();
-        w.write_rows(RowsView::new(&rows, 2)).unwrap();
-        w.close().unwrap();
+        let data = rows_to_columns(&index.columns(), &rows);
+
+        let w = ParquetTableStore::new(index.clone(), NUM_ROWS);
+        w.write_data(file, data.clone()).unwrap();
 
         let s = ParquetTableStore::new(index, NUM_ROWS);
-        let r = s.read_rows(file).unwrap();
-        assert_eq!(r.all_values(), rows);
-    }
-
-    #[bench]
-    fn filter_count(b: &mut Bencher) {
-        if let Ok((store, columns_to_read)) = prepare_donors() {
-            let mut reader =
-                RowParquetReader::open(&store.table, "Donors.parquet", Some(&columns_to_read))
-                    .unwrap();
-
-            b.iter(|| {
-                let start = SystemTime::now();
-                let mut counter = 0;
-                for row_group in 0..reader.parquet_reader.num_row_groups() {
-                    {
-                        let (_, index, _, _) = &reader.column_with_buffer[0];
-                        if let Some(Statistics::ByteArray(stats)) = reader
-                            .parquet_reader
-                            .get_row_group(row_group)
-                            .unwrap()
-                            .metadata()
-                            .column(*index)
-                            .statistics()
-                        {
-                            let min = stats.min().as_utf8().unwrap();
-                            let max = stats.max().as_utf8().unwrap();
-                            println!("Min: {}, Max: {}", min, max);
-                            if !(min <= "San Francisco" && "San Francisco" <= max) {
-                                continue;
-                            }
-                        }
-                    }
-                    let values_read = reader.load_row_group(row_group).unwrap();
-                    let (_, _, accessor, _) = &reader.column_with_buffer[0];
-                    if let ColumnAccessor::Bytes(buffer) = accessor {
-                        for i in 0..values_read {
-                            if buffer[i].as_utf8().unwrap() == "San Francisco" {
-                                counter += 1;
-                            }
-                        }
-                    }
-                }
-                println!(
-                    "San Francisco count ({:?}): {}",
-                    start.elapsed().unwrap(),
-                    counter
-                );
-            });
-        }
-    }
-
-    /*
-    #[bench]
-    fn filter_count_using_scan(b: &mut Bencher) {
-        if let Ok((store, columns_to_read)) = prepare_donors() {
-            b.iter(|| {
-                let start = SystemTime::now();
-                let reader = store
-                    .scan_node(
-                        "Donors.parquet",
-                        &columns_to_read,
-                        Some(Arc::new(|group| {
-                            if let Some(Statistics::ByteArray(stats)) = group.column(0).statistics()
-                            {
-                                let min = stats.min().as_utf8().unwrap();
-                                let max = stats.max().as_utf8().unwrap();
-                                println!("Min: {}, Max: {}", min, max);
-                                min <= "San Francisco" && "San Francisco" <= max
-                            } else {
-                                false
-                            }
-                        })),
-                    )
-                    .unwrap();
-                let filter_expr = binary(
-                    Arc::new(expressions::Column::new("Donor City")),
-                    Operator::Eq,
-                    Arc::new(Literal::new(ScalarValue::Utf8(Some(
-                        "San Francisco".to_string(),
-                    )))),
-                    reader.schema().as_ref(),
-                )
-                .unwrap();
-                let filter = Arc::new(FilterExec::try_new(filter_expr, reader).unwrap());
-                let aggregate = HashAggregateExec::try_new(
-                    AggregateMode::Partial,
-                    vec![],
-                    vec![Arc::new(Count::new(
-                        Arc::new(expressions::Column::new("Donor City")),
-                        "count".to_string(),
-                        DataType::UInt64,
-                    ))],
-                    filter,
-                )
-                .unwrap();
-                let batch = block_on(async {
-                    aggregate
-                        .execute(0)
-                        .await
-                        .unwrap()
-                        .next()
-                        .await
-                        .unwrap()
-                        .unwrap()
-                });
-                let result = batch
-                    .column(0)
-                    .as_any()
-                    .downcast_ref::<UInt64Array>()
-                    .unwrap();
-                println!(
-                    "San Francisco count ({:?}): {}",
-                    start.elapsed().unwrap(),
-                    result.value(0)
-                );
-            });
-        }
-    }
-     */
-
-    fn prepare_donors() -> Result<(ParquetTableStore, Vec<Column>), io::Error> {
-        let store = ParquetTableStore {
-            table: Index::try_new(
-                "donors".to_string(),
-                1,
-                vec![
-                    Column::new("Donor City".to_string(), ColumnType::String, 0),
-                    Column::new("Donor ID".to_string(), ColumnType::String, 1),
-                    Column::new("Donor State".to_string(), ColumnType::String, 2),
-                    Column::new("Donor Is Teacher".to_string(), ColumnType::String, 3),
-                    Column::new("Donor Zip".to_string(), ColumnType::String, 4),
-                ],
-                6,
-            )
-            .unwrap(),
-            row_group_size: 16384,
-        };
-
-        let column_mapping = vec![1, 0, 2, 3, 4];
-
-        let donors = File::open("Donors.csv")?;
-        let mut rdr = ReaderBuilder::new().from_reader(BufReader::new(donors));
-
-        let mut index = 0;
-        let mut to_merge = Vec::new();
-        let column_count = store.table.get_columns().len();
-        let mut current_file = None;
-
-        if fs::metadata("Donors.parquet").is_err() {
-            for record in rdr.records() {
-                let r = record.unwrap();
-                let mut values = Vec::with_capacity(column_count);
-                for c in store.table.get_columns() {
-                    values.push(TableValue::String(
-                        r[column_mapping[c.get_index()]].to_string(),
-                    ));
-                }
-                to_merge.push(Row::new(values));
-                index += 1;
-                if index % 500000 == 0 {
-                    current_file =
-                        merge_for_bench(&store, &mut index, &mut to_merge, &current_file);
-                }
-            }
-
-            merge_for_bench(&store, &mut index, &mut to_merge, &current_file);
-        }
-
-        let columns_to_read = vec![store.table.get_columns()[0].clone()];
-        Ok((store, columns_to_read))
-    }
-
-    fn merge_for_bench(
-        store: &ParquetTableStore,
-        index: &mut i32,
-        mut to_merge: &mut Vec<Row>,
-        current_file: &Option<String>,
-    ) -> Option<String> {
-        println!("Merging {}", index);
-        let dest_file = current_file
-            .as_ref()
-            .map(|f| format!("{}.new", f))
-            .unwrap_or("Donors.parquet".to_string());
-        let mut tmp = Vec::new();
-        swap(&mut tmp, &mut to_merge);
-        tmp.sort_by(|a, b| a.sort_key(2).cmp(&b.sort_key(2)));
-        store
-            .merge_rows_from_heap(
-                current_file.as_ref().map(|s| s.as_str()),
-                vec![dest_file],
-                tmp,
-                2,
-            )
-            .unwrap();
-        fs::rename("Donors.parquet.new", "Donors.parquet").unwrap();
-        Some("Donors.parquet".to_string())
+        let r = concat_record_batches(&s.read_columns(file).unwrap());
+        assert_eq_columns!(r.columns(), &data);
     }
 }

--- a/rust/cubestore/src/table/redistribute.rs
+++ b/rust/cubestore/src/table/redistribute.rs
@@ -1,0 +1,125 @@
+use crate::table::data::concat_record_batches;
+use crate::CubeError;
+use arrow::record_batch::RecordBatch;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::StreamExt;
+use itertools::Itertools;
+use std::future::Future;
+
+/// Redistributes outputs of [s] in chunks of [output_batch_size] rows. [process] can return a batch
+/// to prepend into the next chunk. This is useful if chunks occasionally need to be cut in pieces
+/// of different sizes.
+pub async fn redistribute<F>(
+    s: SendableRecordBatchStream,
+    output_batch_size: usize,
+    mut process: impl FnMut(RecordBatch) -> F,
+) -> Result<(), CubeError>
+where
+    F: Future<Output = Result<Option<RecordBatch>, CubeError>>,
+{
+    let mut s = s.fuse();
+    let mut buf = BatchBuffer::new(output_batch_size);
+    loop {
+        while !buf.has_group() {
+            match s.next().await.transpose()? {
+                None => {
+                    if let Some(b) = buf.take_rest() {
+                        if let Some(b) = process(b).await? {
+                            buf.prepend(b);
+                            continue;
+                        }
+                    }
+                    return Ok(());
+                }
+                Some(b) => buf.append(b),
+            }
+        }
+
+        if let Some(b) = process(buf.take_group()).await? {
+            buf.prepend(b)
+        }
+    }
+}
+
+struct BatchBuffer {
+    pending: Vec<RecordBatch>,
+    num_pending_rows: usize,
+    rows_per_group: usize,
+}
+
+impl BatchBuffer {
+    pub fn new(rows_per_group: usize) -> BatchBuffer {
+        assert!(0 < rows_per_group);
+        BatchBuffer {
+            pending: Vec::new(),
+            num_pending_rows: 0,
+            rows_per_group,
+        }
+    }
+
+    pub fn append(&mut self, r: RecordBatch) {
+        self.num_pending_rows += r.num_rows();
+        self.pending.push(r);
+    }
+
+    pub fn prepend(&mut self, r: RecordBatch) {
+        self.num_pending_rows += r.num_rows();
+        self.pending.insert(0, r);
+    }
+
+    pub fn has_group(&self) -> bool {
+        self.rows_per_group <= self.num_pending_rows
+    }
+
+    pub fn take_group(&mut self) -> RecordBatch {
+        assert!(self.has_group());
+
+        // Take enough batches.
+        let mut last_batch_i = 0;
+        let mut num_rows = self.pending[0].num_rows();
+        while num_rows < self.rows_per_group {
+            last_batch_i += 1;
+            num_rows += self.pending[last_batch_i].num_rows();
+        }
+
+        // Last batch might have extra rows.
+        let last_batch = &self.pending[last_batch_i];
+        let last_batch_rows = last_batch.num_rows();
+        let extra_rows = num_rows - self.rows_per_group;
+        let extra_batch = last_batch.slice(last_batch_rows - extra_rows, extra_rows);
+
+        // Update the state of our buffer.
+        let mut batches;
+        if extra_rows == 0 {
+            batches = self.pending.drain(0..=last_batch_i).collect_vec();
+        } else {
+            batches = self
+                .pending
+                .splice(0..=last_batch_i, [extra_batch])
+                .collect_vec();
+        }
+        self.num_pending_rows -= self.rows_per_group;
+
+        // The last batch still has some extra rows.
+        *batches.last_mut().unwrap() = batches
+            .last()
+            .unwrap()
+            .slice(0, last_batch_rows - extra_rows);
+
+        let r = concat_record_batches(&batches);
+        debug_assert_eq!(r.num_rows(), self.rows_per_group);
+        r
+    }
+
+    pub fn take_rest(&mut self) -> Option<RecordBatch> {
+        if self.num_pending_rows == 0 {
+            return None;
+        }
+        let r = Some(concat_record_batches(&self.pending));
+
+        self.pending.clear();
+        self.num_pending_rows = 0;
+
+        r
+    }
+}


### PR DESCRIPTION
To remove an extra implementation of parquet reads, parquet writes and
an extra merge operation. This also lends the arena-based data
primitives obsolete as column-based storage should also be reasonably
efficient.

This commit also removes `WALStore` and the corresponding code.
It was not used anywhere and used rewritten primitives.