### PR TITLE
fix(cubestore): Support a space separated binary strings for HyperLogLog fields in csv

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -1091,6 +1091,7 @@ version = "0.1.0"
 dependencies = [
  "async-compression",
  "async-trait",
+ "base64 0.13.0",
  "cubestore",
  "futures 0.3.16",
  "futures-timer 3.0.2",

--- a/rust/cubestore/cubestore-sql-tests/Cargo.toml
+++ b/rust/cubestore/cubestore-sql-tests/Cargo.toml
@@ -31,6 +31,7 @@ harness = false
 ipc-channel = { version = "0.14.1" }
 
 [dependencies]
+base64 = "0.13.0"
 async-compression = { version = "0.3.7", features = ["gzip", "tokio"] }
 async-trait = "0.1.36"
 cubestore = { path = "../cubestore" }

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -1252,19 +1252,7 @@ fn parse_binary_string<'a>(buffer: &'a mut Vec<u8>, v: &'a Value) -> Result<&'a 
         // We interpret strings of the form '0f 0a 14 ff' as a list of hex-encoded bytes.
         // MySQL will store bytes of the string itself instead and we should do the same.
         // TODO: Ensure CubeJS does not send strings of this form our way and match MySQL behavior.
-        Value::SingleQuotedString(s) => {
-            parse_space_separated_binstring(buffer, s.as_ref())
-            /*buffer = s
-                .split(' ')
-                .filter(|b| !b.is_empty())
-                .map(|s| {
-                    decode_byte(s).ok_or_else(|| {
-                        CubeError::user(format!("cannot convert value to binary string: {}", v))
-                    })
-                })
-                .try_collect()?;
-            Ok(buffer.as_slice())*/
-        }
+        Value::SingleQuotedString(s) => parse_space_separated_binstring(buffer, s.as_ref()),
         // TODO: allocate directly on arena.
         Value::HexStringLiteral(s) => {
             *buffer = Vec::from_hex(s.as_bytes())?;


### PR DESCRIPTION

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required



**Description of Changes Made (if issue reference is not provided)**

Fix of an error with a broken data import if HyperLogLog data is presented in form `02 f6 4a ...` instead of base64 encoded
