### PR TITLE
fix(@cubejs-client/core): fix HTTP poll not working if Cube API stops and recovers

### DIFF
--- a/packages/cubejs-client-core/src/HttpTransport.js
+++ b/packages/cubejs-client-core/src/HttpTransport.js
@@ -40,9 +40,16 @@ class HttpTransport {
     });
 
     return {
+      /* eslint no-unsafe-finally: off */
       async subscribe(callback) {
-        const result = await runRequest();
-        return callback(result, () => this.subscribe(callback));
+        let result = {
+          error: 'network Error' // add default error message
+        };
+        try {
+          result = await runRequest();
+        } finally {
+          return callback(result, () => this.subscribe(callback));
+        }
       }
     };
   }


### PR DESCRIPTION
fix http  subscribe poll not working https://github.com/cube-js/cube.js/issues/3493
