### PR TITLE
docs: fix table cell overflow issue

### DIFF
--- a/docs/static/styles/_tables.scss
+++ b/docs/static/styles/_tables.scss
@@ -26,6 +26,7 @@ table code {
 
 :not(thead) > tr:nth-child(odd):last-child > td:last-child {
   border-radius: 0 0 4px 0;
+  overflow-wrap: break-word;
 }
 
 th, td {


### PR DESCRIPTION
Story details: https://app.shortcut.com/cube-dev/story/1104