### PR TITLE
chore(native): Store state of JsAsyncChannel as JsBox in this

### DIFF
--- a/packages/cubejs-backend-native/lib/index.ts
+++ b/packages/cubejs-backend-native/lib/index.ts
@@ -47,9 +47,9 @@ function wrapNativeFunctionWithChannelCallback(
     return async (extra: any, channel: any) => {
         try {
             const result = await fn(JSON.parse(extra));
-            native.channel_resolve(channel, JSON.stringify(result));
-          } catch (e) {
-            native.channel_reject(channel);
+            channel.resolve(JSON.stringify(result));
+          } catch (e: any) {
+            channel.reject(e.message || 'Unknown JS exception');
 
             throw e;
           }

--- a/packages/cubejs-backend-native/native.d.ts
+++ b/packages/cubejs-backend-native/native.d.ts
@@ -1,5 +1,0 @@
-declare module 'index.node' {
-    type AsyncChannel = {};
-    function channel_resolve(channel: AsyncChannel, result: string): void;
-    function channel_reject(channel: AsyncChannel): void;
-}

--- a/packages/cubejs-backend-native/src/lib.rs
+++ b/packages/cubejs-backend-native/src/lib.rs
@@ -5,11 +5,11 @@ mod auth;
 mod channel;
 mod config;
 mod transport;
+mod utils;
 
 use std::{collections::HashMap, sync::Arc};
 
 use auth::NodeBridgeAuthService;
-use channel::{channel_reject, channel_resolve};
 use config::NodeConfig;
 use cubesql::telemetry::{track_event, ReportingLogger};
 use log::Level;
@@ -108,8 +108,6 @@ fn register_interface(mut cx: FunctionContext) -> JsResult<JsPromise> {
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("setLogLevel", set_log_level)?;
     cx.export_function("registerInterface", register_interface)?;
-    cx.export_function("channel_resolve", channel_resolve)?;
-    cx.export_function("channel_reject", channel_reject)?;
 
     Ok(())
 }

--- a/packages/cubejs-backend-native/src/utils.rs
+++ b/packages/cubejs-backend-native/src/utils.rs
@@ -1,0 +1,21 @@
+use neon::prelude::*;
+
+#[inline(always)]
+pub fn call_method<'a>(
+    cx: &mut impl Context<'a>,
+    this: Handle<'a, JsFunction>,
+    method_name: &str,
+    args: impl IntoIterator<Item = Handle<'a, JsValue>>,
+) -> JsResult<'a, JsValue> {
+    let method: Handle<JsFunction> = this.get(cx, method_name)?.downcast_or_throw(cx)?;
+    method.call(cx, this, args)
+}
+
+#[inline(always)]
+pub fn bind_method<'a>(
+    cx: &mut impl Context<'a>,
+    fn_value: Handle<'a, JsFunction>,
+    this: Handle<'a, JsValue>,
+) -> JsResult<'a, JsValue> {
+    call_method(cx, fn_value, "bind", vec![this])
+}


### PR DESCRIPTION
Hello!

Internal change. In the previous version of API, I used additional functions to resolve `AsyncChannel`: `channel_resolve` & `channel_reject`. These functions weren't mapped to an object (`AsyncChannel`) and we used an additional argument (first argument) to pass a reference to AsyncChannel via JsBox (external reference in the API). In upcoming changes, I am going to rewrite AsynChannel to be used with `JsPromise` (awaiting results from Promise), but to do it `AsyncChannel` must be a generic object to accept value from the `promise.then`.

For unpacking JsBox from an argument we used a code:

```
    let channel = cx.argument::<JsBox<JsAsyncChannel>>(0)?;
```

But these functions didn't know anything about what type `JsAsyncChannel` will store in it and to resolve this limitation I mapped these functions to an object which works as `this` (via binding)  for these functions.

Thanks