### PR TITLE
fix: Add uniqueidentifier type support

### DIFF
--- a/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
+++ b/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
@@ -5,7 +5,12 @@ const GenericTypeToMSSql = {
   string: 'nvarchar(max)',
   text: 'nvarchar(max)',
   timestamp: 'datetime2',
+  uuid: 'uniqueidentifier'
 };
+
+const MSSqlToGenericType = {
+  uniqueidentifier: 'uuid'
+}
 
 class MSSqlDriver extends BaseDriver {
   constructor(config) {
@@ -129,6 +134,10 @@ class MSSqlDriver extends BaseDriver {
 
   fromGenericType(columnType) {
     return GenericTypeToMSSql[columnType] || super.fromGenericType(columnType);
+  }
+
+  toGenericType(columnType){
+    return MSSqlToGenericType[columnType] || super.toGenericType(columnType);
   }
 
   readOnly() {


### PR DESCRIPTION
Add of type uniqueidentifier in packages/cubejs-mssql-driver/driver/MSSqlDriver.js
This fixes a bug while creating preaggregation tables with uniqueidentifier columns for MSSQL.

Error fixed : 
Error during create table: CREATE TABLE dev_pre_aggregations.... : User: Custom type 'uniqueidentifier' is not supported