### PR TITLE
fix: postgres driver add enum support

### DIFF
--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -143,9 +143,23 @@ export class PostgresDriver<Config extends PostgresDriverConfiguration = Postgre
   }
 
   protected async loadUserDefinedTypes(conn: PoolClient): Promise<void> {
+
     if (!this.userDefinedTypes) {
-      const customTypes = await conn.query(
-        'SELECT oid, typname FROM pg_type WHERE typcategory = \'U\'',
+      // Postgres enum types defined as typcategory = 'E' these can be assumed
+      // to be of type varchar for the drivers purposes.
+      // TODO: if full implmentation the constraints can be looked up via pg_enum
+      // https://www.postgresql.org/docs/9.1/catalog-pg-enum.html
+      const customTypes = await conn.query(`
+            SELECT
+                oid,
+                CASE
+                    WHEN typcategory = 'E' THEN 'varchar'
+                    ELSE typname
+                END
+            FROM
+                pg_type
+            WHERE
+                typcategory in ('U', 'E')'`,
         []
       );
 

--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -158,7 +158,7 @@ export class PostgresDriver<Config extends PostgresDriverConfiguration = Postgre
         FROM
             pg_type
         WHERE
-            typcategory in ('U', 'E')'`,
+            typcategory in ('U', 'E')`,
         []
       );
 

--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -143,23 +143,22 @@ export class PostgresDriver<Config extends PostgresDriverConfiguration = Postgre
   }
 
   protected async loadUserDefinedTypes(conn: PoolClient): Promise<void> {
-
     if (!this.userDefinedTypes) {
       // Postgres enum types defined as typcategory = 'E' these can be assumed
       // to be of type varchar for the drivers purposes.
       // TODO: if full implmentation the constraints can be looked up via pg_enum
       // https://www.postgresql.org/docs/9.1/catalog-pg-enum.html
-      const customTypes = await conn.query(`
-            SELECT
-                oid,
-                CASE
-                    WHEN typcategory = 'E' THEN 'varchar'
-                    ELSE typname
-                END
-            FROM
-                pg_type
-            WHERE
-                typcategory in ('U', 'E')'`,
+      const customTypes = await conn.query(
+        `SELECT
+            oid,
+            CASE
+                WHEN typcategory = 'E' THEN 'varchar'
+                ELSE typname
+            END
+        FROM
+            pg_type
+        WHERE
+            typcategory in ('U', 'E')'`,
         []
       );
 

--- a/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
+++ b/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
@@ -33,7 +33,7 @@ describe('PostgresDriver', () => {
   });
 
   test('type coercion', async () => {
-    await driver.query('CREATE TYPE CUBEJS_TEST_ENUM AS ENUM (\'FOO\')', []);
+    await driver.query('CREATE TYPE CUBEJS_TEST_ENUM AS ENUM (\'FOO\');', []);
 
     const data = await driver.query(
       `

--- a/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
+++ b/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
@@ -33,13 +33,16 @@ describe('PostgresDriver', () => {
   });
 
   test('type coercion', async () => {
+    await driver.query('CREATE TYPE CUBEJS_TEST_ENUM AS ENUM (\'FOO\')', []);
+
     const data = await driver.query(
       `
         SELECT
           CAST('2020-01-01' as DATE) as date,
           CAST('2020-01-01 00:00:00' as TIMESTAMP) as timestamp,
           CAST('2020-01-01 00:00:00+02' as TIMESTAMPTZ) as timestamptz,
-          CAST('1.0' as DECIMAL(10,2)) as decimal
+          CAST('1.0' as DECIMAL(10,2)) as decimal,
+          CAST('FOO' as CUBEJS_TEST_ENUM) as enum
       `,
       []
     );
@@ -52,7 +55,9 @@ describe('PostgresDriver', () => {
         // converted to utc
         timestamptz: '2019-12-31T22:00:00.000',
         // Numerics as string
-        decimal: '1.00'
+        decimal: '1.00',
+        // Enum datatypes as string
+        enum: 'FOO',
       }
     ]);
   });


### PR DESCRIPTION
The user defined enum types were being dropped in the Postgres driver.
As per the postgres documentation these are stored internally as four
bytes on disk however the translations occur at query time to the label
from pg_enum which specifies:

"The length of an enum value's textual label is limited by the NAMEDATALEN
setting compiled into PostgreSQL; in standard builds this means at most
63 bytes." [1]

For the purposes of cubejs it should be acceptable to coerce into a
string.

[1] https://www.postgresql.org/docs/9.1/datatype-enum.html

**Issue Reference this PR resolves**

https://github.com/cube-js/cube.js/issues/3946
