### PR TITLE
fix: Empty pre-aggregation with partitionGranularity throws ParserErr…

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -1226,7 +1226,7 @@ export class PreAggregationPartitionRangeLoader {
       ),
     );
     if (!this.preAggregation.partitionGranularity) {
-      return [startDate, endDate];
+      return this.orNowIfEmpty([startDate, endDate]);
     }
     const wholeSeriesRanges = PreAggregationPartitionRangeLoader.timeSeries(
       this.preAggregation.partitionGranularity,
@@ -1241,7 +1241,21 @@ export class PreAggregationPartitionRangeLoader {
         ),
       ),
     );
-    return [rangeStart, rangeEnd];
+    return this.orNowIfEmpty([rangeStart, rangeEnd]);
+  }
+
+  private orNowIfEmpty(dateRange: QueryDateRange): QueryDateRange {
+    if (!dateRange[0] && !dateRange[1]) {
+      const now = utcToLocalTimeZone(this.preAggregation.timezone, 'YYYY-MM-DDTHH:mm:ss.SSS', new Date().toJSON().substring(0, 23));
+      return [now, now];
+    }
+    if (!dateRange[0]) {
+      return [dateRange[1], dateRange[1]];
+    }
+    if (!dateRange[1]) {
+      return [dateRange[0], dateRange[0]];
+    }
+    return dateRange;
   }
 
   private static checkDataRangeType(range: QueryDateRange) {

--- a/packages/cubejs-testing/birdbox-fixtures/postgresql/schema/PreAggregationTest.js
+++ b/packages/cubejs-testing/birdbox-fixtures/postgresql/schema/PreAggregationTest.js
@@ -342,6 +342,7 @@ cube('EveryHourVisitors', {
       timeDimensionReference: createdAt,
       granularity: 'day',
       partitionGranularity: 'month',
+      external: true,
       refreshKey: {
         every: '1 hour',
         incremental: true,

--- a/packages/cubejs-testing/test/__snapshots__/birdbox-postgresql-pre-aggregations.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/birdbox-postgresql-pre-aggregations.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`postgresql-cubestore HTTP Transport Empty partitions: Empty partitions 1`] = `Array []`;
+
 exports[`postgresql-cubestore HTTP Transport Rolling Mixed With Dimension: Rolling Mixed With Dimension 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/__snapshots__/cli-postgresql-pre-aggregations.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/cli-postgresql-pre-aggregations.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`postgresql HTTP Transport Empty partitions: Empty partitions 1`] = `Array []`;
+
 exports[`postgresql HTTP Transport Rolling Mixed With Dimension: Rolling Mixed With Dimension 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/pre-aggregations-test-case.ts
+++ b/packages/cubejs-testing/test/pre-aggregations-test-case.ts
@@ -73,6 +73,20 @@ const asserts: [options: QueryTestOptions, query: Query][] = [
         'visitors.source': 'asc'
       }
     }
+  ],
+  [
+    { name: 'Empty partitions' },
+    {
+      measures: [
+        'EmptyHourVisitors.checkinsTotal'
+      ],
+      timezone: 'UTC',
+      timeDimensions: [{
+        dimension: 'EmptyHourVisitors.createdAt',
+        granularity: 'day',
+        dateRange: ['2017-01-02', '2022-01-05']
+      }]
+    }
   ]
 ];
 


### PR DESCRIPTION
…or("Expected identifier, found: )")

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
