### PR TITLE
fix(cubestore): Fixed the bug with index selection for different permutations of columns in a group by

### DIFF
--- a/rust/cubestore/cubestore/src/queryplanner/planning.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/planning.rs
@@ -1084,7 +1084,6 @@ pub mod tests {
 
         assert_eq!(pretty_printers::pp_plan(&plan), expected);
 
-
         let plan = initial_plan(
             "SELECT order_customer, order_id \
              FROM s.Orders \

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -656,17 +656,16 @@ impl CubeTable {
         } else if let Some(join_columns) = self.index_snapshot.sort_on() {
             assert!(join_columns.len() <= (self.index_snapshot().index.get_row().sort_key_size() as usize), "The number of columns to sort is greater than the number of sorted columns in the index");
             assert!(
-                self
-                .index_snapshot()
-                .index
-                .get_row()
-                .columns()
-                .iter()
-                .take(join_columns.len())
-                .zip(join_columns.iter())
-                .all(|(icol, jcol)| icol.get_name() == jcol),
+                self.index_snapshot()
+                    .index
+                    .get_row()
+                    .columns()
+                    .iter()
+                    .take(join_columns.len())
+                    .zip(join_columns.iter())
+                    .all(|(icol, jcol)| icol.get_name() == jcol),
                 "The columns to sort don't match the sorted columns in the index"
-                );
+            );
 
             let join_columns = join_columns
                 .iter()

--- a/rust/cubestore/cubestore/src/remotefs/mod.rs
+++ b/rust/cubestore/cubestore/src/remotefs/mod.rs
@@ -439,29 +439,32 @@ mod tests {
             assert!(local_dir.join(filename).is_file());
         }
 
-        remote_fs
-            .list(&name_maker.name("test-"))
-            .await
-            .unwrap()
+        let mut remote_list = remote_fs.list(&name_maker.name("test-")).await.unwrap();
+        remote_list.sort();
+        remote_list
             .iter()
             .zip(root_files.iter())
             .for_each(|(list_name, origin_name)| {
                 assert_eq!(list_name, origin_name);
             });
-        remote_fs
-            .list(&name_maker.name("subdir/"))
-            .await
-            .unwrap()
+
+        let mut remote_list = remote_fs.list(&name_maker.name("subdir/")).await.unwrap();
+        remote_list.sort();
+        remote_list
             .iter()
             .zip(subdir_files.iter())
             .for_each(|(list_name, origin_name)| {
                 assert_eq!(list_name, origin_name);
             });
 
-        remote_fs
+        let mut remote_list = remote_fs
             .list_with_metadata(&name_maker.name("test"))
             .await
-            .unwrap()
+            .unwrap();
+
+        remote_list.sort_by(|a, b| a.remote_path().partial_cmp(b.remote_path()).unwrap());
+
+        remote_list
             .iter()
             .zip(root_files.iter())
             .for_each(|(list_file, origin_name)| {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

* Fixed a bug that required the order of columns in group by to be the same as the order of columns in the index.
* Fixed a bug that made it possible to call MergeSort on unsorted index columns
