### PR TITLE
chore(cubesql): Iterate UDF wildcard replacer over function arguments

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -7442,7 +7442,11 @@ ORDER BY \"COUNT(count)\" DESC"
                     a.attname,
                     t.typname,
                     information_schema._pg_truetypid(a.*, t.*) typid,
-                    information_schema._pg_truetypmod(a.*, t.*) typmod
+                    information_schema._pg_truetypmod(a.*, t.*) typmod,
+                    information_schema._pg_numeric_precision(
+                        information_schema._pg_truetypid(a.*, t.*),
+                        information_schema._pg_truetypmod(a.*, t.*)
+                    ) as_arg
                 FROM pg_attribute a
                 JOIN pg_type t ON t.oid = a.atttypid
                 ORDER BY a.attrelid ASC, a.attnum ASC

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_truetypid_truetypmod.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_truetypid_truetypmod.snap
@@ -1,20 +1,20 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_query(\"\n                SELECT\n                    a.attrelid,\n                    a.attname,\n                    t.typname,\n                    information_schema._pg_truetypid(a.*, t.*) typid,\n                    information_schema._pg_truetypmod(a.*, t.*) typmod\n                FROM pg_attribute a\n                JOIN pg_type t ON t.oid = a.atttypid\n                ORDER BY a.attrelid ASC, a.attnum ASC\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"\n                SELECT\n                    a.attrelid,\n                    a.attname,\n                    t.typname,\n                    information_schema._pg_truetypid(a.*, t.*) typid,\n                    information_schema._pg_truetypmod(a.*, t.*) typmod,\n                    information_schema._pg_numeric_precision(\n                        information_schema._pg_truetypid(a.*, t.*),\n                        information_schema._pg_truetypmod(a.*, t.*)\n                    ) as_arg\n                FROM pg_attribute a\n                JOIN pg_type t ON t.oid = a.atttypid\n                ORDER BY a.attrelid ASC, a.attnum ASC\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
 ---
-+----------+--------------------+-----------+-------+--------+
-| attrelid | attname            | typname   | typid | typmod |
-+----------+--------------------+-----------+-------+--------+
-| 18000    | count              | int8      | 20    | -1     |
-| 18000    | maxPrice           | numeric   | 1700  | -1     |
-| 18000    | minPrice           | numeric   | 1700  | -1     |
-| 18000    | avgPrice           | numeric   | 1700  | -1     |
-| 18000    | order_date         | timestamp | 1114  | -1     |
-| 18000    | customer_gender    | text      | 25    | -1     |
-| 18000    | taxful_total_price | numeric   | 1700  | -1     |
-| 18000    | has_subscription   | bool      | 16    | -1     |
-| 18000    | is_male            | bool      | 16    | -1     |
-| 18000    | is_female          | bool      | 16    | -1     |
-| 18013    | agentCount         | int8      | 20    | -1     |
-| 18013    | agentCountApprox   | int8      | 20    | -1     |
-+----------+--------------------+-----------+-------+--------+
++----------+--------------------+-----------+-------+--------+--------+
+| attrelid | attname            | typname   | typid | typmod | as_arg |
++----------+--------------------+-----------+-------+--------+--------+
+| 18000    | count              | int8      | 20    | -1     | 64     |
+| 18000    | maxPrice           | numeric   | 1700  | -1     | NULL   |
+| 18000    | minPrice           | numeric   | 1700  | -1     | NULL   |
+| 18000    | avgPrice           | numeric   | 1700  | -1     | NULL   |
+| 18000    | order_date         | timestamp | 1114  | -1     | NULL   |
+| 18000    | customer_gender    | text      | 25    | -1     | NULL   |
+| 18000    | taxful_total_price | numeric   | 1700  | -1     | NULL   |
+| 18000    | has_subscription   | bool      | 16    | -1     | NULL   |
+| 18000    | is_male            | bool      | 16    | -1     | NULL   |
+| 18000    | is_female          | bool      | 16    | -1     | NULL   |
+| 18013    | agentCount         | int8      | 20    | -1     | 64     |
+| 18013    | agentCountApprox   | int8      | 20    | -1     | 64     |
++----------+--------------------+-----------+-------+--------+--------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes `UdfWildcardArgReplacer` to iterate over functions nested as function arguments, allowing expressions like `information_schema._pg_numeric_precision(information_schema._pg_truetypid(att.*, ty.*), information_schema._pg_truetypmod(att.*, ty.*))`.
