### PR TITLE
docs(config): correctly show 'Simple' strategy as default for building pre-aggregations with Databricks

### DIFF
--- a/docs/content/Configuration/Databases/Databricks-JDBC.mdx
+++ b/docs/content/Configuration/Databases/Databricks-JDBC.mdx
@@ -51,14 +51,16 @@ here][ref-caching-using-preaggs-build-strats].
 
 | Feature       | Works with read-only mode? | Is default? |
 | ------------- | :------------------------: | :---------: |
-| Export Bucket |             ❌             |     ✅      |
+| Simple        |             ❌             |     ✅      |
+| Export Bucket |             ❌             |     ❌      |
 
-By default, Databricks uses the [export bucket
-strategy][self-preaggs-export-bucket] to build pre-aggregations.
+By default, Databricks JDBC uses a [simple][self-preaggs-simple] strategy to
+build pre-aggregations.
 
-### Batching
+### Simple
 
-Databricks does not support batching.
+No extra configuration is required to configure simple pre-aggregation builds
+for Databricks.
 
 ### Export Bucket
 
@@ -121,4 +123,4 @@ bucket][self-preaggs-export-bucket] **must be** configured.
   /caching/using-pre-aggregations#pre-aggregation-build-strategies
 [ref-schema-ref-types-formats-countdistinctapprox]:
   /schema/reference/types-and-formats#count-distinct-approx
-[self-preaggs-export-bucket]: #export-bucket
+[self-preaggs-simple]: #simple


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required