### PR TITLE
fix(client-core): dayjs locale conflict

### DIFF
--- a/packages/cubejs-client-core/src/ResultSet.js
+++ b/packages/cubejs-client-core/src/ResultSet.js
@@ -12,12 +12,8 @@ import { aliasSeries } from './utils';
 dayjs.extend(quarterOfYear);
 
 // When granularity is week, weekStart Value must be 1. However, since the client can change it globally (https://day.js.org/docs/en/i18n/changing-locale)
-// So the proxy code below has been added.
-const internalDayjs = new Proxy(dayjs, {
-  apply(target, thisArg, argumentsList) {
-    return target(...argumentsList).locale({ ...en, weekStart: 1 });
-  }
-});
+// So the function below has been added.
+const internalDayjs = (...args) => dayjs(...args).locale({ ...en, weekStart: 1 });
 
 export const TIME_SERIES = {
   day: (range) => range.by('d').map(d => d.format('YYYY-MM-DDT00:00:00.000')),

--- a/packages/cubejs-client-core/src/ResultSet.js
+++ b/packages/cubejs-client-core/src/ResultSet.js
@@ -9,11 +9,15 @@ import {
 
 import { aliasSeries } from './utils';
 
-dayjs.locale({
-  ...en,
-  weekStart: 1,
-});
 dayjs.extend(quarterOfYear);
+
+// When granularity is week, weekStart Value must be 1. However, since the client can change it globally (https://day.js.org/docs/en/i18n/changing-locale)
+// So the proxy code below has been added.
+const internalDayjs = new Proxy(dayjs, {
+  apply(target, thisArg, argumentsList) {
+    return target(...argumentsList).locale({ ...en, weekStart: 1 });
+  }
+});
 
 export const TIME_SERIES = {
   day: (range) => range.by('d').map(d => d.format('YYYY-MM-DDT00:00:00.000')),
@@ -60,8 +64,8 @@ export const dayRange = (from, to) => ({
   by: (value) => {
     const results = [];
 
-    let start = dayjs(from);
-    const end = dayjs(to);
+    let start = internalDayjs(from);
+    const end = internalDayjs(to);
 
     while (start.isBefore(end) || start.isSame(end)) {
       results.push(start);
@@ -70,9 +74,9 @@ export const dayRange = (from, to) => ({
 
     return results;
   },
-  snapTo: (value) => dayRange(dayjs(from).startOf(value), dayjs(to).endOf(value)),
-  start: dayjs(from),
-  end: dayjs(to),
+  snapTo: (value) => dayRange(internalDayjs(from).startOf(value), internalDayjs(to).endOf(value)),
+  start: internalDayjs(from),
+  end: internalDayjs(to),
 });
 
 export const QUERY_TYPE = {
@@ -318,7 +322,7 @@ class ResultSet {
     if (!dateRange) {
       const member = ResultSet.timeDimensionMember(timeDimension);
       const dates = pipe(
-        map(row => row[member] && dayjs(row[member])),
+        map(row => row[member] && internalDayjs(row[member])),
         filter(Boolean)
       )(this.timeDimensionBackwardCompatibleData(resultIndex));
 

--- a/packages/cubejs-client-core/src/tests/granularity.test.js
+++ b/packages/cubejs-client-core/src/tests/granularity.test.js
@@ -1,10 +1,119 @@
 import 'jest';
-
+import dayjs from 'dayjs';
+import ko from 'dayjs/locale/ko';
 import ResultSet from '../ResultSet';
 
 describe('ResultSet Granularity', () => {
   describe('chartPivot', () => {
     test('week granularity', () => {
+      const result = new ResultSet({
+        queryType: 'regularQuery',
+        results: [
+          {
+            query: {
+              measures: ['LineItems.count'],
+              timeDimensions: [
+                {
+                  dimension: 'LineItems.createdAt',
+                  granularity: 'week',
+                  dateRange: ['2019-01-08T00:00:00.000', '2019-01-18T00:00:00.000'],
+                },
+              ],
+              filters: [
+                {
+                  operator: 'equals',
+                  values: ['us-ut'],
+                  member: 'Users.state',
+                },
+              ],
+              limit: 2,
+              rowLimit: 2,
+              timezone: 'UTC',
+              order: [],
+              dimensions: [],
+              queryType: 'regularQuery',
+            },
+            data: [
+              {
+                'LineItems.createdAt.week': '2019-01-07T00:00:00.000',
+                'LineItems.createdAt': '2019-01-07T00:00:00.000',
+                'LineItems.count': '2',
+              },
+            ],
+            lastRefreshTime: '2021-07-07T14:31:30.458Z',
+            annotation: {
+              measures: {
+                'LineItems.count': {
+                  title: 'Line Items Count',
+                  shortTitle: 'Count',
+                  type: 'number',
+                  drillMembers: ['LineItems.id', 'LineItems.createdAt'],
+                  drillMembersGrouped: {
+                    measures: [],
+                    dimensions: ['LineItems.id', 'LineItems.createdAt'],
+                  },
+                },
+              },
+              dimensions: {},
+              segments: {},
+              timeDimensions: {
+                'LineItems.createdAt.week': {
+                  title: 'Line Items Created at',
+                  shortTitle: 'Created at',
+                  type: 'time',
+                },
+                'LineItems.createdAt': {
+                  title: 'Line Items Created at',
+                  shortTitle: 'Created at',
+                  type: 'time',
+                },
+              },
+            },
+            slowQuery: false,
+          },
+        ],
+        pivotQuery: {
+          measures: ['LineItems.count'],
+          timeDimensions: [
+            {
+              dimension: 'LineItems.createdAt',
+              granularity: 'week',
+              dateRange: ['2019-01-08T00:00:00.000', '2019-01-18T00:00:00.000'],
+            },
+          ],
+          filters: [
+            {
+              operator: 'equals',
+              values: ['us-ut'],
+              member: 'Users.state',
+            },
+          ],
+          limit: 2,
+          rowLimit: 2,
+          timezone: 'UTC',
+          order: [],
+          dimensions: [],
+          queryType: 'regularQuery',
+        },
+        slowQuery: false,
+      });
+
+      expect(result.chartPivot()).toStrictEqual([
+        {
+          x: '2019-01-07T00:00:00.000',
+          xValues: ['2019-01-07T00:00:00.000'],
+          'LineItems.count': 2,
+        },
+        {
+          x: '2019-01-14T00:00:00.000',
+          xValues: ['2019-01-14T00:00:00.000'],
+          'LineItems.count': 0,
+        },
+      ]);
+    });
+
+    test('week granularity in other locale', () => {
+      dayjs.locale(ko);
       const result = new ResultSet({
         queryType: 'regularQuery',
         results: [


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


Hii^^ I'm using cubeJS for analytics API^^ 
First of all, thank you for creating a really great platform. thanks to you, I'm so into cubeJs these days..

**Description of Changes Made (if issue reference is not provided)**

if I change the locale value of dayjs on the front-end, no value is displayed when granularity is week.

Currently, if you look at the ResultSet code, the weekStart must be set to 1 to work properly.

However, the value can be modified by the client as much as possible (https://day.js.org/docs/en/i18n/changing-locale)

so it seems necessary to guide or cope with it. 

To reproduces the problem, you can overwrite the locale of dayjs with ko or another value and test it.
please refer to the test code..

thank you^^