### PR TITLE
Feature/react chartjs drilldown support

### DIFF
--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -62,6 +62,7 @@
     "react-source-render": "4.0.0-1",
     "sql-formatter": "^3.1.0",
     "throttle-debounce": "^3.0.1",
+    "use-deep-compare": "^1.1.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/cubejs-playground/src/components/DrilldownModal/DrilldownModal.tsx
+++ b/packages/cubejs-playground/src/components/DrilldownModal/DrilldownModal.tsx
@@ -1,21 +1,16 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, useLayoutEffect } from 'react';
 import { Button, Col, Modal, Row, Spin } from 'antd';
 import { Query } from '@cubejs-client/core';
 import { useCubeQuery } from '@cubejs-client/react';
 import { FatalError } from '../../atoms';
 import { TableQueryRenderer } from './TableQueryRenderer';
 
-interface DrilldownModalProps {
-  query: Query;
-  onClose: () => void;
-}
-
 const modalStyle: CSSProperties = {
   top: 50,
   minWidth: 450,
 };
 
-export function DrilldownModal({ query, onClose }: DrilldownModalProps) {
+export function DrilldownModal({ query, onClose, pivotConfig }) {
   const [isOpen, setIsOpen] = React.useState(true);
   const { resultSet, isLoading, error } = useCubeQuery(query, {
     skip: !query,
@@ -48,7 +43,7 @@ export function DrilldownModal({ query, onClose }: DrilldownModalProps) {
         </Row>
       ) : null}
       {resultSet && !isLoading ? (
-        <TableQueryRenderer resultSet={resultSet} pivotConfig={{}} />
+        <TableQueryRenderer resultSet={resultSet} pivotConfig={pivotConfig} />
       ) : null}
     </Modal>
   );

--- a/packages/cubejs-playground/src/components/DrilldownModal/DrilldownModal.tsx
+++ b/packages/cubejs-playground/src/components/DrilldownModal/DrilldownModal.tsx
@@ -1,0 +1,55 @@
+import React, { CSSProperties } from 'react';
+import { Button, Col, Modal, Row, Spin } from 'antd';
+import { Query } from '@cubejs-client/core';
+import { useCubeQuery } from '@cubejs-client/react';
+import { FatalError } from '../../atoms';
+import { TableQueryRenderer } from './TableQueryRenderer';
+
+interface DrilldownModalProps {
+  query: Query;
+  onClose: () => void;
+}
+
+const modalStyle: CSSProperties = {
+  top: 50,
+  minWidth: 450,
+};
+
+export function DrilldownModal({ query, onClose }: DrilldownModalProps) {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const { resultSet, isLoading, error } = useCubeQuery(query, {
+    skip: !query,
+  });
+
+  const handleCancel = () => {
+    setIsOpen(false);
+    onClose();
+  };
+
+  return (
+    <Modal
+      style={modalStyle}
+      visible={isOpen}
+      onCancel={handleCancel}
+      width="auto"
+      footer={[
+        <Button key="close" onClick={handleCancel}>
+          Close
+        </Button>,
+      ]}
+      centered
+    >
+      {error ? <FatalError error={error} /> : null}
+      {isLoading && !error ? (
+        <Row justify="center">
+          <Col>
+            <Spin />
+          </Col>
+        </Row>
+      ) : null}
+      {resultSet && !isLoading ? (
+        <TableQueryRenderer resultSet={resultSet} pivotConfig={{}} />
+      ) : null}
+    </Modal>
+  );
+}

--- a/packages/cubejs-playground/src/components/DrilldownModal/TableQueryRenderer.tsx
+++ b/packages/cubejs-playground/src/components/DrilldownModal/TableQueryRenderer.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useDeepCompareMemo } from 'use-deep-compare';
+import { Table } from 'antd';
+
+const TABLE_PAGE_SIZE = 50;
+
+const formatTableData = (columns, data) => {
+  function flatten(columns = []) {
+    return columns.reduce<any>((memo, column: any) => {
+      if (column.children) {
+        return [...memo, ...flatten(column.children)];
+      }
+
+      return [...memo, column];
+    }, []);
+  }
+
+  const typeByIndex = flatten(columns).reduce((memo, column) => {
+    return { ...memo, [column.dataIndex]: column };
+  }, {});
+
+  function formatValue(value, { type, format }: any = {}) {
+    if (value == undefined) {
+      return value;
+    }
+
+    if (type === 'boolean') {
+      return Boolean(value).toString();
+    }
+
+    if (type === 'number' && format === 'percent') {
+      return [parseFloat(value).toFixed(2), '%'].join('');
+    }
+
+    return value.toString();
+  }
+
+  function format(row) {
+    return Object.fromEntries(
+      Object.entries(row).map(([dataIndex, value]) => {
+        return [dataIndex, formatValue(value, typeByIndex[dataIndex])];
+      })
+    );
+  }
+
+  return data.map(format);
+};
+
+export function TableQueryRenderer({ resultSet, pivotConfig }) {
+  const [tableColumns, dataSource] = useDeepCompareMemo(() => {
+    const columns = resultSet.tableColumns(pivotConfig);
+    return [
+      columns,
+      formatTableData(columns, resultSet.tablePivot(pivotConfig)),
+    ];
+  }, [resultSet, pivotConfig]);
+
+  return (
+    <Table
+      pagination={{ pageSize: TABLE_PAGE_SIZE }}
+      columns={tableColumns}
+      dataSource={dataSource}
+    />
+  );
+}

--- a/packages/cubejs-playground/src/components/PlaygroundQueryBuilder/QueryBuilderContainer.tsx
+++ b/packages/cubejs-playground/src/components/PlaygroundQueryBuilder/QueryBuilderContainer.tsx
@@ -1,5 +1,5 @@
 import { LockOutlined, ThunderboltOutlined } from '@ant-design/icons';
-import { CubeProvider } from '@cubejs-client/react';
+import { CubeContext, CubeProvider } from '@cubejs-client/react';
 import { Card, Space } from 'antd';
 import { useLayoutEffect } from 'react';
 import { useHistory } from 'react-router';
@@ -67,20 +67,26 @@ export function QueryBuilderContainer({
 
   return (
     <CubeProvider cubejsApi={cubejsApi}>
-      <RollupDesignerContext apiUrl={apiUrl!}>
-        <ChartRendererStateProvider>
-          <StyledCard bordered={false}>
-            <QueryTabsRenderer
-              apiUrl={apiUrl!}
-              token={currentToken!}
-              dashboardSource={props.dashboardSource}
-              securityContextToken={securityContextToken}
-              onTabChange={props.onTabChange}
-              onSecurityContextModalOpen={() => setIsModalOpen(true)}
-            />
-          </StyledCard>
-        </ChartRendererStateProvider>
-      </RollupDesignerContext>
+      <CubeContext.Consumer>
+        {({ cubejsApi }) =>
+          cubejsApi ? (
+            <RollupDesignerContext apiUrl={apiUrl!}>
+              <ChartRendererStateProvider>
+                <StyledCard bordered={false}>
+                  <QueryTabsRenderer
+                    apiUrl={apiUrl!}
+                    token={currentToken!}
+                    dashboardSource={props.dashboardSource}
+                    securityContextToken={securityContextToken}
+                    onTabChange={props.onTabChange}
+                    onSecurityContextModalOpen={() => setIsModalOpen(true)}
+                  />
+                </StyledCard>
+              </ChartRendererStateProvider>
+            </RollupDesignerContext>
+          ) : null
+        }
+      </CubeContext.Consumer>
     </CubeProvider>
   );
 }

--- a/packages/cubejs-playground/src/components/QueryTabs/QueryTabs.tsx
+++ b/packages/cubejs-playground/src/components/QueryTabs/QueryTabs.tsx
@@ -1,7 +1,7 @@
-import { ChartType, Query } from '@cubejs-client/core';
+import { ChartType, PivotConfig, Query } from '@cubejs-client/core';
 import { Tabs } from 'antd';
 import equals from 'fast-deep-equal';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useLayoutEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { event } from '../../events';
@@ -73,7 +73,10 @@ export function QueryTabs({
     ],
   });
 
-  const [drilldownQuery, setDrilldownQuery] = useState<Query | null>(null);
+  const [drilldownConfig, setDrilldownConfig] = useState<{
+    query?: Query | null;
+    pivotConfig?: PivotConfig | null;
+  }>({});
 
   useEffect(() => {
     window['__cubejsPlayground'] = {
@@ -156,7 +159,12 @@ export function QueryTabs({
             setSlowQuery(queryId, isQuerySlow);
             isQuerySlow && setSlowQueryFromCache(queryId, false);
           },
-          onQueryDrilldown: (ddQuery) => setDrilldownQuery(ddQuery),
+          onQueryDrilldown: (query, pivotConfig) => {
+            setDrilldownConfig({
+              query,
+              pivotConfig,
+            });
+          },
         };
       },
     };
@@ -227,7 +235,7 @@ export function QueryTabs({
   function handleDrilldownModalClose() {
     const MODAL_ANIMATION_TIME = 300; // ms
     setTimeout(() => {
-      setDrilldownQuery(null);
+      setDrilldownConfig({});
     }, MODAL_ANIMATION_TIME);
   }
 
@@ -283,9 +291,10 @@ export function QueryTabs({
           closable={tabs.length > 1}
         >
           {children(tab, handleTabSave)}
-          {drilldownQuery ? (
+          {drilldownConfig.query ? (
             <DrilldownModal
-              query={drilldownQuery}
+              query={drilldownConfig.query}
+              pivotConfig={drilldownConfig.pivotConfig}
               onClose={handleDrilldownModalClose}
             />
           ) : null}

--- a/packages/cubejs-playground/src/components/QueryTabs/QueryTabs.tsx
+++ b/packages/cubejs-playground/src/components/QueryTabs/QueryTabs.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { event } from '../../events';
 import { useLocalStorage } from '../../hooks';
 import { QueryLoadResult } from '../ChartRenderer/ChartRenderer';
+import { DrilldownModal } from '../DrilldownModal/DrilldownModal';
 import { useChartRendererStateMethods } from './ChartRendererStateProvider';
 
 const { TabPane } = Tabs;
@@ -71,6 +72,8 @@ export function QueryTabs({
       },
     ],
   });
+
+  const [drilldownQuery, setDrilldownQuery] = useState<Query | null>(null);
 
   useEffect(() => {
     window['__cubejsPlayground'] = {
@@ -153,6 +156,7 @@ export function QueryTabs({
             setSlowQuery(queryId, isQuerySlow);
             isQuerySlow && setSlowQueryFromCache(queryId, false);
           },
+          onQueryDrilldown: (ddQuery) => setDrilldownQuery(ddQuery),
         };
       },
     };
@@ -220,6 +224,13 @@ export function QueryTabs({
     saveTabs({ activeId, tabs });
   }
 
+  function handleDrilldownModalClose() {
+    const MODAL_ANIMATION_TIME = 300; // ms
+    setTimeout(() => {
+      setDrilldownQuery(null);
+    }, MODAL_ANIMATION_TIME);
+  }
+
   if (!ready || !queryTabs.activeId) {
     return null;
   }
@@ -272,6 +283,12 @@ export function QueryTabs({
           closable={tabs.length > 1}
         >
           {children(tab, handleTabSave)}
+          {drilldownQuery ? (
+            <DrilldownModal
+              query={drilldownQuery}
+              onClose={handleDrilldownModalClose}
+            />
+          ) : null}
         </TabPane>
       ))}
     </StyledTabs>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,7 +1106,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@azure/core-auth@^1.1.4":
+"@azure/core-auth@1.2.0", "@azure/core-auth@^1.1.4":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.2.0.tgz#a5a181164e99f8446a3ccf9039345ddc9bb63bb9"
   integrity sha512-KUl+Nwn/Sm6Lw5d3U90m1jZfNSL087SPcqHLxwn2T6PupNKmcgsEbDjHB25gDvHO4h7pBsTlrdJAY7dz+Qk8GA==
@@ -5539,7 +5539,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
+"@types/ramda@0.27.40", "@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
   version "0.27.40"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.40.tgz#99f307356fe553095ee4d3c2af2b0eb3af7a8413"
   integrity sha512-V99ZfTH2tqVYdLDAlgh2uT+N074HPgqnAsMjALKSBqogYd0HbuuGMqNukJ6fk9Ml/Htaus76fsc4Yh3p7q1VdQ==
@@ -10737,6 +10737,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+dequal@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-1.0.0.tgz#41c6065e70de738541c82cdbedea5292277a017e"
+  integrity sha512-/Nd1EQbQbI9UbSHrMiKZjFLrXSnU328iQdZKPQf78XQI6C+gutkFUeoHpG5J08Ioa6HeRbRNFpSIclh1xyG0mw==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -21480,7 +21485,7 @@ rc-tree-select@~4.3.0:
     rc-tree "^4.0.0"
     rc-util "^5.0.5"
 
-rc-tree@^4.0.0, rc-tree@~4.1.0:
+rc-tree@4.1.5, rc-tree@^4.0.0, rc-tree@~4.1.0:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.1.5.tgz#734ab1bfe835e78791be41442ca0e571147ab6fa"
   integrity sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==
@@ -24620,7 +24625,7 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2, testcontainers@^7.9.0:
+testcontainers@7.12.1, testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2, testcontainers@^7.9.0:
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-7.12.1.tgz#8ca81eadf559ee2ab648d64623e350a13d681d09"
   integrity sha512-iqUBvEChe7+Z1Q4ChInx21g1vm/Q5mxFnu4B4Y8RgXdaOmLN4eNAbJj0ZbYtR70waFrqJQHBZrODLQzc4uYo5Q==
@@ -25484,6 +25489,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-deep-compare@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-deep-compare/-/use-deep-compare-1.1.0.tgz#85580dde751f68400bf6ef7e043c7f986595cef8"
+  integrity sha512-6yY3zmKNCJ1jjIivfZMZMReZjr8e6iC6Uqtp701jvWJ6ejC/usXD+JjmslZDPJQgX8P4B1Oi5XSLHkOLeYSJsA==
+  dependencies:
+    dequal "1.0.0"
 
 use-memo-one@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

There's no issue, I just needed this feature.

**Description of Changes Made (if issue reference is not provided)**

**This merge request must be merged together with [this merge request in cubejs-playground-templates](https://github.com/cube-js/cubejs-playground-templates/pull/8)**

After reading that merge request please continue the steps here:

1. The drill down query is received by `onQueryDrilldown` in `cubejs-playground/src/components/QueryTabs/QueryTabs.tsx`
2. The drill down query is saved in a state there and a modal is opened
3. The modal will fetch the drill down query and show it in a table.

# Notes
- I did not include the build of the new chart templates inside the merge request since it's uglified and can't be reviewed, however, they should be built after merging this and put inside cubejs-playground package public folder.

- I only supported react chartjs charts because I wanna see the feedback first, other libraries are going to be merged after the feedback.

- The scrollbar on the chart is not caused by me, pulling the latest master from [cubejs-playground-templates](https://github.com/cube-js/cubejs-playground-templates) and building it for the playground will cause the same bug without changing anything. I will fix it if I get any directions on what causes the problem and how to resolve it.

# Demo

https://user-images.githubusercontent.com/15963779/135304501-5bdea0bd-9901-4a51-8c4c-2036d3b2ca32.mp4




