### PR TITLE
fix(cubejs-client-ngx): correct all filters being replaced on FilterMember.replace

### DIFF
--- a/packages/cubejs-client-ngx/src/query-builder/query-members.ts
+++ b/packages/cubejs-client-ngx/src/query-builder/query-members.ts
@@ -277,7 +277,7 @@ export class FilterMember {
     this.query.setPartialQuery({
       filters: this.filters.map((filter) => {
         const field = filter.member ? 'member' : 'dimension';
-        return filter.member || filter.dimension === name
+        return filter.member === name || filter.dimension === name
           ? {
               ...filter,
               [field]: replaceWithName,


### PR DESCRIPTION
**Check List**
No test setup for package.  May do a new PR and add tests to this package if I get some time in next few weeks.

**Description of Changes Made (if issue reference is not provided)**
Updated the .replace method on FilterMember for the client-cubejs-ngx library.  The previous logic would update every single filter with the replaceWithName if the filter in question had a 'member' attribute; regardless of whether or not the member matched the item to replace.