### PR TITLE
fix(@cubejs-backend/schema-compiler): add missing `sql` key validator to dimension validation

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -53,7 +53,7 @@ const everyCronTimeZone = Joi.string().custom((value, helper) => {
 });
 
 const BaseDimensionWithoutSubQuery = {
-  sql:  Joi.func().required(),
+  sql:  Joi.func(),
   aliases: Joi.array().items(Joi.string()),
   type: Joi.any().valid('string', 'number', 'boolean', 'time', 'geo').required(),
   fieldType: Joi.any().valid('string'),

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.js
@@ -53,6 +53,7 @@ const everyCronTimeZone = Joi.string().custom((value, helper) => {
 });
 
 const BaseDimensionWithoutSubQuery = {
+  sql:  Joi.func().required(),
   aliases: Joi.array().items(Joi.string()),
   type: Joi.any().valid('string', 'number', 'boolean', 'time', 'geo').required(),
   fieldType: Joi.any().valid('string'),

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -82,6 +82,30 @@ describe('Cube Validation', () => {
     expect(validationResult.error).toBeTruthy();
   });
 
+  it('sql key support in dimensions', async () => {
+    const cubeValidator = new CubeValidator(new CubeSymbols());
+    const cube = {
+      name: 'name',
+      sql: () => '',
+      fileName: 'fileName',
+      dimensions: {
+        example: {
+          type: 'string',
+          sql: () => ''
+        }
+      }
+    };
+
+    const validationResult = cubeValidator.validate(cube, {
+      error: (message, e) => {
+        // this callback should not be invoked
+        expect(true).toBeFalsy();
+      }
+    });
+
+    expect(validationResult.error).toBeFalsy();
+  });
+
   it('OriginalSqlSchema', async () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
     const cube = {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] ~~Docs have been added / updated if required~~

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

We were trying to create dimensions in our cube, one of which happens to be an enum field with multiple possible values. Here's what the dimension section looked like:

```javascript
dimensions: {
    medium: {
      sql: `${CUBE}.medium`,
      type: 'string',
      title: `Medium`,
      case: {
        when: [
          {
            sql: `medium = 'email'`,
            label: 'Email',
          },
        ],
        else: { label: 'Unknown' },
      }
  }
}
```
as per the docs in https://cube.dev/docs/schema/reference/dimensions . However, we used to see this error 

```javascript
Error: Compile errors:
Pipelines cube: "dimensions.medium" does not match any of the allowed types
Possible reasons (one of):
  * (dimensions.medium.sql = CUBE => `${CUBE}.medium`) is not allowed
  * (dimensions.medium.case = [object Object]) is not allowed
    at ErrorReporter.throwIfAny (/app/node_modules/@cubejs-backend/schema-compiler/src/compiler/ErrorReporter.ts:127:13)
    at DataSchemaCompiler.throwIfAnyErrors (/app/node_modules/@cubejs-backend/schema-compiler/src/compiler/DataSchemaCompiler.js:147:23)
    at /app/node_modules/@cubejs-backend/schema-compiler/src/compiler/DataSchemaCompiler.js:67:16
    at CompilerApi.metaConfig (/app/node_modules/@cubejs-backend/server-core/src/core/CompilerApi.js:154:13)
    at ApiGateway.meta (/app/node_modules/@cubejs-backend/api-gateway/src/gateway.ts:502:26)
    at /app/node_modules/@cubejs-backend/api-gateway/src/gateway.ts:346:7
```

Versions of the dependencies:
```
"@cubejs-backend/postgres-driver": "^0.28.60",
"@cubejs-backend/server": "^0.28.60",
```

Upon going through the relevant sections and some debugging, we realised it was because the validator did not have a provision to add an `sql` key in dimensions, although documentation mentioned otherwise. We tried tweaking the validator and it passed successfully. Hence this PR.