### PR TITLE
fix(cubejs-playground): fix history header scrolling in graphql explorer

### DIFF
--- a/packages/cubejs-playground/src/components/GraphQL/GraphiQLSandbox.tsx
+++ b/packages/cubejs-playground/src/components/GraphQL/GraphiQLSandbox.tsx
@@ -19,9 +19,14 @@ const Wrapper = styled.div`
   overflow: hidden;
 
   .graphiql-container {
+    box-sizing: initial;
+
+    * {
+      box-sizing: initial;
+    }
+
     .topBar {
       background: none;
-      padding: 24px 0 24px;
     }
 
     .docExplorerShow {
@@ -33,7 +38,7 @@ const Wrapper = styled.div`
     .CodeMirror-lines {
       background: white;
     }
-    
+
     .doc-explorer-title-bar {
       height: 50px;
     }
@@ -53,7 +58,7 @@ export default function GraphiQLSandbox({
 }: GraphiQLSandboxProps) {
   const { token: securityContextToken } = useSecurityContext();
   const playgroundToken = useToken();
-  
+
   const token = securityContextToken || playgroundToken;
 
   const fetcher = useMemo(() => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

None

**Description of Changes Made (if issue reference is not provided)**

This PR fixes the bug with the scrolling header in the graphiql explorer.