### PR TITLE
fix(cubesql): Handle `Flush` pg-wire message

### DIFF
--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -236,6 +236,7 @@ impl AsyncPostgresShim {
                 protocol::FrontendMessage::Close(body) => self.close(body).await,
                 protocol::FrontendMessage::Describe(body) => self.describe(body).await,
                 protocol::FrontendMessage::Sync => self.sync().await,
+                protocol::FrontendMessage::Flush => self.flush().await,
                 protocol::FrontendMessage::Terminate => return Ok(()),
                 command_id => {
                     return Err(ConnectionError::Protocol(
@@ -401,6 +402,11 @@ impl AsyncPostgresShim {
         ))
         .await?;
 
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> Result<(), ConnectionError> {
+        // TODO: flush network buffers here once buffering has been implemented
         Ok(())
     }
 

--- a/rust/cubesql/pg-srv/src/buffer.rs
+++ b/rust/cubesql/pg-srv/src/buffer.rs
@@ -31,6 +31,7 @@ pub async fn read_message<Reader: AsyncReadExt + Unpin + Send>(
             FrontendMessage::PasswordMessage(protocol::PasswordMessage::deserialize(cursor).await?)
         }
         b'X' => FrontendMessage::Terminate,
+        b'H' => FrontendMessage::Flush,
         b'S' => FrontendMessage::Sync,
         identifier => {
             return Err(ErrorResponse::error(

--- a/rust/cubesql/pg-srv/src/protocol.rs
+++ b/rust/cubesql/pg-srv/src/protocol.rs
@@ -694,6 +694,8 @@ pub enum FrontendMessage {
     Describe(Describe),
     Execute(Execute),
     Close(Close),
+    /// Flush network buffer
+    Flush,
     /// Close connection
     Terminate,
     /// Finish
@@ -880,10 +882,10 @@ mod tests {
             r#"
             50 00 00 00 77 6e 61 6d 65 64 2d 73 74 6d 74 00   P...wnamed-stmt.
             0a 20 20 20 20 20 20 53 45 4c 45 43 54 20 6e 75   .      SELECT nu
-            6d 2c 20 73 74 72 2c 20 62 6f 6f 6c 0a 20 20 20   m, str, bool.   
+            6d 2c 20 73 74 72 2c 20 62 6f 6f 6c 0a 20 20 20   m, str, bool.
             20 20 20 46 52 4f 4d 20 74 65 73 74 64 61 74 61      FROM testdata
             0a 20 20 20 20 20 20 57 48 45 52 45 20 6e 75 6d   .      WHERE num
-            20 3d 20 24 31 20 41 4e 44 20 73 74 72 20 3d 20    = $1 AND str = 
+            20 3d 20 24 31 20 41 4e 44 20 73 74 72 20 3d 20    = $1 AND str =
             24 32 20 41 4e 44 20 62 6f 6f 6c 20 3d 20 24 33   $2 AND bool = $3
             0a 20 20 20 20 00 00 00                           .    ...
             "#
@@ -915,7 +917,7 @@ mod tests {
             r#"
             42 00 00 00 2d 00 6e 61 6d 65 64 2d 73 74 6d 74   B...-.named-stmt
             00 00 00 00 03 00 00 00 01 35 00 00 00 04 74 65   .........5....te
-            73 74 00 00 00 04 74 72 75 65 00 01 00 00         st....true....            
+            73 74 00 00 00 04 74 72 75 65 00 01 00 00         st....true....
             "#
             .to_string(),
         );
@@ -980,7 +982,7 @@ mod tests {
     async fn test_frontend_message_parse_describe() -> Result<(), ProtocolError> {
         let buffer = parse_hex_dump(
             r#"
-            44 00 00 00 08 53 73 30 00                        D....Ss0.          
+            44 00 00 00 08 53 73 30 00                        D....Ss0.
             "#
             .to_string(),
         );
@@ -1033,7 +1035,7 @@ mod tests {
     async fn test_frontend_message_execute() -> Result<(), ProtocolError> {
         let buffer = parse_hex_dump(
             r#"
-            45 00 00 00 09 00 00 00 00 00                     E.........      
+            45 00 00 00 09 00 00 00 00 00                     E.........
             "#
             .to_string(),
         );


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR handles `Flush` pg-wire message, used by Excel Devart extension. As there's no network buffer implemented at the moment, the message is simply ignored instead of throwing an error.
