### PR TITLE
fix(cubejs-playground): responsive filter group size

### DIFF
--- a/packages/cubejs-playground/src/QueryBuilder/FilterGroup.tsx
+++ b/packages/cubejs-playground/src/QueryBuilder/FilterGroup.tsx
@@ -31,8 +31,6 @@ const FilterGroup = ({
             availableCubes={availableMembers}
             style={{
               minWidth: 150,
-              textOverflow: 'ellipsis',
-              overflow: 'hidden',
             }}
             onClick={(updateWith) =>
               updateMethods.update(m, { ...m, dimension: updateWith })

--- a/packages/cubejs-playground/src/QueryBuilder/FilterGroup.tsx
+++ b/packages/cubejs-playground/src/QueryBuilder/FilterGroup.tsx
@@ -30,7 +30,7 @@ const FilterGroup = ({
             disabled={disabled}
             availableCubes={availableMembers}
             style={{
-              width: 150,
+              minWidth: 150,
               textOverflow: 'ellipsis',
               overflow: 'hidden',
             }}


### PR DESCRIPTION
The field selector inside FILTERS should expand to contain the full name of the field.