### PR TITLE
style: Make eslint no-unused-vars ignore unused args/vars starting with _

### DIFF
--- a/packages/cubejs-linter/index.js
+++ b/packages/cubejs-linter/index.js
@@ -44,12 +44,13 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'error',
     'no-extra-semi': 'off',
     '@typescript-eslint/no-extra-semi': 'error',
+    'no-underscore-dangle': 'off',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
-        argsIgnorePattern: '^.+Unused',
-        varsIgnorePattern: '^.+Unused',
+        argsIgnorePattern: '^_.+',
+        varsIgnorePattern: '^_.+',
       },
     ],
     // '@typescript-eslint/no-var-requires': 'error',

--- a/packages/cubejs-linter/index.js
+++ b/packages/cubejs-linter/index.js
@@ -45,7 +45,13 @@ module.exports = {
     'no-extra-semi': 'off',
     '@typescript-eslint/no-extra-semi': 'error',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^.+Unused',
+        varsIgnorePattern: '^.+Unused',
+      },
+    ],
     // '@typescript-eslint/no-var-requires': 'error',
     '@typescript-eslint/prefer-as-const': 'error',
     '@typescript-eslint/prefer-namespace-keyword': 'error',

--- a/packages/cubejs-linter/index.js
+++ b/packages/cubejs-linter/index.js
@@ -49,8 +49,8 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
-        argsIgnorePattern: '^_.+',
-        varsIgnorePattern: '^_.+',
+        argsIgnorePattern: '^_.*',
+        varsIgnorePattern: '^_.*',
       },
     ],
     // '@typescript-eslint/no-var-requires': 'error',

