### PR TITLE
feat(cubestore): Repartition single chunks instead of partition as a …

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/job.rs
+++ b/rust/cubestore/cubestore/src/metastore/job.rs
@@ -17,6 +17,7 @@ pub enum JobType {
     TableImportCSV(/*location*/ String),
     MultiPartitionSplit,
     FinishMultiSplit,
+    RepartitionChunk,
 }
 
 fn get_job_type_index(j: &JobType) -> u32 {
@@ -28,6 +29,7 @@ fn get_job_type_index(j: &JobType) -> u32 {
         JobType::TableImportCSV(_) => 5,
         JobType::MultiPartitionSplit => 6,
         JobType::FinishMultiSplit => 7,
+        JobType::RepartitionChunk => 8,
     }
 }
 

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -487,9 +487,13 @@ impl SchedulerImpl {
         }
         if let MetaStoreEvent::DeleteJob(job) = event {
             match job.get_row().job_type() {
-                JobType::Repartition => match job.get_row().row_reference() {
-                    RowKey::Table(TableId::Partitions, p) => {
-                        let p = self.meta_store.get_partition(*p).await?;
+                JobType::RepartitionChunk => match job.get_row().row_reference() {
+                    RowKey::Table(TableId::Chunks, c) => {
+                        let c = self.meta_store.get_chunk(*c).await?;
+                        let p = self
+                            .meta_store
+                            .get_partition(c.get_row().get_partition_id())
+                            .await?;
                         self.schedule_repartition_if_needed(&p).await?
                     }
                     _ => panic!(

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -1840,7 +1840,7 @@ mod tests {
     async fn high_frequency_inserts() {
         Config::test("high_frequency_inserts")
             .update_config(|mut c| {
-                c.partition_split_threshold = 1000000;
+                c.partition_split_threshold = 100;
                 c.compaction_chunks_count_threshold = 100;
                 c
             })

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -202,7 +202,7 @@ pub trait ChunkDataStore: DIService + Send + Sync {
         in_memory: bool,
     ) -> Result<Vec<ChunkUploadJob>, CubeError>;
     async fn repartition(&self, partition_id: u64) -> Result<(), CubeError>;
-    async fn repartition_chunk(&self, partition_id: u64) -> Result<(), CubeError>;
+    async fn repartition_chunk(&self, chunk_id: u64) -> Result<(), CubeError>;
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError>;
     async fn add_memory_chunk(&self, chunk_id: u64, batch: RecordBatch) -> Result<(), CubeError>;
     async fn free_memory_chunk(&self, chunk_id: u64) -> Result<(), CubeError>;

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -202,6 +202,7 @@ pub trait ChunkDataStore: DIService + Send + Sync {
         in_memory: bool,
     ) -> Result<Vec<ChunkUploadJob>, CubeError>;
     async fn repartition(&self, partition_id: u64) -> Result<(), CubeError>;
+    async fn repartition_chunk(&self, partition_id: u64) -> Result<(), CubeError>;
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError>;
     async fn add_memory_chunk(&self, chunk_id: u64, batch: RecordBatch) -> Result<(), CubeError>;
     async fn free_memory_chunk(&self, chunk_id: u64) -> Result<(), CubeError>;
@@ -327,6 +328,7 @@ impl ChunkDataStore for ChunkStore {
         panic!("not used");
     }
 
+    // TODO shouldn't be used anymore. Deprecate and remove
     async fn repartition(&self, partition_id: u64) -> Result<(), CubeError> {
         let partition = self.meta_store.get_partition(partition_id).await?;
         if partition.get_row().is_active() {
@@ -376,6 +378,55 @@ impl ChunkDataStore for ChunkStore {
                     .await?,
             );
         }
+
+        let new_chunk_ids: Result<Vec<(u64, Option<u64>)>, CubeError> = join_all(new_chunks)
+            .await
+            .into_iter()
+            .map(|c| {
+                let (c, file_size) = c??;
+                Ok((c.get_id(), file_size))
+            })
+            .collect();
+
+        self.meta_store
+            .swap_chunks(old_chunks, new_chunk_ids?)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn repartition_chunk(&self, chunk_id: u64) -> Result<(), CubeError> {
+        let chunk = self.meta_store.get_chunk(chunk_id).await?;
+        if !chunk.get_row().active() {
+            log::debug!("Skipping repartition of inactive chunk: {:?}", chunk);
+            return Ok(());
+        }
+        let partition = self
+            .meta_store
+            .get_partition(chunk.get_row().get_partition_id())
+            .await?;
+        if partition.get_row().is_active() {
+            return Err(CubeError::internal(format!(
+                "Tried to repartition active partition: {:?}",
+                partition
+            )));
+        }
+        let mut new_chunks = Vec::new();
+        let mut old_chunks = Vec::new();
+        let chunk_id = chunk.get_id();
+        old_chunks.push(chunk_id);
+        let batches = self.get_chunk_columns(chunk).await?;
+        let mut columns = Vec::new();
+        for i in 0..batches[0].num_columns() {
+            columns.push(arrow::compute::concat(
+                &batches.iter().map(|b| b.column(i).as_ref()).collect_vec(),
+            )?)
+        }
+        new_chunks.append(
+            &mut self
+                .partition_rows(partition.get_row().get_index_id(), columns, false)
+                .await?,
+        );
 
         let new_chunk_ids: Result<Vec<(u64, Option<u64>)>, CubeError> = join_all(new_chunks)
             .await


### PR DESCRIPTION
…whole to speed up ingestion of big tables

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

In the case of ingestion of 200M+ row tables, the biggest bottleneck is the very first repartitioning. It requires the single node to download all the chunk files and scan through them. The solution is to repartition every single chunk separately and schedule nodes by chunk id in a round-robin fashion except for in-memory chunks where partitioning should be done on the partition owner node.
