### PR TITLE
fix(cubesql): Allow quoted variables with SHOW <variable> syntax

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -4568,7 +4568,11 @@ mod tests {
         // Postgres escaped with quotes
         insta::assert_snapshot!(
             "show_variable_quoted",
-            execute_query("show \"max_allowed_packet\";".to_string(), DatabaseProtocol::PostgreSQL).await?
+            execute_query(
+                "show \"max_allowed_packet\";".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
         );
 
         Ok(())

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__show_variable_quoted.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__show_variable_quoted.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"show \\\"max_allowed_packet\\\";\".to_string(),\n              DatabaseProtocol::PostgreSQL).await?"
+---
++----------+
+| setting  |
++----------+
+| 67108864 |
++----------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

This PR fixes processing queries with variable names quoted with SHOW <variable> syntax, such as `SHOW "lc_collate"`.