### PR TITLE
misc: Disable build for x86_64-pc-windows-gnu (replaced by msvc)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -447,7 +447,6 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
         include:
@@ -463,13 +462,6 @@ jobs:
             cross: true
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
-            compress: false
-          - os: ubuntu-20.04
-            target: x86_64-pc-windows-gnu
-            executable_name: cubestored.exe
-            cross: true
-            strip: true
-            # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
           - os: windows-2019
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/rust-master.yml
+++ b/.github/workflows/rust-master.yml
@@ -155,7 +155,6 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - x86_64-pc-windows-gnu
           - x86_64-apple-darwin
         include:
           - os: ubuntu-20.04
@@ -170,13 +169,6 @@ jobs:
             cross: true
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
-            compress: false
-          - os: ubuntu-20.04
-            target: x86_64-pc-windows-gnu
-            executable_name: cubestored.exe
-            cross: true
-            strip: true
-            # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
           - os: macos-latest
             target: x86_64-apple-darwin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,7 +98,6 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
         include:
@@ -114,13 +113,6 @@ jobs:
             cross: true
             strip: true
             # cubestored: CantPackException: bad DT_HASH nbucket=0x344  len=0x1890
-            compress: false
-          - os: ubuntu-20.04
-            target: x86_64-pc-windows-gnu
-            executable_name: cubestored.exe
-            cross: true
-            strip: true
-            # cubestored.exe: CantPackException: superfluous data between sections
             compress: false
           - os: windows-2019
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Hello!

We started to support Windows build for Cube Store from GNU builds, but after some time we switched to MSVC because: GNU toolkit requires GNU libc which is not installed on Windows by default. 

Thanks