### PR TITLE
docs: fix menu scroll when item is selected

### DIFF
--- a/docs/src/templates/DocTemplate.tsx
+++ b/docs/src/templates/DocTemplate.tsx
@@ -14,7 +14,7 @@ import last from 'lodash/last';
 import { renameCategory } from '../rename-category';
 
 import 'katex/dist/katex.min.css';
-import '../../static/styles/math.scss'
+import '../../static/styles/math.scss';
 
 import FeedbackBlock from '../components/FeedbackBlock';
 import ScrollLink, {
@@ -37,7 +37,7 @@ import {
 import { LoomVideo } from '../components/LoomVideo/LoomVideo';
 import { Grid } from '../components/Grid/Grid';
 import { GridItem } from '../components/Grid/GridItem';
-import ScrollSpyH2 from '../components/Headers/ScrollSpyH2'
+import ScrollSpyH2 from '../components/Headers/ScrollSpyH2';
 import ScrollSpyH3 from '../components/Headers/ScrollSpyH3';
 import MyH2 from '../components/Headers/MyH2';
 import MyH3 from '../components/Headers/MyH3';
@@ -124,8 +124,10 @@ class DocTemplate extends Component<Props, State> {
       noscrollmenu: false,
     });
 
-    const hackFixFileAbsPath = this.props.pageContext.fileAbsolutePath
-      .replace('/opt/build/repo/', '')
+    const hackFixFileAbsPath = this.props.pageContext.fileAbsolutePath.replace(
+      '/opt/build/repo/',
+      ''
+    );
 
     this.createAnchors(
       <MDXForSideMenu {...this.props} />,
@@ -251,7 +253,10 @@ class DocTemplate extends Component<Props, State> {
         }
 
         sectionTags.push({
-          id: currentID,
+          id:
+            currentParentID != currentID
+              ? `${currentParentID}-${currentID}`
+              : currentID,
           type: item.type,
           nodes: [],
           title: item.props.children[0],


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

Fix scroll to correct element if multiple child menu have the same id. 

Eg: in https://cube.dev/docs/@cubejs-client-vue, clicking on QueryRender > props scrolls to **QueryBuilder** > props.

<img width="277" alt="Capture d’écran 2021-12-13 à 11 14 20" src="https://user-images.githubusercontent.com/10157845/145793771-0f38969c-5dc2-42e8-9160-fce41816ec56.png">



