### PR TITLE
docs(recipes): fix recipes menu order

### DIFF
--- a/docs/content/Examples-Tutorials-Recipes/Recipes/Optimizing-complex-cubes.mdx
+++ b/docs/content/Examples-Tutorials-Recipes/Recipes/Optimizing-complex-cubes.mdx
@@ -2,8 +2,8 @@
 title: Using originalSql and rollup pre-aggregations effectively
 permalink: /recipes/using-originalsql-and-rollups-effectively
 category: Examples & Tutorials
-subCategory: Query Acceleration
-menuOrder: 4
+subCategory: Query acceleration
+menuOrder: 6
 ---
 
 ## Use case


### PR DESCRIPTION
The "Query Acceleration" category is duplicated:
<img width="620" alt="Screenshot 2021-11-19 at 11 52 49" src="https://user-images.githubusercontent.com/18264667/142578627-a300364d-ef4d-422f-8672-422708082366.png">

I changed the category name as in previous recipes  😃 