### PR TITLE
feat(schema-compiler): Allow filtering with or/and in FILTER_PARAMS.

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseGroupFilter.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseGroupFilter.js
@@ -8,6 +8,10 @@ export class BaseGroupFilter {
     this.dimension = filter.dimension;
   }
 
+  conditionSql(column) {
+    return `(\n${this.values.map(f => f.conditionSql(column)).join(` ${this.operator.toUpperCase()} `)}\n)`;
+  }
+
   filterToWhere() {
     const r = this.values.map(f => {
       const sql = f.filterToWhere();
@@ -21,6 +25,10 @@ export class BaseGroupFilter {
       return null;
     }
     return r;
+  }
+
+  filterParams() {
+    return this.values.map(f => f.filterParams());
   }
 
   getMembers() {


### PR DESCRIPTION
The BaseGroupFilter needs to implement the `filterParams` and
`conditionSql` methods order to support using or/and filters with
FILTER_PARAMS.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**
If `FILTER_PARAMS` were used in a cube's `sql` it would not allow filtering with `or`/`and` filters and would crash at query time because `filtersProxy` was not a method on `BaseGroupFilter`. Now when resolving the FILTER_PARAMS filters any OR/AND filters are able to be added correctly.