### PR TITLE
fix(cubestore): Introduce file suffixes to avoid parquet write clashe…

### DIFF
--- a/rust/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/src/cluster/mod.rs
@@ -1470,7 +1470,11 @@ impl ClusterImpl {
                     log::debug!("Startup warmup cancelled");
                     return;
                 }
-                ack_error!(self.remote_fs.download_file(&chunk_file_name(c)).await);
+                ack_error!(
+                    self.remote_fs
+                        .download_file(&chunk_file_name(c.get_id(), c.get_row().suffix()))
+                        .await
+                );
             }
         }
         log::debug!("Startup warmup finished");

--- a/rust/cubestore/src/queryplanner/info_schema/system_partitions.rs
+++ b/rust/cubestore/src/queryplanner/info_schema/system_partitions.rs
@@ -1,3 +1,4 @@
+use crate::metastore::partition::partition_file_name;
 use crate::metastore::{IdRow, MetaStore, MetaStoreTable, Partition};
 use crate::queryplanner::InfoSchemaTableDef;
 use crate::CubeError;
@@ -25,6 +26,17 @@ impl InfoSchemaTableDef for SystemPartitionsTableDef {
                         partitions
                             .iter()
                             .map(|row| row.get_id())
+                            .collect::<Vec<_>>(),
+                    ))
+                }),
+            ),
+            (
+                Field::new("file_name", DataType::Utf8, false),
+                Box::new(|partitions| {
+                    Arc::new(StringArray::from(
+                        partitions
+                            .iter()
+                            .map(|row| partition_file_name(row.get_id(), row.get_row().suffix()))
                             .collect::<Vec<_>>(),
                     ))
                 }),

--- a/rust/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/src/scheduler/mod.rs
@@ -281,7 +281,10 @@ impl SchedulerImpl {
                     .await?;
             } else if chunk.get_row().uploaded() {
                 self.remote_fs
-                    .delete_file(ChunkStore::chunk_remote_path(chunk.get_id()).as_str())
+                    .delete_file(
+                        ChunkStore::chunk_remote_path(chunk.get_id(), chunk.get_row().suffix())
+                            .as_str(),
+                    )
                     .await?
             }
         }

--- a/rust/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/src/sql/mod.rs
@@ -2009,7 +2009,11 @@ mod tests {
                     .collect::<Vec<_>>();
                 assert_eq!(
                     files,
-                    vec![format!("{}.parquet", last_active_partition.get_id())]
+                    vec![format!(
+                        "{}-{}.parquet",
+                        last_active_partition.get_id(),
+                        last_active_partition.get_row().suffix().as_ref().unwrap()
+                    )]
                 )
             })
             .await

--- a/rust/cubestore/src/store/mod.rs
+++ b/rust/cubestore/src/store/mod.rs
@@ -24,6 +24,7 @@ use std::{
 use crate::cluster::Cluster;
 use crate::config::injection::DIService;
 use crate::config::ConfigObj;
+use crate::metastore::chunks::chunk_file_name;
 use crate::table::data::cmp_partition_key;
 use crate::table::parquet::{arrow_schema, ParquetTableStore};
 use arrow::array::{Array, ArrayRef, Int64Builder, StringBuilder, UInt64Array};
@@ -299,11 +300,11 @@ impl ChunkStore {
     }
 
     pub fn chunk_file_name(chunk: IdRow<Chunk>) -> String {
-        Self::chunk_remote_path(chunk.get_id())
+        Self::chunk_remote_path(chunk.get_id(), chunk.get_row().suffix())
     }
 
-    pub fn chunk_remote_path(chunk_id: u64) -> String {
-        format!("{}.chunk.parquet", chunk_id)
+    pub fn chunk_remote_path(chunk_id: u64, suffix: &Option<String>) -> String {
+        chunk_file_name(chunk_id, suffix)
     }
 }
 


### PR DESCRIPTION
…s in case of meta store recovery

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
