### PR TITLE
docs(config): fix broken link to Export Bucket documentation

### DIFF
--- a/docs/content/Configuration/Databases/AWS-Redshift.mdx
+++ b/docs/content/Configuration/Databases/AWS-Redshift.mdx
@@ -107,7 +107,7 @@ Database][ref-recipe-enable-ssl].
   https://docs.aws.amazon.com/redshift/latest/dg/r_Users.html
 [aws-redshift]: https://aws.amazon.com/redshift/
 [aws-vpc]: https://aws.amazon.com/vpc/
-[ref-caching-large-preaggs]: /using-pre-aggregations#large-pre-aggregations
+[ref-caching-large-preaggs]: /caching/using-pre-aggregations#export-bucket
 [ref-caching-using-preaggs-build-strats]:
   /caching/using-pre-aggregations#pre-aggregation-build-strategies
 [ref-recipe-enable-ssl]: /recipes/enable-ssl-connections-to-database

--- a/docs/content/Configuration/Databases/Google-BigQuery.mdx
+++ b/docs/content/Configuration/Databases/Google-BigQuery.mdx
@@ -116,7 +116,7 @@ BigQuery connections are made over HTTPS.
   https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin
 [google-support-create-svc-account]:
   https://support.google.com/a/answer/7378726?hl=en
-[ref-caching-large-preaggs]: /using-pre-aggregations#large-pre-aggregations
+[ref-caching-large-preaggs]: /caching/using-pre-aggregations#export-bucket
 [ref-caching-using-preaggs-build-strats]:
   /caching/using-pre-aggregations#pre-aggregation-build-strategies
 [ref-env-var]: /reference/environment-variables#database-connection

--- a/docs/content/Configuration/Databases/Snowflake.mdx
+++ b/docs/content/Configuration/Databases/Snowflake.mdx
@@ -114,7 +114,6 @@ connections are made over HTTPS.
 
 [dbt-docs-snowflake-account]:
   https://docs.getdbt.com/reference/warehouse-profiles/snowflake-profile#account
-[ref-caching-large-preaggs]: /using-pre-aggregations#large-pre-aggregations
 [ref-caching-using-preaggs-build-strats]:
   /caching/using-pre-aggregations#pre-aggregation-build-strategies
 [ref-env-var]: /reference/environment-variables#database-connection


### PR DESCRIPTION
Thanks @tanvi-cota

Story details: https://app.shortcut.com/cube-dev/story/1146