### PR TITLE
Add HTTP status code to RequestError

### DIFF
--- a/packages/cubejs-client-core/src/RequestError.js
+++ b/packages/cubejs-client-core/src/RequestError.js
@@ -1,6 +1,7 @@
 export default class RequestError extends Error {
-  constructor(message, response) {
+  constructor(message, response, status) {
     super(message);
     this.response = response;
+    this.status = status;
   }
 }

--- a/packages/cubejs-client-core/src/index.js
+++ b/packages/cubejs-client-core/src/index.js
@@ -56,7 +56,7 @@ class CubejsApi {
     });
     this.pollInterval = options.pollInterval || 5;
     this.parseDateMeasures = options.parseDateMeasures;
-    
+
     this.updateAuthorizationPromise = null;
   }
 
@@ -73,7 +73,7 @@ class CubejsApi {
       callback = options;
       options = undefined;
     }
-    
+
     options = options || {};
 
     const mutexKey = options.mutexKey || 'default';
@@ -127,11 +127,11 @@ class CubejsApi {
         }
         return null;
       };
-      
+
       if (options.subscribe && !skipAuthorizationUpdate) {
         await this.updateTransportAuthorization();
       }
-      
+
       skipAuthorizationUpdate = false;
 
       if (response.status === 502) {
@@ -162,7 +162,7 @@ class CubejsApi {
           await requestInstance.unsubscribe();
         }
 
-        const error = new RequestError(body.error, body); // TODO error class
+        const error = new RequestError(body.error, body, response.status); // TODO error class
         if (callback) {
           callback(error);
         } else {
@@ -209,7 +209,7 @@ class CubejsApi {
       await this.updateAuthorizationPromise;
       return;
     }
-    
+
     if (typeof this.apiToken === 'function') {
       this.updateAuthorizationPromise = new Promise(async (resolve, reject) => {
         try {
@@ -224,7 +224,7 @@ class CubejsApi {
           this.updateAuthorizationPromise = null;
         }
       });
-      
+
       await this.updateAuthorizationPromise;
     }
   }


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

* https://github.com/cube-js/cube.js/issues/833

This PR adds the status code into the `RequestError` class.
