### PR TITLE
feat(cubesql): Support `PREPARE` queries in pg-wire

### DIFF
--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -643,6 +643,20 @@ impl PostgresIntegrationTestSuite {
 
         Ok(())
     }
+
+    // Hightouch uses it
+    async fn test_simple_query_prepare(&self) -> RunResult<()> {
+        self.test_simple_query("PREPARE simple_query AS SELECT 1".to_string(), |_| {})
+            .await?;
+
+        self.test_simple_query(
+            "PREPARE simple_query_parens AS (SELECT 1)".to_string(),
+            |_| {},
+        )
+        .await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -664,6 +678,7 @@ impl AsyncTestSuite for PostgresIntegrationTestSuite {
         self.test_simple_cursors_without_hold().await?;
         self.test_simple_cursors_close_specific().await?;
         self.test_simple_cursors_close_all().await?;
+        self.test_simple_query_prepare().await?;
         self.test_snapshot_execute_query(
             "SELECT COUNT(*) count, status FROM Orders GROUP BY status".to_string(),
             None,

--- a/rust/cubesql/cubesql/src/sql/types.rs
+++ b/rust/cubesql/cubesql/src/sql/types.rs
@@ -95,6 +95,7 @@ impl StatusFlags {
 #[derive(Debug, Clone)]
 pub enum CommandCompletion {
     Begin,
+    Prepare,
     Commit,
     Use,
     Rollback,
@@ -111,6 +112,7 @@ impl CommandCompletion {
         match self {
             // IDENTIFIER ONLY
             CommandCompletion::Begin => CommandComplete::Plain("BEGIN".to_string()),
+            CommandCompletion::Prepare => CommandComplete::Plain("PREPARE".to_string()),
             CommandCompletion::Commit => CommandComplete::Plain("COMMIT".to_string()),
             CommandCompletion::Rollback => CommandComplete::Plain("ROLLBACK".to_string()),
             CommandCompletion::Set => CommandComplete::Plain("SET".to_string()),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR adds support for `PREPARE` queries, similar to `Parse` packet with a difference of them being sent as a simple query. These are used by Hightouch. A related simple test is also added.
