### PR TITLE
chore(cubesql): Reaggregate CubeScan projections

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -86,6 +86,8 @@ impl CostFunction<LogicalPlanLanguage> for BestCubePlan {
             LogicalPlanLanguage::InnerAggregateSplitReplacer(_) => 1,
             LogicalPlanLanguage::OuterProjectionSplitReplacer(_) => 1,
             LogicalPlanLanguage::OuterAggregateSplitReplacer(_) => 1,
+            LogicalPlanLanguage::GroupExprSplitReplacer(_) => 1,
+            LogicalPlanLanguage::GroupAggregateSplitReplacer(_) => 1,
             LogicalPlanLanguage::MemberPushdownReplacer(_) => 1,
             _ => 0,
         };

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -316,6 +316,14 @@ crate::plan_to_language! {
             members: Vec<LogicalPlan>,
             alias_to_cube: Vec<(String, String)>,
         },
+        GroupExprSplitReplacer {
+            members: Vec<LogicalPlan>,
+            alias_to_cube: Vec<(String, String)>,
+        },
+        GroupAggregateSplitReplacer {
+            members: Vec<LogicalPlan>,
+            alias_to_cube: Vec<(String, String)>,
+        },
     }
 }
 
@@ -796,6 +804,17 @@ fn outer_projection_split_replacer(members: impl Display, alias_to_cube: impl Di
 fn outer_aggregate_split_replacer(members: impl Display, alias_to_cube: impl Display) -> String {
     format!(
         "(OuterAggregateSplitReplacer {} {})",
+        members, alias_to_cube
+    )
+}
+
+fn group_expr_split_replacer(members: impl Display, alias_to_cube: impl Display) -> String {
+    format!("(GroupExprSplitReplacer {} {})", members, alias_to_cube)
+}
+
+fn group_aggregate_split_replacer(members: impl Display, alias_to_cube: impl Display) -> String {
+    format!(
+        "(GroupAggregateSplitReplacer {} {})",
         members, alias_to_cube
     )
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -846,7 +846,8 @@ impl MemberRules {
         column_expr_var: &'static str,
         alias_expr_var: Option<&'static str>,
         inner_replacer: bool,
-    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool {
+    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool + Copy
+    {
         let original_expr_var = var!(original_expr_var);
         let outer_granularity_var = var!(outer_granularity_var);
         let inner_granularity_var = var!(inner_granularity_var);
@@ -940,7 +941,8 @@ impl MemberRules {
         column_expr_var: &'static str,
         alias_expr_var: Option<&'static str>,
         inner_replacer: bool,
-    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool {
+    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool + Copy
+    {
         Self::transform_original_expr_nested_date_trunc(
             original_expr_var,
             granularity_var,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR introduces rewrites to enable aggregation on top of projection with CubeScan, allowing re-aggregation (DF post-processing). An example use case is to extract `MONTH` with `DatePart` without `GROUP BY` clause.
