### PR TITLE
chore(dependabot): example' rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/packages"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/examples"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "production"
+    ignore:
+      - update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
I changed the settings so that the bot only reports essential notifications in the examples.