### PR TITLE
chore(oracle-driver): Use oracledb as optionalDependency

### DIFF
--- a/packages/cubejs-oracle-driver/package.json
+++ b/packages/cubejs-oracle-driver/package.json
@@ -14,8 +14,10 @@
   "main": "driver/OracleDriver.js",
   "dependencies": {
     "@cubejs-backend/query-orchestrator": "^0.28.52",
-    "oracledb": "^4.2.0",
     "ramda": "^0.27.0"
+  },
+  "optionalDependencies": {
+    "oracledb": "^4.2.0"
   },
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
Hello!

It's needed to unblock developers of Cube.js which are using arm64.

Thanks