### PR TITLE
fix(cubejs): Default value for options.queueOptions

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -1634,7 +1634,7 @@ export class PreAggregations {
           redisPool: this.options.redisPool,
           // Centralized continueWaitTimeout that can be overridden in queueOptions
           continueWaitTimeout: this.options.continueWaitTimeout,
-          ...(await this.options.queueOptions(dataSource)),
+          ...(this.options.queueOptions ? await this.options.queueOptions(dataSource) : {}),
           getQueueEventsBus: this.getQueueEventsBus,
         }
       );

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -247,7 +247,7 @@ export class QueryCache {
           redisPool: this.options.redisPool,
           // Centralized continueWaitTimeout that can be overridden in queueOptions
           continueWaitTimeout: this.options.continueWaitTimeout,
-          ...(await this.options.queueOptions(dataSource)),
+          ...(this.options.queueOptions ? await this.options.queueOptions(dataSource) : {}),
         }
       );
     }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Adds a default value for `options.queueOptions`. Prevents "error": "TypeError: this.options.queueOptions is not a function".
