### PR TITLE
fix(prestodb): timestamp cast

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.js
@@ -41,7 +41,7 @@ export class PrestodbQuery extends BaseQuery {
   }
 
   timeStampCast(value) {
-    return `CAST(${value} as TIMESTAMP)`; // TODO
+    return `from_iso8601_timestamp(${value})`;
   }
 
   dateTimeCast(value) {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
Athena pre-aggregations refresh uses incompatible date format #4221

**Description of Changes Made (if issue reference is not provided)**
Use same iso8601 timestamp function in timestamp cast as in datetime cast, resolving formatting issues in both prestodb and athena
