### PR TITLE
fix(base-query): escape date_from and date_to in generated series SQL

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -821,7 +821,7 @@ export class BaseQuery {
     const values = timeDimension.timeSeries().map(
       ([from, to]) => `('${from}', '${to}')`
     );
-    return `SELECT ${this.dateTimeCast('date_from')}, ${this.dateTimeCast('date_to')} FROM (VALUES ${values}) ${this.asSyntaxTable} dates (date_from, date_to)`;
+    return `SELECT ${this.dateTimeCast('date_from')} as ${this.escapeColumnName('date_from')}, ${this.dateTimeCast('date_to')} as ${this.escapeColumnName('date_to')} FROM (VALUES ${values}) ${this.asSyntaxTable} dates (date_from, date_to)`;
   }
 
   /**


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

When running `rollingWindow` queries against Snowflake, the generated SQL doesn't compile properly.

<details><summary>Generated Series SQL Example</summary>

```sql
    SELECT
      date_from::TIMESTAMP,
      date_to::TIMESTAMP
    FROM
      (
        VALUES
          (
            '2021-09-13T00:00:00.000',
            '2021-09-19T23:59:59.999'
          ),
          (
            '2021-09-20T00:00:00.000',
            '2021-09-26T23:59:59.999'
          )
      ) AS dates (date_from, date_to)
```
</details>

The generated series SQL results in columns named `"DATE_FROM::TIMESTAMP"` and `"DATE_TO::TIMESTAMP"`. The references to these columns as `"date_from"` and `"date_to"` elsewhere causes compilation errors.

**Description of Changes Made (if issue reference is not provided)**

This just adds aliases into the generated series SQL so the column name is proper for other references:

<details><summary>Resulting Series SQL Example</summary>

```sql
    SELECT
      date_from::TIMESTAMP as "date_from",
      date_to::TIMESTAMP as "date_to"
    FROM
      (
        VALUES
          (
            '2021-09-13T00:00:00.000',
            '2021-09-19T23:59:59.999'
          ),
          (
            '2021-09-20T00:00:00.000',
            '2021-09-26T23:59:59.999'
          )
      ) AS dates (date_from, date_to)
```
</details>

This will allow references to work as intended.