### PR TITLE
docs(deployment): improve Docker reverse proxy documentation

### DIFF
--- a/docs/content/Deployment/Platform-Docker.mdx
+++ b/docs/content/Deployment/Platform-Docker.mdx
@@ -138,7 +138,7 @@ You can also use a reverse proxy to enable HTTP 2.0 and GZIP compression
 
 </InfoBox>
 
-First we'll create a new server configuration file called `cube.conf`:
+First we'll create a new server configuration file called `nginx/cube.conf`:
 
 ```
 server {
@@ -160,7 +160,7 @@ server {
 
   location / {
     # Remember to replace `localhost` with `host.docker.internal` if you're on macOS/Windows
-    proxy_pass http://localhost:4000/;
+    proxy_pass http://cube:4000/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -173,14 +173,18 @@ Then we'll add a new service to our Docker Compose stack:
 ```yaml
 services:
   ...
-  webserver:
+  nginx:
     image: nginx
     ports:
       - 443:443
     volumes:
-      - ./nginx:/etc/nginx
+      - ./nginx:/etc/nginx/conf.d
       - ./ssl:/etc/ssl/private
 ```
+
+Don't forget to create a `ssl` directory with the `cert.pem` and `key.pem` files inside so the Nginx service can find them.
+
+For automatically provisioning SSL certificates with LetsEncrypt, [this blog post](https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71) may be useful
 
 ## Security
 

--- a/docs/content/Deployment/Platform-Docker.mdx
+++ b/docs/content/Deployment/Platform-Docker.mdx
@@ -159,7 +159,6 @@ server {
   ssl_stapling_verify         on;
 
   location / {
-    # Remember to replace `localhost` with `host.docker.internal` if you're on macOS/Windows
     proxy_pass http://cube:4000/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -184,7 +183,7 @@ services:
 
 Don't forget to create a `ssl` directory with the `cert.pem` and `key.pem` files inside so the Nginx service can find them.
 
-For automatically provisioning SSL certificates with LetsEncrypt, [this blog post](https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71) may be useful
+For automatically provisioning SSL certificates with LetsEncrypt, [this blog post](https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71) may be useful.
 
 ## Security
 


### PR DESCRIPTION
I've been working on deploying an httos cubejs instance using `docker-compose` over the past few days. Although it was good enough for me to finally make it, as an absolute Docker Compose beginner I ran into some issues that might have been obvious to a more experienced dev, but they weren't for me. Although it was a cool learning experience, I think updating the documentation to be more accurate and work out of the box will make things easier for those ahead.

The changes are:
- Specify that the `cube.conf` file goes inside a `nginx` directory, otherwise nothing will be mounted in the corresponding
- Don't mount the `nginx` directly on top of `etc/nginx`, do it on `etc/nginx/conf.d` instead, otherwise it will overwrite existing nginx configuration, and the webserver will fail to start.
- In the nginx `proxy_pass` configuration, change the `localhost` reference to a `cube` reference; in Docker Compose it appears that each service has it's own separate `localhost`, and that configuration in Linux would cause nginx to fail with a 502 error. Referencing the `cube` service instead works as expected.
- Add some extra helpful lines, and a link to a good resource I found and followed to set up SSL with LetsEncrypt.
- Lastly, I changed the `webserver` service name to `nginx`. It's a small change and shouldn't be too important one way or another, but in this case the linked resource assumes the nginx service is named `nginx`, so why not

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
