### PR TITLE
chore: extend meta response for catalog

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -424,13 +424,13 @@ class ApiGateway {
         .map((meta) => meta.config)
         .map((cube) => ({
           ...transformCube(cube, cubeDefinitions),
-          measures: cube.measures.filter(visibilityFilter).map((measure) => ({
+          measures: cube.measures?.filter(visibilityFilter).map((measure) => ({
             ...transformMeasure(measure, cubeDefinitions),
           })),
-          dimensions: cube.dimensions.filter(visibilityFilter).map((dimension) => ({
+          dimensions: cube.dimensions?.filter(visibilityFilter).map((dimension) => ({
             ...transformDimension(dimension, cubeDefinitions),
           })),
-          segments: cube.segments.map((segment) => ({
+          segments: cube.segments?.map((segment) => ({
             ...transformSegment(segment, cubeDefinitions),
           })),
           joins: transformJoins(cubeDefinitions[cube.name]?.joins),

--- a/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
+++ b/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
@@ -1,4 +1,4 @@
-function stringifyMemberSql(sql: any) {
+function stringifyMemberSql(sql?: () => string) {
   if (!sql) {
     return undefined;
   }
@@ -26,7 +26,7 @@ function handleDimensionCaseCondition(caseCondition: any) {
 
   return {
     ...caseCondition,
-    when: caseCondition?.when?.map((item) => ({
+    when: Object.values(caseCondition?.when)?.map((item: any) => ({
       ...item,
       sql: stringifyMemberSql(item.sql),
       label: item?.label?.sql ? stringifyMemberSql(item.label.sql) : item?.label,
@@ -55,10 +55,11 @@ function transformMeasure(measure: any, cubeDefinitions: any) {
 
 function transformDimension(dimension: any, cubeDefinitions: any) {
   const { cubeName, memberName } = getMemberPath(dimension.name);
+
   return {
     ...dimension,
     sql: stringifyMemberSql(cubeDefinitions[cubeName]?.dimensions?.[memberName]?.sql),
-    case: handleDimensionCaseCondition(cubeDefinitions[cubeName]?.dimension?.[memberName]?.case),
+    case: handleDimensionCaseCondition(cubeDefinitions[cubeName]?.dimensions?.[memberName]?.case),
   };
 }
 
@@ -98,6 +99,9 @@ function transformPreAggregations(preAggregations: any) {
 }
 
 export {
+  getMemberPath,
+  handleDimensionCaseCondition,
+  stringifyMemberSql,
   transformCube,
   transformMeasure,
   transformDimension,

--- a/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
+++ b/packages/cubejs-api-gateway/src/helpers/transformMetaExtended.ts
@@ -1,0 +1,117 @@
+function stringifyMemberSql(sql: any) {
+  if (!sql) {
+    return undefined;
+  }
+
+  const sqlStr = sql.toString();
+  return sqlStr.substring(sqlStr.indexOf('=>') + 3);
+}
+
+function isVisible(member: any) {
+  if (member.hasOwnProperty('shown')) {
+    return member.shown;
+  }
+
+  return true;
+}
+
+function handleDimensionCaseCondition(caseCondition: any) {
+  if (!caseCondition) {
+    return undefined;
+  }
+
+  return {
+    ...caseCondition,
+    when: caseCondition?.when?.map((item) => ({
+      ...item,
+      sql: stringifyMemberSql(item.sql),
+      label: item?.label?.sql ? stringifyMemberSql(item.label.sql) : item?.label,
+    })),
+  };
+}
+
+function transformCube(cube: any) {
+  return {
+    ...cube,
+    isVisible: isVisible(cube),
+    extends: stringifyMemberSql(cube?.extends),
+    sql: stringifyMemberSql(cube?.sql)
+  };
+}
+
+function transformMeasures(measures: any) {
+  if (!measures) {
+    return undefined;
+  }
+
+  return Object.entries(measures)?.map(([measureName, measure]: [measureName: string, measure: any]) => ({
+    ...measure,
+    name: measureName,
+    isVisible: isVisible(measure),
+    sql: stringifyMemberSql(measure?.sql),
+    filters: measure?.filters?.map((filter) => ({
+      sql: stringifyMemberSql(filter.sql),
+    })),
+  }));
+}
+
+function transformDimensions(dimensions: any) {
+  if (!dimensions) {
+    return undefined;
+  }
+
+  return Object.entries(dimensions)?.map(([dimensionName, dimension]: [dimensionName: string, dimension: any]) => ({
+    ...dimension,
+    name: dimensionName,
+    isVisible: isVisible(dimension),
+    sql: stringifyMemberSql(dimension?.sql),
+    case: handleDimensionCaseCondition(dimension?.case),
+  }));
+}
+
+function transformJoins(joins: any) {
+  if (!joins) {
+    return undefined;
+  }
+
+  return Object.entries(joins)?.map(([joinName, join]: [joinName: string, join: any]) => ({
+    ...join,
+    name: joinName,
+    sql: stringifyMemberSql(join.sql),
+  }));
+}
+
+function transformSegments(segments: any) {
+  if (!segments) {
+    return undefined;
+  }
+
+  return Object.entries(segments)?.map(([segmentName, segment]: [segmentName: string, segment: any]) => ({
+    ...segment,
+    name: segmentName,
+    sql: stringifyMemberSql(segment.sql),
+  }));
+}
+
+function transformPreAggregations(preAggregations: any) {
+  if (!preAggregations) {
+    return undefined;
+  }
+
+  return Object.entries(preAggregations)?.map(([preAggregationName, preAggregation]: [preAggregationName: string, preAggregation: any]) => ({
+    ...preAggregation,
+    name: preAggregationName,
+    timeDimensionReference: stringifyMemberSql(preAggregation.timeDimensionReference),
+    dimensionReferences: stringifyMemberSql(preAggregation.dimensionReferences),
+    measureReferences: stringifyMemberSql(preAggregation.measureReferences),
+  }));
+}
+
+export {
+  transformCube,
+  transformMeasures,
+  transformDimensions,
+  transformJoins,
+  transformPreAggregations,
+  transformSegments
+};

--- a/packages/cubejs-api-gateway/test/helpers/transformMetaExtended.test.ts
+++ b/packages/cubejs-api-gateway/test/helpers/transformMetaExtended.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable no-template-curly-in-string */
+/* eslint-disable quote-props */
+/**
+ * @license Apache-2.0
+ * @copyright Cube Dev, Inc.
+ * @fileoverview transformMetaExtended related helpers unit tests.
+ */
+
+/* globals describe,test,expect */
+
+import {
+  stringifyMemberSql,
+  getMemberPath,
+  handleDimensionCaseCondition,
+  transformCube,
+  transformDimension,
+  transformMeasure,
+} from '../../src/helpers/transformMetaExtended';
+
+const MockUsersCube = {
+  measures: {
+    count: {
+      sql: () => 'id',
+      type: 'count',
+    },
+  },
+  dimensions: {
+    id: {
+      sql: () => 'id',
+      type: 'string',
+      primaryKey: true,
+      shown: true,
+    },
+    email: {
+      sql: () => 'email',
+      type: 'string',
+    },
+    plan: {
+      case: {
+        when: {
+          '0': {
+            // eslint-disable-next-line quotes
+            sql: () => `tenantEnterpriseFlag = true`,
+            label: 'Enterprise',
+          },
+          '1': {
+            // eslint-disable-next-line quotes
+            sql: () => `stripe_customer_id IS NOT NULL`,
+            label: 'Standard',
+          },
+        },
+        else: {
+          label: 'Free',
+        },
+      },
+      type: 'string',
+    },
+    sessionsCount: {
+      sql: () => '${AweWebSessions.count}',
+      type: 'number',
+      subQuery: true,
+    },
+  },
+  segments: {
+  },
+  refreshKey: {
+    every: '1 hour',
+  },
+  // eslint-disable-next-line quotes
+  sql: () => `SELECT * FROM MockUsers`,
+  name: 'MockUsersCube',
+  fileName: 'MockUsersCube.js',
+};
+
+const MockDimensionCaseResult = {
+  when: [
+    {
+      sql: '`tenantEnterpriseFlag = true`',
+      label: 'Enterprise'
+    },
+    {
+      sql: '`stripe_customer_id IS NOT NULL`',
+      label: 'Standard'
+    }
+  ],
+  else: {
+    label: 'Free'
+  }
+};
+
+describe('transformMetaExtended helpers', () => {
+  test('stringifyMemberSql', () => {
+    expect(stringifyMemberSql(undefined)).toBeUndefined();
+    expect(stringifyMemberSql(MockUsersCube.sql)).toBeDefined();
+    expect(stringifyMemberSql(MockUsersCube.sql)).toBe('`SELECT * FROM MockUsers`');
+  });
+
+  test('getMemberPath', () => {
+    expect(getMemberPath('Users.count')).toBeDefined();
+    expect(getMemberPath('Users.count')).toEqual({ cubeName: 'Users', memberName: 'count' });
+  });
+
+  test('handleDimensionCaseCondition', () => {
+    expect(handleDimensionCaseCondition(undefined)).toBeUndefined();
+    const handledCaseCondition = handleDimensionCaseCondition(MockUsersCube.dimensions.plan.case);
+    expect(handledCaseCondition).toBeDefined();
+    expect(handledCaseCondition).toEqual(MockDimensionCaseResult);
+  });
+
+  test('transformCube', () => {
+    const handledCube = transformCube(MockUsersCube, MockUsersCube);
+    expect(handledCube).toBeDefined();
+    expect(handledCube).toMatchObject({ name: 'MockUsersCube' });
+    expect(handledCube).toHaveProperty('measures');
+    expect(handledCube).toHaveProperty('dimensions');
+  });
+
+  test('transformDimension', () => {
+    const handledDimension = transformDimension(MockUsersCube.dimensions.id, MockUsersCube);
+    expect(handledDimension).toBeDefined();
+    expect(handledDimension).toHaveProperty('sql');
+  });
+
+  test('transformMeasure', () => {
+    const handledMeasure = transformMeasure(MockUsersCube.measures.count, MockUsersCube);
+    expect(handledMeasure).toBeDefined();
+    expect(handledMeasure).toHaveProperty('sql');
+    expect(handledMeasure).toMatchObject({ type: 'count' });
+  });
+});

--- a/packages/cubejs-api-gateway/test/helpers/transformMetaExtended.test.ts
+++ b/packages/cubejs-api-gateway/test/helpers/transformMetaExtended.test.ts
@@ -182,12 +182,14 @@ describe('transformMetaExtended helpers', () => {
   });
 
   test('transformJoins', () => {
+    expect(transformJoins(undefined)).toBeUndefined();
     const handledJoins = transformJoins(MOCK_USERS_CUBE.joins);
     expect(handledJoins).toBeDefined();
     expect(handledJoins?.length).toBe(2);
   });
 
   test('transformPreAggregations', () => {
+    expect(transformPreAggregations(undefined)).toBeUndefined();
     const handledPreAggregations = transformPreAggregations(MOCK_USERS_CUBE.preAggregations);
     expect(handledPreAggregations).toBeDefined();
     expect(handledPreAggregations?.length).toBe(2);

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -339,6 +339,30 @@ describe('API Gateway', () => {
     expect(res.body.query.measures).toStrictEqual(['Foo.bar']);
   });
 
+  test('meta endpoint to get schema information', async () => {
+    const { app } = createApiGateway();
+
+    const res = await request(app)
+      .get('/cubejs-api/v1/meta')
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(200);
+    expect(res.body).toHaveProperty('cubes');
+    expect(res.body.cubes[0]?.name).toBe('Foo');
+    expect(res.body.cubes[0]?.hasOwnProperty('sql')).toBe(false);
+  });
+
+  test('meta endpoint extended to get schema information with additional data', async () => {
+    const { app } = createApiGateway();
+
+    const res = await request(app)
+      .get('/cubejs-api/v1/meta?extended')
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(200);
+    expect(res.body).toHaveProperty('cubes');
+    expect(res.body.cubes[0]?.name).toBe('Foo');
+    expect(res.body.cubes[0]?.hasOwnProperty('sql')).toBe(true);
+  });
+
   describe('multi query support', () => {
     const searchParams = new URLSearchParams({
       query: JSON.stringify({

--- a/packages/cubejs-api-gateway/test/mocks.ts
+++ b/packages/cubejs-api-gateway/test/mocks.ts
@@ -94,6 +94,43 @@ export const compilerApi = jest.fn().mockImplementation(() => ({
     ];
   },
 
+  async metaConfigExtended() {
+    const metaConfig = [
+      {
+        config: {
+          name: 'Foo',
+          measures: [
+            {
+              name: 'Foo.bar',
+              sql: 'bar',
+            },
+          ],
+          dimensions: [
+            {
+              name: 'Foo.id',
+            },
+            {
+              name: 'Foo.time',
+            },
+          ],
+        },
+      },
+    ];
+
+    const cubeDefinitions = {
+      Foo: {
+        sql: () => 'SELECT * FROM Foo',
+        measures: {},
+        dimension: {},
+      }
+    };
+
+    return {
+      metaConfig,
+      cubeDefinitions,
+    };
+  },
+
   async preAggregations() {
     return preAggregationsResultFactory();
   }

--- a/packages/cubejs-server-core/src/core/CompilerApi.js
+++ b/packages/cubejs-server-core/src/core/CompilerApi.js
@@ -172,13 +172,12 @@ export class CompilerApi {
     return (await this.getCompilers(options)).metaTransformer.cubes;
   }
 
-  async metaExtended(options) {
-    const { builtCubes } = (await this.getCompilers(options)).cubeEvaluator;
-    return Object.values(builtCubes).map(builtCube => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { allDefinitions, ...cube } = builtCube;
-      return cube;
-    });
+  async metaConfigExtended(options) {
+    const { metaTransformer } = await this.getCompilers(options);
+    return {
+      metaConfig: metaTransformer?.cubes,
+      cubeDefinitions: metaTransformer?.cubeEvaluator?.cubeDefinitions,
+    };
   }
 
   canUsePreAggregationForTransformedQuery(transformedQuery, refs) {

--- a/packages/cubejs-server-core/src/core/CompilerApi.js
+++ b/packages/cubejs-server-core/src/core/CompilerApi.js
@@ -172,6 +172,15 @@ export class CompilerApi {
     return (await this.getCompilers(options)).metaTransformer.cubes;
   }
 
+  async metaExtended(options) {
+    const { builtCubes } = (await this.getCompilers(options)).cubeEvaluator;
+    return Object.values(builtCubes).map(builtCube => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { allDefinitions, ...cube } = builtCube;
+      return cube;
+    });
+  }
+
   canUsePreAggregationForTransformedQuery(transformedQuery, refs) {
     return PreAggregations.canUsePreAggregationForTransformedQueryFn(transformedQuery, refs);
   }

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -46,6 +46,11 @@ cube('Bar', {
   ]),
 };
 
+const repositoryWithoutContent: SchemaFileRepository = {
+  localPath: () => __dirname,
+  dataSchemaFiles: () => Promise.resolve([{ fileName: 'main.js', content: '' }]),
+};
+
 describe('index.test', () => {
   beforeEach(() => {
     delete process.env.CUBEJS_EXT_DB_TYPE;
@@ -318,7 +323,32 @@ describe('index.test', () => {
     test('CompilerApi metaConfigExtended', async () => {
       const metaConfigExtended = await compilerApi.metaConfigExtended({ requestId: 'XXX' });
       expect(metaConfigExtended).toHaveProperty('metaConfig');
+      expect(metaConfigExtended.metaConfig.length).toBeGreaterThan(0);
       expect(metaConfigExtended).toHaveProperty('cubeDefinitions');
+      expect(metaConfigExtendedSpy).toHaveBeenCalled();
+      metaConfigExtendedSpy.mockClear();
+    });
+  });
+
+  describe('CompilerApi with empty cube on input', () => {
+    const logger = jest.fn(() => {});
+    const compilerApi = new CompilerApi(repositoryWithoutContent, <any>'mysql', { logger });
+    const metaConfigSpy = jest.spyOn(compilerApi, 'metaConfig');
+    const metaConfigExtendedSpy = jest.spyOn(compilerApi, 'metaConfigExtended');
+
+    test('CompilerApi metaConfig', async () => {
+      const metaConfig = await compilerApi.metaConfig({ requestId: 'XXX' });
+      expect(metaConfig).toEqual([]);
+      expect(metaConfigSpy).toHaveBeenCalled();
+      metaConfigSpy.mockClear();
+    });
+
+    test('CompilerApi metaConfigExtended', async () => {
+      const metaConfigExtended = await compilerApi.metaConfigExtended({ requestId: 'XXX' });
+      expect(metaConfigExtended).toHaveProperty('metaConfig');
+      expect(metaConfigExtended.metaConfig).toEqual([]);
+      expect(metaConfigExtended).toHaveProperty('cubeDefinitions');
+      expect(metaConfigExtended.cubeDefinitions).toEqual({});
       expect(metaConfigExtendedSpy).toHaveBeenCalled();
       metaConfigExtendedSpy.mockClear();
     });

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -100,7 +100,7 @@ describe('index.test', () => {
       await driverFactory('mongo');
 
       throw new Error('driverFactory will call dbType and dbType must throw an exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Unexpected return type, dbType must return string (dataSource: "mongo"), actual: null');
     }
   });
@@ -115,7 +115,7 @@ describe('index.test', () => {
       await driverFactory('default');
 
       throw new Error('driverFactory will call dbType and dbType must throw an exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Unexpected return type, driverFactory must return driver (dataSource: "default"), actual: null');
     }
   });
@@ -130,7 +130,7 @@ describe('index.test', () => {
       await orchestratorOptions.externalDriverFactory();
 
       throw new Error('driverFactory will call dbType and dbType must throw an exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('Unexpected return type, externalDriverFactory must return driver, actual: null');
     }
   });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

We need to extend /meta endpoint response with additional data for the schema.

- Add SQL field to cubes / measures / dimensions
- Add "Segments" and "Filters"
- Add "Cases" to dimensions
- Add “Joins”
