### PR TITLE
fix(schema-compiler): Handle `null` Values in Security Context

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2393,7 +2393,7 @@ export class BaseQuery {
           unsafeValue: () => paramValue
         });
         return methods(target)[name] ||
-          typeof propValue === 'object' && this.contextSymbolsProxy(propValue) ||
+          typeof propValue === 'object' && propValue !== null && this.contextSymbolsProxy(propValue) ||
           methods(propValue);
       }
     });


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

(if it is okay, please validate the above, as doing so should be a lot easier for someone that already has things setup locally)

**Description of Changes Made**

This change should allow `null` to exist as a value of a property within the security context. Prior to this change, if a `null` value was encountered in the security context, a `Cannot create proxy with a non-object as target or handler` error would be thrown, as `typeof null === "object"`. This PR should resolve this by explicitly checking for `null` before passing the property value to `contextSymbolsProxy`.