### PR TITLE
feat(@cubejs-backend/native): show meta errors in Cube SQL response

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -1,4 +1,4 @@
-import { setLogLevel, registerInterface, SqlInterfaceInstance } from '@cubejs-backend/native';
+import { setLogLevel, registerInterface, SqlInterfaceInstance, LogLevel } from '@cubejs-backend/native';
 import { displayCLIWarning, getEnv } from '@cubejs-backend/shared';
 
 import * as crypto from 'crypto';
@@ -20,7 +20,7 @@ export class SQLServer {
     protected readonly apiGateway: ApiGateway,
   ) {
     setLogLevel(
-      process.env.CUBEJS_LOG_LEVEL === 'trace' ? 'trace' : 'warn'
+      (process.env.CUBEJS_LOG_LEVEL as LogLevel) ?? 'warn',
     );
   }
 

--- a/packages/cubejs-backend-native/DEVELOPMENT.md
+++ b/packages/cubejs-backend-native/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 - `rustup`
 
-# Build and run
+## Build and run
 
 ```bash
 cd packages/cubejs-backend-native
@@ -17,4 +17,15 @@ In a Cube project with Cube SQL enabled, run:
 ```bash
 yarn link "@cubejs-backend/native"
 yarn dev
+```
+
+## Known Issues
+
+### `SIGKILL`
+
+Occasionally during development on macOS ARM devices, the generated `index.node`
+can be corrupted. To fix this, remove the file and rebuild:
+
+```bash
+rm -rf index.node && yarn native:build && yarn test:unit
 ```

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -76,7 +76,7 @@ function wrapNativeFunctionWithChannelCallback(
     };
 };
 
-type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
 
 export const setLogLevel = (level: LogLevel): void => {
     const native = loadNative();

--- a/rust/cubesql/cubeclient/DEVELOPMENT.md
+++ b/rust/cubesql/cubeclient/DEVELOPMENT.md
@@ -11,8 +11,8 @@ brew install openapi-generator
 Regenerate models:
 
 ```bash
-$ cd rust
-$ openapi-generator generate -i ../packages/cubejs-api-gateway/openspec.yml -g rust -o cubeclient
+cd rust/cubesql
+openapi-generator generate -i ../../packages/cubejs-api-gateway/openspec.yml -g rust -o cubeclient
 ```
 
 The above command will also overwrite `src/apis/default_api.rs`, remember to do the following:


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

```bash
❯ mysql -h 127.0.0.1 --port 3306 -u cubesql --password
Enter password:
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2
Server version: 8.0.25

Copyright (c) 2000, 2021, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> SELECT * FROM Orders;
ERROR 1815 (HY000): Error: Compile errors:
Syntax error during 'Orders.js' parsing: Unexpected token, expected "," (21:2):
  measures: {
  ^
LineItems cube: Cube Orders doesn't exist
mysql>
```
