### PR TITLE
chore(docs): Remove workshop info box

### DIFF
--- a/docs/content/Examples-Tutorials-Recipes/Examples.md
+++ b/docs/content/Examples-Tutorials-Recipes/Examples.md
@@ -6,12 +6,6 @@ redirect_from:
   - /tutorials/
 ---
 
-<InfoBox>
-  <b>Building Data Applications with Cube</b> workshop on May 18, 2022.<br/>
-  Learn all about building a modern data app with Cube.<br />
-  <a href="https://us02web.zoom.us/webinar/register/WN_DUeCHp5fRESAXsV_A1C_eg">Register for the workshop now</a> or see the agenda at the <a href="https://cube.dev/events/building-data-app/">event page</a>. 👈
-</InfoBox>
-
 Below you can find tutorials to help you get started with Cube.js.
 
 If you're already building something with Cube, please explore [recipes](/recipes) —

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -29,12 +29,6 @@ class IndexPage extends Component<Props> {
       <div className={styles.docContent}>
         <Helmet title="Main | Cube Docs" />
         <h1>Documentation</h1>
-
-        <InfoBox>
-          <b>Building Data Applications with Cube</b> workshop on May 18, 2022.<br/>
-          Learn all about building a modern data app with Cube.<br />
-          <a href="https://us02web.zoom.us/webinar/register/WN_DUeCHp5fRESAXsV_A1C_eg">Register for the workshop now</a> or see the agenda at the <a href="https://cube.dev/events/building-data-app/">event page</a>. 👈
-        </InfoBox>
         
         <Row>
           <Col span={24}>


### PR DESCRIPTION
Remove info boxes for the "building data apps with Cube" workshop in documentation pages
