### PR TITLE
fix(helm-charts): correct s3 output location env variable

### DIFF
--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -233,7 +233,7 @@ CUBEJS_REDIS_PASSWORD.
   value: {{ .Values.database.aws.region | quote }}
 {{- end }}
 {{- if .Values.database.aws.outputLocation }}
-- name: CUBEJS_AWS_OUTPUT_LOCATION
+- name: CUBEJS_AWS_S3_OUTPUT_LOCATION
   value: {{ .Values.database.aws.outputLocation | quote }}
 {{- end }}
 {{- if .Values.database.aws.secret }}


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

`CUBEJS_AWS_OUTPUT_LOCATION` isn't used by CubeJS and it's `CUBEJS_AWS_S3_OUTPUT_LOCATION` instead. This PR just corrects it.