--- a/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
+++ b/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
@@ -92,8 +92,7 @@ export class BaseDriver {
    *
    * @param {Object} [options]
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(options) {
+  constructor(_options = {}) {
     //
   }
 
@@ -187,7 +186,7 @@ export class BaseDriver {
    * @param {any} [options]
    * @return {Promise<Array<any>>}
    */
-  async query(queryUnused, valuesUnused, optionsUnused = {}) {
+  async query(_query, _values, _options = {}) {
     throw new Error('Not implemented');
   }
 
@@ -195,7 +194,7 @@ export class BaseDriver {
    * @public
    * @return {Promise<any>}
    */
-  async downloadQueryResults(query, values, optionsUnused) {
+  async downloadQueryResults(query, values, _options) {
     const rows = await this.query(query, values);
     if (rows.length === 0) {
       throw new Error(
@@ -286,7 +285,7 @@ export class BaseDriver {
    * @param {number} paramIndex
    * @return {string}
    */
-  param(paramIndexUnused) {
+  param(_paramIndex) {
     return '?';
   }
 
@@ -294,8 +293,7 @@ export class BaseDriver {
     return 10000;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async downloadTable(table, options) {
+  async downloadTable(table, _options) {
     return { rows: await this.query(`SELECT * FROM ${table}`) };
   }
 
@@ -303,8 +301,7 @@ export class BaseDriver {
     return this.uploadTableWithIndexes(table, columns, tableData, [], null);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async uploadTableWithIndexes(table, columns, tableData, indexesSql, uniqueKeyColumns, queryTracingObj) {
+  async uploadTableWithIndexes(table, columns, tableData, indexesSql, _uniqueKeyColumns, _queryTracingObj) {
     if (!tableData.rows) {
       throw new Error(`${this.constructor} driver supports only rows upload`);
     }
@@ -329,8 +326,7 @@ export class BaseDriver {
     }
   }
 
-  // eslint-disable-next-line no-unused-vars
-  toColumnValue(value, genericTypeUnused) {
+  toColumnValue(value, _genericType) {
     return value;
   }
 

--- a/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
+++ b/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
@@ -187,7 +187,7 @@ export class BaseDriver {
    * @param {any} [options]
    * @return {Promise<Array<any>>}
    */
-  async query(queryUnused, valuesUnused, optionsUnused) {
+  async query(queryUnused, valuesUnused, optionsUnused = {}) {
     throw new Error('Not implemented');
   }
 

--- a/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
+++ b/packages/cubejs-query-orchestrator/src/driver/BaseDriver.js
@@ -187,7 +187,7 @@ export class BaseDriver {
    * @param {any} [options]
    * @return {Promise<Array<any>>}
    */
-  async query(query, values, options) {
+  async query(queryUnused, valuesUnused, optionsUnused) {
     throw new Error('Not implemented');
   }
 
@@ -195,7 +195,7 @@ export class BaseDriver {
    * @public
    * @return {Promise<any>}
    */
-  async downloadQueryResults(query, values, options) {
+  async downloadQueryResults(query, values, optionsUnused) {
     const rows = await this.query(query, values);
     if (rows.length === 0) {
       throw new Error(
@@ -286,7 +286,7 @@ export class BaseDriver {
    * @param {number} paramIndex
    * @return {string}
    */
-  param(paramIndex) {
+  param(paramIndexUnused) {
     return '?';
   }
 
@@ -330,7 +330,7 @@ export class BaseDriver {
   }
 
   // eslint-disable-next-line no-unused-vars
-  toColumnValue(value, genericType) {
+  toColumnValue(value, genericTypeUnused) {
     return value;
   }
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -379,7 +379,7 @@ export class QueryCache {
       dataSource: string
     }
   ) {
-    return cacheKeyQueries.map((q, i) => {
+    return cacheKeyQueries.map((q) => {
       const [query, values, queryOptions]: QueryTuple = Array.isArray(q) ? q : [q, [], {}];
 
       return this.cacheQueryResult(

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.js
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.js
@@ -81,7 +81,7 @@ export class QueryQueue {
       const orphanedTimeout = 'orphanedTimeout' in query ? query.orphanedTimeout : this.orphanedTimeout;
       const orphanedTime = time + (orphanedTimeout * 1000);
       // eslint-disable-next-line no-unused-vars
-      const [added, b, c, queueSize, addedToQueueTime] = await redisClient.addToQueue(
+      const [added, bUnused, cUnused, queueSize, addedToQueueTime] = await redisClient.addToQueue(
         keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
       );
 
@@ -390,8 +390,7 @@ export class QueryQueue {
   async processQuery(queryKey) {
     const redisClient = await this.queueDriver.createConnection();
     let insertedCount;
-    // eslint-disable-next-line no-unused-vars
-    let removedCount;
+    let removedCountUnused;
     let activeKeys;
     let queueSize;
     let query;
@@ -400,7 +399,7 @@ export class QueryQueue {
       const processingId = await redisClient.getNextProcessingId();
       const retrieveResult = await redisClient.retrieveForProcessing(queryKey, processingId);
       if (retrieveResult) {
-        [insertedCount, removedCount, activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
+        [insertedCount, removedCountUnused, activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
       }
       const activated = activeKeys && activeKeys.indexOf(this.redisHash(queryKey)) !== -1;
       if (!query) {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.js
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryQueue.js
@@ -80,8 +80,7 @@ export class QueryQueue {
 
       const orphanedTimeout = 'orphanedTimeout' in query ? query.orphanedTimeout : this.orphanedTimeout;
       const orphanedTime = time + (orphanedTimeout * 1000);
-      // eslint-disable-next-line no-unused-vars
-      const [added, bUnused, cUnused, queueSize, addedToQueueTime] = await redisClient.addToQueue(
+      const [added, _b, _c, queueSize, addedToQueueTime] = await redisClient.addToQueue(
         keyScore, queryKey, orphanedTime, queryHandler, query, priority, options
       );
 
@@ -390,7 +389,7 @@ export class QueryQueue {
   async processQuery(queryKey) {
     const redisClient = await this.queueDriver.createConnection();
     let insertedCount;
-    let removedCountUnused;
+    let _removedCount;
     let activeKeys;
     let queueSize;
     let query;
@@ -399,7 +398,7 @@ export class QueryQueue {
       const processingId = await redisClient.getNextProcessingId();
       const retrieveResult = await redisClient.retrieveForProcessing(queryKey, processingId);
       if (retrieveResult) {
-        [insertedCount, removedCountUnused, activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
+        [insertedCount, _removedCount, activeKeys, queueSize, query, processingLockAcquired] = retrieveResult;
       }
       const activated = activeKeys && activeKeys.indexOf(this.redisHash(queryKey)) !== -1;
       if (!query) {

--- a/packages/cubejs-query-orchestrator/test/unit/BaseDriver.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/BaseDriver.test.ts
@@ -5,7 +5,7 @@ class BaseDriverImplementedMock extends BaseDriver {
     super();
   }
 
-  public async query(queryUnused, valuesUnused) {
+  public async query(_query, _values) {
     return this.response;
   }
 }

--- a/packages/cubejs-query-orchestrator/test/unit/BaseDriver.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/BaseDriver.test.ts
@@ -5,7 +5,7 @@ class BaseDriverImplementedMock extends BaseDriver {
     super();
   }
 
-  public async query(query, values) {
+  public async query(queryUnused, valuesUnused) {
     return this.response;
   }
 }

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
@@ -44,15 +44,15 @@ class MockDriver {
     return { rows: await this.query(`SELECT * FROM ${table}`) };
   }
 
-  async tableColumnTypes(table) {
+  async tableColumnTypes(tableUnused) {
     return [];
   }
 
-  async uploadTable(table, columns, tableData) {
+  async uploadTable(table, columns, tableDataUnused) {
     await this.createTable(table, columns);
   }
 
-  createTable(quotedTableName, columns) {
+  createTable(quotedTableName, columnsUnused) {
     this.tables.push(quotedTableName);
   }
 

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable global-require,no-unused-vars */
+/* eslint-disable global-require */
 /* globals describe, jest, beforeEach, test, expect */
 import R from 'ramda';
 
@@ -44,15 +44,15 @@ class MockDriver {
     return { rows: await this.query(`SELECT * FROM ${table}`) };
   }
 
-  async tableColumnTypes(tableUnused) {
+  async tableColumnTypes(_table) {
     return [];
   }
 
-  async uploadTable(table, columns, tableDataUnused) {
+  async uploadTable(table, columns, _tableData) {
     await this.createTable(table, columns);
   }
 
-  createTable(quotedTableName, columnsUnused) {
+  createTable(quotedTableName, _columns) {
     this.tables.push(quotedTableName);
   }
 

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
@@ -213,7 +213,7 @@ describe('QueryOrchestrator', () => {
   });
 
   test('index is part of query key', async () => {
-    const firstPromise = queryOrchestrator.fetchQuery({
+    queryOrchestrator.fetchQuery({
       query: 'SELECT "orders__created_at_week" "orders__created_at_week", sum("orders__count") "orders__count" FROM (SELECT * FROM stb_pre_aggregations.orders_number_and_count20191102) as partition_union  WHERE ("orders__created_at_week" >= ($1::timestamptz::timestamptz AT TIME ZONE \'UTC\') AND "orders__created_at_week" <= ($2::timestamptz::timestamptz AT TIME ZONE \'UTC\')) GROUP BY 1 ORDER BY 1 ASC LIMIT 10000',
       values: ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z'],
       cacheKeyQueries: {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]

* Make eslint no-unused-vars ignore unused args/vars starting with _
* Fix @cubejs-backend/query-orchestrator lint errors.