### PR TITLE
feat(cubesql): Define standard_conforming_strings (Preset compatibility)

### DIFF
--- a/rust/cubesql/cubesql/src/sql/database_variables/postgres/session_vars.rs
+++ b/rust/cubesql/cubesql/src/sql/database_variables/postgres/session_vars.rs
@@ -78,5 +78,14 @@ pub fn defaults() -> DatabaseVariables {
         ),
     );
 
+    variables.insert(
+        "standard_conforming_strings".to_string(),
+        DatabaseVariable::system(
+            "standard_conforming_strings".to_string(),
+            ScalarValue::Utf8(Some("on".to_string())),
+            None,
+        ),
+    );
+
     variables
 }

--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -511,6 +511,12 @@ impl AsyncPostgresShim {
             protocol::ParameterStatus::new("integer_datetimes".to_string(), "on".to_string()),
             protocol::ParameterStatus::new("TimeZone".to_string(), "Etc/UTC".to_string()),
             protocol::ParameterStatus::new("IntervalStyle".to_string(), "postgres".to_string()),
+            // Some drivers rely on it, for example, SQLAlchemy
+            // https://github.com/sqlalchemy/sqlalchemy/blob/6104c163eb58e35e46b0bb6a237e824ec1ee1d15/lib/sqlalchemy/dialects/postgresql/base.py#L2994
+            protocol::ParameterStatus::new(
+                "standard_conforming_strings".to_string(),
+                "on".to_string(),
+            ),
         ];
 
         self.write_multi(params).await?;


### PR DESCRIPTION
Hello!

This PR fixes a compatibility issue with SQLAlchemy. It's important for Superset/Preset.

Thanks