### PR TITLE
chore(examples): rename outdated term at heading and switch control label

### DIFF
--- a/examples/external-rollups/dashboard-app/src/App.js
+++ b/examples/external-rollups/dashboard-app/src/App.js
@@ -42,7 +42,7 @@ const AppLayout = ({ children }) => (
             marginRight: "1em"
           }}
         >
-          Cube.js External Rollups Example
+          Cube Store pre-aggregations Example
         </h2>
       </div>
       <div
@@ -94,7 +94,7 @@ const Dashboard = ({ children, onPreAggChange, onDateRangeChange, onCategoryChan
     <Col span={24} lg={12} align="left">
       <Switch
         onChange={checked => onPreAggChange(checked ? "PreAgg" : "")}
-      /> Use external rollups (pre-aggregations)
+      /> Use Cube Store pre-aggregations
     </Col>
     <Col span={24} lg={6} align="right">
       <Radio.Group


### PR DESCRIPTION
Change outdated 'External rollups' to 'Cube Store pre-aggregations'
