### PR TITLE
chore(cubesql): Workaround CTEs with subqueries

### DIFF
--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__sigma_computing_with_subquery_query.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__sigma_computing_with_subquery_query.snap
@@ -1,0 +1,18 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                with\n                    nsp as (\n                        select oid\n                        from pg_catalog.pg_namespace\n                        where nspname = 'public'\n                    ),\n                    tbl as (\n                        select oid\n                        from pg_catalog.pg_class\n                        where\n                            relname = 'KibanaSampleDataEcommerce' and\n                            relnamespace = (select oid from nsp)\n                    )\n                select\n                    attname,\n                    typname,\n                    description\n                from pg_attribute a\n                join pg_type on atttypid = pg_type.oid\n                left join pg_description on\n                    attrelid = objoid and\n                    attnum = objsubid\n                where\n                    attnum > 0 and\n                    attrelid = (select oid from tbl)\n                order by attnum\n                ;\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++--------------------+-----------+-------------+
+| attname            | typname   | description |
++--------------------+-----------+-------------+
+| count              | int8      | NULL        |
+| maxPrice           | numeric   | NULL        |
+| minPrice           | numeric   | NULL        |
+| avgPrice           | numeric   | NULL        |
+| order_date         | timestamp | NULL        |
+| customer_gender    | text      | NULL        |
+| taxful_total_price | numeric   | NULL        |
+| has_subscription   | bool      | NULL        |
+| is_male            | bool      | NULL        |
+| is_female          | bool      | NULL        |
++--------------------+-----------+-------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR contains changes to workaround Sigma Computing query that uses subqueries in `WITH`. It also adds a relevant test.
