### PR TITLE
Accept immutable queries

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -784,6 +784,10 @@ declare module '@cubejs-client/core' {
 
   export type TimeDimension = TimeDimensionComparison | TimeDimensionRanged;
 
+  type DeeplyReadonly<T> = {
+    readonly [K in keyof T]: DeeplyReadonly<T[K]>;
+  };
+
   export interface Query {
     measures?: string[];
     dimensions?: string[];
@@ -939,7 +943,7 @@ declare module '@cubejs-client/core' {
      * If empty query is provided no filtering is done based on query context and all available members are retrieved.
      * @param query - context query to provide filtering of members available to add to this query
      */
-    membersForQuery(query: Query | null, memberType: MemberType): TCubeMeasure[] | TCubeDimension[] | TCubeMember[];
+    membersForQuery(query: DeeplyReadonly<Query> | null, memberType: MemberType): TCubeMeasure[] | TCubeDimension[] | TCubeMember[];
 
     /**
      * Get meta information for a cube member
@@ -974,7 +978,7 @@ declare module '@cubejs-client/core' {
    * @order 2
    */
   export class CubejsApi {
-    load(query: Query | Query[], options?: LoadMethodOptions): Promise<ResultSet>;
+    load(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<ResultSet>;
     /**
      * Fetch data for the passed `query`.
      *
@@ -999,9 +1003,9 @@ declare module '@cubejs-client/core' {
      * ```
      * @param query - [Query object](query-format)
      */
-    load(query: Query | Query[], options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
+    load(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
     load(
-      query: Query | Query[],
+      query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[],
       options?: LoadMethodOptions,
       callback?: LoadMethodCallback<ResultSet>,
       responseFormat?: string
@@ -1031,14 +1035,14 @@ declare module '@cubejs-client/core' {
      * );
      * ```
      */
-    subscribe(query: Query | Query[], options: LoadMethodOptions | null, callback: LoadMethodCallback<ResultSet>): void;
+    subscribe(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options: LoadMethodOptions | null, callback: LoadMethodCallback<ResultSet>): void;
 
-    sql(query: Query | Query[], options?: LoadMethodOptions): Promise<SqlQuery>;
+    sql(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<SqlQuery>;
     /**
      * Get generated SQL string for the given `query`.
      * @param query - [Query object](query-format)
      */
-    sql(query: Query | Query[], options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
+    sql(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
 
     meta(options?: LoadMethodOptions): Promise<Meta>;
     /**
@@ -1046,11 +1050,11 @@ declare module '@cubejs-client/core' {
      */
     meta(options?: LoadMethodOptions, callback?: LoadMethodCallback<Meta>): void;
 
-    dryRun(query: Query | Query[], options?: LoadMethodOptions): Promise<DryRunResponse>;
+    dryRun(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<DryRunResponse>;
     /**
      * Get query related meta without query execution
      */
-    dryRun(query: Query | Query[], options: LoadMethodOptions, callback?: LoadMethodCallback<DryRunResponse>): void;
+    dryRun(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options: LoadMethodOptions, callback?: LoadMethodCallback<DryRunResponse>): void;
   }
 
   /**
@@ -1112,7 +1116,7 @@ declare module '@cubejs-client/core' {
   /**
    * @hidden
    */
-  export function isQueryPresent(query: Query | Query[] | null | undefined): boolean;
+  export function isQueryPresent(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[] | null | undefined): boolean;
   export function movePivotItem(
     pivotConfig: PivotConfig,
     sourceIndex: number,
@@ -1125,7 +1129,7 @@ declare module '@cubejs-client/core' {
    */
   export function moveItemInArray<T = any>(list: T[], sourceIndex: number, destinationIndex: number): T[];
 
-  export function defaultOrder(query: Query): { [key: string]: QueryOrder };
+  export function defaultOrder(query: DeeplyReadonly<Query>): { [key: string]: QueryOrder };
 
   export interface TFlatFilter {
     /**
@@ -1159,9 +1163,9 @@ declare module '@cubejs-client/core' {
   /**
    * @hidden
    */
-  export function getQueryMembers(query: Query): string[];
+  export function getQueryMembers(query: DeeplyReadonly<Query>): string[];
 
-  export function areQueriesEqual(query1: Query | null, query2: Query | null): boolean;
+  export function areQueriesEqual(query1: DeeplyReadonly<Query> | null, query2: DeeplyReadonly<Query> | null): boolean;
 
   export type ProgressResponse = {
     stage: string;

--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -978,7 +978,7 @@ declare module '@cubejs-client/core' {
    * @order 2
    */
   export class CubejsApi {
-    load(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<ResultSet>;
+    load(query: DeeplyReadonly<Query | Query[]>, options?: LoadMethodOptions): Promise<ResultSet>;
     /**
      * Fetch data for the passed `query`.
      *
@@ -1003,9 +1003,9 @@ declare module '@cubejs-client/core' {
      * ```
      * @param query - [Query object](query-format)
      */
-    load(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
+    load(query: DeeplyReadonly<Query | Query[]>, options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
     load(
-      query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[],
+      query: DeeplyReadonly<Query | Query[]>,
       options?: LoadMethodOptions,
       callback?: LoadMethodCallback<ResultSet>,
       responseFormat?: string
@@ -1035,14 +1035,14 @@ declare module '@cubejs-client/core' {
      * );
      * ```
      */
-    subscribe(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options: LoadMethodOptions | null, callback: LoadMethodCallback<ResultSet>): void;
+    subscribe(query: DeeplyReadonly<Query | Query[]>, options: LoadMethodOptions | null, callback: LoadMethodCallback<ResultSet>): void;
 
-    sql(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<SqlQuery>;
+    sql(query: DeeplyReadonly<Query | Query[]>, options?: LoadMethodOptions): Promise<SqlQuery>;
     /**
      * Get generated SQL string for the given `query`.
      * @param query - [Query object](query-format)
      */
-    sql(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
+    sql(query: DeeplyReadonly<Query | Query[]>, options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
 
     meta(options?: LoadMethodOptions): Promise<Meta>;
     /**
@@ -1050,11 +1050,11 @@ declare module '@cubejs-client/core' {
      */
     meta(options?: LoadMethodOptions, callback?: LoadMethodCallback<Meta>): void;
 
-    dryRun(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<DryRunResponse>;
+    dryRun(query: DeeplyReadonly<Query | Query[]>, options?: LoadMethodOptions): Promise<DryRunResponse>;
     /**
      * Get query related meta without query execution
      */
-    dryRun(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options: LoadMethodOptions, callback?: LoadMethodCallback<DryRunResponse>): void;
+    dryRun(query: DeeplyReadonly<Query | Query[]>, options: LoadMethodOptions, callback?: LoadMethodCallback<DryRunResponse>): void;
   }
 
   /**
@@ -1116,7 +1116,7 @@ declare module '@cubejs-client/core' {
   /**
    * @hidden
    */
-  export function isQueryPresent(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[] | null | undefined): boolean;
+  export function isQueryPresent(query: DeeplyReadonly<Query | Query[]> | null | undefined): boolean;
   export function movePivotItem(
     pivotConfig: PivotConfig,
     sourceIndex: number,

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -241,7 +241,12 @@ class CubejsApi {
       responseFormat === ResultType.COMPACT &&
       query.responseFormat !== ResultType.COMPACT
     ) {
-      query.responseFormat = ResultType.COMPACT;
+      return {
+        ...query,
+        responseFormat: ResultType.COMPACT,
+      };
+    } else {
+      return query;
     }
   }
 
@@ -287,11 +292,9 @@ class CubejsApi {
   load(query, options, callback, responseFormat = ResultType.DEFAULT) {
     if (responseFormat === ResultType.COMPACT) {
       if (Array.isArray(query)) {
-        query.forEach((q) => {
-          this.patchQueryInternal(q, ResultType.COMPACT);
-        });
+        query = query.map((q) => this.patchQueryInternal(q, ResultType.COMPACT));
       } else {
-        this.patchQueryInternal(query, ResultType.COMPACT);
+        query = this.patchQueryInternal(query, ResultType.COMPACT);
       }
     }
     return this.loadMethod(
@@ -318,11 +321,9 @@ class CubejsApi {
   subscribe(query, options, callback, responseFormat = ResultType.DEFAULT) {
     if (responseFormat === ResultType.COMPACT) {
       if (Array.isArray(query)) {
-        query.forEach((q) => {
-          this.patchQueryInternal(q, ResultType.COMPACT);
-        });
+        query = query.map((q) => this.patchQueryInternal(q, ResultType.COMPACT));
       } else {
-        this.patchQueryInternal(query, ResultType.COMPACT);
+        query = this.patchQueryInternal(query, ResultType.COMPACT);
       }
     }
     return this.loadMethod(

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -427,7 +427,7 @@ declare module '@cubejs-client/react' {
    * @order 1
    * @stickyTypes
    */
-  export function useCubeQuery<TData>(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
+  export function useCubeQuery<TData>(query: DeeplyReadonly<Query | Query[]>, options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
 
   type UseCubeQueryOptions = {
     /**

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -30,6 +30,7 @@ declare module '@cubejs-client/react' {
     DateRange,
     UnaryOperator,
     BinaryOperator,
+    DeeplyReadonly,
   } from '@cubejs-client/core';
 
   type CubeProviderProps = {
@@ -426,7 +427,7 @@ declare module '@cubejs-client/react' {
    * @order 1
    * @stickyTypes
    */
-  export function useCubeQuery<TData>(query: Query | Query[], options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
+  export function useCubeQuery<TData>(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
 
   type UseCubeQueryOptions = {
     /**


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet (n/a)
- [x] Docs have been added / updated if required (n/a)

#4160

Change the declared types of the core methods that accept a Query to accept a query that has been defined using `as const`. This is a less intrusive change than making the Query type itself deeply readonly.

Also, when the `responseFormat` is `COMPACT`, don't modify the passed queries' `responseFormat`, but rather create a new query. The prior behavior is inconsistent with the new types, and it probably wasn't the best behavior anyway.