### PR TITLE
chore: add deprecation warning for non-Cube Store databases being used as an external database

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -65,7 +65,8 @@ means no more updates. Please upgrade to Node.js 10 or higher.
 This option for [`@cubejs-client/ws-transport`][link-hearbeatinterval] has been
 replaced by `heartBeatInterval`.
 
-[link-hearbeatinterval]: https://cube.dev/docs/@cubejs-client-ws-transport#web-socket-transport-hear-beat-interval
+[link-hearbeatinterval]:
+  https://cube.dev/docs/@cubejs-client-ws-transport#web-socket-transport-hear-beat-interval
 
 ### `CUBEJS_ENABLE_TLS`
 
@@ -75,7 +76,8 @@ We no longer recommend setting TLS options via Cube.js. Developers should set up
 TLS on a load balancer or reverse proxy instead. [Read more
 here][link-enable-https].
 
-[link-enable-https]: https://cube.dev/docs/deployment/production-checklist#enable-https
+[link-enable-https]:
+  https://cube.dev/docs/deployment/production-checklist#enable-https
 
 ### Embedding Cube.js within Express
 
@@ -90,7 +92,8 @@ file][link-migration] and deploy Cube.js as a microservice (or multiple
 microservices, if necessary).
 
 [link-cube-docker]: https://cube.dev/blog/cubejs-loves-docker
-[link-migration]: https://cube.dev/docs/configuration/overview#migrating-from-express-to-docker
+[link-migration]:
+  https://cube.dev/docs/configuration/overview#migrating-from-express-to-docker
 
 ### Absolute import for `@cubejs-backend/query-orchestrator`
 
@@ -122,7 +125,8 @@ instance. Now orchestrator instances can be shared by Cube.js instances and
 across different tenants, if need be. Single-tenant setups should consider
 removing the `contextToDataSourceId` property completely.
 
-[link-contexttoorchestratorid]: https://cube.dev/docs/config#options-reference-context-to-orchestrator-id
+[link-contexttoorchestratorid]:
+  https://cube.dev/docs/config#options-reference-context-to-orchestrator-id
 
 ### Absolute import for `@cubejs-backend/server-core`
 
@@ -205,7 +209,9 @@ You should use:
 
 ```js
 cube(`visitors`, {
-  sql: `select * from visitors WHERE ${SECURITY_CONTEXT.source.filter('source')}`,
+  sql: `select * from visitors WHERE ${SECURITY_CONTEXT.source.filter(
+    'source'
+  )}`,
 });
 ```
 
@@ -249,7 +255,8 @@ const server = new CubejsServer({
     req.authInfo = jwt.verify({ u: auth }, pem);
   },
   contextToAppId: ({ authInfo }) => `APP_${authInfo.userId}`,
-  preAggregationsSchema: ({ authInfo }) => `pre_aggregations_${authInfo.userId}`,
+  preAggregationsSchema: ({ authInfo }) =>
+    `pre_aggregations_${authInfo.userId}`,
 });
 ```
 
@@ -264,7 +271,8 @@ const server = new CubejsServer({
   // And here we're now using the `securityContext` parameter
   contextToAppId: ({ securityContext }) => `APP_${securityContext.userId}`,
   // And the same here
-  preAggregationsSchema: ({ securityContext }) => `pre_aggregations_${securityContext.userId}`,
+  preAggregationsSchema: ({ securityContext }) =>
+    `pre_aggregations_${securityContext.userId}`,
 });
 ```
 
@@ -295,14 +303,24 @@ CUBEJS_REDIS_TLS=true
 
 **Removed in Release: v0.29.0**
 
-Node.js 15 reached [End of Life on June 1, 2021][link-nodejs-eol]. This
-means no more updates. Please upgrade to Node.js 14 or higher.
+Node.js 15 reached [End of Life on June 1, 2021][link-nodejs-eol]. This means no
+more updates. Please upgrade to Node.js 14 or higher.
 
 ### Node.js 12
 
 **Deprecated in Release: v0.29.0**
 
-Node.js 12 reached [End of Life on May 19, 2021][link-nodejs-eol]. This
-means no more updates. Please upgrade to Node.js 14 or higher.
+Node.js 12 reached [End of Life on May 19, 2021][link-nodejs-eol]. This means no
+more updates. Please upgrade to Node.js 14 or higher.
 
 [link-nodejs-eol]: https://github.com/nodejs/Release#end-of-life-releases
+
+### Using non-Cube Store databases as external database
+
+**Deprecated in Release: v0.29.0**
+
+Cube no longer supports using databases such as MySQL and Postgres as external
+databases. [Please switch to using Cube Store][link-running-in-prod] as it is a
+more robust and reliable solution.
+
+[link-running-in-prod]: https://cube.dev/docs/caching/running-in-production

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -339,6 +339,12 @@ export class CubejsServerCore {
       );
     }
 
+    if (devServer && externalDbType !== 'cubestore') {
+      displayCLIWarning(
+        `Using ${externalDbType} as an external database is deprecated. Please use Cube Store instead: https://cube.dev/docs/caching/running-in-production`
+      );
+    }
+
     if (externalDbType === 'cubestore' && devServer && !opts.serverless) {
       if (!definedExtDBVariables.length) {
         const cubeStorePackage = this.requireCubeStoreDriver();


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

![image](https://user-images.githubusercontent.com/1781985/149966562-6b40321d-8e00-4584-8c7f-4efdf2190ee0.png)
