### PR TITLE
feat(cubesql): Support current_schema() and current_schemas() postgres functions

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -131,6 +131,24 @@ pub fn create_connection_id_udf(state: Arc<SessionState>) -> ScalarUDF {
     )
 }
 
+pub fn create_current_schema_udf() -> ScalarUDF {
+    let current_schema = make_scalar_function(move |_args: &[ArrayRef]| {
+        let mut builder = StringBuilder::new(1);
+
+        builder.append_value("public").unwrap();
+
+        Ok(Arc::new(builder.finish()) as ArrayRef)
+    });
+
+    create_udf(
+        "current_schema",
+        vec![],
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        current_schema,
+    )
+}
+
 #[allow(unused_macros)]
 macro_rules! downcast_boolean_arr {
     ($ARG:expr) => {{

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -1614,9 +1614,7 @@ impl QueryPlanner {
             (ast::Statement::ExplainTable { table_name, .. }, DatabaseProtocol::MySQL) => {
                 self.explain_table_to_plan(&table_name)
             }
-            (ast::Statement::Explain { statement, .. }, DatabaseProtocol::MySQL) => {
-                self.explain_to_plan(&statement)
-            }
+            (ast::Statement::Explain { statement, .. }, _) => self.explain_to_plan(&statement),
             (ast::Statement::Use { db_name }, DatabaseProtocol::MySQL) => {
                 self.use_to_plan(&db_name)
             }
@@ -4802,6 +4800,15 @@ mod tests {
             execute_query(
                 "explain select count, avgPrice from KibanaSampleDataEcommerce;".to_string(),
                 DatabaseProtocol::MySQL
+            )
+            .await?
+        );
+
+        // EXPLAIN for Postgres
+        insta::assert_snapshot!(
+            execute_query(
+                "explain select 1+1;".to_string(),
+                DatabaseProtocol::PostgreSQL
             )
             .await?
         );

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -41,10 +41,10 @@ use self::engine::df::scan::CubeScanNode;
 use self::engine::information_schema::mysql::ext::CubeColumnMySqlExt;
 use self::engine::provider::CubeContext;
 use self::engine::udf::{
-    create_connection_id_udf, create_convert_tz_udf, create_current_user_udf, create_db_udf,
-    create_if_udf, create_instr_udf, create_isnull_udf, create_least_udf, create_locate_udf,
-    create_time_format_udf, create_timediff_udf, create_ucase_udf, create_user_udf,
-    create_version_udf,
+    create_connection_id_udf, create_convert_tz_udf, create_current_schema_udf,
+    create_current_user_udf, create_db_udf, create_if_udf, create_instr_udf, create_isnull_udf,
+    create_least_udf, create_locate_udf, create_time_format_udf, create_timediff_udf,
+    create_ucase_udf, create_user_udf, create_version_udf,
 };
 use self::parser::parse_sql_to_statement;
 use crate::compile::engine::udf::{
@@ -2184,6 +2184,7 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_date_sub_udf());
         ctx.register_udf(create_date_add_udf());
         ctx.register_udf(create_str_to_date());
+        ctx.register_udf(create_current_schema_udf());
 
         ctx.register_udaf(create_measure_udaf());
 
@@ -5103,6 +5104,20 @@ mod tests {
             "pgcatalog_pgconstraint_postgres",
             execute_query(
                 "SELECT * FROM pg_catalog.pg_constraint".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_current_schema_postgres() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "current_schema_postgres",
+            execute_query(
+                "SELECT current_schema()".to_string(),
                 DatabaseProtocol::PostgreSQL
             )
             .await?

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -42,9 +42,10 @@ use self::engine::information_schema::mysql::ext::CubeColumnMySqlExt;
 use self::engine::provider::CubeContext;
 use self::engine::udf::{
     create_connection_id_udf, create_convert_tz_udf, create_current_schema_udf,
-    create_current_user_udf, create_db_udf, create_if_udf, create_instr_udf, create_isnull_udf,
-    create_least_udf, create_locate_udf, create_time_format_udf, create_timediff_udf,
-    create_ucase_udf, create_user_udf, create_version_udf,
+    create_current_schemas_udf, create_current_user_udf, create_db_udf, create_if_udf,
+    create_instr_udf, create_isnull_udf, create_least_udf, create_locate_udf,
+    create_time_format_udf, create_timediff_udf, create_ucase_udf, create_user_udf,
+    create_version_udf,
 };
 use self::parser::parse_sql_to_statement;
 use crate::compile::engine::udf::{
@@ -2185,6 +2186,7 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_date_add_udf());
         ctx.register_udf(create_str_to_date());
         ctx.register_udf(create_current_schema_udf());
+        ctx.register_udf(create_current_schemas_udf());
 
         ctx.register_udaf(create_measure_udaf());
 
@@ -5125,4 +5127,29 @@ mod tests {
 
         Ok(())
     }
+
+    /* TODO: @ovr
+    #[tokio::test]
+    async fn test_current_schemas_postgres() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "current_schemas_postgres",
+            execute_query(
+                "SELECT current_schemas(false)".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        insta::assert_snapshot!(
+            "current_schemas_including_implicit_postgres",
+            execute_query(
+                "SELECT current_schemas(true)".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+    */
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__current_schema_postgres.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__current_schema_postgres.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT current_schema()\".to_string(),\n              DatabaseProtocol::PostgreSQL).await?"
+---
++------------------+
+| current_schema() |
++------------------+
+| public           |
++------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__explain-3.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__explain-3.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"explain select 1+1;\".to_string(),\n              DatabaseProtocol::PostgreSQL).await?"
+---
++---------------------------------+
+| Execution Plan                  |
++---------------------------------+
+| Projection: Int64(1) + Int64(1) |
+|   EmptyRelation                 |
++---------------------------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `current_schema()` and initial support for `current_schemas(…)` postgres functions.
Additionally, it fixes EXPLAIN queries, enabling them to work with postgres.
