### PR TITLE
feat(gateway): Add GraphQL endpoint

### DIFF
--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -33,6 +33,7 @@
     "body-parser": "^1.19.0",
     "chrono-node": "^2.2.6",
     "express-graphql": "^0.12.0",
+    "graphql": "^15.3.0",
     "graphql-scalars": "^1.10.0",
     "jsonwebtoken": "^8.3.0",
     "jwk-to-pem": "^2.0.4",
@@ -60,9 +61,6 @@
     "should": "^13.2.3",
     "supertest": "^4.0.2",
     "typescript": "~4.1.5"
-  },
-  "peerDependencies": {
-    "graphql": "^14.7.0 || ^15.3.0"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -32,11 +32,15 @@
     "@hapi/joi": "^15.1.1",
     "body-parser": "^1.19.0",
     "chrono-node": "^2.2.6",
+    "express-graphql": "^0.12.0",
+    "graphql-scalars": "^1.10.0",
     "jsonwebtoken": "^8.3.0",
     "jwk-to-pem": "^2.0.4",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
     "node-fetch": "^2.6.1",
+    "nexus": "^1.1.0",
+    "querystring": "^0.2.1",
     "ramda": "^0.27.0",
     "uuid": "^8.3.2"
   },
@@ -56,6 +60,9 @@
     "should": "^13.2.3",
     "supertest": "^4.0.2",
     "typescript": "~4.1.5"
