### PR TITLE
fix (firebolt-driver) incorrect firebolt query generation for timestamp conversion

### DIFF
--- a/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
@@ -1,31 +1,28 @@
 import { BaseQuery, ParamAllocator } from '@cubejs-backend/schema-compiler';
 
 const GRANULARITY_TO_INTERVAL: Record<string, string> = {
-  day: 'Day',
-  hour: 'Hour',
-  minute: 'Minute',
-  second: 'Second',
-  month: 'Month',
-  quarter: 'Quarter',
-  year: 'Year',
+  day: 'DAY',
+  week: 'WEEK',
+  hour: 'HOUR',
+  minute: 'MINUTE',
+  second: 'SECOND',
+  month: 'MONTH',
+  quarter: 'QUARTER',
+  year: 'YEAR'
 };
 
 export class FireboltQuery extends BaseQuery {
   public paramAllocator!: ParamAllocator;
 
   public convertTz(field: string) {
-    return `toTimeZone(${field}, '${this.timezone}')`;
+    return field;
+  }
+
+  public timeStampCast(value: string) {
+    return `${value}::timestamp`;
   }
 
   public timeGroupedColumn(granularity: string, dimension: string) {
-    if (granularity === 'week') {
-      return `toDateTime(toMonday(${dimension}, '${this.timezone}'), '${this.timezone}')`;
-    } else {
-      const interval = GRANULARITY_TO_INTERVAL[granularity];
-
-      return `toDateTime(${
-        granularity === 'second' ? 'toDateTime' : `toStartOf${interval}`
-      }(${dimension}, '${this.timezone}'), '${this.timezone}')`;
-    }
+    return `DATE_TRUNC('${GRANULARITY_TO_INTERVAL[granularity]}', ${dimension})`;
   }
 }

