### PR TITLE
fix(cubestore): speed up HLL++ merges, up to 180x in some cases 

### DIFF
--- a/rust/cubestore/src/queryplanner/hll.rs
+++ b/rust/cubestore/src/queryplanner/hll.rs
@@ -40,7 +40,7 @@ impl Hll {
         }
     }
 
-    pub fn cardinality(&self) -> u64 {
+    pub fn cardinality(&mut self) -> u64 {
         match self {
             Hll::Airlift(h) => h.cardinality(),
             Hll::ZetaSketch(h) => h.cardinality(),

--- a/rust/cubezetasketch/src/sparse.rs
+++ b/rust/cubezetasketch/src/sparse.rs
@@ -21,6 +21,7 @@ use crate::state::State;
 use crate::Result;
 use crate::ZetaError;
 use std::cmp::min;
+use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 pub struct SparseRepresentation {
@@ -29,8 +30,26 @@ pub struct SparseRepresentation {
      * normal. See `MAXIMUM_SPARSE_DATA_FRACTION` for more details.
      */
     max_sparse_data_bytes: u32,
+
     /** Helper object for encoding and decoding individual sparse values. */
     encoding: SparseEncoding,
+
+    /**
+     * A buffer of integers which should be merged into the difference encoded [sparse_data]. The
+     * sparse representation in [sparse_data] is more space efficient but also slower to read and
+     * write to, so this buffer allows us to quickly return when adding new values.
+     *
+     * Original implementation uses vector here, we choose to use BTreeSet to improve merge times.
+     * This involves a higher memory footprint, but allows to very efficiently buffer elements
+     * on merges.
+     */
+    buffer: BTreeSet<u32>,
+    /**
+     * The maximum number of elements that the [buffer] may contain before it is flushed into the
+     * sparse [sparseData] representation. See [MAXIMUM_BUFFER_ELEMENTS_FRACTION] for details on
+     * how this is computed.
+     */
+    max_buffer_elements: u32,
 }
 
 impl SparseRepresentation {
@@ -47,6 +66,35 @@ impl SparseRepresentation {
      * independently (e.g. improving runtime performance while trading off for peak memory usage).
      */
     const MAXIMUM_SPARSE_DATA_FRACTION: f32 = 0.75;
+
+    /**
+     * The maximum amount of elements that the temporary `buffer` may contain before it is
+     * flushed, relative to the number of bytes that the data in the normal representation would
+     * require.
+     *
+     * The thinking for this is as follows: If the number of bytes that the normal representation
+     * would occupy is `m`, then the maximum number of bytes that the encoded sparse data can
+     * occupy is `0.75m` (see [MAXIMUM_SPARSE_DATA_FRACTION] above). This leaves `0.25m = m/4` bytes
+     * of memory that the temporary buffer can use before the overall in-memory
+     * footprint of the sparse representation exceeds that of the normal representation. Since each
+     * element in the buffer requires 4 bytes (32-bit integers), we can at most keep `m/16` elements
+     * before we exceed the in-memory footprint of the normal representation data.
+     *
+     * Now the problem is that writing and reading the difference encoded data is CPU expensive (it
+     * is by far the limiting factor for sparse adds and merges) so there is a tradeoff between the
+     * memory footprint and the CPU cost.
+     * For this reason, we add a correction factor that allows the sparse representation to use a bit
+     * more memory and thereby greatly increases the speed of adds and merges.
+     *
+     * A value of `4` was chosen in consistency with a legacy HLL++ implementation but this
+     * is something to be evaluated critically.
+     *
+     * This results in a final elements to bytes ratio of `4 * m/16 = m/4`. This means that the
+     * sparse representation can (in the worst case) use 1.75x the amount of RAM than the normal
+     * representation would. It will always use less than [MAXIMUM_SPARSE_DATA_FRACTION] times the
+     * amount of space on disk, however.
+     */
+    const MAXIMUM_BUFFER_ELEMENTS_FRACTION: f32 = 1. - Self::MAXIMUM_SPARSE_DATA_FRACTION;
 
     pub fn new(state: &State) -> Result<SparseRepresentation> {
         Self::check_precision(state.precision, state.sparse_precision)?;
@@ -69,11 +117,20 @@ impl SparseRepresentation {
                 max_sparse_data_bytes
             )));
         }
+        let max_buffer_elements = (m as f32 * Self::MAXIMUM_BUFFER_ELEMENTS_FRACTION) as u32;
+        if max_buffer_elements <= 0 {
+            return Err(ZetaError::new(format!(
+                "max_buffer_elements must be > 0, got {}",
+                max_buffer_elements
+            )));
+        }
         // We have no good way of checking whether the data actually contains the given number of
         // elements without decoding the data, which would be inefficient here.
         return Ok(SparseRepresentation {
             max_sparse_data_bytes,
             encoding,
+            max_buffer_elements,
+            buffer: BTreeSet::new(),
         });
     }
 
@@ -96,7 +153,11 @@ impl SparseRepresentation {
         return Ok(());
     }
 
-    pub fn cardinality(&self, state: &State) -> u64 {
+    pub fn cardinality(&mut self, state: &mut State) -> u64 {
+        // This is the only place that panics instead of returning errors.
+        // TODO: we should either (1) panic everywhere or (2) return an error here.
+        self.flush_buffer(state).expect("could not flush buffer");
+
         // Linear counting over the number of empty sparse buckets.
         let buckets = 1 << state.sparse_precision;
         let num_zeros = buckets - state.sparse_size;
@@ -114,7 +175,7 @@ impl SparseRepresentation {
     ) -> Result<Option<NormalRepresentation>> {
         // TODO: Add special case when 'this' is empty and 'other' has only encoded data.
         // In that case, we can just copy over the sparse data without needing to decode and dedupe.
-        return self.add_sparse_values(state, &other.encoding, other_state.sparse_data.as_deref());
+        return self.add_sparse_values(state, other, other_state);
     }
 
     #[must_use]
@@ -132,29 +193,50 @@ impl SparseRepresentation {
     fn add_sparse_values(
         &mut self,
         state: &mut State,
-        encoding: &SparseEncoding,
-        sparse_data: Option<&[u8]>,
+        other: &SparseRepresentation,
+        other_state: &State,
     ) -> Result<Option<NormalRepresentation>> {
-        self.encoding.assert_compatible(encoding);
-
-        // Special case when encodings are the same. Then we can profit from the fact that sparse_values
-        // are sorted (as defined in the add_sparse_values contract) and do a merge-join.
-        let self_data = state.sparse_data.take();
-        self.merge_and_set(
-            state,
-            Self::sorted_iterator(self_data.as_deref()),
-            Self::sorted_iterator(sparse_data),
-        )?;
+        self.encoding.assert_compatible(&other.encoding);
+        if !other.buffer.is_empty() {
+            self.buffer.extend(other.buffer.iter())
+        }
+        if other_state.sparse_size < 0 {
+            return Err(ZetaError::new(format!(
+                "negative sparse_size: {}",
+                other_state.sparse_size
+            )));
+        }
+        if (other_state.sparse_size as u32) < self.max_buffer_elements {
+            for e in Self::sorted_iterator(other_state.sparse_data.as_deref()) {
+                let e = e?;
+                self.buffer.insert(e);
+            }
+        } else {
+            // Special case when encodings are the same. Then we can profit from the fact that
+            // sparse_values are sorted (as defined in the add_sparse_values contract) and do a
+            // merge-join.
+            self.flush_buffer(state)?;
+            let self_data = state.sparse_data.take();
+            self.merge_and_set(
+                state,
+                Self::sorted_iterator(self_data.as_deref()),
+                Self::sorted_iterator(other_state.sparse_data.as_deref()),
+            )?;
+        }
         // TODO: Merge without risking to grow this representation above its maximum size.
         return Ok(self.update_representation(state)?);
     }
 
-    fn merge_and_set<Iter: Iterator<Item = Result<u32>>>(
+    fn merge_and_set<Iter1, Iter2>(
         &self,
         state: &mut State,
-        mut l: Iter,
-        mut r: Iter,
-    ) -> Result<()> {
+        mut l: Iter1,
+        mut r: Iter2,
+    ) -> Result<()>
+    where
+        Iter1: Iterator<Item = Result<u32>>,
+        Iter2: Iterator<Item = Result<u32>>,
+    {
         let mut data = Vec::new();
         struct MergeState<'a> {
             encoder: DifferenceEncoder<'a>,
@@ -165,6 +247,7 @@ impl SparseRepresentation {
                 self.encoder.put_int(v);
                 self.size += 1;
             }
+
             fn consume<Iter: Iterator<Item = Result<u32>>>(&mut self, mut it: Iter) -> Result<()> {
                 while let Some(v) = it.next().transpose()? {
                     self.encoder.put_int(v);
@@ -248,6 +331,10 @@ impl SparseRepresentation {
         return DifferenceDecoder::new(sparse_data.unwrap_or(&[]));
     }
 
+    fn buffer_iterator<'a>(&'a self) -> impl Iterator<Item = Result<u32>> + 'a {
+        self.buffer.iter().map(|v| Ok(*v))
+    }
+
     /// Updates the sparse representation:
     ///    - If the temporary list has become too large, serialize it into the sparse bytes
     ///      representation.
@@ -257,6 +344,9 @@ impl SparseRepresentation {
     /// `None` if the sparse representation can continue to be be used.
     #[must_use]
     fn update_representation(&mut self, state: &mut State) -> Result<Option<NormalRepresentation>> {
+        if (self.max_buffer_elements as usize) < self.buffer.len() {
+            self.flush_buffer(state)?;
+        }
         // Upgrade to normal if the sparse data exceeds the maximum allowed amount of memory.
         //
         // Note that sparse_data will allocate a larger buffer on the heap (of size
@@ -289,7 +379,34 @@ impl SparseRepresentation {
             self.encoding(),
             Self::sorted_iterator(sparse_data.as_deref()),
         )?;
+        if !self.buffer.is_empty() {
+            representation.add_sparse_values(state, self.encoding(), self.buffer_iterator())?;
+            self.buffer.clear();
+        }
 
         return Ok(representation);
+    }
+
+    pub fn requires_compaction(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+
+    pub fn compact(&mut self, state: &mut State) -> Result<()> {
+        self.flush_buffer(state)
+    }
+
+    fn flush_buffer(&mut self, state: &mut State) -> Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+
+        let data = state.sparse_data.take();
+        self.merge_and_set(
+            state,
+            Self::sorted_iterator(data.as_deref()),
+            self.buffer_iterator(),
+        )?;
+        self.buffer.clear();
+        return Ok(());
     }
 }


### PR DESCRIPTION
Add a buffer that delays write into VLE-encoded array for Sparse HLLs.
This produces 45x improvement for merging 10k single-value HLLs.
This adds up to 180x improvement with the previous commit.

The buffer is a `BTreeSet` instead of vector in the original
implementation. This allows to keep the buffer smaller and do less
compactions in some cases, e.g. when merging HLLs with many common
elements. It does use more memory and CPU when merging HLLs with
many different hashes.