### PR TITLE
Fix the URL of dump db file

### DIFF
--- a/examples/material-ui-dashboard/README.md
+++ b/examples/material-ui-dashboard/README.md
@@ -15,7 +15,7 @@ if you already have Cube.js Backend up and running you can skip this step.
 Let's start by setting up a database with some sample data. We'll use PostgresQL and our example e-commerce dataset for this tutorial. You can download and import it by running the following commands.
 
 ```
-$ curl http://cube.dev/downloads/ecom-dump.sql > ecom-dump.sql
+$ curl https://cube.dev/downloads/ecom-dump.sql > ecom-dump.sql
 $ createdb ecom
 $ psql --dbname ecom -f ecom-dump.sql
 ```


### PR DESCRIPTION
**Description of Changes Made**

When the command `curl http://cube.dev/downloads/ecom-dump.sql > ecom-dump.sql` is used, the result file is:
```
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>CloudFront</center>
</body>
</html>
```
because of the redirection of the http request to the respective https.

The proposed simple fix (at the url) is enough in order to download the file successfully.
