### PR TITLE
chore(cubesql): Stop optimizing queries twice (on streaming)

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=24265c4602640fb03536b472a29e3e7ff8cd937f#24265c4602640fb03536b472a29e3e7ff8cd937f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d73dfda09a25719aff0e7919d77cad3be91724b3#d73dfda09a25719aff0e7919d77cad3be91724b3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=24265c4602640fb03536b472a29e3e7ff8cd937f#24265c4602640fb03536b472a29e3e7ff8cd937f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d73dfda09a25719aff0e7919d77cad3be91724b3#d73dfda09a25719aff0e7919d77cad3be91724b3"
 dependencies = [
  "ahash",
  "arrow",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=24265c4602640fb03536b472a29e3e7ff8cd937f#24265c4602640fb03536b472a29e3e7ff8cd937f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d73dfda09a25719aff0e7919d77cad3be91724b3#d73dfda09a25719aff0e7919d77cad3be91724b3"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=24265c4602640fb03536b472a29e3e7ff8cd937f#24265c4602640fb03536b472a29e3e7ff8cd937f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d73dfda09a25719aff0e7919d77cad3be91724b3#d73dfda09a25719aff0e7919d77cad3be91724b3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=24265c4602640fb03536b472a29e3e7ff8cd937f#24265c4602640fb03536b472a29e3e7ff8cd937f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d73dfda09a25719aff0e7919d77cad3be91724b3#d73dfda09a25719aff0e7919d77cad3be91724b3"
 dependencies = [
  "ahash",
  "arrow",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=24265c4602640fb03536b472a29e3e7ff8cd937f#24265c4602640fb03536b472a29e3e7ff8cd937f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d73dfda09a25719aff0e7919d77cad3be91724b3#d73dfda09a25719aff0e7919d77cad3be91724b3"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "24265c4602640fb03536b472a29e3e7ff8cd937f", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "d73dfda09a25719aff0e7919d77cad3be91724b3", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }


### PR DESCRIPTION
Hello!

<img width="1510" alt="image" src="https://user-images.githubusercontent.com/572096/176516330-0dc66eaa-ea86-4626-af13-2be2a07bcddc.png">

In the previous version of the DF when some called `execute_stream` it calls `create_physical_plan` where there was a call to `optimize` which led to a double optimization of the `LogicalPlan`. Right now, we disabled all optimizers excluding built-in optimizers placed in the implementation of LogicalNode (for example JOIN).

Thanks