### PR TITLE
docs(deployment): add links to Migrating to Cube Cloud blog post

### DIFF
--- a/docs/content/Deployment/Platform-Cube-Cloud.mdx
+++ b/docs/content/Deployment/Platform-Cube-Cloud.mdx
@@ -11,6 +11,13 @@ a purpose-built platform to run Cube applications in production. It is made by
 the creators of Cube and incorporates all the best practices of running and
 scaling Cube applications.
 
+<InfoBox>
+
+Are you moving from a self-hosted installation to Cube Cloud? [Click
+here][blog-migrate-to-cube-cloud] to learn more.
+
+</InfoBox>
+
 <div style="text-align: center">
   <img
     src="https://raw.githubusercontent.com/cube-js/cube.js/master/docs/content/Deployment/how-cube-cloud-works.png"
@@ -27,6 +34,8 @@ scaling Cube applications.
 
 Learn more about [deployment with Cube Cloud here][ref-cubecloud-getstart].
 
+[blog-migrate-to-cube-cloud]:
+  https://cube.dev/blog/migrating-from-self-hosted-to-cube-cloud/
 [link-cube-cloud]: https://cubecloud.dev
 [link-cube-cloud-waitlist]: https://cube.dev/cloud
 [ref-cubecloud-getstart]: /cloud/getting-started

--- a/docs/content/Deployment/Production-Checklist.mdx
+++ b/docs/content/Deployment/Production-Checklist.mdx
@@ -5,6 +5,14 @@ category: Deployment
 menuOrder: 2
 ---
 
+<InfoBox>
+
+Thinking of migrating to the cloud instead? [Click
+here][blog-migrate-to-cube-cloud] to learn more about migrating a self-hosted
+installation to [Cube Cloud][link-cube-cloud].
+
+</InfoBox>
+
 This is a checklist for configuring and securing Cube.js for a production
 deployment.
 
@@ -137,9 +145,12 @@ your monitoring service of choice to use the [`/readyz`][ref-api-readyz] and
 [`/livez`][ref-api-livez] API endpoints so you can check on the Cube.js
 deployment's health and be alerted to any issues.
 
+[blog-migrate-to-cube-cloud]:
+  https://cube.dev/blog/migrating-from-self-hosted-to-cube-cloud/
 [gh-ioredis]: https://github.com/luin/ioredis
 [gh-node-redis]: https://github.com/NodeRedis/node-redis
 [link-caddy]: https://caddyserver.com/
+[link-cube-cloud]: https://cubecloud.dev
 [link-cubejs-dev-vs-prod]: /configuration/overview#development-mode
 [link-k8s-healthcheck-api]:
   https://kubernetes.io/docs/reference/using-api/health-checks/


### PR DESCRIPTION
Story details: https://app.shortcut.com/cube-dev/story/1150