### PR TITLE
examples(k8s): added cubestore data dir env var

### DIFF
--- a/examples/kubernetes/cluster/cubestore-router-statefulset.yaml
+++ b/examples/kubernetes/cluster/cubestore-router-statefulset.yaml
@@ -18,6 +18,8 @@ spec:
         - env: # Refer to https://cube.dev/docs/reference/environment-variables for more options
             - name: CUBESTORE_META_PORT
               value: "9999"
+            - name: CUBESTORE_DATA_DIR
+              value: /cube/.cubestore/data
             - name: CUBESTORE_REMOTE_DIR
               value: /cube/data
             - name: CUBESTORE_SERVER_NAME

--- a/examples/kubernetes/cluster/cubestore-workers-statefulset.yaml
+++ b/examples/kubernetes/cluster/cubestore-workers-statefulset.yaml
@@ -23,6 +23,8 @@ spec:
                   fieldPath: metadata.name
             - name: CUBESTORE_META_ADDR
               value: cubestore-router:9999
+            - name: CUBESTORE_DATA_DIR
+              value: /cube/.cubestore/data
             - name: CUBESTORE_REMOTE_DIR
               value: /cube/data
               # The $(POD_NAME) is a way of referencing dependent env vars


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

This adds a K8s config example to resolve the issue of not having dedicated data dirs for Cube Store.

**Description of Changes Made (if issue reference is not provided)**

This example will be used in the docs where @hassankhan will implement updates. As per @ilya-biryukov request to use the same remote dir and dedicated data dirs, this example will now adhere to this requirement.
