### PR TITLE
GraphQL: Make dimensions and measures nullable fields.

### DIFF
--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -354,7 +354,7 @@ export function makeSchema(metaConfig: any) {
         definition(t) {
           cube.config.measures.forEach(measure => {
             if (measure.isVisible) {
-              t.nonNull.field(safeName(measure.name), {
+              t.field(safeName(measure.name), {
                 type: mapType(measure.type),
                 description: measure.description
               });
@@ -362,7 +362,7 @@ export function makeSchema(metaConfig: any) {
           });
           cube.config.dimensions.forEach(dimension => {
             if (dimension.isVisible) {
-              t.nonNull.field(safeName(dimension.name), {
+              t.field(safeName(dimension.name), {
                 type: mapType(dimension.type),
                 description: dimension.description
               });


### PR DESCRIPTION
Fixes: https://github.com/cube-js/cube.js/issues/4399

Please see the discussion on this ticket on why this breaks things.

Currently the actual cubeJS schema does not have nullable types, and assuming all dimensions and measures are non-Nullable is not necessarily correct and blocking the use of the graphQL api entirely for cubes that can return null for dimensions or measures.

I think the ideal solution is to implement nullable types in the actual cubeJS schema so they can be translated 100% correct to a graphQL schema. However that is probably an overall bigger change.

For now, allowing graphQL Member fields to be nullable generates a more useable schema than the current nonNull configuration. (neither are 100% accurate though).

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#4399