### PR TITLE
feat(cubestore): partitioned indexes for faster joins 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1217,7 +1217,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube#65d3c5ba9be852ad3628af25df32fecde089e8a6"
+source = "git+https://github.com/cube-js/arrow-datafusion?branch=cube#ff85bdd9c52f849f63b541979b67a1f3ec8f5b77"
 dependencies = [
  "ahash 0.7.4",
  "arrow 5.0.0",
@@ -4297,7 +4297,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "sqlparser"
 version = "0.9.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=c3c77dd2aa408a7cb0c9f27e5e9fc1b101351dcd#c3c77dd2aa408a7cb0c9f27e5e9fc1b101351dcd"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=e6e90af10616c1699ecd21f27d1e67a7f646d042#e6e90af10616c1699ecd21f27d1e67a7f646d042"
 dependencies = [
  "log",
 ]

--- a/rust/cubestore/Cargo.toml
+++ b/rust/cubestore/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.13.0"
 bumpalo = "3.6.1"
 tokio = { version = "1.0", features = ["full", "rt"] }
 warp = { git = 'https://github.com/seanmonstar/warp', version = "0.3.0" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "c3c77dd2aa408a7cb0c9f27e5e9fc1b101351dcd" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "e6e90af10616c1699ecd21f27d1e67a7f646d042" }
 serde_derive = "1.0.115"
 serde = "1.0.115"
 serde_bytes = "0.11.5"

--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -686,6 +686,11 @@ impl JobRunner {
                 .update_status(job_id, JobStatus::Error(cube_err.to_string()))
                 .await?;
             error!(
+                "Error while running job {}: {}",
+                job_id,
+                cube_err.display_with_backtrace()
+            );
+            error!(
                 "Running job error ({:?}): {:?}",
                 start.elapsed()?,
                 self.meta_store.get_job(job_id).await?

--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -1232,7 +1232,7 @@ impl ClusterImpl {
         node_name: &str,
         m: NetworkMessage,
     ) -> Result<NetworkMessage, CubeError> {
-        if self.server_name == node_name {
+        if self.server_name == node_name || is_self_reference(node_name) {
             // TODO: query_timeout currently used for all messages.
             // TODO timeout config
             Ok(timeout(
@@ -1256,7 +1256,7 @@ impl ClusterImpl {
         m: NetworkMessage,
     ) -> Result<Box<dyn WorkerConnection>, CubeError> {
         assert!(m.is_streaming_request());
-        if self.server_name == node_name {
+        if self.server_name == node_name || is_self_reference(node_name) {
             let c: Box<dyn WorkerConnection> = Box::new(LoopbackConnection {
                 stream: ClusterImpl::start_stream_on_worker(self.clone(), m).await,
             });
@@ -1526,4 +1526,8 @@ impl MessageStream for QueryStream {
         let finished = batch.is_none();
         (NetworkMessage::SelectResultBatch(Ok(batch)), finished)
     }
+}
+
+fn is_self_reference(name: &str) -> bool {
+    name.starts_with("@loop:")
 }

--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -1428,7 +1428,8 @@ impl ClusterImpl {
             if node_name != self.server_name {
                 continue;
             }
-            if let Some(file) = partition_file_name(p.parent_partition_id, p.partition_id) {
+            if p.has_main_table {
+                let file = partition_file_name(p.partition_id);
                 if self.stop_token.is_cancelled() {
                     log::debug!("Startup warmup cancelled");
                     return;

--- a/rust/cubestore/src/lib.rs
+++ b/rust/cubestore/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(hash_set_entry)]
 #![feature(map_first_last)]
 #![feature(arc_new_cyclic)]
+#![feature(is_sorted)]
 // #![feature(trace_macros)]
 
 // trace_macros!(true);

--- a/rust/cubestore/src/metastore/index.rs
+++ b/rust/cubestore/src/metastore/index.rs
@@ -15,6 +15,7 @@ impl Index {
         columns: Vec<Column>,
         sort_key_size: u64,
         partition_split_key_size: Option<u64>,
+        multi_index_id: Option<u64>,
     ) -> Result<Index, CubeError> {
         if sort_key_size == 0 {
             return Err(CubeError::user(format!(
@@ -28,6 +29,7 @@ impl Index {
             columns,
             sort_key_size,
             partition_split_key_size,
+            multi_index_id,
         })
     }
 
@@ -54,6 +56,10 @@ impl Index {
 
     pub fn partition_split_key_size(&self) -> &Option<u64> {
         &self.partition_split_key_size
+    }
+
+    pub fn multi_index_id(&self) -> Option<u64> {
+        self.multi_index_id
     }
 }
 

--- a/rust/cubestore/src/metastore/job.rs
+++ b/rust/cubestore/src/metastore/job.rs
@@ -15,6 +15,8 @@ pub enum JobType {
     TableImport,
     Repartition,
     TableImportCSV(/*location*/ String),
+    MultiPartitionSplit,
+    FinishMultiSplit,
 }
 
 fn get_job_type_index(j: &JobType) -> u32 {
@@ -24,6 +26,8 @@ fn get_job_type_index(j: &JobType) -> u32 {
         JobType::TableImport => 3,
         JobType::Repartition => 4,
         JobType::TableImportCSV(_) => 5,
+        JobType::MultiPartitionSplit => 6,
+        JobType::FinishMultiSplit => 7,
     }
 }
 

--- a/rust/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/src/metastore/mod.rs
@@ -846,7 +846,7 @@ pub trait MetaStore: DIService + Send + Sync {
 /// Information required to produce partition name on remote fs.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct PartitionName {
-    pub parent_partition_id: Option<u64>,
+    pub has_main_table: bool,
     pub partition_id: u64,
 }
 
@@ -3085,10 +3085,9 @@ impl MetaStore for RocksMetaStore {
                                 .cloned(),
                         );
                     }
-
                     partitions.push((
                         PartitionName {
-                            parent_partition_id: p.row.parent_partition_id,
+                            has_main_table: p.row.has_main_table_file(),
                             partition_id: p.id,
                         },
                         chunks,

--- a/rust/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/src/metastore/mod.rs
@@ -2,6 +2,7 @@ pub mod chunks;
 pub mod index;
 pub mod job;
 pub mod listener;
+pub mod multi_index;
 pub mod partition;
 pub mod schema;
 pub mod source;
@@ -26,6 +27,10 @@ use crate::config::{Config, ConfigObj};
 use crate::metastore::chunks::{ChunkIndexKey, ChunkRocksIndex};
 use crate::metastore::index::IndexIndexKey;
 use crate::metastore::job::{Job, JobIndexKey, JobRocksIndex, JobRocksTable, JobStatus, JobType};
+use crate::metastore::multi_index::{
+    MultiIndexIndexKey, MultiPartition, MultiPartitionIndexKey, MultiPartitionRocksIndex,
+    MultiPartitionRocksTable,
+};
 use crate::metastore::partition::PartitionIndexKey;
 use crate::metastore::source::{
     Source, SourceCredentials, SourceIndexKey, SourceRocksIndex, SourceRocksTable,
@@ -51,6 +56,7 @@ use futures_timer::Delay;
 use index::{IndexRocksIndex, IndexRocksTable};
 use itertools::Itertools;
 use log::trace;
+use multi_index::{MultiIndex, MultiIndexRocksIndex, MultiIndexRocksTable};
 use parquet::basic::{ConvertedType, Repetition};
 use parquet::{basic::Type, schema::types};
 use partition::{PartitionRocksIndex, PartitionRocksTable};
@@ -59,8 +65,10 @@ use rocksdb::backup::BackupEngineOptions;
 use rocksdb::checkpoint::Checkpoint;
 use schema::{SchemaRocksIndex, SchemaRocksTable};
 use smallvec::alloc::fmt::Formatter;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
+use std::mem::take;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -343,6 +351,25 @@ pub enum ColumnType {
     Boolean,
 }
 
+impl Display for ColumnType {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let s = match self {
+            ColumnType::Decimal { scale, .. } => return write!(f, "decimal({})", scale),
+            ColumnType::String => "text",
+            ColumnType::Int => "int",
+            ColumnType::Bytes => "bytes",
+            ColumnType::HyperLogLog(HllFlavour::Airlift) => "hyperloglog",
+            ColumnType::HyperLogLog(HllFlavour::ZetaSketch) => "hyperloglogpp",
+            ColumnType::HyperLogLog(HllFlavour::Postgres) => "hll_postgres",
+            ColumnType::HyperLogLog(HllFlavour::Snowflake) => "hll_snowflake",
+            ColumnType::Timestamp => "timestamp",
+            ColumnType::Float => "float",
+            ColumnType::Boolean => "boolean",
+        };
+        f.write_str(s)
+    }
+}
+
 impl ColumnType {
     pub fn target_scale(&self) -> i32 {
         match self {
@@ -490,7 +517,9 @@ pub struct Index {
     columns: Vec<Column>,
     sort_key_size: u64,
     #[serde(default)]
-    partition_split_key_size: Option<u64>
+    partition_split_key_size: Option<u64>,
+    #[serde(default)]
+    multi_index_id: Option<u64>
 }
 }
 
@@ -498,6 +527,7 @@ pub struct Index {
 pub struct IndexDef {
     pub name: String,
     pub columns: Vec<String>,
+    pub multi_index: Option<String>,
 }
 
 data_frame_from! {
@@ -505,6 +535,8 @@ data_frame_from! {
 pub struct Partition {
     index_id: u64,
     parent_partition_id: Option<u64>,
+    #[serde(default)]
+    multi_partition_id: Option<u64>,
     min_value: Option<Row>,
     max_value: Option<Row>,
     active: bool,
@@ -663,6 +695,13 @@ meta_store_table_impl!(IndexMetaStoreTable, Index, IndexRocksTable);
 meta_store_table_impl!(PartitionMetaStoreTable, Partition, PartitionRocksTable);
 meta_store_table_impl!(TableMetaStoreTable, Table, TableRocksTable);
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PartitionData {
+    pub partition: IdRow<Partition>,
+    pub index: IdRow<Index>,
+    pub chunks: Vec<IdRow<Chunk>>,
+}
+
 #[cuberpc::service]
 pub trait MetaStore: DIService + Send + Sync {
     async fn wait_for_current_seq_to_sync(&self) -> Result<(), CubeError>;
@@ -720,8 +759,24 @@ pub trait MetaStore: DIService + Send + Sync {
     async fn get_partition_for_compaction(
         &self,
         partition_id: u64,
-    ) -> Result<(IdRow<Partition>, IdRow<Index>), CubeError>;
+    ) -> Result<
+        (
+            IdRow<Partition>,
+            IdRow<Index>,
+            Option<IdRow<MultiPartition>>,
+        ),
+        CubeError,
+    >;
     async fn get_partition_chunk_sizes(&self, partition_id: u64) -> Result<u64, CubeError>;
+    /// Swaps chunks inside the same partition.
+    /// The operation will not be commited if partition_id is inside a multi-partition that started
+    /// a multi-split. Returns true iff the operation is committed.
+    async fn swap_compacted_chunks(
+        &self,
+        partition_id: u64,
+        old_chunk_ids: Vec<u64>,
+        new_chunk: u64,
+    ) -> Result<bool, CubeError>;
     async fn swap_active_partitions(
         &self,
         current_active: Vec<u64>,
@@ -737,10 +792,10 @@ pub trait MetaStore: DIService + Send + Sync {
     ) -> Result<IdRow<Partition>, CubeError>;
     async fn can_delete_middle_man_partition(&self, partition_id: u64) -> Result<bool, CubeError>;
     async fn all_inactive_middle_man_partitions(&self) -> Result<Vec<IdRow<Partition>>, CubeError>;
-    async fn get_partition_ids_with_chunks_created_seconds_ago(
+    async fn get_partitions_with_chunks_created_seconds_ago(
         &self,
         seconds_ago: i64,
-    ) -> Result<Vec<u64>, CubeError>;
+    ) -> Result<Vec<IdRow<Partition>>, CubeError>;
 
     fn index_table(&self) -> IndexMetaStoreTable;
     async fn create_index(
@@ -757,6 +812,47 @@ pub trait MetaStore: DIService + Send + Sync {
     ) -> Result<Vec<IdRow<Partition>>, CubeError>;
     async fn get_index(&self, index_id: u64) -> Result<IdRow<Index>, CubeError>;
 
+    async fn create_partitioned_index(
+        &self,
+        schema: String,
+        name: String,
+        columns: Vec<Column>,
+        if_not_exists: bool,
+    ) -> Result<IdRow<MultiIndex>, CubeError>;
+    async fn get_multi_partition(&self, id: u64) -> Result<IdRow<MultiPartition>, CubeError>;
+    /// Retrieve a partial subtrees that contain common parents for all [multi_part_ids]. We
+    /// guarantee that all nodes on the paths to common parents are in the results. No attempt is
+    /// made to retrieve extra children, however.
+    async fn get_multi_partition_subtree(
+        &self,
+        multi_part_ids: Vec<u64>,
+    ) -> Result<HashMap<u64, MultiPartition>, CubeError>;
+    async fn create_multi_partition(
+        &self,
+        p: MultiPartition,
+    ) -> Result<IdRow<MultiPartition>, CubeError>;
+    async fn prepare_multi_partition_for_split(
+        &self,
+        multi_partition_id: u64,
+    ) -> Result<(IdRow<MultiIndex>, IdRow<MultiPartition>, Vec<PartitionData>), CubeError>;
+    async fn commit_multi_partition_split(
+        &self,
+        multi_partition_id: u64,
+        new_multi_partitions: Vec<u64>,
+        new_multi_partition_rows: Vec<u64>,
+        old_partitions: Vec<u64>,
+        old_chunks: Vec<u64>,
+        new_partitions: Vec<u64>,
+        new_partition_rows: Vec<u64>,
+    ) -> Result<(), CubeError>;
+    async fn find_unsplit_partitions(&self, multi_partition_id: u64)
+        -> Result<Vec<u64>, CubeError>;
+    async fn prepare_multi_split_finish(
+        &self,
+        multi_partition_id: u64,
+        partition_id: u64,
+    ) -> Result<(PartitionData, Vec<IdRow<MultiPartition>>), CubeError>;
+
     async fn get_active_partitions_and_chunks_by_index_id_for_select(
         &self,
         index_id: Vec<u64>,
@@ -764,7 +860,7 @@ pub trait MetaStore: DIService + Send + Sync {
 
     async fn get_warmup_partitions(
         &self,
-    ) -> Result<Vec<(PartitionName, Vec</*chunk_id*/ u64>)>, CubeError>;
+    ) -> Result<Vec<(IdRow<Partition>, Vec</*chunk_id*/ u64>)>, CubeError>;
 
     fn chunks_table(&self) -> ChunkMetaStoreTable;
     async fn create_chunk(
@@ -843,13 +939,6 @@ pub trait MetaStore: DIService + Send + Sync {
     async fn debug_dump(&self, out_path: String) -> Result<(), CubeError>;
 }
 
-/// Information required to produce partition name on remote fs.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-pub struct PartitionName {
-    pub has_main_table: bool,
-    pub partition_id: u64,
-}
-
 crate::di_service!(RocksMetaStore, [MetaStore]);
 crate::di_service!(MetaStoreRpcClient, [MetaStore]);
 
@@ -876,6 +965,12 @@ pub enum MetaStoreEvent {
     DeleteTable(IdRow<Table>),
     DeleteWAL(IdRow<WAL>),
     DeleteSource(IdRow<Source>),
+
+    UpdateMultiIndex(IdRow<MultiIndex>, IdRow<MultiIndex>),
+    DeleteMultiIndex(IdRow<MultiIndex>),
+
+    UpdateMultiPartition(IdRow<MultiPartition>, IdRow<MultiPartition>),
+    DeleteMultiPartition(IdRow<MultiPartition>),
 }
 
 type SecondaryKey = Vec<u8>;
@@ -982,7 +1077,9 @@ enum_from_primitive! {
         Chunks = 0x0500,
         WALs = 0x0600,
         Jobs = 0x0700,
-        Sources = 0x0800
+        Sources = 0x0800,
+        MultiIndexes = 0x0900,
+        MultiPartitions = 0x0A00
     }
 }
 
@@ -2063,8 +2160,11 @@ impl RocksMetaStore {
         rocks_partition: &PartitionRocksTable,
         table_cols: &Vec<Column>,
         table_id: &IdRow<Table>,
+        multi_index: Option<&IdRow<MultiIndex>>,
+        multi_partitions: &[IdRow<MultiPartition>],
         index_def: IndexDef,
     ) -> Result<IdRow<Index>, CubeError> {
+        debug_assert_eq!(multi_index.is_some(), !multi_partitions.is_empty());
         if let Some(not_found) = index_def
             .columns
             .iter()
@@ -2146,6 +2246,30 @@ impl RocksMetaStore {
         }
         assert_eq!(index_columns.len(), table_cols.len());
 
+        // Validate the columns match types specified in the MultiIndex.
+        if let Some(mi) = multi_index {
+            let mi = &mi.row;
+            if sorted_key_size as usize != mi.key_columns().len() {
+                return Err(CubeError::user(format!(
+                    "Partitioned index '{}' has {} columns, got {} columns in ADD TO PARTITIONED INDEX",
+                    mi.name(),
+                    mi.key_columns().len(),
+                    sorted_key_size
+                )));
+            }
+            for i in 0..(sorted_key_size as usize) {
+                let l = &index_columns[i];
+                let r = &mi.key_columns()[i];
+                if l.get_column_type() != &r.column_type {
+                    return Err(CubeError::user(
+                        format!("Type of table column '{}'({}) is different from type of partitioned index column '{}'({}). Index name is '{}'",
+                            l.name, l.column_type, r.name, r.column_type, mi.name()
+                        )
+                    ));
+                }
+            }
+        }
+
         let index = Index::try_new(
             index_def.name,
             table_id.get_id(),
@@ -2153,10 +2277,24 @@ impl RocksMetaStore {
             sorted_key_size,
             // Seq column shouldn't participate in partition split. Otherwise we can't do shared nothing calculations across partitions.
             table_id.get_row().seq_column().map(|_| sorted_key_size - 1),
+            multi_index.map(|i| i.id),
         )?;
         let index_id = rocks_index.insert(index, batch_pipe)?;
-        let partition = Partition::new(index_id.id, None, None);
-        let _ = rocks_partition.insert(partition, batch_pipe)?;
+        if multi_partitions.is_empty() {
+            rocks_partition.insert(Partition::new(index_id.id, None, None, None), batch_pipe)?;
+        } else {
+            for p in multi_partitions {
+                rocks_partition.insert(
+                    Partition::new(
+                        index_id.id,
+                        Some(p.id),
+                        p.row.min_row().cloned(),
+                        p.row.max_row().cloned(),
+                    ),
+                    batch_pipe,
+                )?;
+            }
+        }
         Ok(index_id)
     }
 
@@ -2209,14 +2347,17 @@ impl RocksMetaStore {
         db_ref: DbTableRef,
         batch_pipe: &mut BatchPipe,
         uploaded_chunk_ids: &[u64],
-    ) -> Result<u64, CubeError> {
+    ) -> Result<(u64, HashMap</*partition_id*/ u64, /*rows*/ u64>), CubeError> {
         let table = ChunkRocksTable::new(db_ref.clone());
         let mut activated_row_count = 0;
+        let mut partitions = HashMap::new();
         for id in uploaded_chunk_ids {
-            activated_row_count += table.get_row_or_not_found(*id)?.get_row().get_row_count();
+            let chunk = table.get_row_or_not_found(*id)?.into_row();
+            *partitions.entry(chunk.get_partition_id()).or_default() += chunk.get_row_count();
+            activated_row_count += chunk.get_row_count();
             table.update_with_fn(*id, |row| row.set_uploaded(true), batch_pipe)?;
         }
-        return Ok(activated_row_count);
+        return Ok((activated_row_count, partitions));
     }
 
     fn invalidate_caches(&self) {
@@ -2388,6 +2529,8 @@ impl MetaStore for RocksMetaStore {
             let rocks_index = IndexRocksTable::new(db_ref.clone());
             let rocks_schema = SchemaRocksTable::new(db_ref.clone());
             let rocks_partition = PartitionRocksTable::new(db_ref.clone());
+            let rocks_multi_index = MultiIndexRocksTable::new(db_ref.clone());
+            let rocks_multi_partition = MultiPartitionRocksTable::new(db_ref.clone());
 
             let schema_id =
                 rocks_schema.get_single_row_by_index(&schema_name, &SchemaRocksIndex::Name)?;
@@ -2430,12 +2573,34 @@ impl MetaStore for RocksMetaStore {
             );
             let table_id = rocks_table.insert(table, batch_pipe)?;
             for index_def in indexes.into_iter() {
+                let multi_index;
+                let mut multi_partitions;
+                match &index_def.multi_index {
+                    None => {
+                        multi_index = None;
+                        multi_partitions = vec![];
+                    }
+                    Some(mi) => {
+                        let mi = rocks_multi_index.get_single_row_by_index(
+                            &MultiIndexIndexKey::ByName(schema_id.get_id(), mi.clone()),
+                            &MultiIndexRocksIndex::ByName,
+                        )?;
+                        multi_partitions = rocks_multi_partition.get_rows_by_index(
+                            &MultiPartitionIndexKey::ByMultiIndexId(mi.get_id()),
+                            &MultiPartitionRocksIndex::ByMultiIndexId,
+                        )?;
+                        multi_partitions.retain(|m| m.row.active());
+                        multi_index = Some(mi);
+                    }
+                }
                 RocksMetaStore::add_index(
                     batch_pipe,
                     &rocks_index,
                     &rocks_partition,
                     &table_columns,
                     &table_id,
+                    multi_index.as_ref(),
+                    &multi_partitions,
                     index_def,
                 )?;
             }
@@ -2465,8 +2630,11 @@ impl MetaStore for RocksMetaStore {
                 &rocks_partition,
                 &table_columns,
                 &table_id,
+                None,
+                &[],
                 IndexDef {
                     name: "default".to_string(),
+                    multi_index: None,
                     columns: def_index_columns,
                 },
             )?;
@@ -2537,7 +2705,8 @@ impl MetaStore for RocksMetaStore {
             let tables_table = TableRocksTable::new(db_ref.clone());
             let indexes_table = IndexRocksTable::new(db_ref.clone());
             let partitions_table = PartitionRocksTable::new(db_ref.clone());
-            let chunks_table = ChunkRocksTable::new(db_ref);
+            let chunks_table = ChunkRocksTable::new(db_ref.clone());
+            let multi_partitions_table = MultiPartitionRocksTable::new(db_ref.clone());
 
             let indexes = indexes_table
                 .get_rows_by_index(&IndexIndexKey::TableId(table_id), &IndexRocksIndex::TableID)?;
@@ -2547,14 +2716,29 @@ impl MetaStore for RocksMetaStore {
                     &PartitionRocksIndex::IndexId,
                 )?;
                 for partition in partitions.into_iter() {
+                    let mut removed_rows = 0;
+                    if partition.row.is_active() {
+                        removed_rows += partition.row.main_table_row_count;
+                    }
                     let chunks = chunks_table.get_rows_by_index(
                         &ChunkIndexKey::ByPartitionId(partition.get_id()),
                         &ChunkRocksIndex::PartitionId,
                     )?;
                     for chunk in chunks.into_iter() {
+                        if chunk.row.active {
+                            removed_rows += chunk.row.row_count;
+                        }
                         chunks_table.delete(chunk.get_id(), batch_pipe)?;
                     }
                     partitions_table.delete(partition.get_id(), batch_pipe)?;
+
+                    if let Some(m) = partition.row.multi_partition_id {
+                        multi_partitions_table.update_with_fn(
+                            m,
+                            |r| r.subtract_rows(removed_rows),
+                            batch_pipe,
+                        )?;
+                    }
                 }
                 indexes_table.delete(index.get_id(), batch_pipe)?;
             }
@@ -2588,7 +2772,14 @@ impl MetaStore for RocksMetaStore {
     async fn get_partition_for_compaction(
         &self,
         partition_id: u64,
-    ) -> Result<(IdRow<Partition>, IdRow<Index>), CubeError> {
+    ) -> Result<
+        (
+            IdRow<Partition>,
+            IdRow<Index>,
+            Option<IdRow<MultiPartition>>,
+        ),
+        CubeError,
+    > {
         self.read_operation(move |db_ref| {
             let partition = PartitionRocksTable::new(db_ref.clone())
                 .get_row(partition_id)?
@@ -2603,13 +2794,19 @@ impl MetaStore for RocksMetaStore {
                     partition.get_row().get_index_id(),
                     partition_id
                 )))?;
-            if !partition.get_row().is_active() {
+            let multi_part = match partition.get_row().multi_partition_id {
+                None => None,
+                Some(m) => {
+                    Some(MultiPartitionRocksTable::new(db_ref.clone()).get_row_or_not_found(m)?)
+                }
+            };
+            if !partition.get_row().is_active() && !multi_part.is_some() {
                 return Err(CubeError::internal(format!(
                     "Cannot compact inactive partition: {:?}",
                     partition.get_row()
                 )));
             }
-            Ok((partition, index))
+            Ok((partition, index, multi_part))
         })
         .await
     }
@@ -2619,12 +2816,33 @@ impl MetaStore for RocksMetaStore {
         Ok(chunks.iter().map(|r| r.get_row().row_count).sum())
     }
 
+    async fn swap_compacted_chunks(
+        &self,
+        partition_id: u64,
+        old_chunk_ids: Vec<u64>,
+        new_chunk: u64,
+    ) -> Result<bool, CubeError> {
+        self.write_operation(move |db, pipe| {
+            let p = PartitionRocksTable::new(db.clone()).get_row_or_not_found(partition_id)?;
+            if let Some(mp) = p.row.multi_partition_id {
+                let mp = MultiPartitionRocksTable::new(db.clone()).get_row_or_not_found(mp)?;
+                if mp.row.prepared_for_split() {
+                    // When run concurrently with multi-split, the latter takes precedence.
+                    return Ok(false);
+                }
+            }
+            RocksMetaStore::swap_chunks_impl(old_chunk_ids, vec![new_chunk], db, pipe)?;
+            Ok(true)
+        })
+        .await
+    }
+
     async fn swap_active_partitions(
         &self,
         current_active: Vec<u64>,
         new_active: Vec<u64>,
         compacted_chunk_ids: Vec<u64>,
-        new_active_min_max: Vec<(u64, (Option<Row>, Option<Row>))>,
+        mut new_active_min_max: Vec<(u64, (Option<Row>, Option<Row>))>,
     ) -> Result<(), CubeError> {
         trace!(
             "Swapping partitions: deactivating ({}), deactivating chunks ({}), activating ({})",
@@ -2632,95 +2850,18 @@ impl MetaStore for RocksMetaStore {
             compacted_chunk_ids.iter().join(", "),
             new_active.iter().join(", ")
         );
-        self.write_operation(move |db_ref, batch_pipe| {
-            let table = PartitionRocksTable::new(db_ref.clone());
-            let chunk_table = ChunkRocksTable::new(db_ref.clone());
-            let indexes_table = IndexRocksTable::new(db_ref.clone());
-            let tables_table = TableRocksTable::new(db_ref.clone());
-
-            // Rows are compacted using unique key columns and totals don't match
-            let skip_row_count_sanity_check = if let Some(current) = current_active.iter().next() {
-                let current_partition =
-                    table.get_row(*current)?.ok_or(CubeError::internal(format!(
-                        "Current partition is not found during swap active: {}",
-                        current
-                    )))?;
-                let index = indexes_table.get_row_or_not_found(current_partition.get_row().get_index_id())?;
-                let table = tables_table.get_row_or_not_found(index.get_row().table_id())?;
-                table.get_row().unique_key_columns().is_some()
-            } else {
-                false
-            };
-
-            let mut deactivated_row_count = 0;
-            let mut activated_row_count = 0;
-
-            for current in current_active.iter() {
-                let current_partition =
-                    table.get_row(*current)?.ok_or(CubeError::internal(format!(
-                        "Current partition is not found during swap active: {}",
-                        current
-                    )))?;
-                // TODO this check is not atomic
-                // TODO Swapping partitions: deactivating (34), deactivating chunks (404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414), activating (35)
-                // TODO Swapping partitions: deactivating (34), deactivating chunks (404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414), activating (36)
-                if !current_partition.get_row().is_active() {
-                    return Err(CubeError::internal(format!(
-                        "Current partition is not active: {:?}",
-                        current_partition.get_row()
-                    )));
-                }
-                table.update(
-                    current_partition.get_id(),
-                    current_partition.get_row().to_active(false),
-                    current_partition.get_row(),
-                    batch_pipe,
-                )?;
-                deactivated_row_count += current_partition.get_row().main_table_row_count()
-            }
-
-            for (new, (count, (min_value, max_value))) in
-                new_active.iter().zip(new_active_min_max.into_iter())
-            {
-                let new_partition = table.get_row(*new)?.ok_or(CubeError::internal(format!(
-                    "New partition is not found during swap active: {}",
-                    new
-                )))?;
-                if new_partition.get_row().is_active() {
-                    return Err(CubeError::internal(format!(
-                        "New partition is already active: {:?}",
-                        new_partition.get_row()
-                    )));
-                }
-                table.update(
-                    new_partition.get_id(),
-                    new_partition
-                        .get_row()
-                        .to_active(true)
-                        .update_min_max_and_row_count(min_value, max_value, count),
-                    new_partition.get_row(),
-                    batch_pipe,
-                )?;
-                activated_row_count += count;
-            }
-
-            for chunk_id in compacted_chunk_ids.iter() {
-                deactivated_row_count += chunk_table.get_row_or_not_found(*chunk_id)?.get_row().get_row_count();
-                chunk_table.update_with_fn(*chunk_id, |row| row.deactivate(), batch_pipe)?;
-            }
-
-            if !skip_row_count_sanity_check && activated_row_count != deactivated_row_count {
-                return Err(CubeError::internal(format!(
-                    "Deactivated row count ({}) doesn't match activated row count ({}) during swap of partition ({}) and ({}) chunks to new partitions ({})",
-                    deactivated_row_count,
-                    activated_row_count,
-                    current_active.iter().join(", "),
-                    compacted_chunk_ids.iter().join(", "),
-                    new_active.iter().join(", ")
-                )))
-            }
-
-            Ok(())
+        self.write_operation(move |db, pipe| {
+            swap_active_partitions_impl(
+                db,
+                pipe,
+                current_active,
+                new_active,
+                compacted_chunk_ids,
+                move |i, p| {
+                    let (rows, (min, max)) = take(&mut new_active_min_max[i]);
+                    p.update_min_max_and_row_count(min, max, rows)
+                },
+            )
         })
         .await
     }
@@ -2905,10 +3046,10 @@ impl MetaStore for RocksMetaStore {
         .await
     }
 
-    async fn get_partition_ids_with_chunks_created_seconds_ago(
+    async fn get_partitions_with_chunks_created_seconds_ago(
         &self,
         seconds_ago: i64,
-    ) -> Result<Vec<u64>, CubeError> {
+    ) -> Result<Vec<IdRow<Partition>>, CubeError> {
         self.read_operation(move |db_ref| {
             let chunks_table = ChunkRocksTable::new(db_ref.clone());
 
@@ -2928,10 +3069,14 @@ impl MetaStore for RocksMetaStore {
                             .unwrap_or(false)
                 })
                 .map(|c| c.get_row().get_partition_id())
-                .unique()
-                .collect::<Vec<_>>();
+                .unique();
 
-            Ok(partition_ids)
+            let partitions_table = PartitionRocksTable::new(db_ref.clone());
+            let partitions = partition_ids
+                .map(|id| partitions_table.get_row_or_not_found(id))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(partitions)
         })
         .await
     }
@@ -2975,6 +3120,8 @@ impl MetaStore for RocksMetaStore {
                 &rocks_partition,
                 table.get_row().get_columns(),
                 &table,
+                None,
+                &[],
                 index_def,
             )?)
         })
@@ -3021,6 +3168,36 @@ impl MetaStore for RocksMetaStore {
         .await
     }
 
+    async fn create_partitioned_index(
+        &self,
+        schema: String,
+        name: String,
+        key_columns: Vec<Column>,
+        if_not_exists: bool,
+    ) -> Result<IdRow<MultiIndex>, CubeError> {
+        self.write_operation(move |db, pipe| {
+            let mindexes = MultiIndexRocksTable::new(db.clone());
+            let mpartitions = MultiPartitionRocksTable::new(db.clone());
+            let schemas = SchemaRocksTable::new(db.clone());
+            let schema_id = schemas
+                .get_single_row_by_index(&schema, &SchemaRocksIndex::Name)?
+                .id;
+            if if_not_exists {
+                let mut existing = mindexes.get_rows_by_index(
+                    &MultiIndexIndexKey::ByName(schema_id, name.clone()),
+                    &MultiIndexRocksIndex::ByName,
+                )?;
+                if !existing.is_empty() {
+                    return Ok(existing.remove(0));
+                }
+            }
+            let r = mindexes.insert(MultiIndex::new(schema_id, name, key_columns), pipe)?;
+            mpartitions.insert(MultiPartition::new_root(r.id), pipe)?;
+            Ok(r)
+        })
+        .await
+    }
+
     async fn get_active_partitions_and_chunks_by_index_id_for_select(
         &self,
         index_id: Vec<u64>,
@@ -3055,7 +3232,7 @@ impl MetaStore for RocksMetaStore {
         .await
     }
 
-    async fn get_warmup_partitions(&self) -> Result<Vec<(PartitionName, Vec<u64>)>, CubeError> {
+    async fn get_warmup_partitions(&self) -> Result<Vec<(IdRow<Partition>, Vec<u64>)>, CubeError> {
         self.read_operation(|db| {
             // Do full scan, likely only a small number chunks and partitions are inactive.
             let mut partition_to_chunks = HashMap::new();
@@ -3085,13 +3262,7 @@ impl MetaStore for RocksMetaStore {
                                 .cloned(),
                         );
                     }
-                    partitions.push((
-                        PartitionName {
-                            has_main_table: p.row.has_main_table_file(),
-                            partition_id: p.id,
-                        },
-                        chunks,
-                    ));
+                    partitions.push((p, chunks));
                 }
             }
             Ok(partitions)
@@ -3187,7 +3358,7 @@ impl MetaStore for RocksMetaStore {
             let deactivated_row_count = wal_table.get_row_or_not_found(wal_id_to_delete)?.get_row().get_row_count();
             wal_table.delete(wal_id_to_delete, batch_pipe)?;
 
-            let activated_row_count = Self::activate_chunks_impl(db_ref, batch_pipe, &uploaded_ids)?;
+            let (activated_row_count, _) = Self::activate_chunks_impl(db_ref, batch_pipe, &uploaded_ids)?;
 
             if activated_row_count != deactivated_row_count * index_count {
                 return Err(CubeError::internal(format!(
@@ -3212,13 +3383,25 @@ impl MetaStore for RocksMetaStore {
             "Activating chunks ({})",
             uploaded_chunk_ids.iter().join(", ")
         );
-        self.write_operation(move |db_ref, batch_pipe| {
-            TableRocksTable::new(db_ref.clone()).update_with_fn(
+        self.write_operation(move |db, pipe| {
+            TableRocksTable::new(db.clone()).update_with_fn(
                 table_id,
                 |t| t.update_has_data(true),
-                batch_pipe,
+                pipe,
             )?;
-            Self::activate_chunks_impl(db_ref, batch_pipe, &uploaded_chunk_ids)?;
+            let (_, partition_rows) =
+                Self::activate_chunks_impl(db.clone(), pipe, &uploaded_chunk_ids)?;
+            let partition = PartitionRocksTable::new(db.clone());
+            let mut mpartition_rows = HashMap::new();
+            for (p, rows) in partition_rows {
+                if let Some(mp) = partition.get_row_or_not_found(p)?.row.multi_partition_id {
+                    *mpartition_rows.entry(mp).or_default() += rows;
+                }
+            }
+            let mpartition = MultiPartitionRocksTable::new(db.clone());
+            for (mp, rows) in mpartition_rows {
+                mpartition.update_with_fn(mp, |p| p.add_rows(rows), pipe)?;
+            }
             Ok(())
         })
         .await?;
@@ -3230,35 +3413,11 @@ impl MetaStore for RocksMetaStore {
         deactivate_ids: Vec<u64>,
         uploaded_ids: Vec<u64>,
     ) -> Result<(), CubeError> {
-        trace!(
-            "Swapping chunks: deactivating ({}), activating ({})",
-            deactivate_ids.iter().join(", "),
-            uploaded_ids.iter().join(", ")
-        );
+        assert!(!uploaded_ids.is_empty());
         self.write_operation(move |db_ref, batch_pipe| {
-            let table = ChunkRocksTable::new(db_ref.clone());
-            let mut deactivated_row_count = 0;
-            let mut activated_row_count = 0;
-            for id in deactivate_ids.iter() {
-                deactivated_row_count += table.get_row_or_not_found(*id)?.get_row().get_row_count();
-                table.update_with_fn(*id, |row| row.deactivate(), batch_pipe)?;
-            }
-            for id in uploaded_ids.iter() {
-                activated_row_count += table.get_row_or_not_found(*id)?.get_row().get_row_count();
-                table.update_with_fn(*id, |row| row.set_uploaded(true), batch_pipe)?;
-            }
-            if deactivate_ids.len() > 0 && activated_row_count != deactivated_row_count {
-                return Err(CubeError::internal(format!(
-                    "Deactivated row count ({}) doesn't match activated row count ({}) during swap of ({}) to ({}) chunks",
-                    deactivated_row_count,
-                    activated_row_count,
-                    deactivate_ids.iter().join(", "),
-                    uploaded_ids.iter().join(", ")
-                )))
-            }
-            Ok(())
+            RocksMetaStore::swap_chunks_impl(deactivate_ids, uploaded_ids, db_ref, batch_pipe)
         })
-            .await
+        .await
     }
 
     async fn delete_chunk(&self, chunk_id: u64) -> Result<IdRow<Chunk>, CubeError> {
@@ -3567,6 +3726,228 @@ impl MetaStore for RocksMetaStore {
         })
         .await
     }
+
+    async fn get_multi_partition(&self, id: u64) -> Result<IdRow<MultiPartition>, CubeError> {
+        self.read_operation(move |db| MultiPartitionRocksTable::new(db).get_row_or_not_found(id))
+            .await
+    }
+
+    async fn get_multi_partition_subtree(
+        &self,
+        multi_part_ids: Vec<u64>,
+    ) -> Result<HashMap<u64, MultiPartition>, CubeError> {
+        self.read_operation(move |db| {
+            let table = MultiPartitionRocksTable::new(db);
+            let mut r = HashMap::new();
+            for m in multi_part_ids {
+                let mut curr = m;
+                loop {
+                    let e = match r.entry(m) {
+                        Entry::Occupied(_) => break,
+                        Entry::Vacant(e) => e,
+                    };
+
+                    let row = table.get_row_or_not_found(curr)?;
+                    let parent = row.row.parent_multi_partition_id();
+
+                    e.insert(row.row);
+                    curr = match parent {
+                        Some(parent) => parent,
+                        None => break,
+                    };
+                }
+            }
+            Ok(r)
+        })
+        .await
+    }
+
+    async fn create_multi_partition(
+        &self,
+        p: MultiPartition,
+    ) -> Result<IdRow<MultiPartition>, CubeError> {
+        self.write_operation(move |db, pipe| MultiPartitionRocksTable::new(db).insert(p, pipe))
+            .await
+    }
+
+    async fn prepare_multi_partition_for_split(
+        &self,
+        multi_partition_id: u64,
+    ) -> Result<(IdRow<MultiIndex>, IdRow<MultiPartition>, Vec<PartitionData>), CubeError> {
+        let (mi, mp, pds) = self
+            .read_operation(move |db| {
+                let mindex = MultiIndexRocksTable::new(db.clone());
+                let mpartition = MultiPartitionRocksTable::new(db.clone());
+                let index = IndexRocksTable::new(db.clone());
+                let partition = PartitionRocksTable::new(db.clone());
+                let chunk = ChunkRocksTable::new(db.clone());
+
+                let mp = mpartition.get_row_or_not_found(multi_partition_id)?;
+                if !mp.row.active() {
+                    return Err(CubeError::internal(
+                        "refusing to split inactive multi-partition".to_string(),
+                    ));
+                }
+                let mi = mindex.get_row_or_not_found(mp.row.multi_index_id())?;
+                let ps = partition.get_rows_by_index(
+                    &PartitionIndexKey::ByMultiPartitionId(Some(multi_partition_id)),
+                    &PartitionRocksIndex::MultiPartitionId,
+                )?;
+
+                let mut pds = Vec::with_capacity(ps.len());
+                for partition in ps {
+                    let index = index.get_row_or_not_found(partition.row.get_index_id())?;
+                    let mut chunks = chunk.get_rows_by_index(
+                        &ChunkIndexKey::ByPartitionId(partition.get_id()),
+                        &ChunkRocksIndex::PartitionId,
+                    )?;
+                    chunks.retain(|c| c.row.active);
+                    pds.push(PartitionData {
+                        partition,
+                        index,
+                        chunks,
+                    })
+                }
+                Ok((mi, mp, pds))
+            })
+            .await?;
+
+        // We try to keep the write operation small.
+        self.write_operation(move |db, pipe| {
+            MultiPartitionRocksTable::new(db).update_with_fn(
+                mp.get_id(),
+                |p| p.mark_prepared_for_split(),
+                pipe,
+            )?;
+            Ok((mi, mp, pds))
+        })
+        .await
+    }
+
+    async fn commit_multi_partition_split(
+        &self,
+        multi_partition_id: u64,
+        new_multi_partitions: Vec<u64>,
+        new_multi_partition_rows: Vec<u64>,
+        old_partitions: Vec<u64>,
+        old_chunks: Vec<u64>,
+        new_partitions: Vec<u64>,
+        new_partition_rows: Vec<u64>,
+    ) -> Result<(), CubeError> {
+        assert_eq!(new_multi_partitions.len(), new_multi_partition_rows.len());
+        assert_eq!(new_partition_rows.len(), new_partitions.len());
+        let total_new_rows = new_multi_partition_rows.iter().sum();
+        self.write_operation(move |db, pipe| {
+            log::trace!(
+                "Committing split of multi-partition {} to {:?}. {} rows in old split into {:?}",
+                multi_partition_id,
+                new_multi_partitions,
+                total_new_rows,
+                new_multi_partition_rows
+            );
+            let mpartitions = MultiPartitionRocksTable::new(db.clone());
+            mpartitions.update_with_fn(
+                multi_partition_id,
+                |p| {
+                    assert!(
+                        p.active(),
+                        "refusing to commit split of inactive multi-partition"
+                    );
+                    p.set_active(false).subtract_rows(total_new_rows)
+                },
+                pipe,
+            )?;
+            for i in 0..new_multi_partitions.len() {
+                mpartitions.update_with_fn(
+                    new_multi_partitions[i],
+                    |p| p.set_active(true).add_rows(new_multi_partition_rows[i]),
+                    pipe,
+                )?;
+            }
+            swap_active_partitions_impl(
+                db,
+                pipe,
+                old_partitions,
+                new_partitions,
+                old_chunks,
+                |i, p| p.update_row_count(new_partition_rows[i]),
+            )?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn find_unsplit_partitions(
+        &self,
+        multi_partition_id: u64,
+    ) -> Result<Vec<u64>, CubeError> {
+        self.read_operation(move |db| {
+            let mparts = MultiPartitionRocksTable::new(db.clone());
+            let mchildren = mparts.get_row_ids_by_index(
+                &MultiPartitionIndexKey::ByParentId(Some(multi_partition_id)),
+                &MultiPartitionRocksIndex::ByParentId,
+            )?;
+
+            let parts = PartitionRocksTable::new(db.clone());
+            let mut with_children = HashSet::new();
+            for c in mchildren {
+                let new_parts = parts.get_rows_by_index(
+                    &PartitionIndexKey::ByMultiPartitionId(Some(c)),
+                    &PartitionRocksIndex::MultiPartitionId,
+                )?;
+                for p in new_parts {
+                    with_children.insert(p.row.parent_partition_id.unwrap());
+                }
+            }
+            let mut ps = parts.get_row_ids_by_index(
+                &PartitionIndexKey::ByMultiPartitionId(Some(multi_partition_id)),
+                &PartitionRocksIndex::MultiPartitionId,
+            )?;
+            ps.retain(|p| !with_children.contains(p));
+            Ok(ps)
+        })
+        .await
+    }
+
+    async fn prepare_multi_split_finish(
+        &self,
+        multi_partition_id: u64,
+        partition_id: u64,
+    ) -> Result<(PartitionData, Vec<IdRow<MultiPartition>>), CubeError> {
+        self.read_operation(move |db| {
+            log::trace!(
+                "Preparing to finish split of {} (partition {})",
+                multi_partition_id,
+                partition_id
+            );
+            let mpartitions = MultiPartitionRocksTable::new(db.clone());
+            let children = mpartitions.get_rows_by_index(
+                &MultiPartitionIndexKey::ByParentId(Some(multi_partition_id)),
+                &MultiPartitionRocksIndex::ByParentId,
+            )?;
+
+            let partitions = PartitionRocksTable::new(db.clone());
+            let partition = partitions.get_row_or_not_found(partition_id)?;
+
+            let indexes = IndexRocksTable::new(db.clone());
+            let index = indexes.get_row_or_not_found(partition.row.index_id)?;
+
+            let chunks = ChunkRocksTable::new(db.clone());
+            let mut chunks = chunks.get_rows_by_index(
+                &ChunkIndexKey::ByPartitionId(partition_id),
+                &ChunkRocksIndex::PartitionId,
+            )?;
+            chunks.retain(|c| c.row.active);
+
+            let d = PartitionData {
+                partition,
+                index,
+                chunks,
+            };
+            Ok((d, children))
+        })
+        .await
+    }
 }
 
 fn get_table_impl(
@@ -3594,6 +3975,102 @@ fn get_default_index_impl(db_ref: DbTableRef, table_id: u64) -> Result<IdRow<Ind
             "Missing default index for table {}",
             table_id
         )))
+}
+
+fn swap_active_partitions_impl(
+    db_ref: DbTableRef,
+    batch_pipe: &mut BatchPipe,
+    current_active: Vec<u64>,
+    new_active: Vec<u64>,
+    compacted_chunk_ids: Vec<u64>,
+    mut update_new_partition_stats: impl FnMut(/*index*/ usize, &Partition) -> Partition,
+) -> Result<(), CubeError> {
+    let index_table = IndexRocksTable::new(db_ref.clone());
+    let table_table = TableRocksTable::new(db_ref.clone());
+    let table = PartitionRocksTable::new(db_ref.clone());
+    let chunk_table = ChunkRocksTable::new(db_ref.clone());
+
+    // Rows are compacted using unique key columns and totals don't match
+    let skip_row_count_sanity_check = if let Some(current) = current_active.first() {
+        let current_partition = table.get_row(*current)?.ok_or(CubeError::internal(format!(
+            "Current partition is not found during swap active: {}",
+            current
+        )))?;
+        let index = index_table.get_row_or_not_found(current_partition.get_row().get_index_id())?;
+        let table = table_table.get_row_or_not_found(index.get_row().table_id())?;
+        table.get_row().unique_key_columns().is_some()
+    } else {
+        false
+    };
+
+    let mut deactivated_row_count = 0;
+    let mut activated_row_count = 0;
+
+    for current in current_active.iter() {
+        let current_partition = table.get_row(*current)?.ok_or(CubeError::internal(format!(
+            "Current partition is not found during swap active: {}",
+            current
+        )))?;
+        // TODO this check is not atomic
+        // TODO Swapping partitions: deactivating (34), deactivating chunks (404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414), activating (35)
+        // TODO Swapping partitions: deactivating (34), deactivating chunks (404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414), activating (36)
+        if !current_partition.get_row().is_active() {
+            return Err(CubeError::internal(format!(
+                "Current partition is not active: {:?}",
+                current_partition.get_row()
+            )));
+        }
+        table.update(
+            current_partition.get_id(),
+            current_partition.get_row().to_active(false),
+            current_partition.get_row(),
+            batch_pipe,
+        )?;
+        deactivated_row_count += current_partition.get_row().main_table_row_count()
+    }
+
+    for i in 0..new_active.len() {
+        let new = new_active[i];
+        let new_partition = table.get_row(new)?.ok_or(CubeError::internal(format!(
+            "New partition is not found during swap active: {}",
+            new
+        )))?;
+        if new_partition.get_row().is_active() {
+            return Err(CubeError::internal(format!(
+                "New partition is already active: {:?}",
+                new_partition.get_row()
+            )));
+        }
+        let updated = update_new_partition_stats(i, new_partition.get_row()).to_active(true);
+        activated_row_count += updated.main_table_row_count;
+        table.update(
+            new_partition.get_id(),
+            updated,
+            new_partition.get_row(),
+            batch_pipe,
+        )?;
+    }
+
+    for chunk_id in compacted_chunk_ids.iter() {
+        deactivated_row_count += chunk_table
+            .get_row_or_not_found(*chunk_id)?
+            .get_row()
+            .get_row_count();
+        chunk_table.update_with_fn(*chunk_id, |row| row.deactivate(), batch_pipe)?;
+    }
+
+    if !skip_row_count_sanity_check && activated_row_count != deactivated_row_count {
+        return Err(CubeError::internal(format!(
+            "Deactivated row count ({}) doesn't match activated row count ({}) during swap of partition ({}) and ({}) chunks to new partitions ({})",
+            deactivated_row_count,
+            activated_row_count,
+            current_active.iter().join(", "),
+            compacted_chunk_ids.iter().join(", "),
+            new_active.iter().join(", ")
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -3921,6 +4398,7 @@ mod tests {
                 columns.clone(),
                 columns.len() as u64 - 1,
                 None,
+                None,
             )
             .unwrap();
             let expected_res = vec![IdRow::new(1, expected_index)];
@@ -4102,5 +4580,78 @@ mod tests {
             fs::remove_dir_all(config.local_dir()).unwrap();
             fs::remove_dir_all(config.remote_dir()).unwrap();
         }
+    }
+}
+
+impl RocksMetaStore {
+    fn swap_chunks_impl(
+        deactivate_ids: Vec<u64>,
+        uploaded_ids: Vec<u64>,
+        db_ref: DbTableRef,
+        batch_pipe: &mut BatchPipe,
+    ) -> Result<(), CubeError> {
+        trace!(
+            "Swapping chunks: deactivating ({}), activating ({})",
+            deactivate_ids.iter().join(", "),
+            uploaded_ids.iter().join(", ")
+        );
+        let chunks = ChunkRocksTable::new(db_ref.clone());
+        let mut partition_to_row_diffs = HashMap::<u64, i64>::new();
+        let mut deactivated_row_count = 0;
+        let mut activated_row_count = 0;
+        for id in deactivate_ids.iter() {
+            let chunk = chunks.get_row_or_not_found(*id)?;
+            deactivated_row_count += chunk.row.row_count;
+            *partition_to_row_diffs
+                .entry(chunk.row.partition_id)
+                .or_default() -= chunk.row.row_count as i64;
+            chunks.update_with_fn(*id, |row| row.deactivate(), batch_pipe)?;
+        }
+        for id in uploaded_ids.iter() {
+            let chunk = chunks.get_row_or_not_found(*id)?;
+            activated_row_count += chunk.row.row_count;
+            *partition_to_row_diffs
+                .entry(chunk.row.partition_id)
+                .or_default() += chunk.row.row_count as i64;
+            chunks.update_with_fn(*id, |row| row.set_uploaded(true), batch_pipe)?;
+        }
+        if deactivate_ids.len() > 0 && activated_row_count != deactivated_row_count {
+            return Err(CubeError::internal(format!(
+                "Deactivated row count ({}) doesn't match activated row count ({}) during swap of ({}) to ({}) chunks",
+                deactivated_row_count,
+                activated_row_count,
+                deactivate_ids.iter().join(", "),
+                uploaded_ids.iter().join(", ")
+            )));
+        }
+        // Update row counts of multi partitions.
+        let partitions = PartitionRocksTable::new(db_ref.clone());
+        let mut multipart_to_row_diffs = HashMap::<u64, i64>::new();
+        for (p, diff) in partition_to_row_diffs {
+            let p = partitions.get_row_or_not_found(p)?;
+            let m = match p.row.multi_partition_id {
+                None => continue,
+                Some(m) => m,
+            };
+            *multipart_to_row_diffs.entry(m).or_default() += diff;
+        }
+        let multi_partitions = MultiPartitionRocksTable::new(db_ref.clone());
+        for (m, diff) in multipart_to_row_diffs {
+            if diff == 0 {
+                continue;
+            }
+            multi_partitions.update_with_fn(
+                m,
+                |m| {
+                    if 0 < diff {
+                        m.add_rows(diff as u64)
+                    } else {
+                        m.subtract_rows((-diff) as u64)
+                    }
+                },
+                batch_pipe,
+            )?;
+        }
+        Ok(())
     }
 }

--- a/rust/cubestore/src/metastore/multi_index.rs
+++ b/rust/cubestore/src/metastore/multi_index.rs
@@ -1,0 +1,287 @@
+//! Multi indexes split data inside **multiple** tables into ranges with the same key ranges. This
+//! allows efficient implementation of combining data by key, e.g. JOIN by column equality.
+//!
+//! Each multi-index owns a tree of multi-partitions. Each multi-partition defines a range of keys
+//! and guarantees that ordinary partitions that store the data have the same key range.
+//! Multi-partitioned are compacted and repartitioned by applying the same operation to ordinary
+//! partitions they own.
+use super::RocksTable;
+use crate::data_frame_from;
+use crate::metastore::{
+    BaseRocksSecondaryIndex, Column, IdRow, IndexId, MetaStoreEvent, RocksSecondaryIndex, TableId,
+};
+use crate::rocks_table_impl;
+use crate::table::Row;
+use byteorder::{BigEndian, WriteBytesExt};
+use rocksdb::DB;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::io::Cursor;
+use std::io::Write;
+
+data_frame_from! {
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
+pub struct MultiIndex {
+    schema_id: u64,
+    name: String,
+    key_columns: Vec<Column>
+}
+}
+
+impl MultiIndex {
+    pub fn new(schema_id: u64, name: String, key_columns: Vec<Column>) -> MultiIndex {
+        MultiIndex {
+            schema_id,
+            name,
+            key_columns,
+        }
+    }
+
+    pub fn schema_id(&self) -> u64 {
+        self.schema_id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn key_columns(&self) -> &[Column] {
+        &self.key_columns
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum MultiIndexRocksIndex {
+    ByName = 1,
+}
+
+impl BaseRocksSecondaryIndex<MultiIndex> for MultiIndexRocksIndex {
+    fn index_key_by(&self, row: &MultiIndex) -> Vec<u8> {
+        self.key_to_bytes(&self.typed_key_by(row))
+    }
+
+    fn get_id(&self) -> u32 {
+        RocksSecondaryIndex::get_id(self)
+    }
+
+    fn is_unique(&self) -> bool {
+        RocksSecondaryIndex::is_unique(self)
+    }
+}
+
+rocks_table_impl!(MultiIndex, MultiIndexRocksTable, TableId::MultiIndexes, {
+    vec![Box::new(MultiIndexRocksIndex::ByName)]
+});
+
+#[derive(Hash, Clone, Debug)]
+pub enum MultiIndexIndexKey {
+    ByName(u64, String),
+}
+
+impl RocksSecondaryIndex<MultiIndex, MultiIndexIndexKey> for MultiIndexRocksIndex {
+    fn typed_key_by(&self, i: &MultiIndex) -> MultiIndexIndexKey {
+        match self {
+            MultiIndexRocksIndex::ByName => {
+                MultiIndexIndexKey::ByName(i.schema_id, i.name.to_string())
+            }
+        }
+    }
+
+    fn key_to_bytes(&self, key: &MultiIndexIndexKey) -> Vec<u8> {
+        match key {
+            MultiIndexIndexKey::ByName(schema, name) => {
+                let mut w = Cursor::new(Vec::with_capacity(8 + name.len()));
+                w.write_u64::<BigEndian>(*schema).unwrap();
+                w.write_all(name.as_bytes()).unwrap();
+                w.into_inner()
+            }
+        }
+    }
+
+    fn is_unique(&self) -> bool {
+        match self {
+            MultiIndexRocksIndex::ByName => true,
+        }
+    }
+
+    fn get_id(&self) -> IndexId {
+        *self as IndexId
+    }
+}
+
+data_frame_from! {
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct MultiPartition {
+   multi_index_id: u64,
+   parent_multi_partition_id: Option<u64>,
+   min_row: Option<Row>,
+   max_row: Option<Row>,
+   active: bool,
+   /// When this is true, compactions must not run to avoid concurrent modifications with split.
+   prepared_for_split: bool,
+   /// All active rows, including main tables and chunks of all partitions.
+   total_row_count: u64
+}
+}
+
+impl MultiPartition {
+    // Note that roots are active by default.
+    pub fn new_root(multi_index_id: u64) -> MultiPartition {
+        MultiPartition {
+            multi_index_id,
+            parent_multi_partition_id: None,
+            min_row: None,
+            max_row: None,
+            total_row_count: 0,
+            prepared_for_split: false,
+            active: true,
+        }
+    }
+
+    // Note that children are inactive by default.
+    pub fn new_child(
+        parent: &IdRow<MultiPartition>,
+        min_row: Option<Row>,
+        max_row: Option<Row>,
+    ) -> MultiPartition {
+        MultiPartition {
+            multi_index_id: parent.row.multi_index_id,
+            parent_multi_partition_id: Some(parent.id),
+            min_row,
+            max_row,
+            total_row_count: 0,
+            prepared_for_split: false,
+            active: false,
+        }
+    }
+
+    pub fn total_row_count(&self) -> u64 {
+        self.total_row_count
+    }
+    pub fn add_rows(&self, rows: u64) -> MultiPartition {
+        let mut s = self.clone();
+        s.total_row_count += rows;
+        s
+    }
+    pub fn subtract_rows(&self, rows: u64) -> MultiPartition {
+        let mut s = self.clone();
+        assert!(
+            rows <= s.total_row_count,
+            "{} and {}",
+            rows,
+            self.total_row_count,
+        );
+        s.total_row_count -= rows;
+        s
+    }
+    pub fn active(&self) -> bool {
+        self.active
+    }
+    pub fn set_active(&self, v: bool) -> MultiPartition {
+        let mut s = self.clone();
+        s.active = v;
+        s
+    }
+    pub fn mark_prepared_for_split(&self) -> MultiPartition {
+        let mut s = self.clone();
+        s.prepared_for_split = true;
+        s
+    }
+    pub fn prepared_for_split(&self) -> bool {
+        self.prepared_for_split
+    }
+    pub fn multi_index_id(&self) -> u64 {
+        self.multi_index_id
+    }
+    pub fn min_row(&self) -> Option<&Row> {
+        self.min_row.as_ref()
+    }
+    pub fn max_row(&self) -> Option<&Row> {
+        self.max_row.as_ref()
+    }
+    pub fn parent_multi_partition_id(&self) -> Option<u64> {
+        self.parent_multi_partition_id
+    }
+}
+
+rocks_table_impl!(
+    MultiPartition,
+    MultiPartitionRocksTable,
+    TableId::MultiPartitions,
+    {
+        vec![
+            Box::new(MultiPartitionRocksIndex::ByMultiIndexId),
+            Box::new(MultiPartitionRocksIndex::ByParentId),
+        ]
+    }
+);
+
+#[derive(Hash, Clone, Debug)]
+pub enum MultiPartitionIndexKey {
+    ByMultiIndexId(u64),
+    ByParentId(Option<u64>),
+}
+
+impl BaseRocksSecondaryIndex<MultiPartition> for MultiPartitionRocksIndex {
+    fn index_key_by(&self, row: &MultiPartition) -> Vec<u8> {
+        self.key_to_bytes(&self.typed_key_by(row))
+    }
+
+    fn get_id(&self) -> u32 {
+        RocksSecondaryIndex::get_id(self)
+    }
+
+    fn is_unique(&self) -> bool {
+        RocksSecondaryIndex::is_unique(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum MultiPartitionRocksIndex {
+    ByMultiIndexId = 0,
+    ByParentId = 1,
+}
+
+impl RocksSecondaryIndex<MultiPartition, MultiPartitionIndexKey> for MultiPartitionRocksIndex {
+    fn typed_key_by(&self, p: &MultiPartition) -> MultiPartitionIndexKey {
+        match self {
+            MultiPartitionRocksIndex::ByMultiIndexId => {
+                MultiPartitionIndexKey::ByMultiIndexId(p.multi_index_id)
+            }
+            MultiPartitionRocksIndex::ByParentId => {
+                MultiPartitionIndexKey::ByParentId(p.parent_multi_partition_id)
+            }
+        }
+    }
+
+    fn key_to_bytes(&self, key: &MultiPartitionIndexKey) -> Vec<u8> {
+        match key {
+            MultiPartitionIndexKey::ByMultiIndexId(id) => {
+                let mut w = Cursor::new(Vec::with_capacity(8));
+                w.write_u64::<BigEndian>(*id).unwrap();
+                w.into_inner()
+            }
+            MultiPartitionIndexKey::ByParentId(id) => {
+                let mut w = Cursor::new(Vec::with_capacity(9));
+                match id {
+                    None => w.write_u8(0).unwrap(),
+                    Some(id) => {
+                        w.write_u8(1).unwrap();
+                        w.write_u64::<BigEndian>(*id).unwrap();
+                    }
+                }
+                w.into_inner()
+            }
+        }
+    }
+
+    fn is_unique(&self) -> bool {
+        match self {
+            MultiPartitionRocksIndex::ByMultiIndexId => false,
+            MultiPartitionRocksIndex::ByParentId => false,
+        }
+    }
+
+    fn get_id(&self) -> IndexId {
+        *self as IndexId
+    }
+}

--- a/rust/cubestore/src/metastore/partition.rs
+++ b/rust/cubestore/src/metastore/partition.rs
@@ -45,7 +45,14 @@ impl Partition {
     }
 
     pub fn get_full_name(&self, partition_id: u64) -> Option<String> {
-        partition_file_name(self.parent_partition_id, partition_id)
+        match self.has_main_table_file() {
+            false => None,
+            true => Some(partition_file_name(partition_id)),
+        }
+    }
+
+    pub fn has_main_table_file(&self) -> bool {
+        self.main_table_row_count != 0
     }
 
     pub fn to_active(&self, active: bool) -> Partition {
@@ -100,8 +107,8 @@ impl Partition {
     }
 }
 
-pub fn partition_file_name(parent_partition_id: Option<u64>, partition_id: u64) -> Option<String> {
-    parent_partition_id.and(Some(format!("{}.parquet", partition_id)))
+pub fn partition_file_name(partition_id: u64) -> String {
+    format!("{}.parquet", partition_id)
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/rust/cubestore/src/queryplanner/filter_by_key_range.rs
+++ b/rust/cubestore/src/queryplanner/filter_by_key_range.rs
@@ -1,0 +1,182 @@
+use crate::queryplanner::serialized_plan::{RowFilter, RowRange};
+use crate::table::data::cmp_partition_key;
+use arrow::array::ArrayRef;
+use arrow::datatypes::SchemaRef;
+use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::cube_ext::stream::StreamWithSchema;
+use datafusion::error::DataFusionError;
+use datafusion::physical_plan::{
+    Distribution, ExecutionPlan, OptimizerHints, Partitioning, SendableRecordBatchStream,
+};
+use futures::StreamExt;
+use itertools::Itertools;
+use std::any::Any;
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct FilterByKeyRangeExec {
+    input: Arc<dyn ExecutionPlan>,
+    key_len: usize,
+    filter: Arc<RowFilter>,
+}
+
+impl FilterByKeyRangeExec {
+    /// Input must be sorted by row key. Filter and input schema must match.
+    pub fn issue_filters(
+        input: Arc<dyn ExecutionPlan>,
+        filter: Arc<RowFilter>,
+        key_len: usize,
+    ) -> Arc<dyn ExecutionPlan> {
+        if filter.matches_all_rows() {
+            return input;
+        }
+        Arc::new(FilterByKeyRangeExec {
+            input,
+            filter,
+            key_len,
+        })
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for FilterByKeyRangeExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.input.output_partitioning()
+    }
+
+    fn required_child_distribution(&self) -> Distribution {
+        self.input.required_child_distribution()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn with_new_children(
+        &self,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        assert_eq!(children.len(), 1);
+        Ok(Arc::new(FilterByKeyRangeExec {
+            input: children.remove(0),
+            filter: self.filter.clone(),
+            key_len: self.key_len,
+        }))
+    }
+
+    fn output_hints(&self) -> OptimizerHints {
+        self.input.output_hints()
+    }
+
+    async fn execute(
+        &self,
+        partition: usize,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        let i = self.input.execute(partition).await?;
+        let s = i.schema();
+        let f = self.filter.clone();
+        let key_len = self.key_len;
+        Ok(Box::pin(StreamWithSchema::wrap(
+            s,
+            i.flat_map(move |b| {
+                let r;
+                match b {
+                    Ok(b) => r = apply_row_filter(b, key_len, &f),
+                    err => r = vec![err],
+                }
+                futures::stream::iter(r)
+            }),
+        )))
+    }
+}
+
+fn apply_row_filter(
+    b: RecordBatch,
+    key_len: usize,
+    f: &RowFilter,
+) -> Vec<Result<RecordBatch, ArrowError>> {
+    let num_rows = b.num_rows();
+    if num_rows == 0 {
+        return vec![Ok(b)];
+    }
+
+    let mut intervals = Vec::new();
+    let key_cols = &b.columns()[0..key_len];
+    for r in &f.or_filters {
+        if !has_matches(key_cols, r) {
+            continue;
+        }
+        let mut start = 0;
+        if r.start.is_some() {
+            let s = r.start.as_ref().unwrap().values();
+            while start < num_rows
+                && cmp_partition_key(key_len, s, key_cols, start) > Ordering::Equal
+            {
+                start += 1
+            }
+        }
+        let mut end = num_rows;
+        if r.end.is_some() {
+            let e = r.end.as_ref().unwrap().values();
+            while 0 < end && cmp_partition_key(key_len, e, key_cols, end - 1) <= Ordering::Equal {
+                end -= 1
+            }
+        }
+        assert!(start <= end, "{} <= {}", start, end);
+        intervals.push((start, end));
+    }
+
+    // Merge intersecting intervals together.
+    intervals.sort_unstable();
+    for i in 1..intervals.len() {
+        if intervals[i - 1].1 <= intervals[i].0 {
+            intervals[i - 1].1 = intervals[i].1;
+            intervals[i].0 = intervals[i - 1].0;
+        }
+    }
+    intervals.dedup();
+
+    intervals
+        .into_iter()
+        .map(move |(start, end)| Ok(b.slice(start, end - start)))
+        .collect_vec()
+}
+
+fn has_matches(cols: &[ArrayRef], r: &RowRange) -> bool {
+    assert_ne!(cols.len(), 0);
+    assert_ne!(cols[0].len(), 0);
+    let key_len = cols.len();
+    let num_rows = cols[0].len();
+    if r.start.is_some()
+        && cmp_partition_key(
+            key_len,
+            r.start.as_ref().unwrap().values().as_slice(),
+            cols,
+            num_rows - 1,
+        ) > Ordering::Equal
+    {
+        return false;
+    }
+    if r.end.is_some()
+        && cmp_partition_key(
+            key_len,
+            r.end.as_ref().unwrap().values().as_slice(),
+            cols,
+            0,
+        ) <= Ordering::Equal
+    {
+        return false;
+    }
+    return true;
+}

--- a/rust/cubestore/src/queryplanner/planning.rs
+++ b/rust/cubestore/src/queryplanner/planning.rs
@@ -35,6 +35,7 @@ use flatbuffers::bitflags::_core::fmt::Formatter;
 use itertools::Itertools;
 
 use crate::cluster::Cluster;
+use crate::metastore::multi_index::MultiPartition;
 use crate::metastore::table::{Table, TablePath};
 use crate::metastore::{Chunk, IdRow, Index, MetaStore, Partition, Schema};
 use crate::queryplanner::optimizations::rewrite_plan::{rewrite_plan, PlanRewriter};
@@ -44,20 +45,45 @@ use crate::queryplanner::serialized_plan::{IndexSnapshot, PartitionSnapshot, Ser
 use crate::queryplanner::topk::{materialize_topk, plan_topk, ClusterAggregateTopK};
 use crate::queryplanner::CubeTableLogical;
 use crate::CubeError;
+use serde::{Deserialize as SerdeDeser, Deserializer, Serialize as SerdeSer, Serializer};
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
+use std::iter::FromIterator;
 
 #[cfg(test)]
 pub async fn choose_index(
     p: &LogicalPlan,
     metastore: &dyn PlanIndexStore,
-) -> Result<(LogicalPlan, Vec<IndexSnapshot>), DataFusionError> {
+) -> Result<(LogicalPlan, PlanningMeta), DataFusionError> {
     choose_index_ext(p, metastore, true).await
+}
+
+/// Information required to distribute the logical plan into multiple workers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlanningMeta {
+    pub indices: Vec<IndexSnapshot>,
+    /// Non-empty only if indices point to multi-partitions.
+    /// Custom serde handlers as flatbuffers can't handle hash maps with integer keys.
+    #[serde(deserialize_with = "de_vec_as_map")]
+    #[serde(serialize_with = "se_vec_as_map")]
+    pub multi_part_subtree: HashMap<u64, MultiPartition>,
+}
+
+fn se_vec_as_map<S: Serializer>(m: &HashMap<u64, MultiPartition>, s: S) -> Result<S::Ok, S::Error> {
+    m.iter().collect_vec().serialize(s)
+}
+
+fn de_vec_as_map<'de, D: Deserializer<'de>>(
+    d: D,
+) -> Result<HashMap<u64, MultiPartition>, D::Error> {
+    Vec::<(u64, MultiPartition)>::deserialize(d).map(HashMap::from_iter)
 }
 
 pub async fn choose_index_ext(
     p: &LogicalPlan,
     metastore: &dyn PlanIndexStore,
     enable_topk: bool,
-) -> Result<(LogicalPlan, Vec<IndexSnapshot>), DataFusionError> {
+) -> Result<(LogicalPlan, PlanningMeta), DataFusionError> {
     // Prepare information to choose the index.
     let mut collector = CollectConstraints::default();
     rewrite_plan(p, &None, &mut collector)?;
@@ -78,10 +104,19 @@ pub async fn choose_index_ext(
         )
         .await?;
     assert_eq!(tables.len(), collector.constraints.len());
-    let mut indices = Vec::new();
+    let mut candidates = Vec::new();
     for (c, inputs) in collector.constraints.iter().zip(tables) {
-        indices.push(pick_index(c, inputs.0, inputs.1, inputs.2).await?)
+        candidates.push(pick_index(c, inputs.0, inputs.1, inputs.2).await?)
     }
+    // We pick partitioned index only when all tables request the same one.
+    let mut indices: Vec<_> = match all_have_same_partitioned_index(&candidates) {
+        true => candidates
+            .into_iter()
+            .map(|c| c.partitioned_index.unwrap())
+            .collect(),
+        false => candidates.into_iter().map(|c| c.ordinary_index).collect(),
+    };
+
     let partitions = metastore
         .get_active_partitions_and_chunks_by_index_id_for_select(
             indices.iter().map(|i| i.index.get_id()).collect_vec(),
@@ -105,7 +140,44 @@ pub async fn choose_index_ext(
     let plan = rewrite_plan(p, &(), &mut r)?;
     assert_eq!(r.next_index, indices.len());
 
-    Ok((plan, indices))
+    let mut multi_parts = Vec::new();
+    for i in &indices {
+        for p in &i.partitions {
+            if let Some(m) = p.partition.get_row().multi_partition_id() {
+                multi_parts.push(m);
+            }
+        }
+    }
+
+    let multi_part_subtree = metastore.get_multi_partition_subtree(multi_parts).await?;
+    Ok((
+        plan,
+        PlanningMeta {
+            indices,
+            multi_part_subtree,
+        },
+    ))
+}
+
+fn all_have_same_partitioned_index(cs: &[IndexCandidate]) -> bool {
+    if cs.is_empty() {
+        return true;
+    }
+    let multi_index_id = |c: &IndexCandidate| {
+        c.partitioned_index
+            .as_ref()
+            .and_then(|i| i.index.get_row().multi_index_id())
+    };
+    let id = match multi_index_id(&cs[0]) {
+        Some(id) => id,
+        None => return false,
+    };
+    for c in &cs[1..] {
+        if multi_index_id(c) != Some(id) {
+            return false;
+        }
+    }
+    return true;
 }
 
 #[async_trait]
@@ -118,6 +190,10 @@ pub trait PlanIndexStore: Send + Sync {
         &self,
         index_id: Vec<u64>,
     ) -> Result<Vec<Vec<(IdRow<Partition>, Vec<IdRow<Chunk>>)>>, CubeError>;
+    async fn get_multi_partition_subtree(
+        &self,
+        multi_part_ids: Vec<u64>,
+    ) -> Result<HashMap<u64, MultiPartition>, CubeError>;
 }
 
 #[async_trait]
@@ -134,6 +210,13 @@ impl<'a> PlanIndexStore for &'a dyn MetaStore {
         index_id: Vec<u64>,
     ) -> Result<Vec<Vec<(IdRow<Partition>, Vec<IdRow<Chunk>>)>>, CubeError> {
         MetaStore::get_active_partitions_and_chunks_by_index_id_for_select(*self, index_id).await
+    }
+
+    async fn get_multi_partition_subtree(
+        &self,
+        multi_part_ids: Vec<u64>,
+    ) -> Result<HashMap<u64, MultiPartition>, CubeError> {
+        MetaStore::get_multi_partition_subtree(*self, multi_part_ids).await
     }
 }
 
@@ -305,7 +388,7 @@ impl ChooseIndex<'_> {
                     snapshot.clone(),
                     // Filled by workers
                     HashMap::new(),
-                    HashSet::new(),
+                    Vec::new(),
                 )?);
 
                 let index_schema = source.schema();
@@ -322,55 +405,76 @@ impl ChooseIndex<'_> {
     }
 }
 
+struct IndexCandidate {
+    pub ordinary_index: IndexSnapshot,
+    pub partitioned_index: Option<IndexSnapshot>,
+}
+
 // Picks the index, but not partitions snapshots.
 async fn pick_index(
     c: &IndexConstraints,
     schema: IdRow<Schema>,
     table: IdRow<Table>,
     indices: Vec<IdRow<Index>>,
-) -> Result<IndexSnapshot, DataFusionError> {
+) -> Result<IndexCandidate, DataFusionError> {
     let sort_on = c.sort_on.as_ref().map(|sc| (&sc.sort_on, sc.required));
 
     let mut indices = indices.into_iter();
     let default_index = indices.next().expect("no default index");
-    let (index, sort_on) = if let Some(projection_column_indices) = &c.projection {
+    let (index, mut partitioned_index, sort_on) = if let Some(projection_column_indices) =
+        &c.projection
+    {
         let projection_columns = CubeTable::project_to_table(&table, &projection_column_indices);
-        if let Some((index, _)) = indices
-            .filter_map(|i| {
-                if let Some((join_on_columns, _)) = sort_on.as_ref() {
-                    // TODO: join_on_columns may be larger than sort_key_size of the index.
-                    let join_columns_in_index = join_on_columns
-                        .iter()
-                        .map(|c| {
-                            i.get_row()
-                                .get_columns()
-                                .iter()
-                                .find(|ic| ic.get_name().as_str() == c.as_str())
-                                .cloned()
-                        })
-                        .collect::<Option<Vec<_>>>();
-                    let join_columns_in_index = match join_columns_in_index {
-                        None => return None,
-                        Some(c) => c,
-                    };
-                    let join_columns_indices =
-                        CubeTable::project_to_index_positions(&join_columns_in_index, &i);
-                    for (i, col_i) in join_columns_indices.iter().enumerate() {
-                        if col_i != &Some(i) {
-                            return None;
-                        }
-                    }
+        let mut partitioned_index = None;
+        let mut ordinary_index = None;
+        let mut ordinary_score = usize::MAX;
+        for i in indices {
+            if let Some((join_on_columns, _)) = sort_on.as_ref() {
+                // TODO: join_on_columns may be larger than sort_key_size of the index.
+                let join_columns_in_index = join_on_columns
+                    .iter()
+                    .map(|c| {
+                        i.get_row()
+                            .get_columns()
+                            .iter()
+                            .find(|ic| ic.get_name().as_str() == c.as_str())
+                            .cloned()
+                    })
+                    .collect::<Option<Vec<_>>>();
+                let join_columns_in_index = match join_columns_in_index {
+                    None => continue,
+                    Some(c) => c,
+                };
+                let join_columns_indices =
+                    CubeTable::project_to_index_positions(&join_columns_in_index, &i);
+
+                let matches = join_columns_indices
+                    .iter()
+                    .enumerate()
+                    .all(|(i, col_i)| Some(i) == *col_i);
+                if !matches {
+                    continue;
                 }
-                let projected_index_positions =
-                    CubeTable::project_to_index_positions(&projection_columns, &i);
-                let score = projected_index_positions
-                    .into_iter()
-                    .fold_options(0, |a, b| a + b);
-                score.map(|s| (i, s))
-            })
-            .min_by_key(|(_, s)| *s)
-        {
-            (index, sort_on)
+            }
+            let projected_index_positions =
+                CubeTable::project_to_index_positions(&projection_columns, &i);
+            let score = projected_index_positions
+                .into_iter()
+                .fold_options(0, |a, b| a + b);
+            if let Some(score) = score {
+                if i.get_row().multi_index_id().is_some() {
+                    debug_assert!(partitioned_index.is_none());
+                    partitioned_index = Some(i);
+                    continue;
+                }
+                if score < ordinary_score {
+                    ordinary_index = Some(i);
+                    ordinary_score = score;
+                }
+            }
+        }
+        if let Some(index) = ordinary_index {
+            (index, partitioned_index, sort_on)
         } else {
             if let Some((join_on_columns, true)) = sort_on.as_ref() {
                 let table_name = c.table.table_name();
@@ -384,7 +488,7 @@ async fn pick_index(
                     join_on_columns.join(", ")
                 )));
             }
-            (default_index, None)
+            (default_index, partitioned_index, None)
         }
     } else {
         if let Some((join_on_columns, _)) = sort_on {
@@ -394,17 +498,33 @@ async fn pick_index(
                 join_on_columns.join(", ")
             )));
         }
-        (default_index, None)
+        (default_index, None, None)
     };
 
-    Ok(IndexSnapshot {
-        index,
-        partitions: Vec::new(), // filled with results of `pick_partitions` later.
-        table_path: TablePath {
-            table,
-            schema: Arc::new(schema),
-        },
-        sort_on: sort_on.map(|(cols, _)| cols.clone()),
+    // Only use partitioned index for joins. Joins are indicated by the required flag.
+    if !sort_on
+        .as_ref()
+        .map(|(_, required)| *required)
+        .unwrap_or(false)
+    {
+        partitioned_index = None;
+    }
+
+    let schema = Arc::new(schema);
+    let create_snapshot = |index| {
+        IndexSnapshot {
+            index,
+            partitions: Vec::new(), // filled with results of `pick_partitions` later.
+            table_path: TablePath {
+                table: table.clone(),
+                schema: schema.clone(),
+            },
+            sort_on: sort_on.as_ref().map(|(cols, _)| (*cols).clone()),
+        }
+    };
+    Ok(IndexCandidate {
+        ordinary_index: create_snapshot(index),
+        partitioned_index: partitioned_index.map(create_snapshot),
     })
 }
 
@@ -653,7 +773,7 @@ impl CubeExtensionPlanner {
                 schema,
                 c.clone(),
                 self.serialized_plan.clone(),
-                snapshots.clone(),
+                snapshots,
                 input,
                 use_streaming,
             )))
@@ -753,6 +873,7 @@ pub mod tests {
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
 
+    use crate::metastore::multi_index::MultiPartition;
     use crate::metastore::table::{Table, TablePath};
     use crate::metastore::{Chunk, Column, ColumnType, IdRow, Index, Partition, Schema};
     use crate::queryplanner::planning::{choose_index, PlanIndexStore};
@@ -761,6 +882,7 @@ pub mod tests {
     use crate::sql::parser::{CubeStoreParser, Statement};
     use crate::CubeError;
     use datafusion::catalog::TableReference;
+    use std::collections::HashMap;
 
     #[tokio::test]
     pub async fn test_choose_index() {
@@ -999,6 +1121,7 @@ pub mod tests {
                 put_first("customer_city", &customers_cols),
                 1,
                 None,
+                None,
             )
             .unwrap(),
         );
@@ -1027,6 +1150,7 @@ pub mod tests {
                 put_first("order_customer", &orders_cols),
                 2,
                 None,
+                None,
             )
             .unwrap(),
         );
@@ -1036,6 +1160,7 @@ pub mod tests {
                 customers,
                 put_first("order_city", &orders_cols),
                 2,
+                None,
                 None,
             )
             .unwrap(),
@@ -1101,6 +1226,7 @@ pub mod tests {
                     table_id,
                     t.get_columns().clone(),
                     t.get_columns().len() as u64,
+                    None,
                     None,
                 )
                 .unwrap(),
@@ -1193,6 +1319,14 @@ pub mod tests {
                         .collect()
                 })
                 .collect())
+        }
+
+        async fn get_multi_partition_subtree(
+            &self,
+            multi_part_ids: Vec<u64>,
+        ) -> Result<HashMap<u64, MultiPartition>, CubeError> {
+            assert!(multi_part_ids.is_empty());
+            Ok(HashMap::new())
         }
     }
 

--- a/rust/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/src/sql/cache.rs
@@ -111,6 +111,7 @@ impl SqlResultCache {
 #[cfg(test)]
 mod tests {
     use crate::queryplanner::serialized_plan::SerializedPlan;
+    use crate::queryplanner::PlanningMeta;
     use crate::sql::cache::SqlResultCache;
     use crate::store::DataFrame;
     use crate::table::{Row, TableValue};
@@ -119,6 +120,7 @@ mod tests {
     use flatbuffers::bitflags::_core::sync::atomic::AtomicI64;
     use futures::future::join_all;
     use futures_timer::Delay;
+    use std::collections::HashMap;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
     use std::time::Duration;
@@ -132,7 +134,10 @@ mod tests {
                 produce_one_row: false,
                 schema,
             },
-            Vec::new(),
+            PlanningMeta {
+                indices: Vec::new(),
+                multi_part_subtree: HashMap::new(),
+            },
         )
         .await?;
         let counter = Arc::new(AtomicI64::new(1));

--- a/rust/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/src/store/compaction.rs
@@ -1,6 +1,7 @@
 use crate::config::injection::DIService;
 use crate::config::ConfigObj;
 use crate::metastore::MetaStore;
+use crate::metastore::partition::partition_file_name;
 use crate::remotefs::RemoteFs;
 use crate::store::{ChunkDataStore, ROW_GROUP_SIZE};
 use crate::table::data::cmp_partition_key;
@@ -122,7 +123,7 @@ impl CompactionService for CompactionServiceImpl {
 
         let mut new_partition_local_files = Vec::new();
         for p in new_partitions.iter() {
-            let new_remote_path = p.get_row().get_full_name(p.get_id()).unwrap();
+            let new_remote_path = partition_file_name(p.get_id());
             new_partition_local_files.push(self.remote_fs.temp_upload_path(&new_remote_path).await?)
         }
 
@@ -200,7 +201,7 @@ impl CompactionService for CompactionServiceImpl {
         {
             match p {
                 EitherOrBoth::Both(p, _) => {
-                    let new_remote_path = p.get_row().get_full_name(p.get_id()).unwrap();
+                    let new_remote_path = partition_file_name(p.get_id());
                     self.remote_fs
                         .upload_file(&new_partition_local_files[i], new_remote_path.as_str())
                         .await?;

--- a/rust/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/src/store/compaction.rs
@@ -1,26 +1,35 @@
 use crate::config::injection::DIService;
 use crate::config::ConfigObj;
-use crate::metastore::MetaStore;
+use crate::metastore::multi_index::MultiPartition;
 use crate::metastore::partition::partition_file_name;
+use crate::metastore::{IdRow, MetaStore, Partition, PartitionData};
 use crate::remotefs::RemoteFs;
-use crate::store::{ChunkDataStore, ROW_GROUP_SIZE};
-use crate::table::data::cmp_partition_key;
+use crate::store::{ChunkDataStore, ChunkStore, ROW_GROUP_SIZE};
+use crate::table::data::{cmp_min_rows, cmp_partition_key};
 use crate::table::parquet::{arrow_schema, ParquetTableStore};
 use crate::table::redistribute::redistribute;
 use crate::table::{Row, TableValue};
 use crate::CubeError;
-use arrow::array::ArrayRef;
+use arrow::array::{ArrayRef, UInt64Array};
 use arrow::compute::{lexsort_to_indices, SortColumn, SortOptions};
+use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::cube_ext;
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::expressions::Column;
+use datafusion::physical_plan::expressions::{Column, Count, Literal};
+use datafusion::physical_plan::hash_aggregate::{
+    AggregateMode, AggregateStrategy, HashAggregateExec,
+};
 use datafusion::physical_plan::memory::MemoryExec;
 use datafusion::physical_plan::merge_sort::{LastRowByUniqueKeyExec, MergeSortExec};
 use datafusion::physical_plan::parquet::ParquetExec;
 use datafusion::physical_plan::union::UnionExec;
-use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
+use datafusion::physical_plan::{
+    AggregateExpr, ExecutionPlan, PhysicalExpr, SendableRecordBatchStream,
+};
+use datafusion::scalar::ScalarValue;
+use futures::StreamExt;
 use itertools::{EitherOrBoth, Itertools};
 use num::integer::div_ceil;
 use num::Integer;
@@ -30,10 +39,19 @@ use std::fs::File;
 use std::mem::take;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
+use tokio::task::JoinHandle;
 
 #[async_trait]
 pub trait CompactionService: DIService + Send + Sync {
     async fn compact(&self, partition_id: u64) -> Result<(), CubeError>;
+    /// Split multi-partition that has too many rows. Figures out the keys based on stored data.
+    async fn split_multi_partition(&self, multi_partition_id: u64) -> Result<(), CubeError>;
+    /// Process partitions that were added concurrently with multi-split.
+    async fn finish_multi_split(
+        &self,
+        multi_partition_id: u64,
+        partition_id: u64,
+    ) -> Result<(), CubeError>;
 }
 
 pub struct CompactionServiceImpl {
@@ -64,6 +82,19 @@ impl CompactionServiceImpl {
 #[async_trait]
 impl CompactionService for CompactionServiceImpl {
     async fn compact(&self, partition_id: u64) -> Result<(), CubeError> {
+        let (partition, index, multi_part) = self
+            .meta_store
+            .get_partition_for_compaction(partition_id)
+            .await?;
+        if let Some(mp) = &multi_part {
+            if mp.get_row().prepared_for_split() {
+                log::debug!(
+                    "Cancelled compaction of {}. It runs concurrently with multi-split",
+                    partition_id
+                );
+                return Ok(());
+            }
+        }
         let mut chunks = self
             .meta_store
             .get_chunks_by_partition(partition_id, false)
@@ -82,26 +113,36 @@ impl CompactionService for CompactionServiceImpl {
                 }
             })
             .collect::<Vec<_>>();
-        let (partition, index) = self
-            .meta_store
-            .get_partition_for_compaction(partition_id)
-            .await?;
         let partition_id = partition.get_id();
         let chunks_row_count = chunks
             .iter()
             .map(|c| c.get_row().get_row_count())
             .sum::<u64>();
-        let total_rows = partition.get_row().main_table_row_count() + chunks_row_count;
-        let new_partitions_count =
-            div_ceil(total_rows, self.config.partition_split_threshold()) as usize;
-
-        let mut new_partitions = Vec::new();
-        for _ in 0..new_partitions_count {
-            new_partitions.push(
+        // For multi-partitions, we only compact chunks and never change the main table.
+        // And we never split, multi-partitions have a different process for that.
+        let new_chunk = match &multi_part {
+            None => None,
+            Some(_) => Some(
                 self.meta_store
-                    .create_partition(partition.get_row().child(partition.get_id()))
+                    .create_chunk(partition_id, chunks_row_count as usize, false)
                     .await?,
-            );
+            ),
+        };
+        let mut total_rows = chunks_row_count;
+        if new_chunk.is_none() {
+            total_rows += partition.get_row().main_table_row_count();
+        }
+        let mut new_partitions = Vec::new();
+        if new_chunk.is_none() {
+            let new_partitions_count =
+                div_ceil(total_rows, self.config.partition_split_threshold()) as usize;
+            for _ in 0..new_partitions_count {
+                new_partitions.push(
+                    self.meta_store
+                        .create_partition(Partition::new_child(&partition, None))
+                        .await?,
+                );
+            }
         }
 
         let mut data = Vec::new();
@@ -114,20 +155,27 @@ impl CompactionService for CompactionServiceImpl {
         }
 
         let store = ParquetTableStore::new(index.get_row().clone(), ROW_GROUP_SIZE);
-        let old_partition_local =
-            if let Some(f) = partition.get_row().get_full_name(partition.get_id()) {
-                Some(self.remote_fs.download_file(&f).await?)
-            } else {
-                None
-            };
-
-        let mut new_partition_local_files = Vec::new();
-        for p in new_partitions.iter() {
-            let new_remote_path = partition_file_name(p.get_id());
-            new_partition_local_files.push(self.remote_fs.temp_upload_path(&new_remote_path).await?)
+        let old_partition_remote = match &new_chunk {
+            Some(_) => None,
+            None => partition.get_row().get_full_name(partition.get_id()),
+        };
+        let old_partition_local = if let Some(f) = old_partition_remote {
+            Some(self.remote_fs.download_file(&f).await?)
+        } else {
+            None
+        };
+        let mut new_local_files = Vec::new();
+        if let Some(c) = &new_chunk {
+            let remote = ChunkStore::chunk_remote_path(c.get_id());
+            new_local_files.push(self.remote_fs.temp_upload_path(&remote).await?);
+        } else {
+            for p in new_partitions.iter() {
+                let new_remote_path = partition_file_name(p.get_id());
+                new_local_files.push(self.remote_fs.temp_upload_path(&new_remote_path).await?);
+            }
         }
 
-        let new_partition_file_names = new_partition_local_files.clone();
+        let new_local_files2 = new_local_files.clone();
         let key_size = index.get_row().sort_key_size() as usize;
         let (store, new) = cube_ext::spawn_blocking(move || -> Result<_, CubeError> {
             // Concat rows from all chunks.
@@ -176,21 +224,31 @@ impl CompactionService for CompactionServiceImpl {
             .meta_store
             .get_table_by_id(index.get_row().table_id())
             .await?;
+        let unique_key = table.get_row().unique_key_columns();
+        let records = merge_chunks(key_size, main_table, new, unique_key).await?;
+        let count_and_min =
+            write_to_files(records, total_rows as usize, store, new_local_files2).await?;
 
-        let records = merge_chunks(
-            key_size,
-            main_table,
-            new,
-            table.get_row().unique_key_columns(),
-        )
-        .await?;
-        let count_and_min = write_to_files(
-            records,
-            total_rows as usize,
-            store,
-            new_partition_file_names,
-        )
-        .await?;
+        let chunk_ids = chunks.iter().map(|c| c.get_id()).collect_vec();
+        if let Some(c) = &new_chunk {
+            assert_eq!(new_local_files.len(), 1);
+            let remote = ChunkStore::chunk_remote_path(c.get_id());
+            self.remote_fs
+                .upload_file(&new_local_files[0], &remote)
+                .await?;
+            let swapped = self
+                .meta_store
+                .swap_compacted_chunks(partition_id, chunk_ids, c.get_id())
+                .await?;
+            if !swapped {
+                log::debug!(
+                    "Cancelled compaction of {}. It runs concurrently with multi-split",
+                    partition_id
+                );
+                self.remote_fs.delete_file(&remote).await?;
+            }
+            return Ok(());
+        }
 
         let mut filtered_partitions = Vec::new();
 
@@ -203,14 +261,14 @@ impl CompactionService for CompactionServiceImpl {
                 EitherOrBoth::Both(p, _) => {
                     let new_remote_path = partition_file_name(p.get_id());
                     self.remote_fs
-                        .upload_file(&new_partition_local_files[i], new_remote_path.as_str())
+                        .upload_file(&new_local_files[i], new_remote_path.as_str())
                         .await?;
                     filtered_partitions.push(p);
                 }
                 EitherOrBoth::Left(p) => {
                     self.meta_store.delete_partition(p.get_id()).await?;
                     // TODO: ensure all files get removed on errors.
-                    let _ = tokio::fs::remove_file(&new_partition_local_files[i]).await;
+                    let _ = tokio::fs::remove_file(&new_local_files[i]).await;
                 }
                 EitherOrBoth::Right(_) => {
                     return Err(CubeError::internal(format!(
@@ -228,7 +286,7 @@ impl CompactionService for CompactionServiceImpl {
                     .iter()
                     .map(|p| p.get_id())
                     .collect::<Vec<_>>(),
-                chunks.iter().map(|c| c.get_id()).collect(),
+                chunk_ids,
                 count_and_min
                     .iter()
                     .zip_longest(count_and_min.iter().skip(1 as usize))
@@ -295,6 +353,243 @@ impl CompactionService for CompactionServiceImpl {
 
         Ok(())
     }
+
+    async fn split_multi_partition(&self, multi_partition_id: u64) -> Result<(), CubeError> {
+        let (multi_index, multi_partition, partitions) = self
+            .meta_store
+            .prepare_multi_partition_for_split(multi_partition_id)
+            .await?;
+        log::trace!(
+            "Preparing to split multi-partition {}:{:?} with partitions {:?}",
+            multi_partition_id,
+            multi_partition.get_row(),
+            partitions
+        );
+        let key_len = multi_index.get_row().key_columns().len();
+
+        // Find key ranges for new partitions.
+        let files = download_files(&partitions, self.remote_fs.clone()).await?;
+        let keys = find_partition_keys(
+            keys_with_counts(&files, key_len).await?,
+            key_len,
+            self.config.partition_split_threshold() as usize,
+        )
+        .await?;
+        // There is no point if we cannot split the partition.
+        log::trace!(
+            "Split keys for multi-partition {}:{:?}",
+            multi_partition_id,
+            keys
+        );
+        if keys.len() == 0 {
+            return Ok(());
+        }
+
+        // Split multi-partition.
+        let create_child = |min, max| {
+            self.meta_store
+                .create_multi_partition(MultiPartition::new_child(&multi_partition, min, max))
+        };
+        let mut mchildren = Vec::with_capacity(1 + keys.len());
+        mchildren.push(
+            create_child(
+                multi_partition.get_row().min_row().cloned(),
+                Some(keys[0].clone()),
+            )
+            .await?,
+        );
+        for i in 0..keys.len() - 1 {
+            mchildren.push(create_child(Some(keys[i].clone()), Some(keys[i + 1].clone())).await?);
+        }
+        mchildren.push(
+            create_child(
+                Some(keys.last().unwrap().clone()),
+                multi_partition.get_row().max_row().cloned(),
+            )
+            .await?,
+        );
+
+        let mut s = MultiSplit::new(
+            self.meta_store.clone(),
+            self.remote_fs.clone(),
+            keys,
+            key_len,
+            multi_partition_id,
+            mchildren,
+        );
+        for p in &partitions {
+            s.split_single_partition(p).await?;
+        }
+        s.finish().await
+    }
+
+    async fn finish_multi_split(
+        &self,
+        multi_partition_id: u64,
+        partition_id: u64,
+    ) -> Result<(), CubeError> {
+        let (data, mut children) = self
+            .meta_store
+            .prepare_multi_split_finish(multi_partition_id, partition_id)
+            .await?;
+        log::trace!(
+            "Preparing to finish split of {} with partition {:?} and multi-part children {:?}",
+            multi_partition_id,
+            data,
+            children
+        );
+
+        let key_len = data.index.get_row().sort_key_size() as usize;
+        children.sort_unstable_by(|l, r| {
+            cmp_min_rows(key_len, l.get_row().min_row(), r.get_row().min_row())
+        });
+        assert!(2 <= children.len(), "2 <= {}", children.len());
+
+        let keys = children
+            .iter()
+            .skip(1)
+            .map(|c| c.get_row().min_row().cloned().unwrap())
+            .collect_vec();
+
+        let mut s = MultiSplit::new(
+            self.meta_store.clone(),
+            self.remote_fs.clone(),
+            keys,
+            key_len,
+            multi_partition_id,
+            children,
+        );
+        s.split_single_partition(&data).await?;
+        s.finish().await
+    }
+}
+
+/// Compute keys that partitions must be split by.
+async fn find_partition_keys(
+    p: HashAggregateExec,
+    key_len: usize,
+    rows_per_partition: usize,
+) -> Result<Vec<Row>, CubeError> {
+    let mut s = p.execute(0).await?;
+    let mut points = Vec::new();
+    let mut row_count = 0;
+    while let Some(b) = s.next().await.transpose()? {
+        let counts = b
+            .column(key_len)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap()
+            .values();
+        for i in 0..b.num_rows() {
+            let c = counts[i] as usize;
+            if rows_per_partition < row_count + c {
+                points.push(Row::new(TableValue::from_columns(
+                    &b.columns()[0..key_len],
+                    i,
+                )));
+                row_count = 0;
+            }
+            row_count += c;
+        }
+    }
+
+    Ok(points)
+}
+
+async fn read_files(
+    files: &[String],
+    key_len: usize,
+    projection: Option<Vec<usize>>,
+) -> Result<Arc<dyn ExecutionPlan>, CubeError> {
+    assert!(!files.is_empty());
+    let mut inputs = Vec::<Arc<dyn ExecutionPlan>>::with_capacity(files.len());
+    for f in files {
+        inputs.push(Arc::new(ParquetExec::try_from_files(
+            &[f.as_str()],
+            projection.clone(),
+            None,
+            ROW_GROUP_SIZE,
+            1,
+            None,
+        )?));
+    }
+    let plan = Arc::new(UnionExec::new(inputs));
+    let fields = plan.schema();
+    let fields = fields.fields();
+    let mut columns = Vec::with_capacity(fields.len());
+    for i in 0..key_len {
+        columns.push(Column::new(fields[i].name().as_str(), i));
+    }
+    Ok(Arc::new(MergeSortExec::try_new(plan, columns.clone())?))
+}
+
+/// The returned execution plan computes all keys in sorted order and the count of rows that have
+/// this key in the input files.
+async fn keys_with_counts(
+    files: &[String],
+    key_len: usize,
+) -> Result<HashAggregateExec, CubeError> {
+    let projection = (0..key_len).collect_vec();
+    let plan = read_files(files, key_len, Some(projection.clone())).await?;
+
+    let fields = plan.schema();
+    let fields = fields.fields();
+    let mut key = Vec::<(Arc<dyn PhysicalExpr>, String)>::with_capacity(key_len);
+    for i in 0..key_len {
+        let name = fields[i].name().clone();
+        let col = Column::new(fields[i].name().as_str(), i);
+        key.push((Arc::new(col), name));
+    }
+    let agg: Vec<Arc<dyn AggregateExpr>> = vec![Arc::new(Count::new(
+        Arc::new(Literal::new(ScalarValue::Int64(Some(1)))),
+        "#mi_row_count",
+        DataType::UInt64,
+    ))];
+    let plan_schema = plan.schema();
+    let plan = HashAggregateExec::try_new(
+        AggregateStrategy::InplaceSorted,
+        Some(projection),
+        AggregateMode::Full,
+        key,
+        agg,
+        plan,
+        plan_schema,
+    )?;
+    Ok(plan)
+}
+
+fn collect_remote_files(p: &PartitionData, out: &mut Vec<String>) {
+    if p.partition.get_row().is_active() {
+        if let Some(f) = p.partition.get_row().get_full_name(p.partition.get_id()) {
+            out.push(f)
+        }
+    }
+    for c in &p.chunks {
+        out.push(ChunkStore::chunk_remote_path(c.get_id()));
+    }
+}
+
+async fn download_files(
+    ps: &[PartitionData],
+    fs: Arc<dyn RemoteFs>,
+) -> Result<Vec<String>, CubeError> {
+    let mut tasks = Vec::new();
+    let mut remote_files = Vec::new();
+    for p in ps {
+        collect_remote_files(p, &mut remote_files);
+        for f in &mut remote_files {
+            let f = take(f);
+            let fs = fs.clone();
+            tasks.push(cube_ext::spawn(async move { fs.download_file(&f).await }))
+        }
+        remote_files.clear();
+    }
+
+    let mut results = Vec::new();
+    for t in tasks {
+        results.push(t.await??)
+    }
+    Ok(results)
 }
 
 /// Writes [records] into [files], trying to split into equally-sized rows, with an additional
@@ -306,10 +601,79 @@ pub(crate) async fn write_to_files(
     store: ParquetTableStore,
     files: Vec<String>,
 ) -> Result<Vec<(usize, Vec<TableValue>)>, CubeError> {
-    let schema = Arc::new(store.arrow_schema());
+    let rows_per_file = (num_rows as usize).div_ceil(&files.len());
     let key_size = store.key_size() as usize;
     let partition_split_key_size = store.partition_split_key_size() as usize;
-    let rows_per_file = (num_rows as usize).div_ceil(&files.len());
+
+    let mut last_row = Vec::new();
+    // (num_rows, first_row) for all processed writers.
+    let stats = Arc::new(Mutex::new(vec![(0, Vec::new())]));
+    let stats_ref = stats.clone();
+
+    let pick_writer = |b: &RecordBatch| -> WriteBatchTo {
+        let stats_ref = stats_ref.clone();
+        let mut stats = stats_ref.lock().unwrap();
+
+        let (num_rows, first_row) = stats.last_mut().unwrap();
+        if first_row.is_empty() {
+            *first_row = TableValue::from_columns(&b.columns()[0..key_size], 0);
+        }
+        if *num_rows + b.num_rows() < rows_per_file {
+            *num_rows += b.num_rows();
+            return WriteBatchTo::Current;
+        }
+
+        let mut i;
+        if last_row.is_empty() {
+            i = rows_per_file - *num_rows - 1;
+            last_row = TableValue::from_columns(&b.columns()[0..key_size], i);
+            i += 1;
+        } else {
+            i = 0;
+        }
+        // Keep writing into the same file until we see a different key.
+        while i < b.num_rows()
+            && cmp_partition_key(partition_split_key_size, &last_row, b.columns(), i)
+                == Ordering::Equal
+        {
+            i += 1;
+        }
+        if i == b.num_rows() {
+            *num_rows += b.num_rows();
+            return WriteBatchTo::Current;
+        }
+
+        *num_rows += i;
+        stats.push((0, Vec::new()));
+        last_row.clear();
+        return WriteBatchTo::Next {
+            rows_for_current: i,
+        };
+    };
+
+    write_to_files_impl(records, store, files, pick_writer).await?;
+
+    let mut stats = take(stats.lock().unwrap().deref_mut());
+    if stats.last().unwrap().0 == 0 {
+        stats.pop();
+    }
+    Ok(stats)
+}
+
+enum WriteBatchTo {
+    /// Current batch must be fully written into the current file.
+    Current,
+    /// Current batch must be written (partially or fully) into the next file.
+    Next { rows_for_current: usize },
+}
+
+async fn write_to_files_impl(
+    records: SendableRecordBatchStream,
+    store: ParquetTableStore,
+    files: Vec<String>,
+    mut pick_writer: impl FnMut(&RecordBatch) -> WriteBatchTo,
+) -> Result<(), CubeError> {
+    let schema = Arc::new(store.arrow_schema());
     let mut writers = files.into_iter().map(move |f| -> Result<_, CubeError> {
         Ok(ArrowWriter::try_new(
             File::create(f)?,
@@ -338,57 +702,21 @@ pub(crate) async fn write_to_files(
         Ok(())
     });
 
-    // Stats for the current writer.
-    let mut writer_i = Ok(0); // Ok(n) marks active file, Err(n) marks finished file.
-    let mut last_row = Vec::new();
-    // (num_rows, first_row) for all processed writers.
-    let stats = Arc::new(Mutex::new(vec![(0, Vec::new())]));
-    let stats_ref = stats.clone();
+    let mut writer_i = 0;
     let mut process_row_group = move |b: RecordBatch| -> Result<_, CubeError> {
-        let stats_ref = stats_ref.clone();
-        let mut stats = stats_ref.lock().unwrap();
-        if let Err(n) = writer_i {
-            writer_i = Ok(n + 1);
-            stats.push((0, Vec::new()));
-            last_row.clear();
+        match pick_writer(&b) {
+            WriteBatchTo::Current => Ok(((writer_i, b), None)),
+            WriteBatchTo::Next {
+                rows_for_current: n,
+            } => {
+                let current_writer = writer_i;
+                writer_i += 1; // Next iteration will write into the next file.
+                Ok((
+                    (current_writer, b.slice(0, n)),
+                    Some(b.slice(n, b.num_rows() - n)),
+                ))
+            }
         }
-
-        let (num_rows, first_row) = stats.last_mut().unwrap();
-        let current_writer = writer_i.unwrap();
-
-        if first_row.is_empty() {
-            *first_row = TableValue::from_columns(&b.columns()[0..key_size], 0);
-        }
-        if *num_rows + b.num_rows() < rows_per_file {
-            *num_rows += b.num_rows();
-            return Ok(((current_writer, b), None));
-        }
-        let mut i;
-        if last_row.is_empty() {
-            i = rows_per_file - *num_rows - 1;
-            last_row = TableValue::from_columns(&b.columns()[0..key_size], i);
-            i += 1;
-        } else {
-            i = 0;
-        }
-        // Keep writing into the same file until we see a different key.
-        while i < b.num_rows()
-            && cmp_partition_key(partition_split_key_size, &last_row, b.columns(), i)
-                == Ordering::Equal
-        {
-            i += 1;
-        }
-        if i == b.num_rows() {
-            *num_rows += b.num_rows();
-            return Ok(((current_writer, b), None));
-        }
-
-        *num_rows += i;
-        writer_i = Err(current_writer); // Next iteration will write into a new file.
-        return Ok((
-            (current_writer, b.slice(0, i)),
-            Some(b.slice(i, b.num_rows() - i)),
-        ));
     };
     let err = redistribute(records, ROW_GROUP_SIZE, move |b| {
         let r = process_row_group(b);
@@ -405,8 +733,66 @@ pub(crate) async fn write_to_files(
     io_job.await??;
     err?;
 
-    let stats = take(stats.lock().unwrap().deref_mut());
-    Ok(stats)
+    Ok(())
+}
+
+async fn write_to_files_by_keys(
+    records: SendableRecordBatchStream,
+    store: ParquetTableStore,
+    files: Vec<String>,
+    keys: Vec<Row>,
+) -> Result<Vec<usize>, CubeError> {
+    assert_eq!(files.len(), 1 + keys.len());
+    let mut row_counts = Vec::with_capacity(files.len());
+    row_counts.push(0);
+    let row_counts = Arc::new(Mutex::new(row_counts));
+    let key_size = store.key_size() as usize;
+    let mut next_key = 0;
+    let row_counts_ref = row_counts.clone();
+    let pick_writer = move |b: &RecordBatch| {
+        assert_ne!(b.num_rows(), 0);
+        let mut row_counts = row_counts_ref.lock().unwrap();
+        if next_key == keys.len() {
+            *row_counts.last_mut().unwrap() += b.num_rows();
+            return WriteBatchTo::Current;
+        }
+        if cmp_partition_key(
+            key_size,
+            keys[next_key].values().as_slice(),
+            b.columns(),
+            b.num_rows() - 1,
+        ) > Ordering::Equal
+        {
+            *row_counts.last_mut().unwrap() += b.num_rows();
+            return WriteBatchTo::Current;
+        }
+        for i in 0..b.num_rows() {
+            if cmp_partition_key(key_size, keys[next_key].values().as_slice(), b.columns(), i)
+                <= Ordering::Equal
+            {
+                *row_counts.last_mut().unwrap() += i;
+                row_counts.push(0);
+
+                next_key += 1;
+                return WriteBatchTo::Next {
+                    rows_for_current: i,
+                };
+            }
+        }
+        panic!("impossible")
+    };
+    let num_files = files.len();
+    write_to_files_impl(records, store, files, pick_writer).await?;
+
+    let mut row_counts: Vec<usize> = take(row_counts.lock().unwrap().as_mut());
+    assert!(
+        row_counts.len() <= num_files,
+        "{} <= {}",
+        row_counts.len(),
+        num_files
+    );
+    row_counts.resize(num_files, 0);
+    Ok(row_counts)
 }
 
 async fn merge_chunks(
@@ -594,5 +980,143 @@ mod tests {
         );
 
         RocksMetaStore::cleanup_test_metastore("compaction");
+    }
+}
+
+struct MultiSplit {
+    meta: Arc<dyn MetaStore>,
+    fs: Arc<dyn RemoteFs>,
+    keys: Vec<Row>,
+    key_len: usize,
+    multi_partition_id: u64,
+    new_multi_parts: Vec<IdRow<MultiPartition>>,
+    new_multi_rows: Vec<u64>,
+    old_chunks: Vec<u64>,
+    old_partitions: Vec<u64>,
+    new_partitions: Vec<u64>,
+    new_partition_rows: Vec<u64>,
+    uploads: Vec<JoinHandle<Result<(), CubeError>>>,
+}
+
+impl MultiSplit {
+    fn new(
+        meta: Arc<dyn MetaStore>,
+        fs: Arc<dyn RemoteFs>,
+        keys: Vec<Row>,
+        key_len: usize,
+        multi_partition_id: u64,
+        new_multi_parts: Vec<IdRow<MultiPartition>>,
+    ) -> MultiSplit {
+        let new_multi_rows = vec![0; new_multi_parts.len()];
+        MultiSplit {
+            meta,
+            fs,
+            keys,
+            key_len,
+            multi_partition_id,
+            new_multi_parts,
+            new_multi_rows,
+            old_chunks: Vec::new(),
+            old_partitions: Vec::new(),
+            new_partitions: Vec::new(),
+            new_partition_rows: Vec::new(),
+            uploads: Vec::new(),
+        }
+    }
+
+    async fn split_single_partition(&mut self, p: &PartitionData) -> Result<(), CubeError> {
+        let mchildren = &self.new_multi_parts;
+        let mrow_counts = &mut self.new_multi_rows;
+        let old_chunks = &mut self.old_chunks;
+        let old_partitions = &mut self.old_partitions;
+        let new_partitions = &mut self.new_partitions;
+        let new_partition_rows = &mut self.new_partition_rows;
+        let uploads = &mut self.uploads;
+
+        let mut children = Vec::with_capacity(mchildren.len());
+        for mc in mchildren.iter() {
+            let c = Partition::new_child(&p.partition, Some(mc.get_id()));
+            let c = c.update_min_max_and_row_count(
+                mc.get_row().min_row().cloned(),
+                mc.get_row().max_row().cloned(),
+                0,
+            );
+            children.push(self.meta.create_partition(c).await?)
+        }
+
+        let mut in_files = Vec::new();
+        collect_remote_files(&p, &mut in_files);
+        for f in &mut in_files {
+            *f = self.fs.local_file(f).await?;
+        }
+
+        let mut out_files = Vec::with_capacity(children.len());
+        let mut out_remote_paths = Vec::with_capacity(children.len());
+        for c in &children {
+            let remote_path = partition_file_name(c.get_id());
+            out_files.push(self.fs.temp_upload_path(&remote_path).await?);
+            out_remote_paths.push(remote_path);
+        }
+
+        let store = ParquetTableStore::new(p.index.get_row().clone(), ROW_GROUP_SIZE);
+        let records = if !in_files.is_empty() {
+            read_files(&in_files, self.key_len, None)
+                .await?
+                .execute(0)
+                .await?
+        } else {
+            EmptyExec::new(false, Arc::new(store.arrow_schema()))
+                .execute(0)
+                .await?
+        };
+        let row_counts =
+            write_to_files_by_keys(records, store, out_files.clone(), self.keys.clone()).await?;
+
+        for i in 0..row_counts.len() {
+            mrow_counts[i] += row_counts[i] as u64;
+        }
+        old_partitions.push(p.partition.get_id());
+        for c in &p.chunks {
+            old_chunks.push(c.get_id());
+        }
+        for i in 0..children.len() {
+            new_partitions.push(children[i].get_id());
+            new_partition_rows.push(row_counts[i] as u64)
+        }
+        for i in 0..row_counts.len() {
+            if row_counts[i] == 0 {
+                continue;
+            }
+            let fs = self.fs.clone();
+            let local_path = take(&mut out_files[i]);
+            let remote_path = take(&mut out_remote_paths[i]);
+            uploads.push(cube_ext::spawn(async move {
+                fs.upload_file(&local_path, &remote_path).await
+            }));
+        }
+        Ok(())
+    }
+
+    async fn finish(self) -> Result<(), CubeError> {
+        for u in self.uploads {
+            u.await??;
+        }
+
+        let mids = self
+            .new_multi_parts
+            .into_iter()
+            .map(|p| p.get_id())
+            .collect_vec();
+        self.meta
+            .commit_multi_partition_split(
+                self.multi_partition_id,
+                mids,
+                self.new_multi_rows,
+                self.old_partitions,
+                self.old_chunks,
+                self.new_partitions,
+                self.new_partition_rows,
+            )
+            .await
     }
 }

--- a/rust/cubestore/src/table/data.rs
+++ b/rust/cubestore/src/table/data.rs
@@ -77,8 +77,8 @@ pub fn cmp_partition_column_same_type(l: &TableValue, r: &dyn Array, ri: usize) 
     )
 }
 
-/// Use for comparing min/max rows insied partitions.
-pub fn cmp_row_markers(key_size: usize, l: &Option<Row>, r: &Option<Row>) -> Ordering {
+/// Use for comparing min row marker inside partitions.
+pub fn cmp_min_rows(key_size: usize, l: Option<&Row>, r: Option<&Row>) -> Ordering {
     match (l, r) {
         (None, None) => Ordering::Equal,
         (None, _) => Ordering::Less,

--- a/rust/cubestore/src/table/parquet.rs
+++ b/rust/cubestore/src/table/parquet.rs
@@ -119,6 +119,7 @@ mod tests {
             ],
             6,
             None,
+            None,
         )
         .unwrap();
 
@@ -206,6 +207,7 @@ mod tests {
                     ),
                 ],
                 3,
+                None,
                 None,
             )
             .unwrap(),
@@ -316,6 +318,7 @@ mod tests {
                 vec![Column::new("b".to_string(), ColumnType::Boolean, 0)],
                 1,
                 None,
+                None,
             )
             .unwrap();
             let tmp_file = NamedTempFile::new().unwrap();
@@ -361,6 +364,7 @@ mod tests {
                 Column::new("bytes".into(), ColumnType::Bytes, 1),
             ],
             1,
+            None,
             None,
         )
         .unwrap();


### PR DESCRIPTION
The index will ensure the data from multiple tables is partitioned
with the same keys and collocated on the same machines. This allows
to evenly distribute the work on JOIN queries and avoid duplicating
same keys on different machines.

However, we need more work to keep partitions at async on ingestion
and compaction.

```
CREATE PARTITIONED INDEX schema.pindex(id int, url text);
CREATE TABLE schema.foo(some_id int, some_url text, data text)
    ADD TO PARTITIONED INDEX pindex(some_id, some_url);
CREATE TABLE schema.bar(other_id int, other_url text, other_data text)
    ADD TO PARTITIONED INDEX pindex(other_id, other_url);

SELECT some_id, data, other_data
FROM schema.foo f
JOIN schema.bar b ON f.some_id = b.other_id AND f.some_url = b.other_url
```

This is an early version. There are known problems and limitations:
  - `DROP TABLE` might cancel multi-index partitioning,
  - There is no way to remove the index, i.e. `DROP PARTITIONED INDEX`,
  - Performance with large number of tables is yet to be evaluated.

Mostly tested on random data and simple queries, we expect to find more
issues and fixes before we stabilize and bring this to CubeJS.