### PR TITLE
fix(cubesql): Fix 0 rows result on `JOIN` with `AND` + `OR` in `WHERE`

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=22301f3b2db9a71e49a22ca994982acc498602f1#22301f3b2db9a71e49a22ca994982acc498602f1"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ce9c81c8c7557d9a7023aa15ea26a5e9fa423197#ce9c81c8c7557d9a7023aa15ea26a5e9fa423197"
 dependencies = [
  "ahash",
  "arrow",
@@ -835,7 +835,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=22301f3b2db9a71e49a22ca994982acc498602f1#22301f3b2db9a71e49a22ca994982acc498602f1"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ce9c81c8c7557d9a7023aa15ea26a5e9fa423197#ce9c81c8c7557d9a7023aa15ea26a5e9fa423197"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=22301f3b2db9a71e49a22ca994982acc498602f1#22301f3b2db9a71e49a22ca994982acc498602f1"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ce9c81c8c7557d9a7023aa15ea26a5e9fa423197#ce9c81c8c7557d9a7023aa15ea26a5e9fa423197"
 dependencies = [
  "async-trait",
  "chrono",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=22301f3b2db9a71e49a22ca994982acc498602f1#22301f3b2db9a71e49a22ca994982acc498602f1"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ce9c81c8c7557d9a7023aa15ea26a5e9fa423197#ce9c81c8c7557d9a7023aa15ea26a5e9fa423197"
 dependencies = [
  "ahash",
  "arrow",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=22301f3b2db9a71e49a22ca994982acc498602f1#22301f3b2db9a71e49a22ca994982acc498602f1"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ce9c81c8c7557d9a7023aa15ea26a5e9fa423197#ce9c81c8c7557d9a7023aa15ea26a5e9fa423197"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "22301f3b2db9a71e49a22ca994982acc498602f1", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "ce9c81c8c7557d9a7023aa15ea26a5e9fa423197", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -7777,4 +7777,34 @@ ORDER BY \"COUNT(count)\" DESC"
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_join_where_and_or() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "join_where_and_or",
+            execute_query(
+                "
+                SELECT
+                    att.attname,
+                    att.attnum,
+                    cl.oid
+                FROM pg_attribute att
+                JOIN pg_class cl ON
+                    cl.oid = attrelid AND (
+                        cl.relkind = 's' OR
+                        cl.relkind = 'r'
+                    )
+                ORDER BY
+                    cl.oid ASC,
+                    att.attnum ASC
+                ;
+                "
+                .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__join_where_and_or.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__join_where_and_or.snap
@@ -1,0 +1,20 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                SELECT\n                    att.attname,\n                    att.attnum,\n                    cl.oid\n                FROM pg_attribute att\n                JOIN pg_class cl ON\n                    cl.oid = attrelid AND (\n                        cl.relkind = 's' OR\n                        cl.relkind = 'r'\n                    )\n                ORDER BY\n                    cl.oid ASC,\n                    att.attnum ASC\n                ;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++--------------------+--------+-------+
+| attname            | attnum | oid   |
++--------------------+--------+-------+
+| count              | 1      | 18000 |
+| maxPrice           | 2      | 18000 |
+| minPrice           | 3      | 18000 |
+| avgPrice           | 4      | 18000 |
+| order_date         | 5      | 18000 |
+| customer_gender    | 6      | 18000 |
+| taxful_total_price | 7      | 18000 |
+| has_subscription   | 8      | 18000 |
+| is_male            | 9      | 18000 |
+| is_female          | 10     | 18000 |
+| agentCount         | 1      | 18013 |
+| agentCountApprox   | 2      | 18013 |
++--------------------+--------+-------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps `arrow-datafusion` to include a fix for queries with `JOIN` having `AND` + `OR` in `WHERE` returning 0 rows.
It also adds a related test.
