### PR TITLE
feat: persistence access mode

### DIFF
--- a/examples/helm-charts/cubestore/README.md
+++ b/examples/helm-charts/cubestore/README.md
@@ -86,6 +86,8 @@ By default local dir are not persisted. You can enable persistance on router and
 | `remoteDir.persistence.resourcePolicy` | Setting it to "keep" to avoid removing PVCs during a helm delete operation | `keep` |
 | `remoteDir.persistence.size`           | Persistent Volume size                                                     | `10Gi` |
 | `remoteDir.persistence.annotations`    | Additional custom annotations for the PVC                                  | `{}`   |
+| `remoteDir.persistence.accessModes`    | Persistent Volume access modes                                             | [`ReadWriteOnce`] |
+| `remoteDir.persistence.storageClass`   | The storage class to use for the remoteDir pvc                             | `""` |
 
 ### Cloud Storage parameters
 
@@ -138,7 +140,7 @@ By default local dir are not persisted. You can enable persistance on router and
 
 | Name                              | Description                                                      | Value             |
 | --------------------------------- | ---------------------------------------------------------------- | ----------------- |
-| `workers.workersCount`            | Number of workers to deploy                                      | `2`               |
+| `workers.workersCount`            | Number of workers to deploy                                      | `1`               |
 | `workers.port`                    | The port for the router node to listen for connections on        | `9001`            |
 | `workers.persistence.enabled`     | Enable persistence for local data using Persistent Volume Claims | `false`           |
 | `workers.persistance.size`        | Persistent Volume size                                           | `10Gi`            |

--- a/examples/helm-charts/cubestore/templates/pvc.yaml
+++ b/examples/helm-charts/cubestore/templates/pvc.yaml
@@ -23,8 +23,13 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - ReadWriteMany
+  {{- range .Values.remoteDir.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}  
   resources:
     requests:
       storage: {{ .Values.remoteDir.persistence.size }}
+  {{- if .Values.remoteDir.persistence.storageClass }}
+  storageClassName: {{ .Values.remoteDir.persistence.storageClass }}
+  {{- end }}
 {{- end }}

--- a/examples/helm-charts/cubestore/values.yaml
+++ b/examples/helm-charts/cubestore/values.yaml
@@ -73,6 +73,19 @@ remoteDir:
     ##
     annotations: {}
 
+    ## Persistent Volume access modes
+    ##
+    accessModes:
+      - ReadWriteOnce
+
+    ## @param remoteDir.persistence.storageClass The storage class to use for the remoteDir pvc
+    ## If defined, storageClassName: <storageClass>
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    storageClass: ""
+
 cloudStorage:
   gcp:
     ## A Base64 encoded JSON key file for connecting to Google Cloud. Required when using Google Cloud Storage
@@ -197,7 +210,7 @@ router:
 workers:
   ## Number of workers to deploy
   ##
-  workersCount: 2
+  workersCount: 1
 
   ## The port for Cube Store workers to listen to connections on
   ##

--- a/examples/helm-charts/cubestore/values.yaml
+++ b/examples/helm-charts/cubestore/values.yaml
@@ -84,7 +84,7 @@ remoteDir:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: ""
+    storageClass:
 
 cloudStorage:
   gcp:


### PR DESCRIPTION


**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Using the default storage class of the AWS EKS cluster (gp2), the default
it is not possible to use the EBS volume for the persistent storage of the
Kubernetes cluster for the persistent volume claim

It should be possible to configure this via values.

The default value for the workersCount must be reduced to 1, because the
ReadWriteOnce volume mode do not support multiple mounts.