### PR TITLE
feat(cubesql): Support `pg_total_relation_size` UDF

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -2375,3 +2375,29 @@ pub fn create_has_schema_privilege_udf(state: Arc<SessionState>) -> ScalarUDF {
         &fun,
     )
 }
+
+pub fn create_pg_total_relation_size_udf() -> ScalarUDF {
+    let fun = make_scalar_function(move |args: &[ArrayRef]| {
+        assert!(args.len() == 1);
+
+        let relids = downcast_primitive_arg!(args[0], "relid", OidType);
+
+        // 8192 is the lowest size for a table that has at least one column
+        // TODO: check if the requested table actually exists
+        let result = relids
+            .iter()
+            .map(|relid| relid.map(|_| 8192))
+            .collect::<PrimitiveArray<Int64Type>>();
+
+        Ok(Arc::new(result))
+    });
+
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Int64)));
+
+    ScalarUDF::new(
+        "pg_total_relation_size",
+        &Signature::exact(vec![DataType::UInt32], Volatility::Immutable),
+        &return_type,
+        &fun,
+    )
+}

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_total_relation_size.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_total_relation_size.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT\n                    oid,\n                    relname,\n                    pg_total_relation_size(oid) relsize\n                FROM pg_class\n                ORDER BY oid ASC\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------+---------------------------+---------+
+| oid   | relname                   | relsize |
++-------+---------------------------+---------+
+| 18000 | KibanaSampleDataEcommerce | 8192    |
+| 18013 | Logs                      | 8192    |
++-------+---------------------------+---------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR adds `pg_total_relation_size` PostgreSQL UDF stub (used by QuickSight), returning the smallest sane table size. It also adds a related test.
