### PR TITLE
docs(getting-started): fix incorrect example and link in Getting Started with Node.js

### DIFF
--- a/docs/content/Getting-Started/Getting-Started-Nodejs.md
+++ b/docs/content/Getting-Started/Getting-Started-Nodejs.md
@@ -58,7 +58,9 @@ You can also add schema files to the `schema` folder manually:
 
 cube(`Users`, {
   measures: {
-    type: `count`,
+    count: {
+      type: `count`,
+    },
   },
 
   dimensions: {
@@ -355,6 +357,6 @@ For more information on deploying with the Serverless Framework, consult the
 [ref-dev-playground]: /dev-tools/dev-playground
 [ref-frontend-intro]: /frontend-introduction
 [ref-docker-deployment-guide]: /deployment/platforms/docker
-[ref-sls-aws-deployment-guide]: /deployment/serverless/aws
+[ref-sls-aws-deployment-guide]: /deployment/platforms/serverless/aws
 [ref-connecting-to-the-database]: /connecting-to-the-database
 [ref-cubejs-schema]: /schema/getting-started


### PR DESCRIPTION
Story details: https://app.shortcut.com/cube-dev/story/1103