### PR TITLE
feat(cubesql): Support Skyvia date granularities

### DIFF
--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -80,6 +80,7 @@ jobs:
           CUBESQL_TESTING_CUBE_TOKEN: ${{ secrets.CUBESQL_TESTING_CUBE_TOKEN }}
           CUBESQL_TESTING_CUBE_URL: ${{ secrets.CUBESQL_TESTING_CUBE_URL }}
           CUBESQL_REWRITE_ENGINE: true
+          CUBESQL_REWRITE_TIMEOUT: 30
         run: cd rust/cubesql && cargo tarpaulin --workspace --no-fail-fast --avoid-cfg-tarpaulin --out Xml
       - name: Upload code coverage
         uses: codecov/codecov-action@v2

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=0a23deccf4e589768177fbaa7a3745c8b25f63c9#0a23deccf4e589768177fbaa7a3745c8b25f63c9"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
 dependencies = [
  "bitflags",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5a02fed46d5e97858b4d3adc82d58ab71226752b#5a02fed46d5e97858b4d3adc82d58ab71226752b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
 dependencies = [
  "arrow",
  "chrono",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5a02fed46d5e97858b4d3adc82d58ab71226752b#5a02fed46d5e97858b4d3adc82d58ab71226752b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
 dependencies = [
  "ahash",
  "arrow",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5a02fed46d5e97858b4d3adc82d58ab71226752b#5a02fed46d5e97858b4d3adc82d58ab71226752b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5a02fed46d5e97858b4d3adc82d58ab71226752b#5a02fed46d5e97858b4d3adc82d58ab71226752b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5a02fed46d5e97858b4d3adc82d58ab71226752b#5a02fed46d5e97858b4d3adc82d58ab71226752b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
 dependencies = [
  "ahash",
  "arrow",
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=5a02fed46d5e97858b4d3adc82d58ab71226752b#5a02fed46d5e97858b4d3adc82d58ab71226752b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
 dependencies = [
  "ahash",
  "arrow",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=0a23deccf4e589768177fbaa7a3745c8b25f63c9#0a23deccf4e589768177fbaa7a3745c8b25f63c9"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/rust/cubesql/Cargo.toml
+++ b/rust/cubesql/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "cubeclient",
     "pg-srv"
 ]
+
+[profile.bench]
+debug = true

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "5a02fed46d5e97858b4d3adc82d58ab71226752b", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "97c7336b56f53bdb833944354932ea45b08b91f5", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -73,6 +73,3 @@ harness = false
 [[bench]]
 name = "benchmarks"
 harness = false
-
-[profile.bench]
-debug = true

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -846,7 +846,7 @@ impl MemberRules {
         column_expr_var: &'static str,
         alias_expr_var: Option<&'static str>,
         inner_replacer: bool,
-    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool + Copy
+    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool + Clone
     {
         let original_expr_var = var!(original_expr_var);
         let outer_granularity_var = var!(outer_granularity_var);
@@ -941,7 +941,7 @@ impl MemberRules {
         column_expr_var: &'static str,
         alias_expr_var: Option<&'static str>,
         inner_replacer: bool,
-    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool + Copy
+    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool + Clone
     {
         Self::transform_original_expr_nested_date_trunc(
             original_expr_var,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR adds rewrites to support Skyvia date granularities. Related tests are included.
It also contains improvements to reaggregation rules, fixes `char_length` test by adding an alias, and fixes a warning with cargo due to profile not being defined at the workspace root.
Additionally, rewrite engine timeout has been raised from 15 to 30 seconds for one CI check since rewrites in debug mode are much slower.
