### PR TITLE
[WIP] Detailed query types

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -1029,7 +1029,7 @@ declare module '@cubejs-client/core' {
     load<T extends DeeplyReadonly<Query | Query[]>>(
       query: T,
       options?: LoadMethodOptions,
-      callback?: LoadMethodCallback<ResultSet>,
+      callback?: LoadMethodCallback<ResultSet<QueryResultType<T>>>,
     ): void;
     load<T extends DeeplyReadonly<Query | Query[]>>(
       query: T,

--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -784,6 +784,10 @@ declare module '@cubejs-client/core' {
 
   export type TimeDimension = TimeDimensionComparison | TimeDimensionRanged;
 
+  type DeeplyReadonly<T> = {
+    readonly [K in keyof T]: DeeplyReadonly<T[K]>;
+  };
+
   export interface Query {
     measures?: string[];
     dimensions?: string[];
@@ -939,7 +943,7 @@ declare module '@cubejs-client/core' {
      * If empty query is provided no filtering is done based on query context and all available members are retrieved.
      * @param query - context query to provide filtering of members available to add to this query
      */
-    membersForQuery(query: Query | null, memberType: MemberType): TCubeMeasure[] | TCubeDimension[] | TCubeMember[];
+    membersForQuery(query: DeeplyReadonly<Query> | null, memberType: MemberType): TCubeMeasure[] | TCubeDimension[] | TCubeMember[];
 
     /**
      * Get meta information for a cube member
@@ -974,7 +978,7 @@ declare module '@cubejs-client/core' {
    * @order 2
    */
   export class CubejsApi {
-    load(query: Query | Query[], options?: LoadMethodOptions): Promise<ResultSet>;
+    load(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<ResultSet>;
     /**
      * Fetch data for the passed `query`.
      *
@@ -999,9 +1003,9 @@ declare module '@cubejs-client/core' {
      * ```
      * @param query - [Query object](query-format)
      */
-    load(query: Query | Query[], options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
+    load(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions, callback?: LoadMethodCallback<ResultSet>): void;
     load(
-      query: Query | Query[],
+      query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[],
       options?: LoadMethodOptions,
       callback?: LoadMethodCallback<ResultSet>,
       responseFormat?: string
@@ -1031,14 +1035,14 @@ declare module '@cubejs-client/core' {
      * );
      * ```
      */
-    subscribe(query: Query | Query[], options: LoadMethodOptions | null, callback: LoadMethodCallback<ResultSet>): void;
+    subscribe(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options: LoadMethodOptions | null, callback: LoadMethodCallback<ResultSet>): void;
 
-    sql(query: Query | Query[], options?: LoadMethodOptions): Promise<SqlQuery>;
+    sql(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<SqlQuery>;
     /**
      * Get generated SQL string for the given `query`.
      * @param query - [Query object](query-format)
      */
-    sql(query: Query | Query[], options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
+    sql(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions, callback?: LoadMethodCallback<SqlQuery>): void;
 
     meta(options?: LoadMethodOptions): Promise<Meta>;
     /**
@@ -1046,11 +1050,11 @@ declare module '@cubejs-client/core' {
      */
     meta(options?: LoadMethodOptions, callback?: LoadMethodCallback<Meta>): void;
 
-    dryRun(query: Query | Query[], options?: LoadMethodOptions): Promise<DryRunResponse>;
+    dryRun(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: LoadMethodOptions): Promise<DryRunResponse>;
     /**
      * Get query related meta without query execution
      */
-    dryRun(query: Query | Query[], options: LoadMethodOptions, callback?: LoadMethodCallback<DryRunResponse>): void;
+    dryRun(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options: LoadMethodOptions, callback?: LoadMethodCallback<DryRunResponse>): void;
   }
 
   /**
@@ -1112,7 +1116,7 @@ declare module '@cubejs-client/core' {
   /**
    * @hidden
    */
-  export function isQueryPresent(query: Query | Query[] | null | undefined): boolean;
+  export function isQueryPresent(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[] | null | undefined): boolean;
   export function movePivotItem(
     pivotConfig: PivotConfig,
     sourceIndex: number,
@@ -1125,7 +1129,7 @@ declare module '@cubejs-client/core' {
    */
   export function moveItemInArray<T = any>(list: T[], sourceIndex: number, destinationIndex: number): T[];
 
-  export function defaultOrder(query: Query): { [key: string]: QueryOrder };
+  export function defaultOrder(query: DeeplyReadonly<Query>): { [key: string]: QueryOrder };
 
   export interface TFlatFilter {
     /**
@@ -1159,9 +1163,9 @@ declare module '@cubejs-client/core' {
   /**
    * @hidden
    */
-  export function getQueryMembers(query: Query): string[];
+  export function getQueryMembers(query: DeeplyReadonly<Query>): string[];
 
-  export function areQueriesEqual(query1: Query | null, query2: Query | null): boolean;
+  export function areQueriesEqual(query1: DeeplyReadonly<Query> | null, query2: DeeplyReadonly<Query> | null): boolean;
 
   export type ProgressResponse = {
     stage: string;

--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -44,6 +44,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^5.2.1",
-    "jest": "^26.0.1"
+    "jest": "^26.0.1",
+    "tsd": "^0.20.0"
   }
 }

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -241,7 +241,12 @@ class CubejsApi {
       responseFormat === ResultType.COMPACT &&
       query.responseFormat !== ResultType.COMPACT
     ) {
-      query.responseFormat = ResultType.COMPACT;
+      return {
+        ...query,
+        responseFormat: ResultType.COMPACT,
+      };
+    } else {
+      return query;
     }
   }
 
@@ -287,11 +292,9 @@ class CubejsApi {
   load(query, options, callback, responseFormat = ResultType.DEFAULT) {
     if (responseFormat === ResultType.COMPACT) {
       if (Array.isArray(query)) {
-        query.forEach((q) => {
-          this.patchQueryInternal(q, ResultType.COMPACT);
-        });
+        query = query.map((q) => this.patchQueryInternal(q, ResultType.COMPACT));
       } else {
-        this.patchQueryInternal(query, ResultType.COMPACT);
+        query = this.patchQueryInternal(query, ResultType.COMPACT);
       }
     }
     return this.loadMethod(
@@ -318,11 +321,9 @@ class CubejsApi {
   subscribe(query, options, callback, responseFormat = ResultType.DEFAULT) {
     if (responseFormat === ResultType.COMPACT) {
       if (Array.isArray(query)) {
-        query.forEach((q) => {
-          this.patchQueryInternal(q, ResultType.COMPACT);
-        });
+        query = query.map((q) => this.patchQueryInternal(q, ResultType.COMPACT));
       } else {
-        this.patchQueryInternal(query, ResultType.COMPACT);
+        query = this.patchQueryInternal(query, ResultType.COMPACT);
       }
     }
     return this.loadMethod(

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -31,6 +31,7 @@ declare module '@cubejs-client/react' {
     UnaryOperator,
     BinaryOperator,
     DeeplyReadonly,
+    QueryResultType,
   } from '@cubejs-client/core';
 
   type CubeProviderProps = {
@@ -427,7 +428,14 @@ declare module '@cubejs-client/react' {
    * @order 1
    * @stickyTypes
    */
-  export function useCubeQuery<TData>(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
+  export function useCubeQuery<TData, TQuery extends DeeplyReadonly<Query | Query[]> = DeeplyReadonly<Query | Query[]>>(
+    query: TQuery,
+    options?: UseCubeQueryOptions,
+  ): UseCubeQueryResult<
+    unknown extends TData
+      ? QueryResultType<TQuery>
+      : TData
+  >;
 
   type UseCubeQueryOptions = {
     /**

--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -30,6 +30,7 @@ declare module '@cubejs-client/react' {
     DateRange,
     UnaryOperator,
     BinaryOperator,
+    DeeplyReadonly,
   } from '@cubejs-client/core';
 
   type CubeProviderProps = {
@@ -426,7 +427,7 @@ declare module '@cubejs-client/react' {
    * @order 1
    * @stickyTypes
    */
-  export function useCubeQuery<TData>(query: Query | Query[], options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
+  export function useCubeQuery<TData>(query: DeeplyReadonly<Query> | DeeplyReadonly<Query>[], options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
 
   type UseCubeQueryOptions = {
     /**


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet (see below)
- [x] Docs have been added / updated if required (n/a)

Implement #4202.

This PR incorporates #4366.

1. The `Query` type is now generic. `Query<'foo' | 'bar'>` is a query with dimension, measures, and time dimensions `foo` and `bar`.
2. `load`, `subscribe`, and `useCubeQuery` will now “look into” the type of the passed query/queries and return the narrowest possible type.

The upshot is that if you write a const query, and pass it into e.g. `load`, then you will get a result whose type has exactly the dimensions and measures that you put in the query.

These changes should in principle be backward-compatible:

- `Query` with no type parameter is equivalent to `Query<string>`, which preserves the prior typing. (The same is true for the time dimension types that needed to be modified.)
- `load`, `subscribe`, and `useCubeQuery` will still accept any input they did before and return exactly the same value. The new declared return types are narrower than the old ones.
- The behavior of `useCubeQuery` with an explicit first type parameter works as before, *unless* you pass an explicit type parameter of `unknown`, which makes no sense.

However, any time a general type (such as `any`) is replaced by a more specific type, it is possible that some code that is not safely typed but did compile before will require a cast to compile afterward.

Notes:

- I improved the types in `@cubejs-client/core` and `@cubejs-client/react`, but not elsewhere (e.g. not in `@cubejs-client/vue`). I have not used those other packages, but I'd be happy to work with someone more familiar with them to incorporate these improvements.
- This PR should not change any actual behavior, so there is no need to update the existing tests. However, it would be nice to add some new type-oriented tests. I have been testing this locally using [`tsd`](https://github.com/SamVerschueren/tsd), and I think that might be a good thing to add to the existing test infrastructure (#4369), but there were dependency conflicts and I didn't include it in this PR.