### PR TITLE
fix(cubesql): Send `Empty Query` message on empty query

### DIFF
--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -1024,8 +1024,12 @@ impl AsyncPostgresShim {
 
         let statements = parse_sql_to_statements(&query.to_string(), DatabaseProtocol::PostgreSQL)?;
 
-        for statement in statements {
-            self.process_simple_query(statement, meta.clone()).await?;
+        if statements.len() == 0 {
+            self.write(protocol::EmptyQuery::new()).await?;
+        } else {
+            for statement in statements {
+                self.process_simple_query(statement, meta.clone()).await?;
+            }
         }
 
         Ok(())

--- a/rust/cubesql/pg-srv/src/protocol.rs
+++ b/rust/cubesql/pg-srv/src/protocol.rs
@@ -219,6 +219,22 @@ impl Serialize for ReadyForQuery {
     }
 }
 
+pub struct EmptyQuery {}
+
+impl EmptyQuery {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Serialize for EmptyQuery {
+    const CODE: u8 = b'I';
+
+    fn serialize(&self) -> Option<Vec<u8>> {
+        Some(vec![])
+    }
+}
+
 pub struct ParameterStatus {
     name: String,
     value: String,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes `pg-wire` protocol to send `Empty Query` message on empty simple query.
