### PR TITLE
feat(cubesql): Support extra information_schema UDFs and pg_get_userbyid

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -1148,6 +1148,44 @@ pub fn create_pg_numeric_precision_udf() -> ScalarUDF {
     )
 }
 
+pub fn create_pg_numeric_scale_udf() -> ScalarUDF {
+    let fun = make_scalar_function(move |args: &[ArrayRef]| {
+        let typids = args[0].as_any().downcast_ref::<Int64Array>().unwrap();
+        let typmods = args[1].as_any().downcast_ref::<Int64Array>().unwrap();
+        let mut builder = Int64Builder::new(typids.len());
+        for i in 0..typids.len() {
+            let typid = typids.value(i);
+            let typmod = typmods.value(i);
+
+            // https://github.com/postgres/postgres/blob/REL_14_2/src/backend/catalog/information_schema.sql#L140
+            let scale = match typid {
+                20 | 21 | 23 => Some(0),
+                1700 => match typmod {
+                    -1 => None,
+                    _ => Some((typmod - 4) & 65535),
+                },
+                _ => None,
+            };
+
+            if scale.is_some() {
+                builder.append_value(scale.unwrap()).unwrap();
+            } else {
+                builder.append_null().unwrap();
+            }
+        }
+
+        Ok(Arc::new(builder.finish()))
+    });
+
+    create_udf(
+        "information_schema._pg_numeric_scale",
+        vec![DataType::Int64, DataType::Int64],
+        Arc::new(DataType::Int64),
+        Volatility::Immutable,
+        fun,
+    )
+}
+
 pub fn create_measure_udaf() -> AggregateUDF {
     create_udaf(
         "measure",

--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -1186,6 +1186,33 @@ pub fn create_pg_numeric_scale_udf() -> ScalarUDF {
     )
 }
 
+pub fn create_pg_get_userbyid_udf(state: Arc<SessionState>) -> ScalarUDF {
+    let fun = make_scalar_function(move |args: &[ArrayRef]| {
+        let role_oids = args[0].as_any().downcast_ref::<Int64Array>().unwrap();
+        let mut builder = StringBuilder::new(role_oids.len());
+        for i in 0..role_oids.len() {
+            let role_oid = role_oids.value(i);
+
+            let user = match role_oid {
+                10 => state.user().unwrap_or("postgres".to_string()),
+                _ => format!("unknown (OID={})", role_oid),
+            };
+
+            builder.append_value(user).unwrap();
+        }
+
+        Ok(Arc::new(builder.finish()))
+    });
+
+    create_udf(
+        "pg_get_userbyid",
+        vec![DataType::Int64],
+        Arc::new(DataType::Utf8),
+        Volatility::Immutable,
+        fun,
+    )
+}
+
 pub fn create_measure_udaf() -> AggregateUDF {
     create_udaf(
         "measure",

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -50,8 +50,9 @@ use self::engine::udf::{
     create_connection_id_udf, create_convert_tz_udf, create_current_schema_udf,
     create_current_schemas_udf, create_current_user_udf, create_db_udf, create_format_type_udf,
     create_if_udf, create_instr_udf, create_isnull_udf, create_least_udf, create_locate_udf,
-    create_pg_datetime_precision_udf, create_pg_numeric_precision_udf, create_time_format_udf,
-    create_timediff_udf, create_ucase_udf, create_user_udf, create_version_udf,
+    create_pg_datetime_precision_udf, create_pg_numeric_precision_udf, create_pg_numeric_scale_udf,
+    create_time_format_udf, create_timediff_udf, create_ucase_udf, create_user_udf,
+    create_version_udf,
 };
 use self::parser::parse_sql_to_statement;
 use crate::compile::engine::udf::{
@@ -2220,6 +2221,7 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_format_type_udf("pg_catalog.format_type"));
         ctx.register_udf(create_pg_datetime_precision_udf());
         ctx.register_udf(create_pg_numeric_precision_udf());
+        ctx.register_udf(create_pg_numeric_scale_udf());
         // udaf
         ctx.register_udaf(create_measure_udaf());
 
@@ -5380,6 +5382,34 @@ mod tests {
             execute_query(
                 "
                 SELECT t.oid, information_schema._pg_numeric_precision(t.oid, 3) p
+                FROM pg_catalog.pg_type t
+                ORDER BY t.oid ASC;
+                "
+                .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_pg_numeric_scale_postgres() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "pg_numeric_scale_simple",
+            execute_query(
+                "SELECT information_schema._pg_numeric_scale(1700, 50);".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        insta::assert_snapshot!(
+            "pg_numeric_scale_types",
+            execute_query(
+                "
+                SELECT t.oid, information_schema._pg_numeric_scale(t.oid, 10) s
                 FROM pg_catalog.pg_type t
                 ORDER BY t.oid ASC;
                 "

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -50,8 +50,8 @@ use self::engine::udf::{
     create_connection_id_udf, create_convert_tz_udf, create_current_schema_udf,
     create_current_schemas_udf, create_current_user_udf, create_db_udf, create_format_type_udf,
     create_if_udf, create_instr_udf, create_isnull_udf, create_least_udf, create_locate_udf,
-    create_pg_datetime_precision_udf, create_time_format_udf, create_timediff_udf,
-    create_ucase_udf, create_user_udf, create_version_udf,
+    create_pg_datetime_precision_udf, create_pg_numeric_precision_udf, create_time_format_udf,
+    create_timediff_udf, create_ucase_udf, create_user_udf, create_version_udf,
 };
 use self::parser::parse_sql_to_statement;
 use crate::compile::engine::udf::{
@@ -2219,6 +2219,7 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_format_type_udf("format_type"));
         ctx.register_udf(create_format_type_udf("pg_catalog.format_type"));
         ctx.register_udf(create_pg_datetime_precision_udf());
+        ctx.register_udf(create_pg_numeric_precision_udf());
         // udaf
         ctx.register_udaf(create_measure_udaf());
 
@@ -5351,6 +5352,34 @@ mod tests {
             execute_query(
                 "
                 SELECT t.oid, information_schema._pg_datetime_precision(t.oid, 3) p
+                FROM pg_catalog.pg_type t
+                ORDER BY t.oid ASC;
+                "
+                .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_pg_numeric_precision_postgres() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "pg_numeric_precision_simple",
+            execute_query(
+                "SELECT information_schema._pg_numeric_precision(1700, 3);".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        insta::assert_snapshot!(
+            "pg_numeric_precision_types",
+            execute_query(
+                "
+                SELECT t.oid, information_schema._pg_numeric_precision(t.oid, 3) p
                 FROM pg_catalog.pg_type t
                 ORDER BY t.oid ASC;
                 "

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -50,9 +50,9 @@ use self::engine::udf::{
     create_connection_id_udf, create_convert_tz_udf, create_current_schema_udf,
     create_current_schemas_udf, create_current_user_udf, create_db_udf, create_format_type_udf,
     create_if_udf, create_instr_udf, create_isnull_udf, create_least_udf, create_locate_udf,
-    create_pg_datetime_precision_udf, create_pg_numeric_precision_udf, create_pg_numeric_scale_udf,
-    create_time_format_udf, create_timediff_udf, create_ucase_udf, create_user_udf,
-    create_version_udf,
+    create_pg_datetime_precision_udf, create_pg_get_userbyid_udf, create_pg_numeric_precision_udf,
+    create_pg_numeric_scale_udf, create_time_format_udf, create_timediff_udf, create_ucase_udf,
+    create_user_udf, create_version_udf,
 };
 use self::parser::parse_sql_to_statement;
 use crate::compile::engine::udf::{
@@ -2222,6 +2222,7 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_pg_datetime_precision_udf());
         ctx.register_udf(create_pg_numeric_precision_udf());
         ctx.register_udf(create_pg_numeric_scale_udf());
+        ctx.register_udf(create_pg_get_userbyid_udf(self.state.clone()));
         // udaf
         ctx.register_udaf(create_measure_udaf());
 
@@ -5414,6 +5415,29 @@ mod tests {
                 ORDER BY t.oid ASC;
                 "
                 .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_pg_get_userbyid_postgres() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "pg_get_userbyid_main",
+            execute_query(
+                "SELECT pg_get_userbyid(10);".to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        insta::assert_snapshot!(
+            "pg_get_userbyid_invalid",
+            execute_query(
+                "SELECT pg_get_userbyid(0);".to_string(),
                 DatabaseProtocol::PostgreSQL
             )
             .await?

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_datetime_precision_simple.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_datetime_precision_simple.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT information_schema._pg_datetime_precision(1184, 3) p\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---+
+| p |
++---+
+| 3 |
++---+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_datetime_precision_types.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_datetime_precision_types.snap
@@ -1,0 +1,53 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                SELECT t.oid, information_schema._pg_datetime_precision(t.oid, 3) p\n                FROM pg_catalog.pg_type t\n                ORDER BY t.oid ASC;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------+------+
+| oid   | p    |
++-------+------+
+| 16    | NULL |
+| 17    | NULL |
+| 19    | NULL |
+| 20    | NULL |
+| 21    | NULL |
+| 23    | NULL |
+| 25    | NULL |
+| 26    | NULL |
+| 27    | NULL |
+| 700   | NULL |
+| 701   | NULL |
+| 790   | NULL |
+| 869   | NULL |
+| 1042  | NULL |
+| 1043  | NULL |
+| 1082  | 0    |
+| 1083  | 3    |
+| 1114  | 3    |
+| 1184  | 3    |
+| 1186  | 3    |
+| 1266  | 3    |
+| 1700  | NULL |
+| 2249  | NULL |
+| 2277  | NULL |
+| 2283  | NULL |
+| 3220  | NULL |
+| 3500  | NULL |
+| 3831  | NULL |
+| 3904  | NULL |
+| 3906  | NULL |
+| 3908  | NULL |
+| 3910  | NULL |
+| 3912  | NULL |
+| 3926  | NULL |
+| 4451  | NULL |
+| 4532  | NULL |
+| 4533  | NULL |
+| 4535  | NULL |
+| 4536  | NULL |
+| 13408 | NULL |
+| 13410 | NULL |
+| 18001 | NULL |
+| 18002 | NULL |
+| 18013 | NULL |
+| 18014 | NULL |
++-------+------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_userbyid_invalid.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_userbyid_invalid.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT pg_get_userbyid(0);\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---------------------------+
+| pg_get_userbyid(Int64(0)) |
++---------------------------+
+| unknown (OID=0)           |
++---------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_userbyid_main.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_userbyid_main.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT pg_get_userbyid(10);\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++----------------------------+
+| pg_get_userbyid(Int64(10)) |
++----------------------------+
+| ovr                        |
++----------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_precision_simple.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_precision_simple.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT information_schema._pg_numeric_precision(1700, 3);\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++----------------------------------------------------------------+
+| information_schema._pg_numeric_precision(Int64(1700),Int64(3)) |
++----------------------------------------------------------------+
+| 65535                                                          |
++----------------------------------------------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_precision_types.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_precision_types.snap
@@ -1,0 +1,53 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                SELECT t.oid, information_schema._pg_numeric_precision(t.oid, 3) p\n                FROM pg_catalog.pg_type t\n                ORDER BY t.oid ASC;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------+-------+
+| oid   | p     |
++-------+-------+
+| 16    | NULL  |
+| 17    | NULL  |
+| 19    | NULL  |
+| 20    | 64    |
+| 21    | 16    |
+| 23    | 32    |
+| 25    | NULL  |
+| 26    | NULL  |
+| 27    | NULL  |
+| 700   | 24    |
+| 701   | 53    |
+| 790   | NULL  |
+| 869   | NULL  |
+| 1042  | NULL  |
+| 1043  | NULL  |
+| 1082  | NULL  |
+| 1083  | NULL  |
+| 1114  | NULL  |
+| 1184  | NULL  |
+| 1186  | NULL  |
+| 1266  | NULL  |
+| 1700  | 65535 |
+| 2249  | NULL  |
+| 2277  | NULL  |
+| 2283  | NULL  |
+| 3220  | NULL  |
+| 3500  | NULL  |
+| 3831  | NULL  |
+| 3904  | NULL  |
+| 3906  | NULL  |
+| 3908  | NULL  |
+| 3910  | NULL  |
+| 3912  | NULL  |
+| 3926  | NULL  |
+| 4451  | NULL  |
+| 4532  | NULL  |
+| 4533  | NULL  |
+| 4535  | NULL  |
+| 4536  | NULL  |
+| 13408 | NULL  |
+| 13410 | NULL  |
+| 18001 | NULL  |
+| 18002 | NULL  |
+| 18013 | NULL  |
+| 18014 | NULL  |
++-------+-------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_scale_simple.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_scale_simple.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT information_schema._pg_numeric_scale(1700, 50);\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------------------------------------------------------------+
+| information_schema._pg_numeric_scale(Int64(1700),Int64(50)) |
++-------------------------------------------------------------+
+| 46                                                          |
++-------------------------------------------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_scale_types.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_numeric_scale_types.snap
@@ -1,0 +1,53 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                SELECT t.oid, information_schema._pg_numeric_scale(t.oid, 10) s\n                FROM pg_catalog.pg_type t\n                ORDER BY t.oid ASC;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------+------+
+| oid   | s    |
++-------+------+
+| 16    | NULL |
+| 17    | NULL |
+| 19    | NULL |
+| 20    | 0    |
+| 21    | 0    |
+| 23    | 0    |
+| 25    | NULL |
+| 26    | NULL |
+| 27    | NULL |
+| 700   | NULL |
+| 701   | NULL |
+| 790   | NULL |
+| 869   | NULL |
+| 1042  | NULL |
+| 1043  | NULL |
+| 1082  | NULL |
+| 1083  | NULL |
+| 1114  | NULL |
+| 1184  | NULL |
+| 1186  | NULL |
+| 1266  | NULL |
+| 1700  | 6    |
+| 2249  | NULL |
+| 2277  | NULL |
+| 2283  | NULL |
+| 3220  | NULL |
+| 3500  | NULL |
+| 3831  | NULL |
+| 3904  | NULL |
+| 3906  | NULL |
+| 3908  | NULL |
+| 3910  | NULL |
+| 3912  | NULL |
+| 3926  | NULL |
+| 4451  | NULL |
+| 4532  | NULL |
+| 4533  | NULL |
+| 4535  | NULL |
+| 4536  | NULL |
+| 13408 | NULL |
+| 13410 | NULL |
+| 18001 | NULL |
+| 18002 | NULL |
+| 18013 | NULL |
+| 18014 | NULL |
++-------+------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for the following UDFs:

- information_schema._pg_datetime_precision
- information_schema._pg_numeric_precision
- information_schema._pg_numeric_scale
- pg_get_userbyid
