### PR TITLE
fix(cubestore): Postpone deletion of partitions and chunks after meta…

### DIFF
--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -304,6 +304,12 @@ pub trait ConfigObj: DIService {
 
     fn import_job_timeout(&self) -> u64;
 
+    fn meta_store_snapshot_interval(&self) -> u64;
+
+    fn meta_store_log_upload_interval(&self) -> u64;
+
+    fn gc_loop_interval(&self) -> u64;
+
     fn stale_stream_timeout(&self) -> u64;
 
     fn select_workers(&self) -> &Vec<String>;
@@ -358,6 +364,9 @@ pub struct ConfigObjImpl {
     /// Must be set to 2*query_timeout in prod, only for overrides in tests.
     pub not_used_timeout: u64,
     pub import_job_timeout: u64,
+    pub meta_store_log_upload_interval: u64,
+    pub meta_store_snapshot_interval: u64,
+    pub gc_loop_interval: u64,
     pub stale_stream_timeout: u64,
     pub select_workers: Vec<String>,
     pub worker_bind_address: Option<String>,
@@ -429,6 +438,18 @@ impl ConfigObj for ConfigObjImpl {
 
     fn import_job_timeout(&self) -> u64 {
         self.import_job_timeout
+    }
+
+    fn meta_store_snapshot_interval(&self) -> u64 {
+        self.meta_store_snapshot_interval
+    }
+
+    fn meta_store_log_upload_interval(&self) -> u64 {
+        self.meta_store_log_upload_interval
+    }
+
+    fn gc_loop_interval(&self) -> u64 {
+        self.gc_loop_interval
     }
 
     fn stale_stream_timeout(&self) -> u64 {
@@ -609,6 +630,9 @@ impl Config {
                 query_timeout,
                 not_used_timeout: 2 * query_timeout,
                 import_job_timeout: env_parse("CUBESTORE_IMPORT_JOB_TIMEOUT", 600),
+                meta_store_log_upload_interval: 30,
+                meta_store_snapshot_interval: 300,
+                gc_loop_interval: 60,
                 stale_stream_timeout: 60,
                 select_workers: env::var("CUBESTORE_WORKERS")
                     .ok()
@@ -683,6 +707,9 @@ impl Config {
                 enable_startup_warmup: true,
                 malloc_trim_every_secs: 0,
                 max_cached_queries: 10_000,
+                meta_store_log_upload_interval: 30,
+                meta_store_snapshot_interval: 300,
+                gc_loop_interval: 60,
             }),
         }
     }

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -2181,6 +2181,8 @@ mod tests {
                 c.partition_split_threshold = 1000000;
                 c.compaction_chunks_count_threshold = 0;
                 c.not_used_timeout = 0;
+                c.meta_store_log_upload_interval = 1;
+                c.gc_loop_interval = 1;
                 c
             })
             .start_test(async move |services| {
@@ -2230,6 +2232,9 @@ mod tests {
                     .await
                     .unwrap();
                 let last_active_partition = active_partitions.iter().next().unwrap();
+
+                // Wait for GC tasks to drop files
+                Delay::new(Duration::from_millis(3000)).await;
 
                 let files = services
                     .remote_fs

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -203,7 +203,6 @@ pub trait ChunkDataStore: DIService + Send + Sync {
     ) -> Result<Vec<ChunkUploadJob>, CubeError>;
     async fn repartition(&self, partition_id: u64) -> Result<(), CubeError>;
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError>;
-    async fn delete_remote_chunk(&self, chunk: IdRow<Chunk>) -> Result<(), CubeError>;
     async fn add_memory_chunk(&self, chunk_id: u64, batch: RecordBatch) -> Result<(), CubeError>;
     async fn free_memory_chunk(&self, chunk_id: u64) -> Result<(), CubeError>;
 }
@@ -435,12 +434,6 @@ impl ChunkDataStore for ChunkStore {
     async fn free_memory_chunk(&self, chunk_id: u64) -> Result<(), CubeError> {
         let mut memory_chunks = self.memory_chunks.write().await;
         memory_chunks.remove(&chunk_id);
-        Ok(())
-    }
-
-    async fn delete_remote_chunk(&self, chunk: IdRow<Chunk>) -> Result<(), CubeError> {
-        let remote_path = ChunkStore::chunk_file_name(chunk);
-        self.remote_fs.delete_file(&remote_path).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
…store log commits to avoid missing files on sudden metastore loss

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

If chunks and partitions files are removed instantly after deletion then there's a chance for files not found errors due to sudden loss of uncommitted metastore changes. This change postpones the deletion of files to avoid this scenario.
