### PR TITLE
chore(cubestore): Inactive partition compaction: replace error with warn

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -3285,12 +3285,6 @@ impl MetaStore for RocksMetaStore {
                     Some(MultiPartitionRocksTable::new(db_ref.clone()).get_row_or_not_found(m)?)
                 }
             };
-            if !partition.get_row().is_active() && !multi_part.is_some() {
-                return Err(CubeError::internal(format!(
-                    "Cannot compact inactive partition: {:?}",
-                    partition.get_row()
-                )));
-            }
             Ok((partition, index, table, multi_part))
         })
         .await

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -90,7 +90,7 @@ impl CompactionService for CompactionServiceImpl {
             .await?;
 
         if !partition.get_row().is_active() && !multi_part.is_some() {
-            log::warn!(
+            log::trace!(
                 "Cannot compact inactive partition: {:?}",
                 partition.get_row()
             );

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -88,6 +88,14 @@ impl CompactionService for CompactionServiceImpl {
             .meta_store
             .get_partition_for_compaction(partition_id)
             .await?;
+
+        if !partition.get_row().is_active() && !multi_part.is_some() {
+            log::warn!(
+                "Cannot compact inactive partition: {:?}",
+                partition.get_row()
+            );
+            return Ok(());
+        }
         if let Some(mp) = &multi_part {
             if mp.get_row().prepared_for_split() {
                 log::debug!(


### PR DESCRIPTION

**Description of Changes Made (if issue reference is not provided)**
`cannot compact inactive partition` error replaced with warning
