### PR TITLE
fix(client-react): update hooks for React 18 StrictMode

### DIFF
--- a/packages/cubejs-client-react/src/hooks/cube-query.js
+++ b/packages/cubejs-client-react/src/hooks/cube-query.js
@@ -3,10 +3,11 @@ import { isQueryPresent, areQueriesEqual } from '@cubejs-client/core';
 
 import CubeContext from '../CubeContext';
 import useDeepCompareMemoize from './deep-compare-memoize';
+import { useIsMounted } from './is-mounted';
 
 export function useCubeQuery(query, options = {}) {
   const mutexRef = useRef({});
-  const isMounted = useRef(true);
+  const isMounted = useIsMounted();
   const [currentQuery, setCurrentQuery] = useState(null);
   const [isLoading, setLoading] = useState(false);
   const [resultSet, setResultSet] = useState(null);
@@ -40,28 +41,22 @@ export function useCubeQuery(query, options = {}) {
         progressCallback,
       });
 
-      if (isMounted.current) {
+      if (isMounted()) {
         setResultSet(response);
         setProgress(null);
       }
     } catch (error) {
-      if (isMounted.current) {
+      if (isMounted()) {
         setError(error);
         setResultSet(null);
         setProgress(null);
       }
     }
 
-    if (isMounted.current) {
+    if (isMounted()) {
       setLoading(false);
     }
   }
-
-  useEffect(() => {
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     const { skip = false, resetResultSetOnChange } = options;
@@ -99,7 +94,7 @@ export function useCubeQuery(query, options = {}) {
                 progressCallback,
               },
               (e, result) => {
-                if (isMounted.current) {
+                if (isMounted()) {
                   if (e) {
                     setError(e);
                   } else {
@@ -114,7 +109,7 @@ export function useCubeQuery(query, options = {}) {
             await fetch();
           }
         } catch (e) {
-          if (isMounted.current) {
+          if (isMounted()) {
             setError(e);
             setResultSet(null);
             setLoading(false);

--- a/packages/cubejs-playground/src/hooks/is-mounted.ts
+++ b/packages/cubejs-playground/src/hooks/is-mounted.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 export function useIsMounted() {
-  const isMountedRef = useRef(true);
+  const isMountedRef = useRef(false);
   const isMounted = useCallback(() => isMountedRef.current, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return () => {
       isMountedRef.current = false;
     };


### PR DESCRIPTION
This is the same fix as #4740 but applied to the `useCubeQuery` hook. I noticed there is another version of `useIsMounted` in playground as well so I updated that as well.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#4904