### PR TITLE
examples(helm-charts): Fix standalone cubejs chart and add ingressClassName support

### DIFF
--- a/examples/helm-charts/cubejs/Chart.yaml
+++ b/examples/helm-charts/cubejs/Chart.yaml
@@ -3,7 +3,7 @@ name: cubejs
 description: A Helm chart for Cubejs
 type: application
 version: 0.1.0
-appVersion: "0.28.32"
+appVersion: "0.28.39"
 keywords:
   - cubejs
 maintainers:

--- a/examples/helm-charts/cubejs/README.md
+++ b/examples/helm-charts/cubejs/README.md
@@ -179,7 +179,7 @@ cubestore:
 | `config.devMode`                   | If true, enables development mode                                                                                               | `false` |
 | `config.debug`                     | If true, enables debug logging                                                                                                  | `false` |
 | `config.logLevel`                  | The logging level for Cube.js                                                                                                   | `warn`  |
-| `config.externalDefault`           | If true, uses Cube Store or an external database for storing Pre-aggregations                                                                           | `true`  |
+| `config.externalDefault`           | If true, uses Cube Store or an external database for storing Pre-aggregations                                                   | `true`  |
 | `config.telemetry`                 | If true, then send telemetry to CubeJS                                                                                          | `false` |
 | `config.apiSecret`                 | The secret key used to sign and verify JWTs. Generated on project scaffold                                                      |         |
 | `config.apiSecretFromSecret.name`  | The secret key used to sign and verify JWTs. Generated on project scaffold (using secret)                                       |         |
@@ -369,11 +369,12 @@ cubestore:
 
 ## Ingress parameters
 
-| Name                  | Description                                                                     | Value                    |
-| --------------------- | ------------------------------------------------------------------------------- | ------------------------ |
-| `ingress.enabled`     | Set to true to enable ingress record generation                                 | `false`                  |
-| `ingress.hostname`    | When the ingress is enabled, a host pointing to this will be created            | `cubejs.local`           |
-| `ingress.path`        | The Path to Cubejs                                                              | `/`                      |
-| `ingress.pathPrefix`  | The PathPrefix                                                                  | `ImplementationSpecific` |
-| `ingress.annotations` | Ingress annotations                                                             | `{}`                     |
-| `ingress.tls`         | Enable TLS configuration for the hostname defined at ingress.hostname parameter | `false`                  |
+| Name                       | Description                                                                     | Value                    |
+| -------------------------- | ------------------------------------------------------------------------------- | ------------------------ |
+| `ingress.enabled`          | Set to true to enable ingress record generation                                 | `false`                  |
+| `ingress.hostname`         | When the ingress is enabled, a host pointing to this will be created            | `cubejs.local`           |
+| `ingress.path`             | The Path to Cubejs                                                              | `/`                      |
+| `ingress.pathPrefix`       | The PathPrefix                                                                  | `ImplementationSpecific` |
+| `ingress.ingressClassName` | The Ingress class name                                                          |                          |
+| `ingress.annotations`      | Ingress annotations                                                             | `{}`                     |
+| `ingress.tls`              | Enable TLS configuration for the hostname defined at ingress.hostname parameter | `false`                  |

--- a/examples/helm-charts/cubejs/templates/_helpers.tpl
+++ b/examples/helm-charts/cubejs/templates/_helpers.tpl
@@ -75,3 +75,13 @@ Return "true" if the API pathType field is supported
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return "true" if the API ingressClassName field is supported
+*/}}
+{{- define "cubejs.ingress.supportsIngressClassname" -}}
+{{- if semverCompare "<1.18-0" .Capabilities.KubeVersion.Version -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}

--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -61,7 +61,7 @@
 - name: CUBEJS_TOPIC_NAME
   value: {{ .Values.config.topicName | quote }}
 {{- end }}
-{{- if .Values.global.redis.enabled }}
+{{- if ((.Values.global).redis).enabled }}
 - name: CUBEJS_REDIS_URL
   value: {{ printf "redis://%s-redis-master:6379" .Release.Name }}
 - name: CUBEJS_REDIS_PASSWORD

--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -61,7 +61,7 @@
 - name: CUBEJS_TOPIC_NAME
   value: {{ .Values.config.topicName | quote }}
 {{- end }}
-{{/*
+{{- /*
 If global.redis.enabled = true,
 we set the default value for CUBEJS_REDIS_URL
 and CUBEJS_REDIS_PASSWORD to the default value
@@ -70,7 +70,7 @@ are not set explicitly.
 Otherwise, when global.redis.enabled = false,
 we require you to set the CUBEJS_REDIS_URL and
 CUBEJS_REDIS_PASSWORD.
-*/}}
+*/ -}}
 {{- if ((.Values.global).redis).enabled }}
 {{- if .Values.redis.url }}
 - name: CUBEJS_REDIS_URL
@@ -374,7 +374,7 @@ CUBEJS_REDIS_PASSWORD.
   value: {{ .Value.database.ssl.passPhrase | quote }}
 {{- end }}
 {{- end }}
-{{/*
+{{- /*
 If global.cubestore.enabled = true,
 we set the default value for cubestore.host
 and cubestore.port to the default value
@@ -383,7 +383,7 @@ are not set explicitly.
 Otherwise, when global.cubestore.enabled = false,
 we require you to set the cubestore.host and
 cubestore.port.
-*/}}
+*/ -}}
 {{- if ((.Values.global).cubestore).enabled }}
 {{- if .Values.cubestore.host }}
 - name: CUBEJS_CUBESTORE_HOST

--- a/examples/helm-charts/cubejs/templates/ingress.yaml
+++ b/examples/helm-charts/cubejs/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "cubejs.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}

--- a/examples/helm-charts/cubejs/values.yaml
+++ b/examples/helm-charts/cubejs/values.yaml
@@ -594,6 +594,10 @@ ingress:
   ##
   pathType: ImplementationSpecific
 
+  ## Ingress Class name
+  ##
+  ingressClassName:
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md


### PR DESCRIPTION
- Fix standalone cubejs chart
- Add ingressClassName to support k8s 1.22
- Update version to 0.28.39
