### PR TITLE
fix(cubestore-driver): Use ILIKE for contains filter

### DIFF
--- a/packages/cubejs-cubestore-driver/src/CubeStoreQuery.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQuery.ts
@@ -14,7 +14,7 @@ const GRANULARITY_TO_INTERVAL: Record<string, string> = {
 
 class CubeStoreFilter extends BaseFilter {
   public likeIgnoreCase(column, not, param) {
-    return `${column}${not ? ' NOT' : ''} LIKE CONCAT('%', ${this.allocateParam(param)}, '%')`;
+    return `${column}${not ? ' NOT' : ''} ILIKE CONCAT('%', ${this.allocateParam(param)}, '%')`;
   }
 }
 


### PR DESCRIPTION
Hello!

Cube.js has a contains filter which is a case insensitive filter (https://cube.dev/docs/query-format/#contains). Starting from `v0.28.37` Cube Store started to support ILIKE operator (https://github.com/cube-js/cube.js/commit/6a3fe647fb5f93932521591b6a7c572b88758bfe) which is the correct way to handle the contains filter.


Thanks