### PR TITLE
fix(native): Post installation issue with npm (avoid bundledDependenc…

### DIFF
--- a/packages/cubejs-backend-native/package.json
+++ b/packages/cubejs-backend-native/package.json
@@ -15,7 +15,7 @@
     "native:build": "tsc && cargo-cp-artifact -a cdylib cubejs-native index.node -- cargo build --message-format=json-render-diagnostics",
     "native:build-debug": "npm run native:build --",
     "native:build-release": "npm run native:build -- --release",
-    "postinstall": "node-pre-gyp install || echo 'Your system is not supported by @cubejs-backend/native, some feature will be unavailable.'",
+    "install": "node-pre-gyp install || echo 'Your system is not supported by @cubejs-backend/native, some feature will be unavailable.'",
     "upload-binary-cross": "mkdir -p native && cp index.node native/index.node && node-pre-gyp package --target_arch=$PACKAGE_TARGET_ARCH --target_platform=$PACKAGE_TARGET_PLATFORM --target_libc=$PACKAGE_TARGET_LIBC && node-pre-gyp-github publish",
     "upload-binary": "mkdir -p native && cp index.node native/index.node && node-pre-gyp package && node-pre-gyp-github publish",
     "test:unit": "jest --forceExit test",
@@ -26,9 +26,6 @@
   },
   "files": [
     "dist/js"
-  ],
-  "bundledDependencies": [
-    "@mapbox/node-pre-gyp"
   ],
   "devDependencies": {
     "@cubejs-infra/node-pre-gyp-github": "^1.0.3",


### PR DESCRIPTION
…ies)

Hello!

I've tested it locally with Verdacio and found that :

```
❯ npm i --save-dev ovr-native
npm ERR! code 127
npm ERR! path /Users/ovr/projects/cube/testing/test/node_modules/ovr-native
npm ERR! command failed
npm ERR! command sh -c node-pre-gyp install
npm ERR! sh: node-pre-gyp: command not found

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ovr/.npm/_logs/2022-04-01T19_13_06_676Z-debug.log
```

After some testing I found that this problem caused by `bundledDepdendecies`.

Authors from node-pre-gyp recommends to avoid it:

- https://github.com/mapbox/node-pre-gyp/commit/1478a538b799c3224ba7faf599119f8cb662024d

Thanks