### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/docs-gen/src/components/helpers.component.ts
+++ b/docs-gen/src/components/helpers.component.ts
@@ -113,7 +113,7 @@ export class ContextAwareHelpersComponent extends ContextAwareRendererComponent 
         includesPath = path.join(this.includes!, includesPath.trim());
         if (fs.existsSync(includesPath) && fs.statSync(includesPath).isFile()) {
           const contents = fs.readFileSync(includesPath, 'utf-8');
-          if (includesPath.substr(-4).toLocaleLowerCase() === '.hbs') {
+          if (includesPath.slice(-4).toLocaleLowerCase() === '.hbs') {
             const template = Handlebars.compile(contents);
             return template(context);
           } else {

--- a/docs-gen/src/subthemes/docusaurus2/theme.ts
+++ b/docs-gen/src/subthemes/docusaurus2/theme.ts
@@ -64,7 +64,7 @@ export default class Docusaurus2Theme extends MarkdownTheme {
     this.getNavigation(renderer.project).children.forEach(rootNavigation => {
       rootNavigation.children.map(item => {
         url = item.url.replace('.md', '');
-        navKey = url.substr(0, url.indexOf('/'));
+        navKey = url.substring(0, url.indexOf('/'));
         if (navKey !== undefined && navKey.length) {
           navKey = navKey[0].toUpperCase() + navKey.slice(1);
         }

--- a/examples/react-dashboard/dashboard-app/config/paths.js
+++ b/examples/react-dashboard/dashboard-app/config/paths.js
@@ -14,7 +14,7 @@ const envPublicUrl = process.env.PUBLIC_URL;
 function ensureSlash(inputPath, needsSlash) {
   const hasSlash = inputPath.endsWith('/');
   if (hasSlash && !needsSlash) {
-    return inputPath.substr(0, inputPath.length - 1);
+    return inputPath.slice(0, -1);
   } else if (!hasSlash && needsSlash) {
     return `${inputPath}/`;
   } else {

--- a/guides/angular-dashboard/data/SiteConfig.js
+++ b/guides/angular-dashboard/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/bigquery-public-datasets/data/SiteConfig.js
+++ b/guides/bigquery-public-datasets/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/clickhouse-dashboard/data/SiteConfig.js
+++ b/guides/clickhouse-dashboard/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/d3-dashboard/data/SiteConfig.js
+++ b/guides/d3-dashboard/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/mapbox/data/SiteConfig.js
+++ b/guides/mapbox/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/material-ui-dashboard/data/SiteConfig.js
+++ b/guides/material-ui-dashboard/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/multi-tenant-analytics/data/SiteConfig.js
+++ b/guides/multi-tenant-analytics/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/react-dashboard/data/SiteConfig.js
+++ b/guides/react-dashboard/data/SiteConfig.js
@@ -22,7 +22,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/react-pivot-table/data/SiteConfig.js
+++ b/guides/react-pivot-table/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/real-time-dashboard/data/SiteConfig.js
+++ b/guides/real-time-dashboard/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/guides/web-analytics/data/SiteConfig.js
+++ b/guides/web-analytics/data/SiteConfig.js
@@ -24,7 +24,7 @@ const config = {
 //}
 
 // Make sure siteUrl doesn't have an ending forward slash
-if (config.siteUrl.substr(-1) === "/")
+if (config.siteUrl.slice(-1) === "/")
   config.siteUrl = config.siteUrl.slice(0, -1);
 
 // Make sure siteRss has a starting forward slash

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -19,7 +19,7 @@ export function convertTimeStrToMs(
 
   if (input.length > 1) {
     // eslint-disable-next-line default-case
-    switch (input.substr(-1).toLowerCase()) {
+    switch (input.slice(-1).toLowerCase()) {
       case 'h':
         return parseInt(input.slice(0, -1), 10) * 60 * 60;
       case 'm':

--- a/packages/cubejs-postgres-driver/src/PostgresDriver.ts
+++ b/packages/cubejs-postgres-driver/src/PostgresDriver.ts
@@ -43,7 +43,7 @@ const timestampDataTypes = [
 const timestampTypeParser = (val: string) => moment.utc(val).format(moment.HTML5_FMT.DATETIME_LOCAL_MS);
 const hllTypeParser = (val: string) => Buffer.from(
   // Postgres uses prefix as \x for encoding
-  val.substr(2),
+  val.slice(2),
   'hex'
 ).toString('base64');
 

--- a/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/utils.ts
@@ -156,21 +156,21 @@ export function parseRedisUrl(url: Readonly<string>): RedisParsedResult {
   }
 
   if (url.startsWith('redis://')) {
-    return parseUrl(url.substr('redis://'.length), result, parseHostPartBasic);
+    return parseUrl(url.slice('redis://'.length), result, parseHostPartBasic);
   }
 
   if (url.startsWith('rediss://')) {
     result.ssl = true;
 
-    return parseUrl(url.substr('rediss://'.length), result, parseHostPartBasic);
+    return parseUrl(url.slice('rediss://'.length), result, parseHostPartBasic);
   }
 
   if (url.startsWith('redis+sentinel://')) {
-    return parseUrl(url.substr('redis+sentinel://'.length), result, parseHostPartSentinel);
+    return parseUrl(url.slice('redis+sentinel://'.length), result, parseHostPartSentinel);
   }
 
   if (url.startsWith('unix://')) {
-    return parseUnixUrl(url.substr('unix://'.length), result);
+    return parseUnixUrl(url.slice('unix://'.length), result);
   }
 
   return parseUrl(url, result, parseHostPartBasic);

--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -526,6 +526,6 @@ export class DevServer {
       .update(apiSecret)
       .digest('hex')
       .replace(/[^\d]/g, '')
-      .substr(0, 10);
+      .slice(0, 10);
   }
 }

--- a/packages/cubejs-testing/cypress/integration/chart-renderers.spec.js
+++ b/packages/cubejs-testing/cypress/integration/chart-renderers.spec.js
@@ -33,7 +33,7 @@ context('Playground: Chart Renderers', () => {
     });
 
     chartTypeByQuery.forEach(([query, chartTypes]) => {
-      const queryHash = crypto.createHash('md5').update(JSON.stringify(query)).digest('hex').substr(0, 5);
+      const queryHash = crypto.createHash('md5').update(JSON.stringify(query)).digest('hex').slice(0, 5);
 
       it(`opens the explore page: query hash ${queryHash}`, () => {
         cy.log(`QUERY: ${JSON.stringify(query)}`);

--- a/rust/cubestore/js-wrapper/src/download.ts
+++ b/rust/cubestore/js-wrapper/src/download.ts
@@ -40,7 +40,7 @@ function parseInfoFromAssetName(assetName: string): { target: string, type: stri
 
     if (targetAndType.endsWith('-shared')) {
       return {
-        target: targetAndType.substr(0, targetAndType.length - '-shared'.length),
+        target: targetAndType.slice(0, -'-shared'.length),
         format,
         type: 'shared'
       };


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

**Description of Changes Made (if issue reference is not provided)**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
