### PR TITLE
fix(athena): Support plain bucket for CUBEJS_DB_EXPORT_BUCKET

### DIFF
--- a/packages/cubejs-athena-driver/src/AthenaDriver.ts
+++ b/packages/cubejs-athena-driver/src/AthenaDriver.ts
@@ -57,7 +57,7 @@ export class AthenaDriver extends BaseDriver implements DriverInterface {
       pollMaxInterval: (config.pollMaxInterval || getEnv('dbPollMaxInterval')) * 1000,
     };
     if (this.config.exportBucket) {
-      this.config.exportBucket = AthenaDriver.trimS3Path(this.config.exportBucket);
+      this.config.exportBucket = AthenaDriver.normalizeS3Path(this.config.exportBucket);
     }
 
     this.athena = new Athena(this.config);
@@ -300,8 +300,14 @@ export class AthenaDriver extends BaseDriver implements DriverInterface {
     return result;
   }
 
-  public static trimS3Path(path: string) {
-    return path.replace(/\/+$/, '');
+  public static normalizeS3Path(path: string): string {
+    // Remove trailing /
+    path = path.replace(/\/+$/, '');
+    // Prepend s3:// prefix to plain bucket
+    if (!path.startsWith('s3://')) {
+      return `s3://${path}`;
+    }
+    return path;
   }
 
   public static splitS3Path(path: string) {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Support plain bucket for CUBEJS_DB_EXPORT_BUCKET, e.g. CUBEJS_DB_EXPORT_BUCKET=cubejs-benchmarks.