### PR TITLE
docs(cloud): fix title of Getting Started pages

### DIFF
--- a/docs/content/Cube-Cloud/Getting-Started/Create-new.md
+++ b/docs/content/Cube-Cloud/Getting-Started/Create-new.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Cube Cloud - Upload with CLI
+title: "Getting Started with Cube Cloud: Create new project"
 permalink: /cloud/getting-started/create
 ---
 

--- a/docs/content/Cube-Cloud/Getting-Started/Upload-with-CLI.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Upload-with-CLI.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Cube Cloud - Upload with CLI
+title: "Getting Started with Cube Cloud: Upload with CLI"
 permalink: /cloud/getting-started/cli
 ---
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/cube-dev/story/1099