### PR TITLE
feat(cubesql): Add PLAIN authentication method to pg-wire

### DIFF
--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -5,7 +5,7 @@ use comfy_table::{Cell as TableCell, Table};
 use cubesql::config::Config;
 use portpicker::pick_unused_port;
 use tokio::time::sleep;
-use tokio_postgres::{NoTls, Row, Socket};
+use tokio_postgres::{NoTls, Row};
 
 use super::basic::{AsyncTestConstructorResult, AsyncTestSuite, RunResult};
 
@@ -59,7 +59,11 @@ impl PostgresIntegrationTestSuite {
         sleep(Duration::from_millis(1 * 1000)).await;
 
         let (client, connection) = tokio_postgres::connect(
-            format!("host=127.0.0.1 port={} user=ovr", random_port).as_str(),
+            format!(
+                "host=127.0.0.1 port={} user=ovr password=skipped",
+                random_port
+            )
+            .as_str(),
             NoTls,
         )
         .await
@@ -93,7 +97,7 @@ impl PostgresIntegrationTestSuite {
         for (idx, row) in res.into_iter().enumerate() {
             let mut values = Vec::new();
 
-            for column in row.columns() {
+            for _column in row.columns() {
                 let value: String = row.get(idx);
                 values.push(value);
             }

--- a/rust/cubesql/cubesql/src/sql/postgres/buffer.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/buffer.rs
@@ -15,6 +15,9 @@ pub async fn read_message<Reader: AsyncReadExt + Unpin + Send>(
     Ok(match reader.read_u8().await? {
         b'Q' => FrontendMessage::Query(protocol::Query::read_from(reader).await?),
         b'X' => FrontendMessage::Terminate,
+        b'p' => {
+            FrontendMessage::PasswordMessage(protocol::PasswordMessage::read_from(reader).await?)
+        }
         identifier => {
             return Err(Error::new(
                 ErrorKind::InvalidData,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

This PR adds support for PLAIN authentication method to pg server.