### PR TITLE
fix(cubesql): Coerce empty subquery result to `NULL`

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5ee92140f026524639ed3675942af62b45dc2913#5ee92140f026524639ed3675942af62b45dc2913"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8b6b910152c8bc5dc88e3957c600cf98977d82d8#8b6b910152c8bc5dc88e3957c600cf98977d82d8"
 dependencies = [
  "ahash",
  "arrow",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5ee92140f026524639ed3675942af62b45dc2913#5ee92140f026524639ed3675942af62b45dc2913"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8b6b910152c8bc5dc88e3957c600cf98977d82d8#8b6b910152c8bc5dc88e3957c600cf98977d82d8"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5ee92140f026524639ed3675942af62b45dc2913#5ee92140f026524639ed3675942af62b45dc2913"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8b6b910152c8bc5dc88e3957c600cf98977d82d8#8b6b910152c8bc5dc88e3957c600cf98977d82d8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5ee92140f026524639ed3675942af62b45dc2913#5ee92140f026524639ed3675942af62b45dc2913"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8b6b910152c8bc5dc88e3957c600cf98977d82d8#8b6b910152c8bc5dc88e3957c600cf98977d82d8"
 dependencies = [
  "ahash",
  "arrow",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5ee92140f026524639ed3675942af62b45dc2913#5ee92140f026524639ed3675942af62b45dc2913"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8b6b910152c8bc5dc88e3957c600cf98977d82d8#8b6b910152c8bc5dc88e3957c600cf98977d82d8"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "5ee92140f026524639ed3675942af62b45dc2913", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "8b6b910152c8bc5dc88e3957c600cf98977d82d8", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -6351,8 +6351,18 @@ ORDER BY \"COUNT(count)\" DESC"
             "format_type",
             execute_query(
                 "
-                SELECT t.oid, t.typname, format_type(t.oid, t.typtypmod) f
-                FROM pg_catalog.pg_type t;
+                SELECT
+                    t.oid,
+                    t.typname,
+                    format_type(t.oid, 20::integer) ft20,
+                    format_type(t.oid, 5::integer) ft5,
+                    format_type(t.oid, 4::integer) ft4,
+                    format_type(t.oid, 0::integer) ft0,
+                    format_type(t.oid, -1::integer) ftneg,
+                    format_type(t.oid, NULL::integer) ftnull
+                FROM pg_catalog.pg_type t
+                ORDER BY t.oid ASC
+                ;
                 "
                 .to_string(),
                 DatabaseProtocol::PostgreSQL

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -6792,7 +6792,36 @@ ORDER BY \"COUNT(count)\" DESC"
         insta::assert_snapshot!(
             "superset_subquery",
             execute_query(
-                "SELECT a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod), (SELECT format_type(d.adbin, d.adrelid) FROM pg_catalog.pg_attrdef d WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) AS DEFAULT, a.attnotnull, a.attnum, a.attrelid as table_oid, pgd.description as comment, a.attgenerated as generated FROM pg_catalog.pg_attribute a LEFT JOIN pg_catalog.pg_description pgd ON ( pgd.objoid = a.attrelid AND pgd.objsubid = a.attnum) WHERE a.attrelid = 13449 AND a.attnum > 0 AND NOT a.attisdropped ORDER BY a.attnum;".to_string(),
+                "
+                SELECT
+                    a.attname,
+                    pg_catalog.format_type(a.atttypid, a.atttypmod),
+                    (
+                        SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+                        FROM pg_catalog.pg_attrdef d
+                        WHERE
+                            d.adrelid = a.attrelid AND
+                            d.adnum = a.attnum AND
+                            a.atthasdef
+                    ) AS DEFAULT,
+                    a.attnotnull,
+                    a.attnum,
+                    a.attrelid as table_oid,
+                    pgd.description as comment,
+                    a.attgenerated as generated
+                FROM pg_catalog.pg_attribute a
+                LEFT JOIN pg_catalog.pg_description pgd ON (
+                    pgd.objoid = a.attrelid AND
+                    pgd.objsubid = a.attnum
+                )
+                WHERE
+                    a.attrelid = 18000
+                    AND a.attnum > 0
+                    AND NOT a.attisdropped
+                ORDER BY a.attnum
+                ;
+                "
+                .to_string(),
                 DatabaseProtocol::PostgreSQL
             )
             .await?

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -6576,8 +6576,18 @@ ORDER BY \"COUNT(count)\" DESC"
         insta::assert_snapshot!(
             "pg_get_expr_1",
             execute_query(
-                "SELECT pg_catalog.pg_get_expr(adbin, adrelid) FROM pg_catalog.pg_attrdef;"
-                    .to_string(),
+                "
+                SELECT
+                    attrelid,
+                    attname,
+                    pg_catalog.pg_get_expr(attname, attrelid) default
+                FROM pg_catalog.pg_attribute
+                ORDER BY
+                    attrelid ASC,
+                    attname ASC
+                ;
+                "
+                .to_string(),
                 DatabaseProtocol::PostgreSQL
             )
             .await?
@@ -6585,8 +6595,18 @@ ORDER BY \"COUNT(count)\" DESC"
         insta::assert_snapshot!(
             "pg_get_expr_2",
             execute_query(
-                "SELECT pg_catalog.pg_get_expr(adbin, adrelid, true) FROM pg_catalog.pg_attrdef;"
-                    .to_string(),
+                "
+                SELECT
+                    attrelid,
+                    attname,
+                    pg_catalog.pg_get_expr(attname, attrelid, true) default
+                FROM pg_catalog.pg_attribute
+                ORDER BY
+                    attrelid ASC,
+                    attname ASC
+                ;
+                "
+                .to_string(),
                 DatabaseProtocol::PostgreSQL
             )
             .await?

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__explain-2.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__explain-2.snap
@@ -1,6 +1,5 @@
 ---
 source: cubesql/src/compile/mod.rs
-assertion_line: 5809
 expression: "execute_query(\"EXPLAIN VERBOSE SELECT 1+1;\".to_string(),\n            DatabaseProtocol::MySQL).await?"
 ---
 +-------------------------------------------------------+--------------------------------------+
@@ -25,7 +24,6 @@ expression: "execute_query(\"EXPLAIN VERBOSE SELECT 1+1;\".to_string(),\n       
 | physical_plan after aggregate_statistics              | SAME TEXT AS ABOVE                   |
 | physical_plan after hash_build_probe_order            | SAME TEXT AS ABOVE                   |
 | physical_plan after coalesce_batches                  | SAME TEXT AS ABOVE                   |
-| physical_plan after repartition                       | SAME TEXT AS ABOVE                   |
 | physical_plan after add_merge_exec                    | SAME TEXT AS ABOVE                   |
 | physical_plan                                         | ProjectionExec: expr=[2 as Int64(2)] |
 |                                                       |   EmptyExec: produce_one_row=true    |

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__format_type.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__format_type.snap
@@ -1,63 +1,62 @@
 ---
 source: cubesql/src/compile/mod.rs
-assertion_line: 6349
-expression: "execute_query(\"\n                SELECT t.oid, t.typname, format_type(t.oid, t.typtypmod) f\n                FROM pg_catalog.pg_type t;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"\n                SELECT\n                    t.oid,\n                    t.typname,\n                    format_type(t.oid, 20::integer) ft20,\n                    format_type(t.oid, 5::integer) ft5,\n                    format_type(t.oid, 4::integer) ft4,\n                    format_type(t.oid, 0::integer) ft0,\n                    format_type(t.oid, -1::integer) ftneg,\n                    format_type(t.oid, NULL::integer) ftnull\n                FROM pg_catalog.pg_type t\n                ORDER BY t.oid ASC\n                ;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
 ---
-+-------+----------------------------+-----------------------------------+
-| oid   | typname                    | f                                 |
-+-------+----------------------------+-----------------------------------+
-| 16    | bool                       | boolean                           |
-| 17    | bytea                      | ???                               |
-| 19    | name                       | name                              |
-| 20    | int8                       | bigint                            |
-| 21    | int2                       | ???                               |
-| 23    | int4                       | integer                           |
-| 25    | text                       | text                              |
-| 26    | oid                        | ???                               |
-| 27    | tid                        | ???                               |
-| 83    | pg_class                   | ???                               |
-| 700   | float4                     | ???                               |
-| 701   | float8                     | ???                               |
-| 790   | money                      | ???                               |
-| 869   | inet                       | ???                               |
-| 1000  | _bool                      | ???                               |
-| 1001  | _bytea                     | ???                               |
-| 1005  | _int2                      | ???                               |
-| 1007  | _int4                      | ???                               |
-| 1009  | _text                      | ???                               |
-| 1016  | _int8                      | ???                               |
-| 1021  | _float4                    | ???                               |
-| 1022  | _float8                    | ???                               |
-| 1042  | bpchar                     | ???                               |
-| 1043  | varchar                    | character varying                 |
-| 1082  | date                       | ???                               |
-| 1083  | time                       | ???                               |
-| 1114  | timestamp                  | timestamp                         |
-| 1184  | timestamptz                | timestamp with time zone          |
-| 1186  | interval                   | ???                               |
-| 1266  | timetz                     | ???                               |
-| 1700  | numeric                    | numeric                           |
-| 2249  | record                     | ???                               |
-| 2277  | anyarray                   | ???                               |
-| 2283  | anyelement                 | ???                               |
-| 3904  | int4range                  | ???                               |
-| 3906  | numrange                   | ???                               |
-| 3908  | tsrange                    | ???                               |
-| 3220  | pg_lsn                     | ???                               |
-| 3500  | anyenum                    | ???                               |
-| 3831  | anyrange                   | ???                               |
-| 3910  | tstzrange                  | ???                               |
-| 3912  | daterange                  | ???                               |
-| 3926  | int8range                  | ???                               |
-| 4532  | nummultirange              | ???                               |
-| 4533  | tsmultirange               | ???                               |
-| 4535  | datemultirange             | ???                               |
-| 4536  | int8multirange             | ???                               |
-| 4451  | int4multirange             | ???                               |
-| 13408 | character_data             | information_schema.character_data |
-| 13410 | sql_identifier             | information_schema.sql_identifier |
-| 18001 | KibanaSampleDataEcommerce  | ???                               |
-| 18002 | _KibanaSampleDataEcommerce | ???                               |
-| 18014 | Logs                       | ???                               |
-| 18015 | _Logs                      | ???                               |
-+-------+----------------------------+-----------------------------------+
++-------+----------------------------+---------------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-----------------------------------+-----------------------------------+
+| oid   | typname                    | ft20                                  | ft5                                  | ft4                                  | ft0                                  | ftneg                             | ftnull                            |
++-------+----------------------------+---------------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-----------------------------------+-----------------------------------+
+| 16    | bool                       | boolean                               | boolean                              | boolean                              | boolean                              | boolean                           | boolean                           |
+| 17    | bytea                      | bytea(20)                             | bytea(5)                             | bytea(4)                             | bytea(0)                             | bytea                             | bytea                             |
+| 19    | name                       | name(20)                              | name(5)                              | name(4)                              | name(0)                              | name                              | name                              |
+| 20    | int8                       | bigint                                | bigint                               | bigint                               | bigint                               | bigint                            | bigint                            |
+| 21    | int2                       | smallint                              | smallint                             | smallint                             | smallint                             | smallint                          | smallint                          |
+| 23    | int4                       | integer                               | integer                              | integer                              | integer                              | integer                           | integer                           |
+| 25    | text                       | text(20)                              | text(5)                              | text(4)                              | text(0)                              | text                              | text                              |
+| 26    | oid                        | oid(20)                               | oid(5)                               | oid(4)                               | oid(0)                               | oid                               | oid                               |
+| 27    | tid                        | tid(20)                               | tid(5)                               | tid(4)                               | tid(0)                               | tid                               | tid                               |
+| 83    | pg_class                   | pg_class(20)                          | pg_class(5)                          | pg_class(4)                          | pg_class(0)                          | pg_class                          | pg_class                          |
+| 700   | float4                     | real                                  | real                                 | real                                 | real                                 | real                              | real                              |
+| 701   | float8                     | double precision                      | double precision                     | double precision                     | double precision                     | double precision                  | double precision                  |
+| 790   | money                      | money(20)                             | money(5)                             | money(4)                             | money(0)                             | money                             | money                             |
+| 869   | inet                       | inet(20)                              | inet(5)                              | inet(4)                              | inet(0)                              | inet                              | inet                              |
+| 1000  | _bool                      | boolean[]                             | boolean[]                            | boolean[]                            | boolean[]                            | boolean[]                         | boolean[]                         |
+| 1001  | _bytea                     | bytea(20)[]                           | bytea(5)[]                           | bytea(4)[]                           | bytea(0)[]                           | bytea[]                           | bytea[]                           |
+| 1005  | _int2                      | smallint[]                            | smallint[]                           | smallint[]                           | smallint[]                           | smallint[]                        | smallint[]                        |
+| 1007  | _int4                      | integer[]                             | integer[]                            | integer[]                            | integer[]                            | integer[]                         | integer[]                         |
+| 1009  | _text                      | text(20)[]                            | text(5)[]                            | text(4)[]                            | text(0)[]                            | text[]                            | text[]                            |
+| 1016  | _int8                      | bigint[]                              | bigint[]                             | bigint[]                             | bigint[]                             | bigint[]                          | bigint[]                          |
+| 1021  | _float4                    | real[]                                | real[]                               | real[]                               | real[]                               | real[]                            | real[]                            |
+| 1022  | _float8                    | double precision[]                    | double precision[]                   | double precision[]                   | double precision[]                   | double precision[]                | double precision[]                |
+| 1042  | bpchar                     | character(16)                         | character(1)                         | character                            | character                            | bpchar                            | character                         |
+| 1043  | varchar                    | character varying(16)                 | character varying(1)                 | character varying                    | character varying                    | character varying                 | character varying                 |
+| 1082  | date                       | date(20)                              | date(5)                              | date(4)                              | date(0)                              | date                              | date                              |
+| 1083  | time                       | time(20) without time zone            | time(5) without time zone            | time(4) without time zone            | time(0) without time zone            | time without time zone            | time without time zone            |
+| 1114  | timestamp                  | timestamp(20) without time zone       | timestamp(5) without time zone       | timestamp(4) without time zone       | timestamp(0) without time zone       | timestamp without time zone       | timestamp without time zone       |
+| 1184  | timestamptz                | timestamp(20) with time zone          | timestamp(5) with time zone          | timestamp(4) with time zone          | timestamp(0) with time zone          | timestamp with time zone          | timestamp with time zone          |
+| 1186  | interval                   | -                                     | -                                    | -                                    | -                                    | interval                          | interval                          |
+| 1266  | timetz                     | time(20) with time zone               | time(5) with time zone               | time(4) with time zone               | time(0) with time zone               | time with time zone               | time with time zone               |
+| 1700  | numeric                    | numeric(0,16)                         | numeric(0,1)                         | numeric(0,0)                         | numeric(65535,65532)                 | numeric                           | numeric                           |
+| 2249  | record                     | record(20)                            | record(5)                            | record(4)                            | record(0)                            | record                            | record                            |
+| 2277  | anyarray                   | anyarray(20)                          | anyarray(5)                          | anyarray(4)                          | anyarray(0)                          | anyarray                          | anyarray                          |
+| 2283  | anyelement                 | anyelement(20)                        | anyelement(5)                        | anyelement(4)                        | anyelement(0)                        | anyelement                        | anyelement                        |
+| 3220  | pg_lsn                     | pg_lsn(20)                            | pg_lsn(5)                            | pg_lsn(4)                            | pg_lsn(0)                            | pg_lsn                            | pg_lsn                            |
+| 3500  | anyenum                    | anyenum(20)                           | anyenum(5)                           | anyenum(4)                           | anyenum(0)                           | anyenum                           | anyenum                           |
+| 3831  | anyrange                   | anyrange(20)                          | anyrange(5)                          | anyrange(4)                          | anyrange(0)                          | anyrange                          | anyrange                          |
+| 3904  | int4range                  | int4range(20)                         | int4range(5)                         | int4range(4)                         | int4range(0)                         | int4range                         | int4range                         |
+| 3906  | numrange                   | numrange(20)                          | numrange(5)                          | numrange(4)                          | numrange(0)                          | numrange                          | numrange                          |
+| 3908  | tsrange                    | tsrange(20)                           | tsrange(5)                           | tsrange(4)                           | tsrange(0)                           | tsrange                           | tsrange                           |
+| 3910  | tstzrange                  | tstzrange(20)                         | tstzrange(5)                         | tstzrange(4)                         | tstzrange(0)                         | tstzrange                         | tstzrange                         |
+| 3912  | daterange                  | daterange(20)                         | daterange(5)                         | daterange(4)                         | daterange(0)                         | daterange                         | daterange                         |
+| 3926  | int8range                  | int8range(20)                         | int8range(5)                         | int8range(4)                         | int8range(0)                         | int8range                         | int8range                         |
+| 4451  | int4multirange             | int4multirange(20)                    | int4multirange(5)                    | int4multirange(4)                    | int4multirange(0)                    | int4multirange                    | int4multirange                    |
+| 4532  | nummultirange              | nummultirange(20)                     | nummultirange(5)                     | nummultirange(4)                     | nummultirange(0)                     | nummultirange                     | nummultirange                     |
+| 4533  | tsmultirange               | tsmultirange(20)                      | tsmultirange(5)                      | tsmultirange(4)                      | tsmultirange(0)                      | tsmultirange                      | tsmultirange                      |
+| 4535  | datemultirange             | datemultirange(20)                    | datemultirange(5)                    | datemultirange(4)                    | datemultirange(0)                    | datemultirange                    | datemultirange                    |
+| 4536  | int8multirange             | int8multirange(20)                    | int8multirange(5)                    | int8multirange(4)                    | int8multirange(0)                    | int8multirange                    | int8multirange                    |
+| 13408 | character_data             | information_schema.character_data(20) | information_schema.character_data(5) | information_schema.character_data(4) | information_schema.character_data(0) | information_schema.character_data | information_schema.character_data |
+| 13410 | sql_identifier             | information_schema.sql_identifier(20) | information_schema.sql_identifier(5) | information_schema.sql_identifier(4) | information_schema.sql_identifier(0) | information_schema.sql_identifier | information_schema.sql_identifier |
+| 18001 | KibanaSampleDataEcommerce  | ???                                   | ???                                  | ???                                  | ???                                  | ???                               | ???                               |
+| 18002 | _KibanaSampleDataEcommerce | ???                                   | ???                                  | ???                                  | ???                                  | ???                               | ???                               |
+| 18014 | Logs                       | ???                                   | ???                                  | ???                                  | ???                                  | ???                               | ???                               |
+| 18015 | _Logs                      | ???                                   | ???                                  | ???                                  | ???                                  | ???                               | ???                               |
++-------+----------------------------+---------------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-----------------------------------+-----------------------------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_expr_1.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_expr_1.snap
@@ -1,9 +1,20 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_query(\"SELECT pg_catalog.pg_get_expr(adbin, adrelid) FROM pg_catalog.pg_attrdef;\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"\n                SELECT\n                    attrelid,\n                    attname,\n                    pg_catalog.pg_get_expr(attname, attrelid) default\n                FROM pg_catalog.pg_attribute\n                ORDER BY\n                    attrelid ASC,\n                    attname ASC\n                ;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
 ---
-+-----------------------------------------------------------------------------------+
-| pg_catalog.pg_get_expr(pg_catalog.pg_attrdef.adbin,pg_catalog.pg_attrdef.adrelid) |
-+-----------------------------------------------------------------------------------+
-| NULL                                                                              |
-+-----------------------------------------------------------------------------------+
++----------+--------------------+---------+
+| attrelid | attname            | default |
++----------+--------------------+---------+
+| 18000    | avgPrice           | NULL    |
+| 18000    | count              | NULL    |
+| 18000    | customer_gender    | NULL    |
+| 18000    | has_subscription   | NULL    |
+| 18000    | is_female          | NULL    |
+| 18000    | is_male            | NULL    |
+| 18000    | maxPrice           | NULL    |
+| 18000    | minPrice           | NULL    |
+| 18000    | order_date         | NULL    |
+| 18000    | taxful_total_price | NULL    |
+| 18013    | agentCount         | NULL    |
+| 18013    | agentCountApprox   | NULL    |
++----------+--------------------+---------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_expr_2.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_get_expr_2.snap
@@ -1,9 +1,20 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_query(\"SELECT pg_catalog.pg_get_expr(adbin, adrelid, true) FROM pg_catalog.pg_attrdef;\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"\n                SELECT\n                    attrelid,\n                    attname,\n                    pg_catalog.pg_get_expr(attname, attrelid, true) default\n                FROM pg_catalog.pg_attribute\n                ORDER BY\n                    attrelid ASC,\n                    attname ASC\n                ;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
 ---
-+-------------------------------------------------------------------------------------------------+
-| pg_catalog.pg_get_expr(pg_catalog.pg_attrdef.adbin,pg_catalog.pg_attrdef.adrelid,Boolean(true)) |
-+-------------------------------------------------------------------------------------------------+
-| NULL                                                                                            |
-+-------------------------------------------------------------------------------------------------+
++----------+--------------------+---------+
+| attrelid | attname            | default |
++----------+--------------------+---------+
+| 18000    | avgPrice           | NULL    |
+| 18000    | count              | NULL    |
+| 18000    | customer_gender    | NULL    |
+| 18000    | has_subscription   | NULL    |
+| 18000    | is_female          | NULL    |
+| 18000    | is_male            | NULL    |
+| 18000    | maxPrice           | NULL    |
+| 18000    | minPrice           | NULL    |
+| 18000    | order_date         | NULL    |
+| 18000    | taxful_total_price | NULL    |
+| 18013    | agentCount         | NULL    |
+| 18013    | agentCountApprox   | NULL    |
++----------+--------------------+---------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__superset_subquery.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__superset_subquery.snap
@@ -1,8 +1,18 @@
 ---
 source: cubesql/src/compile/mod.rs
-assertion_line: 5341
-expression: "execute_query(\"SELECT a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod), (SELECT format_type(d.adbin, d.adrelid) FROM pg_catalog.pg_attrdef d WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) AS DEFAULT, a.attnotnull, a.attnum, a.attrelid as table_oid, pgd.description as comment, a.attgenerated as generated FROM pg_catalog.pg_attribute a LEFT JOIN pg_catalog.pg_description pgd ON ( pgd.objoid = a.attrelid AND pgd.objsubid = a.attnum) WHERE a.attrelid = 13449 AND a.attnum > 0 AND NOT a.attisdropped ORDER BY a.attnum;\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"\n                SELECT\n                    a.attname,\n                    pg_catalog.format_type(a.atttypid, a.atttypmod),\n                    (\n                        SELECT pg_catalog.pg_get_expr(d.adbin, d.adrelid)\n                        FROM pg_catalog.pg_attrdef d\n                        WHERE\n                            d.adrelid = a.attrelid AND\n                            d.adnum = a.attnum AND\n                            a.atthasdef\n                    ) AS DEFAULT,\n                    a.attnotnull,\n                    a.attnum,\n                    a.attrelid as table_oid,\n                    pgd.description as comment,\n                    a.attgenerated as generated\n                FROM pg_catalog.pg_attribute a\n                LEFT JOIN pg_catalog.pg_description pgd ON (\n                    pgd.objoid = a.attrelid AND\n                    pgd.objsubid = a.attnum\n                )\n                WHERE\n                    a.attrelid = 18000\n                    AND a.attnum > 0\n                    AND NOT a.attisdropped\n                ORDER BY a.attnum\n                ;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
 ---
-++
-++
-++
++--------------------+------------------------------------------------+---------+------------+--------+-----------+---------+-----------+
+| attname            | pg_catalog.format_type(a.atttypid,a.atttypmod) | DEFAULT | attnotnull | attnum | table_oid | comment | generated |
++--------------------+------------------------------------------------+---------+------------+--------+-----------+---------+-----------+
+| count              | bigint                                         | NULL    | true       | 1      | 18000     | NULL    |           |
+| maxPrice           | numeric                                        | NULL    | true       | 2      | 18000     | NULL    |           |
+| minPrice           | numeric                                        | NULL    | true       | 3      | 18000     | NULL    |           |
+| avgPrice           | numeric                                        | NULL    | true       | 4      | 18000     | NULL    |           |
+| order_date         | timestamp without time zone                    | NULL    | false      | 5      | 18000     | NULL    |           |
+| customer_gender    | text                                           | NULL    | false      | 6      | 18000     | NULL    |           |
+| taxful_total_price | numeric                                        | NULL    | false      | 7      | 18000     | NULL    |           |
+| has_subscription   | boolean                                        | NULL    | false      | 8      | 18000     | NULL    |           |
+| is_male            | boolean                                        | NULL    | true       | 9      | 18000     | NULL    |           |
+| is_female          | boolean                                        | NULL    | true       | 10     | 18000     | NULL    |           |
++--------------------+------------------------------------------------+---------+------------+--------+-----------+---------+-----------+

--- a/rust/cubesql/pg-srv/src/pg_type.rs
+++ b/rust/cubesql/pg-srv/src/pg_type.rs
@@ -31,6 +31,7 @@ macro_rules! define_pg_types {
         impl PgTypeId {
             pub fn from_oid(oid: u32) -> Option<Self> {
                 match oid {
+                    0 => Some(Self::UNSPECIFIED),
                     $($OID => Some(Self::$NAME),)*
                     _ => None,
                 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes subqueries returning empty result set to NULL (useful for Superset) and adds a related test.
Additionally, it fixes a few UDFs to return correct row amount and adds support for all implemented types in `pg_catalog.format_type` UDF on par with PostgreSQL.