### PR TITLE
fix(@cubejs-backend/cubestore-driver): Wrong order in "create table" for import streaming source. Unique keys should be before indexes.

### DIFF
--- a/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
@@ -284,7 +284,7 @@ export class CubeStoreDriver extends BaseDriver implements DriverInterface {
 
     const createTableSql = this.createTableSql(table, columns);
     // eslint-disable-next-line no-unused-vars
-    const createTableSqlWithLocation = `${createTableSql} ${indexes} UNIQUE KEY (${uniqueKeyColumns.join(',')}) LOCATION ?`;
+    const createTableSqlWithLocation = `${createTableSql} UNIQUE KEY (${uniqueKeyColumns.join(',')}) ${indexes} LOCATION ?`;
 
     await this.query(createTableSqlWithLocation, [`stream://${tableData.streamingSource.name}/${tableData.streamingTable}`], queryTracingObj).catch(e => {
       e.message = `Error during create table: ${createTableSqlWithLocation}: ${e.message}`;


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Wrong order in "create table" for import streaming source. Unique keys should be before indexes.

