### PR TITLE
fix(client-react): update useIsMounted hook to be compatible with React 18 StrictMode

### DIFF
--- a/packages/cubejs-client-react/src/hooks/is-mounted.js
+++ b/packages/cubejs-client-react/src/hooks/is-mounted.js
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react';
 
 export function useIsMounted() {
-  const isMounted = useRef(true);
+  const isMounted = useRef(false);
 
   useEffect(() => {
+    isMounted.current = true;
+
     return () => {
       isMounted.current = false;
     };


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#4570

**Description of Changes Made (if issue reference is not provided)**

Starting in React 18, StrictMode intentionally double-invokes effects (`mount` -> `unmount` -> `mount`) for newly mounted components during development. Because the `isMounted` flag inside the `useIsMounted` hook is only set to true during initialisation, the flag gets set to false immediately during the 'unmount' phase and never gets restored to true. Setting the flag to true in the 'mount' phase restores the correct behaviour.

See: https://github.com/reactwg/react-18/discussions/19