### PR TITLE
fix(cubesql): Reject `SELECT INTO` queries gracefully

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65#2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fefe4e6a4afe3f9113647d2ee381f1d4bafec41a#fefe4e6a4afe3f9113647d2ee381f1d4bafec41a"
 dependencies = [
  "ahash",
  "arrow",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65#2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fefe4e6a4afe3f9113647d2ee381f1d4bafec41a#fefe4e6a4afe3f9113647d2ee381f1d4bafec41a"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65#2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fefe4e6a4afe3f9113647d2ee381f1d4bafec41a#fefe4e6a4afe3f9113647d2ee381f1d4bafec41a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65#2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fefe4e6a4afe3f9113647d2ee381f1d4bafec41a#fefe4e6a4afe3f9113647d2ee381f1d4bafec41a"
 dependencies = [
  "ahash",
  "arrow",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65#2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fefe4e6a4afe3f9113647d2ee381f1d4bafec41a#fefe4e6a4afe3f9113647d2ee381f1d4bafec41a"
 dependencies = [
  "ahash",
  "arrow",
@@ -3354,7 +3354,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "sqlparser"
 version = "0.16.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=99ab5292b11906de5e7ed5d8907423a3b6f231f2#99ab5292b11906de5e7ed5d8907423a3b6f231f2"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=81217ce0dccc446d3d2f42582717b9e8fe960113#81217ce0dccc446d3d2f42582717b9e8fe960113"
 dependencies = [
  "log",
 ]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,12 +9,12 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "2b2bfbd23dec6c7c7eb34ba3a73352bc525e8a65", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "fefe4e6a4afe3f9113647d2ee381f1d4bafec41a", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }
 pg-srv = { path = "../pg-srv" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "99ab5292b11906de5e7ed5d8907423a3b6f231f2" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "81217ce0dccc446d3d2f42582717b9e8fe960113" }
 lazy_static = "1.4.0"
 base64 = "0.13.0"
 tokio = { version = "1.0", features = ["full", "rt"] }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps `sqlparser-rs` to support `SELECT INTO TABLE tblname` syntax and adds an error gracefully rejecting all `SELECT INTO` queries.