### PR TITLE
New implementation of detailed types

### DIFF
--- a/packages/cubejs-client-react/index.d.ts
+++ b/packages/cubejs-client-react/index.d.ts
@@ -31,6 +31,7 @@ declare module '@cubejs-client/react' {
     UnaryOperator,
     BinaryOperator,
     DeeplyReadonly,
+    QueryRecordType,
   } from '@cubejs-client/core';
 
   type CubeProviderProps = {
@@ -428,7 +429,16 @@ declare module '@cubejs-client/react' {
    * @order 1
    * @stickyTypes
    */
-  export function useCubeQuery<TData>(query: DeeplyReadonly<Query | Query[]>, options?: UseCubeQueryOptions): UseCubeQueryResult<TData>;
+  export function useCubeQuery<
+    TData,
+    TQuery extends DeeplyReadonly<Query | Query[]> = DeeplyReadonly<Query | Query[]>>(
+    query: TQuery,
+    options?: UseCubeQueryOptions,
+  ): UseCubeQueryResult<
+    unknown extends TData
+      ? QueryRecordType<TQuery>
+      : TData
+  >;
 
   type UseCubeQueryOptions = {
     /**


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet (n/a)
- [x] Docs have been added / updated if required (n/a)

#4202

A reimplementation of #4375.

This implementation does not make the `Query` type generic. Instead, it leans entirely on `QueryRecordType`. Although this makes `QueryRecordType` more complex, it's probably easier to follow on the whole, and it's certainly a less intrusive change. This implementation should also produce correct types for time dimensions (e.g. inferring `Foo.createdAt.day`), which was a challenge under the prior PR.

As in the prior PR:

- There are no functional changes, so there are no updates to the tests.
- Only `core` and `react` get the augmented types, since I'm not familiar with the other front-end packages.
- The change should be backward-compatible, *except* that when a narrower type can be inferred, it will be. When no narrower type can be inferred, `load()` and company will fall back to `any`.