--- a/packages/cubejs-firebolt-driver/test/Firebolt.test.ts
+++ b/packages/cubejs-firebolt-driver/test/Firebolt.test.ts
@@ -8,7 +8,7 @@ describe('FireboltDriver', () => {
   jest.setTimeout(2 * 60 * 1000);
 
   beforeAll(async () => {
-    tests = new DriverTests(new FireboltDriver({}));
+    tests = new DriverTests(new FireboltDriver({}), { expectStringFields: true });
   });
 
   afterAll(async () => {

--- a/packages/cubejs-firebolt-driver/test/FireboltQuery.test.ts
+++ b/packages/cubejs-firebolt-driver/test/FireboltQuery.test.ts
@@ -1,0 +1,62 @@
+import { prepareCompiler as originalPrepareCompiler } from '@cubejs-backend/schema-compiler';
+import { FireboltQuery } from '../src/FireboltQuery';
+
+const prepareCompiler = (content: string, options: any[]) => originalPrepareCompiler({
+  localPath: () => __dirname,
+  dataSchemaFiles: () => Promise.resolve([{ fileName: 'main.js', content }]),
+}, options);
+
+describe('FireboltQuery', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareCompiler(
+    `
+cube(\`sales\`, {
+  sql: \` select * from public.sales \`,
+
+  measures: {
+    count: {
+      type: 'count'
+    }
+  },
+  dimensions: {
+    category: {
+      type: 'string',
+      sql: 'category'
+    },
+    salesDatetime: {
+      type: 'time',
+      sql: 'sales_datetime'
+    }
+  }
+});
+`,
+    []
+  );
+
+  it('should use DATE_TRUNC for time granuality dimensions', () => compiler.compile().then(() => {
+    const query = new FireboltQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      {
+        measures: ['sales.count'],
+        timeDimensions: [
+          {
+            dimension: 'sales.salesDatetime',
+            granularity: 'day',
+            dateRange: ['2017-01-01', '2017-01-02'],
+          },
+        ],
+        timezone: 'America/Los_Angeles',
+        order: [
+          {
+            id: 'sales.salesDatetime',
+          },
+        ],
+      }
+    );
+
+    const queryAndParams = query.buildSqlAndParams();
+
+    expect(queryAndParams[0]).toContain(
+      'DATE_TRUNC(\'DAY\', "sales".sales_datetime)'
+    );
+  }));
+});

--- a/packages/cubejs-testing/birdbox-fixtures/firebolt/schema/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/firebolt/schema/Orders.js
@@ -1,0 +1,35 @@
+cube('Orders', {
+  sql: `
+  select 1 as id, 100 as amount, '2017-01-01 09:34:21'::timestamp as created_at, 'new' status
+  UNION ALL
+  select 2 as id, 200 as amount, '2017-02-01 19:34:21'::timestamp as created_at, 'new' status
+  UNION ALL
+  select 3 as id, 300 as amount, '2017-01-01 19:34:21'::timestamp as created_at, 'processed' status
+  UNION ALL
+  select 4 as id, 500 as amount, '2017-01-01 19:34:21'::timestamp as created_at, 'processed' status
+  UNION ALL
+  select 5 as id, 600 as amount, '2017-01-01 19:34:21'::timestamp as created_at, 'shipped' status
+  `,
+  measures: {
+    count: {
+      type: 'count',
+    },
+    totalAmount: {
+      sql: 'amount',
+      type: 'sum',
+    },
+    toRemove: {
+      type: 'count',
+    },
+  },
+  dimensions: {
+    status: {
+      sql: 'status',
+      type: 'string',
+    },
+    createdAt: {
+      sql: 'created_at',
+      type: 'time'
+    }
+  },
+});

--- a/packages/cubejs-testing/test/__snapshots__/smoke-firebolt.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-firebolt.test.ts.snap
@@ -1,9 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`firebolt query dimensions: dimensions 1`] = `
+Array [
+  Object {
+    "Orders.count": "4",
+    "Orders.createdAt": "2017-01-01T00:00:00.000",
+    "Orders.createdAt.day": "2017-01-01T00:00:00.000",
+  },
+  Object {
+    "Orders.count": "1",
+    "Orders.createdAt": "2017-02-01T00:00:00.000",
+    "Orders.createdAt.day": "2017-02-01T00:00:00.000",
+  },
+]
+`;
+
 exports[`firebolt query measure: query 1`] = `
 Array [
   Object {
-    "Orders.totalAmount": 1700,
+    "Orders.totalAmount": "1700",
   },
 ]
 `;

--- a/packages/cubejs-testing/test/smoke-firebolt.test.ts
+++ b/packages/cubejs-testing/test/smoke-firebolt.test.ts
@@ -1,6 +1,6 @@
 import cubejs, { CubejsApi } from '@cubejs-client/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { afterAll, beforeAll, jest } from '@jest/globals';
+import { afterAll, beforeAll, jest, expect } from '@jest/globals';
 import { BirdBox, getBirdbox } from '../src';
 import { DEFAULT_CONFIG, testQueryMeasure } from './smoke-tests';
 
@@ -17,7 +17,7 @@ describe('firebolt', () => {
         ...DEFAULT_CONFIG
       },
       {
-        schemaDir: 'questdb/schema',
+        schemaDir: 'firebolt/schema',
       }
     );
     client = cubejs(async () => 'test', {
@@ -30,4 +30,18 @@ describe('firebolt', () => {
   });
 
   test('query measure', () => testQueryMeasure(client));
+
+  test('query dimensions', async () => {
+    const response = await client.load({
+      measures: ['Orders.count'],
+      timeDimensions: [
+        {
+          dimension: 'Orders.createdAt',
+          granularity: 'day',
+        },
+      ],
+    });
+
+    expect(response.rawData()).toMatchSnapshot('dimensions');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,11 +3590,6 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@balena/dockerignore@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@balena/dockerignore/-/dockerignore-1.0.2.tgz#9ffe4726915251e8eb69f44ef3547e0da2c03e0d"
-  integrity sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==
-
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -6348,13 +6343,6 @@
   dependencies:
     "@types/glob" "*"
 
-"@types/archiver@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-5.3.1.tgz#02991e940a03dd1a32678fead4b4ca03d0e387ca"
-  integrity sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==
-  dependencies:
-    "@types/glob" "*"
-
 "@types/babel__code-frame@^7.0.2":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.3.tgz#eda94e1b7c9326700a4b69c485ebbc9498a0b63f"
@@ -6494,14 +6482,6 @@
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.0.tgz#d6afcc1de31e211ee900da3a48ef4f1a496cf05a"
   integrity sha512-3Mc0b2gnypJB8Gwmr+8UVPkwjpf4kg1gVxw8lAI4Y/EzpK50LixU1wBSPN9D+xqiw2Ubb02JO8oM0xpwzvi2mg==
-  dependencies:
-    "@types/docker-modem" "*"
-    "@types/node" "*"
-
-"@types/dockerode@^3.3.8":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@types/dockerode/-/dockerode-3.3.9.tgz#8c6e519fd4d0d86717b2c6a864904f4e6aa8af40"
-  integrity sha512-SYRN5FF/qmwpxUT6snJP5D8k0wgoUKOGVs625XvpRJOOUi6s//UYI4F0tbyE3OmzpI70Fo1+aqpzX27zCrInww==
   dependencies:
     "@types/docker-modem" "*"
     "@types/node" "*"
@@ -6778,30 +6758,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@^12", "@types/node@^12.12.17":
+"@types/node@*", "@types/node@12.12.50", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^10.17.55", "@types/node@^10.17.60", "@types/node@^12", "@types/node@^12.12.17", "@types/node@^14.14.35":
   version "12.20.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.41.tgz#81d7734c5257da9f04354bd9084a6ebbdd5198a5"
   integrity sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q==
-
-"@types/node@12.12.50":
-  version "12.12.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.50.tgz#e9b2e85fafc15f2a8aa8fdd41091b983da5fd6ee"
-  integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
-
-"@types/node@>=13.7.0":
-  version "18.0.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.3.tgz#463fc47f13ec0688a33aec75d078a0541a447199"
-  integrity sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==
-
-"@types/node@^10.17.55", "@types/node@^10.17.60":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
-
-"@types/node@^14.14.35":
-  version "14.18.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.21.tgz#0155ee46f6be28b2ff0342ca1a9b9fd4468bef41"
-  integrity sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -6850,7 +6810,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
+"@types/ramda@0.27.40", "@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
   version "0.27.40"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.40.tgz#99f307356fe553095ee4d3c2af2b0eb3af7a8413"
   integrity sha512-V99ZfTH2tqVYdLDAlgh2uT+N074HPgqnAsMjALKSBqogYd0HbuuGMqNukJ6fk9Ml/Htaus76fsc4Yh3p7q1VdQ==
@@ -8538,19 +8498,6 @@ archiver@^5.3.0:
     tar-stream "^2.2.0"
     zip-stream "^4.1.0"
 
-archiver@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.1.tgz#21e92811d6f09ecfce649fbefefe8c79e57cbbb6"
-  integrity sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==
-  dependencies:
-    archiver-utils "^2.1.0"
-    async "^3.2.3"
-    buffer-crc32 "^0.2.1"
-    readable-stream "^3.6.0"
-    readdir-glob "^1.0.0"
-    tar-stream "^2.2.0"
-    zip-stream "^4.1.0"
-
 are-we-there-yet@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
@@ -8879,11 +8826,6 @@ async@^3.1.0, async@^3.2.0, async@~3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
   integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
-
-async@^3.2.3:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
-  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -12063,13 +12005,6 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
 debug@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -12491,13 +12426,6 @@ docker-compose@^0.23.10:
   dependencies:
     yaml "^1.10.2"
 
-docker-compose@^0.23.17:
-  version "0.23.17"
-  resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.17.tgz#8816bef82562d9417dc8c790aa4871350f93a2ba"
-  integrity sha512-YJV18YoYIcxOdJKeFcCFihE6F4M2NExWM/d4S1ITcS9samHKnNUihz9kjggr0dNtsrbpFNc7/Yzd19DWs+m1xg==
-  dependencies:
-    yaml "^1.10.2"
-
 docker-modem@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/docker-modem/-/docker-modem-3.0.3.tgz#ac4bb1f32f81ac2e7120c5e99a068fab2458a32f"
@@ -12512,14 +12440,6 @@ dockerode@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.3.1.tgz#74f66e239e092e7910e2beae6322d35c44b08cdc"
   integrity sha512-AS2mr8Lp122aa5n6d99HkuTNdRV1wkkhHwBdcnY6V0+28D3DSYwhxAk85/mM9XwD3RMliTxyr63iuvn5ZblFYQ==
-  dependencies:
-    docker-modem "^3.0.0"
-    tar-fs "~2.0.1"
-
-dockerode@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-3.3.2.tgz#f3545700d2f7f86141b58843a755eeb21e38d5cd"
-  integrity sha512-oXN+1XVH2TeyE0Jj9Ci6Fim8ZIDxyqeJrkx9qhEOaRiA+nhLihKfd3M2L+Aqrj5C2ObPw8RVN2zPWvvk0x2dwg==
   dependencies:
     docker-modem "^3.0.0"
     tar-fs "~2.0.1"
@@ -23030,13 +22950,6 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, pr
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-properties-reader@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.2.0.tgz#41d837fe143d8d5f2386b6a869a1975c0b2c595c"
-  integrity sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==
-  dependencies:
-    mkdirp "^1.0.4"
-
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -23730,21 +23643,10 @@ rc-tree-select@~4.3.0:
     rc-tree "^4.0.0"
     rc-util "^5.0.5"
 
-rc-tree@^4.0.0:
+rc-tree@4.1.5, rc-tree@^4.0.0, rc-tree@~4.2.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.1.5.tgz#734ab1bfe835e78791be41442ca0e571147ab6fa"
   integrity sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "2.x"
-    rc-motion "^2.0.1"
-    rc-util "^5.0.0"
-    rc-virtual-list "^3.0.1"
-
-rc-tree@~4.2.1:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.2.2.tgz#4429187cbbfbecbe989714a607e3de8b3ab7763f"
-  integrity sha512-V1hkJt092VrOVjNyfj5IYbZKRMHxWihZarvA5hPL/eqm7o2+0SNkeidFYm7LVVBrAKBpOpa0l8xt04uiqOd+6w==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
@@ -25973,7 +25875,7 @@ sqlstring@^2.3.0, sqlstring@^2.3.1, sqlstring@^2.3.2:
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
   integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==
 
-ssh-remote-port-forward@^1.0.3, ssh-remote-port-forward@^1.0.4:
+ssh-remote-port-forward@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz#72b0c5df8ec27ca300c75805cc6b266dee07e298"
   integrity sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==
@@ -26913,7 +26815,7 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2, testcontainers@^7.9.0:
+testcontainers@7.12.1, testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2, testcontainers@^7.9.0, testcontainers@^8.4.0:
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-7.12.1.tgz#8ca81eadf559ee2ab648d64623e350a13d681d09"
   integrity sha512-iqUBvEChe7+Z1Q4ChInx21g1vm/Q5mxFnu4B4Y8RgXdaOmLN4eNAbJj0ZbYtR70waFrqJQHBZrODLQzc4uYo5Q==
@@ -26930,24 +26832,6 @@ testcontainers@^7.11.1, testcontainers@^7.5.0, testcontainers@^7.6.2, testcontai
     slash "^3.0.0"
     ssh-remote-port-forward "^1.0.3"
     stream-to-array "^2.3.0"
-    tar-fs "^2.1.1"
-
-testcontainers@^8.4.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/testcontainers/-/testcontainers-8.11.0.tgz#f19307557289b7e80c7e1d65b39ab0054a2b2549"
-  integrity sha512-sc9FA40waYXKVTp/Dm9qmcc8I5/TLyZd+JxtnYjIQDp1UvLzAckQPjSlGCDTdM00J2X4KDwG0+jY+8WprZbpnQ==
-  dependencies:
-    "@balena/dockerignore" "^1.0.2"
-    "@types/archiver" "^5.3.1"
-    "@types/dockerode" "^3.3.8"
-    archiver "^5.3.1"
-    byline "^5.0.0"
-    debug "^4.3.4"
-    docker-compose "^0.23.17"
-    dockerode "^3.3.1"
-    get-port "^5.1.1"
-    properties-reader "^2.2.0"
-    ssh-remote-port-forward "^1.0.4"
     tar-fs "^2.1.1"
 
 text-extensions@^1.0.0:


### PR DESCRIPTION

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

Firebolt does not support timezone now. 
This PR changes firebolt driver sql generation to not use timezones in `timeStampCast` and `convertTz`
Also changes `timeGroupedColumn` since Firebolt now supports `DATE_TRUNC`
