### PR TITLE
fix(cubestore): Deactivate tables on data corruption to allow refresh…

### DIFF
--- a/rust/cubestore/cubestore/src/lib.rs
+++ b/rust/cubestore/cubestore/src/lib.rs
@@ -74,6 +74,7 @@ impl std::error::Error for CubeError {}
 pub enum CubeErrorCauseType {
     User,
     Internal,
+    CorruptData,
 }
 
 impl CubeError {
@@ -105,6 +106,21 @@ impl CubeError {
             message,
             backtrace: String::new(),
             cause: CubeErrorCauseType::Internal,
+        }
+    }
+
+    pub fn corrupt_data(message: String) -> CubeError {
+        CubeError {
+            message,
+            backtrace: String::new(),
+            cause: CubeErrorCauseType::CorruptData,
+        }
+    }
+
+    pub fn is_corrupt_data(&self) -> bool {
+        match self.cause {
+            CubeErrorCauseType::CorruptData => true,
+            _ => false,
         }
     }
 

--- a/rust/cubestore/cubestore/src/queryplanner/serialized_plan.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/serialized_plan.rs
@@ -683,7 +683,7 @@ impl SerializedPlan {
         &self.schema_snapshot.index_snapshots
     }
 
-    pub fn files_to_download(&self) -> Vec<(String, Option<u64>)> {
+    pub fn files_to_download(&self) -> Vec<(IdRow<Partition>, String, Option<u64>)> {
         self.list_files_to_download(|id| {
             self.partition_ids_to_execute
                 .binary_search_by_key(&id, |(id, _)| *id)
@@ -692,14 +692,18 @@ impl SerializedPlan {
     }
 
     /// Note: avoid during normal execution, workers must filter the partitions they execute.
-    pub fn all_required_files(&self) -> Vec<(String, Option<u64>)> {
+    pub fn all_required_files(&self) -> Vec<(IdRow<Partition>, String, Option<u64>)> {
         self.list_files_to_download(|_| true)
     }
 
     fn list_files_to_download(
         &self,
         include_partition: impl Fn(u64) -> bool,
-    ) -> Vec<(String, Option<u64>)> {
+    ) -> Vec<(
+        IdRow<Partition>,
+        /* file_name */ String,
+        /* size */ Option<u64>,
+    )> {
         let indexes = self.index_snapshots();
 
         let mut files = Vec::new();
@@ -714,12 +718,17 @@ impl SerializedPlan {
                     .get_row()
                     .get_full_name(partition.partition.get_id())
                 {
-                    files.push((file, partition.partition.get_row().file_size()));
+                    files.push((
+                        partition.partition.clone(),
+                        file,
+                        partition.partition.get_row().file_size(),
+                    ));
                 }
 
                 for chunk in partition.chunks() {
                     if !chunk.get_row().in_memory() {
                         files.push((
+                            partition.partition.clone(),
                             chunk.get_row().get_full_name(chunk.get_id()),
                             chunk.get_row().file_size(),
                         ))

--- a/rust/cubestore/cubestore/src/remotefs/queue.rs
+++ b/rust/cubestore/cubestore/src/remotefs/queue.rs
@@ -418,7 +418,7 @@ impl QueueRemoteFs {
             let actual_size = metadata.len();
             if actual_size != expected_file_size {
                 tokio::fs::remove_file(local_path).await?;
-                return Err(CubeError::internal(format!(
+                return Err(CubeError::corrupt_data(format!(
                     "Expected file size for '{}' is {} but {} received",
                     remote_path, expected_file_size, actual_size
                 )));


### PR DESCRIPTION
… worker to reconcile failing partitions

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Allow autonomous recovery of data corrupt partitions without human intervention.