+  },
+  "peerDependencies": {
+    "graphql": "^14.7.0 || ^15.3.0"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -283,19 +283,23 @@ export class ApiGateway {
     const guestMiddlewares = [];
 
     app.use(`${this.basePath}/graphql`, userMiddlewares, (() => {
-      let schema; // memoized schema
+      let cache;
       return (async (req, res) => {
-        if (!schema) {
+        if (!cache) {
           const metaConfig = await this.getCompilerApi(req.context).metaConfig({
             requestId: req.context.requestId,
           });
-          schema = makeSchema(metaConfig);
+          cache = {
+            metaConfig,
+            schema: makeSchema(metaConfig)
+          };
         }
 
         return graphqlHTTP({
-          schema,
+          schema: cache.schema,
           context: {
             req,
+            metaConfig: cache.metaConfig,
             apiGateway: this
           },
           graphiql: getEnv('nodeEnv') !== 'production'

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -296,7 +296,7 @@ export class ApiGateway {
           schema,
           context: {
             req,
-            endpoint: `http://localhost:${getEnv('port')}${this.basePath}/v1/load`
+            apiGateway: this
           },
           graphiql: getEnv('nodeEnv') !== 'production'
         })(req, res);

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -301,7 +301,7 @@ export function makeSchema(metaConfig: any) {
       definition(t) {
         cube.config.measures.forEach(measure => {
           if (measure.isVisible) {
-            t.field(safeName(measure.name), {
+            t.nonNull.field(safeName(measure.name), {
               type: mapType(measure.type),
               description: measure.description
             });
@@ -309,7 +309,7 @@ export function makeSchema(metaConfig: any) {
         });
         cube.config.dimensions.forEach(dimension => {
           if (dimension.isVisible) {
-            t.field(safeName(dimension.name), {
+            t.nonNull.field(safeName(dimension.name), {
               type: mapType(dimension.type),
               description: dimension.description
             });

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -496,10 +496,10 @@ export function makeSchema(metaConfig: any) {
             .reduce((res, pair) => {
               let path = pair[0].split('.');
               path[0] = unCapitalize(path[0]);
-              if (results.annotation.dimensions[pair[0]]?.type === "time") {
+              if (results.annotation.dimensions[pair[0]]?.type === 'time') {
                 path = [...path, 'value'];
               }
-              return (results.annotation.timeDimensions[pair[0]] && path.length != 3)
+              return (results.annotation.timeDimensions[pair[0]] && path.length !== 3)
                 ? res : R.set(R.lensPath(path), pair[1], res);
             }, {}));
         }

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -1,0 +1,369 @@
+import R from 'ramda';
+import moment from 'moment-timezone';
+import fetch from 'node-fetch';
+import { encode } from 'querystring';
+
+import {
+  GraphQLResolveInfo,
+  ArgumentNode,
+  DirectiveNode,
+  FieldNode,
+  VariableNode,
+  StringValueNode
+} from 'graphql';
+
+import {
+  objectType,
+  enumType,
+  extendType,
+  list,
+  inputObjectType,
+  nullable,
+  nonNull,
+  arg,
+  intArg,
+  stringArg,
+  booleanArg,
+  makeSchema as nexusMakeSchema,
+  asNexusMethod
+} from 'nexus';
+
+import {
+  DateTimeResolver,
+  SafeIntResolver
+} from 'graphql-scalars';
+
+const DateTimeScalar = asNexusMethod(DateTimeResolver, 'date');
+const SafeIntScalar = asNexusMethod(SafeIntResolver, 'safeInt');
+
+const CubeFilterInput = inputObjectType({
+  name: 'CubeFilterInput',
+  definition(t) {
+    t.nonNull.string('member');
+    t.nonNull.field('operator', { type: 'CubeFilterOperator' });
+    t.field('values', { type: list(nullable('String')) });
+    t.field('or', { type: list(nonNull('CubeFilterInput')) });
+    t.field('and', { type: list(nonNull('CubeFilterInput')) });
+  }
+});
+
+const CubeFilterOperator = enumType({
+  name: 'CubeFilterOperator',
+  members: [
+    'equals',
+    'notEquals',
+    'contains',
+    'notContains',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'set',
+    'notSet',
+    'inDateRange',
+    'notInDateRange',
+    'beforeDate',
+    'afterDate'
+  ]
+});
+
+const CubeOrder = enumType({
+  name: 'CubeOrder',
+  members: [
+    'asc',
+    'desc'
+  ]
+});
+
+const CubeGranularity = enumType({
+  name: 'CubeGranularity',
+  members: [
+    'second',
+    'minute',
+    'day',
+    'week',
+    'month',
+    'year'
+  ]
+});
+
+function mapType(type: string) {
+  switch (type) {
+    case 'time':
+      return 'DateTime';
+    case 'string':
+      return 'String';
+    case 'number':
+      return 'SafeInt';
+    default:
+      return 'String';
+  }
+}
+
+function safeName(name: string) {
+  return name.split('.').slice(1).join('');
+}
+
+function unCapitalize(name: string) {
+  return `${name[0].toLowerCase()}${name.slice(1)}`;
+}
+
+function applyDirectives(
+  directives: readonly DirectiveNode[] | undefined,
+  values: Record<string, any>
+) {
+  if (directives === undefined || directives.length === 0) {
+    return true;
+  }
+
+  return directives.reduce((result, directive) => {
+    directive.arguments?.forEach((argument: ArgumentNode) => {
+      if (argument.name.value === 'if') {
+        if (
+          (directive.name.value === 'include' &&
+            !values[(argument.value as VariableNode).name.value]) ||
+          (directive.name.value === 'skip' &&
+            values[(argument.value as VariableNode).name.value])
+        ) {
+          result = false;
+        }
+      }
+    });
+    return result;
+  }, true);
+}
+
+function getFieldNodeChildren(node: FieldNode, infos: GraphQLResolveInfo) {
+  return node.selectionSet?.selections.filter((childNode) => (
+    childNode.kind === 'Field' &&
+    childNode.name.value !== '__typename' &&
+    applyDirectives(childNode.directives, infos.variableValues)
+  )) as FieldNode[];
+}
+
+function getFieldNodeByName(name: string, infos: GraphQLResolveInfo) {
+  return infos.fieldNodes[0].selectionSet?.selections.find(
+    (node) => node.kind === 'Field' &&
+      (node as FieldNode).name.value === name &&
+      applyDirectives(node.directives, infos.variableValues)
+  ) as FieldNode | undefined;
+}
+
+function getMeasures(infos: GraphQLResolveInfo) {
+  const fieldNode = getFieldNodeByName('measures', infos);
+  if (!fieldNode) return [];
+
+  return getFieldNodeChildren(fieldNode, infos)
+    .map(node => node.name.value) || [];
+}
+
+function getDimensions(infos: GraphQLResolveInfo) {
+  const fieldNode = getFieldNodeByName('dimensions', infos);
+  if (!fieldNode) return [];
+
+  return getFieldNodeChildren(fieldNode, infos)
+    .map(node => node.name.value) || [];
+}
+
+function getChildrenFieldsWithArg(name: string, argument: string, infos: GraphQLResolveInfo) {
+  const fieldNode = getFieldNodeByName(name, infos);
+  if (!fieldNode) return [];
+
+  return getFieldNodeChildren(fieldNode, infos)
+    .reduce((res, node) => {
+      const foundArg = node.arguments?.find(a => a.name.value === argument);
+      if (foundArg) {
+        return [...res, [node.name.value, (foundArg.value as StringValueNode).value]];
+      }
+      return res;
+    }, [] as string[][]);
+}
+
+function getFieldsWithArg(argument: string, infos: GraphQLResolveInfo) {
+  return [
+    ...getChildrenFieldsWithArg('measures', argument, infos),
+    ...getChildrenFieldsWithArg('dimensions', argument, infos),
+  ];
+}
+
+export async function proxifyQuery(
+  query: any,
+  endpoint: string,
+  originalReq: any,
+  delay = 500
+): Promise<any> {
+  const url = `${endpoint}?${encode({
+    query: JSON.stringify(query)
+  })}`;
+
+  const headers = { ...originalReq.headers } as Record<string, string>;
+  ['host', 'connexion', 'content-length'].forEach(key => delete headers[key]);
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers
+  });
+
+  if (!response.ok) {
+    if (response.headers.get('content-type')?.includes('application/json')) {
+      const json = await response.json();
+      if (json.error) {
+        throw Error(`Error querying load api: ${json.error}`);
+      }
+    }
+    throw Error(`Error querying load api: status ${response.status}`);
+  }
+
+  const json = await response.json();
+
+  if (json.error === 'Continue wait') {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return proxifyQuery(query, endpoint, originalReq, delay * 1.2);
+  }
+
+  return json;
+}
+
+function parseDates(result: any) {
+  const { timezone } = result.query;
+
+  const dateKeys = Object.entries<any>({
+    ...result.annotation.measures,
+    ...result.annotation.dimensions,
+    ...result.annotation.timeDimensions,
+  }).reduce((res, [key, value]) => (value.type === 'time' ? [...res, key] : res), [] as any);
+
+  result.data.forEach(row => {
+    Object.keys(row).forEach(key => {
+      if (dateKeys.includes(key)) {
+        row[key] = moment.tz(row[key], timezone).toISOString();
+      }
+      return row;
+    });
+  });
+}
+
+export function makeSchema(metaConfig: any) {
+  const types: any[] = [
+    DateTimeScalar,
+    SafeIntScalar,
+    CubeFilterInput,
+    CubeFilterOperator,
+    CubeOrder,
+    CubeGranularity
+  ];
+
+  metaConfig.forEach(cube => {
+    types.push(objectType({
+      name: `${cube.config.name}Measures`,
+      description: `${cube.config.title} measures`,
+      definition(t) {
+        cube.config.measures.forEach(measure => {
+          if (measure.isVisible) {
+            t.field(safeName(measure.name), {
+              type: mapType(measure.type),
+              args: { order: arg({ type: 'CubeOrder' }) }
+            });
+          }
+        });
+      }
+    }));
+
+    types.push(objectType({
+      name: `${cube.config.name}Dimensions`,
+      description: `${cube.config.title} dimensions`,
+      definition(t) {
+        cube.config.dimensions.forEach(dimension => {
+          if (dimension.isVisible) {
+            t.field(safeName(dimension.name), {
+              type: mapType(dimension.type),
+              args: {
+                order: arg({ type: 'CubeOrder' }),
+                ...(dimension.type === 'time' && {
+                  granularity: arg({ type: 'CubeGranularity' })
+                })
+              }
+            });
+          }
+        });
+      }
+    }));
+
+    types.push(objectType({
+      name: cube.config.name,
+      description: cube.config.description,
+      definition(t) {
+        t.nonNull.field('measures', {
+          type: `${cube.config.name}Measures`,
+          resolve: (source) => source
+        });
+        t.nonNull.field('dimensions', {
+          type: `${cube.config.name}Dimensions`,
+          resolve: (source) => source
+        });
+      }
+    }));
+
+    types.push(extendType({
+      type: 'Query',
+      definition(t) {
+        t.nonNull.field(unCapitalize(cube.config.name), {
+          type: list(nonNull(cube.config.name)),
+          args: {
+            filters: arg({
+              type: list(nonNull('CubeFilterInput'))
+            }),
+            limit: intArg(),
+            offset: intArg(),
+            timezone: stringArg(),
+            renewQuery: booleanArg(),
+          },
+          resolve: async (parent, { filters, limit, offset, timezone, renewQuery }, context, infos) => {
+            const measures = getMeasures(infos);
+            const dimensions = getDimensions(infos);
+            const timeDimensions = getFieldsWithArg('granularity', infos);
+            const orders = getFieldsWithArg('orders', infos);
+
+            if (timeDimensions.length > 1) {
+              throw new Error('You must set only one dimension with granularity');
+            }
+
+            const query = {
+              ...(measures.length && {
+                measures: measures.map(measure => `${cube.config.name}.${measure}`)
+              }),
+              ...(dimensions.length && {
+                dimensions: dimensions
+                  .filter(dimension => timeDimensions[0][0] !== dimension)
+                  .map(dimension => `${cube.config.name}.${dimension}`)
+              }),
+              ...(timeDimensions.length && {
+                timeDimensions: timeDimensions.map(timeDimension => ({
+                  dimension: `${cube.config.name}.${timeDimension[0]}`,
+                  granularity: timeDimension[1]
+                })),
+              }),
+              ...(filters && {
+                filters: filters.map(filter => ({ ...filter, member: `${cube.config.name}.${filter.member}` }))
+              }),
+              ...(limit && { limit }),
+              ...(offset && { offset }),
+              ...(orders.length && {
+                order: R.fromPairs(orders.map(order => [`${cube.config.name}.${order[0]}`, order[1]]))
+              }),
+              ...(timezone && { timezone }),
+              ...(renewQuery && { renewQuery }),
+            };
+
+            const results = await proxifyQuery(query, context.endpoint, context.req);
+            parseDates(results);
+
+            return results.data.map(entry => R.fromPairs(R.toPairs(entry).map(pair => [pair[0].split('.').slice(1).join('.'), pair[1]])));
+          }
+        });
+      }
+    }));
+  });
+
+  return nexusMakeSchema({ types });
+}

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -80,6 +80,7 @@ const CubeGranularity = enumType({
   members: [
     'second',
     'minute',
+    'hour',
     'day',
     'week',
     'month',

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -407,7 +407,7 @@ export function makeSchema(metaConfig: any) {
           timezone: stringArg(),
           renewQuery: booleanArg(),
         },
-        resolve: async (parent, { where, limit, offset, timezone, renewQuery }, context, infos) => {
+        resolve: async (parent, { where, limit, offset, timezone, renewQuery }, { req, apiGateway }, infos) => {
           const measures: string[] = [];
           const dimensions: string[] = [];
           const timeDimensions: any[] = [];
@@ -434,7 +434,7 @@ export function makeSchema(metaConfig: any) {
 
             getFieldNodeChildren(cubeNode, infos).forEach(memberNode => {
               const memberName = memberNode.name.value;
-              const memberType = getMemberType(context.metaConfig, cubeName, memberName);
+              const memberType = getMemberType(metaConfig, cubeName, memberName);
 
               if (memberType === 'measure') {
                 measures.push(`${cubeName}.${memberName}`);
@@ -474,10 +474,10 @@ export function makeSchema(metaConfig: any) {
           // eslint-disable-next-line no-async-promise-executor
           const results = await (new Promise<any>(async (resolve, reject) => {
             try {
-              await context.apiGateway.load({
+              await apiGateway.load({
                 query,
                 queryType: QUERY_TYPE.REGULAR_QUERY,
-                context: context.req.context,
+                context: req.context,
                 res: (message) => {
                   if (message.error) {
                     reject(new Error(message.error));

--- a/packages/cubejs-server-core/src/core/CompilerApi.js
+++ b/packages/cubejs-server-core/src/core/CompilerApi.js
@@ -17,6 +17,14 @@ export class CompilerApi {
     this.sqlCache = options.sqlCache;
   }
 
+  setGraphQLSchema(schema) {
+    this.graphqlSchema = schema;
+  }
+
+  getGraphQLSchema() {
+    return this.graphqlSchema;
+  }
+
   async getCompilers({ requestId } = {}) {
     let compilerVersion = (
       this.schemaVersion && await this.schemaVersion() ||


### PR DESCRIPTION
This PR is an implementation of the GraphQL spec described in issue #3433

I think i covered all the main functionalities of the REST API.

## Description

A new endpoint `/cubejs-api/graphql` is added in the gateway.
All security middlewares (checkAuth, queryRewrite, etc.) are still used.

In dev mode, graphiql UI is available.

## How it works
- GraphQL schema is automatically generated using the compilerApi.
- GraphQL AST info are used to generate cubequery at root cube entity level
- Results are remapped to the graphql query shape

## Warning
Current implementation will raise an error for a `continueWait` response. Long polling is not implemented (and not possible with this API design).

## Example

original query:

```json
{
  "measures": ["Stories.count"],
  "dimensions": ["Stories.category"],
  "filters": [{
    "member": "Stories.isDraft",
    "operator": "equals",
    "values": ["No"]
  }],
  "timeDimensions": [{
    "dimension": "Stories.time",
    "dateRange": ["2015-01-01", "2015-12-31"],
    "granularity": "month"
  }],
  "limit": 100,
  "offset": 50,
  "order": {
    "Stories.time": "asc",
    "Stories.count": "desc"
  },
  "timezone": "America/Los_Angeles"
}
```

is equivalent to graphql query:
```graphql
{
  load(limit: 100, offset: 50, timezone: "America/Los_Angeles") {
    stories(granularity: {time: month}, orderBy: { time: asc, count: desc }, where: {isDraft: {equals: "NO"}, time: {inDateRange: ["2015-01-01", "2015-12-31"]}}) {
      count
      category
      time
    }
  }
}

```

directives `@skip` and `@include` are supported:

```graphql
query GetStories($byCategory: Boolean = false) {
  stories(granularity: { time: month }) {
      count
      category @include(if: $byCategory)
      time
  }
} 
```
