### PR TITLE
refactor(api-gateway): add query type, response format

### DIFF
--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -14,9 +14,9 @@
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "scripts": {
-    "test": "npm run unit",
+    "test": "yarn run unit",
     "unit": "jest --coverage dist/test",
-    "build": "rm -rf dist && npm run tsc",
+    "build": "rm -rf dist && yarn run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
     "lint": "eslint src/* test/* --ext .ts,.js",

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -200,7 +200,7 @@ class ApiGateway {
         res: this.resToResultFn(res)
       });
     }));
-    
+
     app.post(`${this.basePath}/v1/sql`, userMiddlewares, (async (req, res) => {
       await this.sql({
         query: req.body.query,
@@ -722,7 +722,7 @@ class ApiGateway {
    * data.
    */
   public async load(request: QueryRequest) {
-    let query;
+    let query: Query | Query[] | undefined;
     const {
       context,
       res,
@@ -733,7 +733,11 @@ class ApiGateway {
 
     try {
       query = this.parseQueryParam(request.query);
-      const resType = query.responseFormat || ResultType.DEFAULT;
+      let resType: ResultType = ResultType.DEFAULT;
+
+      if (!Array.isArray(query) && query.responseFormat) {
+        resType = query.responseFormat;
+      }
 
       this.log({
         type: 'Load Request',

--- a/packages/cubejs-api-gateway/src/types/query.d.ts
+++ b/packages/cubejs-api-gateway/src/types/query.d.ts
@@ -12,6 +12,7 @@ import {
   QueryTimeDimensionGranularity,
   QueryOrderType,
 } from './strings';
+import { ResultType } from './enums';
 
 /**
  * Query base filter definition.
@@ -62,6 +63,7 @@ interface Query {
   timezone?: string;
   renewQuery?: boolean;
   ungrouped?: boolean;
+  responseFormat?: ResultType;
 }
 
 /**


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Variable `query` had `any` type, after changing it to actual typing noticed a few errors raised by TS compiler and fixed them.
Also changed npm to yarn in package json to remove warning when run them, like:
```
❯ yarn test
yarn run v1.22.17
$ npm run unit
npm WARN lifecycle The node binary used for scripts is /var/folders/21/cwdmycgd6jl_l5ngd53h6ktc0000gn/T/yarn--1647596852752-0.47937816308405234/node but npm is using /Users/dmitrika/.nvm/versions/node/v14.19.0/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```
