### PR TITLE
fix: `refreshKey` is evaluated ten times more frequently if `sql` and…

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2311,13 +2311,13 @@ export class BaseQuery {
     );
   }
 
-  refreshKeyRenewalThresholdForInterval(refreshKey, limitedWithMax = true) {
+  refreshKeyRenewalThresholdForInterval(refreshKey, everyWithoutSql = true) {
     const { every } = refreshKey;
 
     if (/^(\d+) (second|minute|hour|day|week)s?$/.test(every)) {
-      const threshold = Math.max(Math.round(this.parseSecondDuration(every) / 10), 1);
+      const threshold = Math.max(Math.round(this.parseSecondDuration(every) / (everyWithoutSql ? 10 : 1)), 1);
 
-      if (limitedWithMax) {
+      if (everyWithoutSql) {
         return Math.min(threshold, 300);
       }
 
@@ -2325,9 +2325,9 @@ export class BaseQuery {
     }
 
     const { interval } = this.calcIntervalForCronString(refreshKey);
-    const threshold = Math.max(Math.round(interval / 10), 1);
+    const threshold = Math.max(Math.round(interval / (everyWithoutSql ? 10 : 1)), 1);
 
-    if (limitedWithMax) {
+    if (everyWithoutSql) {
       return Math.min(threshold, 300);
     }
 

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -513,7 +513,7 @@ describe('SQL Generation', () => {
         [],
         {
           external: false,
-          renewalThreshold: 720,
+          renewalThreshold: 7200,
         }
       ]
     ]);
@@ -562,7 +562,7 @@ describe('SQL Generation', () => {
         {
           external: false,
           // 60 * 60 *2
-          renewalThreshold: 720,
+          renewalThreshold: 7200,
         }
       ]
     ]);


### PR DESCRIPTION
… `every` are simultaneously defined

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


