### PR TITLE
style: Enable for..of loops in eslint

### DIFF
--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint --debug src/* --ext .ts",
+    "lint": "eslint src/* --ext .ts",
     "lint:fix": "eslint --fix src/* --ext .ts",
     "unit": "jest --coverage dist/test"
   },

--- a/packages/cubejs-backend-shared/src/http-utils.ts
+++ b/packages/cubejs-backend-shared/src/http-utils.ts
@@ -1,5 +1,5 @@
 import decompress from 'decompress';
-import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
+import fetch, { Headers, Request, Response } from 'node-fetch';
 import bytes from 'bytes';
 import { throttle } from 'throttle-debounce';
 import { SingleBar } from 'cli-progress';

--- a/packages/cubejs-backend-shared/src/node-check.ts
+++ b/packages/cubejs-backend-shared/src/node-check.ts
@@ -4,7 +4,7 @@ import color from '@oclif/color';
 const currentNodeVersion = process.versions.node;
 const semver = currentNodeVersion.split('.');
 const major = parseInt(<string> semver[0], 10);
-const minor = parseInt(<string> semver[1], 10);
+const _minor = parseInt(<string> semver[1], 10);
 
 if (major < 12 || major === 15) {
   console.error(

--- a/packages/cubejs-backend-shared/test/iterators.test.ts
+++ b/packages/cubejs-backend-shared/test/iterators.test.ts
@@ -1,0 +1,29 @@
+test('for of', () => {
+  const xs = [];
+  for (const x of ['one', 'two', 'three']) {
+    xs.push(x);
+  }
+  expect(xs).toEqual(['one', 'two', 'three']);
+});
+
+test('for of keys', () => {
+  const xs = [];
+  for (const x of Object.keys({ one: 1, two: 2, three: 3 })) {
+    xs.push(x);
+  }
+  expect(xs).toEqual(['one', 'two', 'three']);
+});
+
+async function* gen() {
+  yield 'one';
+  yield 'two';
+  yield 'three';
+}
+
+test('for await', async () => {
+  const xs = [];
+  for await (const x of gen()) {
+    xs.push(x);
+  }
+  expect(xs).toEqual(['one', 'two', 'three']);
+});

--- a/packages/cubejs-linter/index.js
+++ b/packages/cubejs-linter/index.js
@@ -59,6 +59,21 @@ module.exports = {
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/type-annotation-spacing': 'error',
     '@typescript-eslint/space-infix-ops': 'error',
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+      {
+        selector: 'LabeledStatement',
+        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Enable for..of loops in eslint. Among other things, helps with `for await(...)` loops to transform async iterators into arrays. Tested with Node v12.22.9 and v16.13.1.
