### PR TITLE
fix(api-gateway): Sending "Incoming network usage" event after context resolver

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -149,6 +149,7 @@ class ApiGateway {
     const userMiddlewares: RequestHandler[] = [
       this.checkAuthMiddleware,
       this.requestContextMiddleware,
+      this.logNetworkUsage,
       this.requestLoggerMiddleware
     ];
 
@@ -175,8 +176,6 @@ class ApiGateway {
         graphiql: getEnv('nodeEnv') !== 'production' ? { headerEditorEnabled: true } : false,
       })(req, res);
     });
-
-    app.use(this.logNetworkUsage);
 
     app.get(`${this.basePath}/v1/load`, userMiddlewares, (async (req, res) => {
       await this.load({


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

Otherwise, we send events without request-id and other context payloads.
