### PR TITLE
add --directory option to cubejs-cli

### DIFF
--- a/packages/cubejs-cli/src/command/deploy.ts
+++ b/packages/cubejs-cli/src/command/deploy.ts
@@ -119,8 +119,12 @@ export function configureDeployCommand(program: CommanderStatic) {
     .description('Deploy project to Cube Cloud')
     .option('--upload-env', 'Upload .env file to CubeCloud')
     .option('--token <token>', 'Add auth token to CubeCloud')
+    .option('--directory [path]', 'Specify path to conf directory', './')
     .action(
-      (options) => deploy({ directory: process.cwd(), ...options })
+      (options) => deploy({
+        ...options,
+        directory: path.join(process.cwd(), options.directory)
+      })
         .catch(e => displayError(e.stack || e))
     )
     .on('--help', () => {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

None

**Description of Changes Made (if issue reference is not provided)**

Enable an `--directory` option for `cubejs-cli deploy`

```
node ../cube.js/packages/cubejs-cli/dist/src/cli.js deploy --help
Usage: deploy [options]

Deploy project to Cube Cloud

Options:
  --upload-env        Upload .env file to CubeCloud
  --token <token>     Add auth token to CubeCloud
  --directory <path>  Specify path to conf directory (default: "./") 
  -h, --help          output usage information
  ```
  
Can confirm that I successfully uploaded a config directory using the modified code and it worked as expected:

from within my `packages/cube` directory in an adjacent project:

```
node ../../../cube.js/packages/cubejs-cli/dist/src/cli.js deploy --upload-env --token tttoookkkeeennnnnnnnnnnn
Token successfully added!
- Deploying project-name...
- Uploading files | ████████████████████████████████████████ | 100%.
- Done 🎉
```

from the top level of an adjacent project:

```
node ../cube.js/packages/cubejs-cli/dist/src/cli.js deploy --upload-env --token tttoookkkeeennnnnnnnnnnn --directory ./packages/cube
Token successfully added!
- Deploying project-name...
- Uploading files | ████████████████████████████████████████ | 100%.
- Done 🎉
```
