### PR TITLE
fix(cubejs): Fixes configuration such that CUBEJS_PRE_AGGREGATIONS_BUILDER always enables preaggregation building

### DIFF
--- a/packages/cubejs-server-core/src/core/OptsHandler.ts
+++ b/packages/cubejs-server-core/src/core/OptsHandler.ts
@@ -694,13 +694,12 @@ export class OptsHandler {
     // pre-aggs external refresh flag (force to run pre-aggs build flow first if
     // pre-agg is not exists/updated at the query moment). Initially the default
     // was equal to [rollupOnlyMode && !scheduledRefreshTimer].
-    clone.preAggregationsOptions.externalRefresh =
-      clone.preAggregationsOptions.externalRefresh !== undefined
-        ? clone.preAggregationsOptions.externalRefresh
-        : (
-          !this.isPreAggsBuilder() ||
-          clone.rollupOnlyMode && !this.configuredForScheduledRefresh()
-        );
+    if (clone.preAggregationsOptions.externalRefresh === undefined) {
+      clone.preAggregationsOptions.externalRefresh =
+        this.isPreAggsBuilder()
+          ? false
+          : clone.rollupOnlyMode && !this.configuredForScheduledRefresh();
+    }
 
     return clone;
   }

--- a/packages/cubejs-testing/birdbox-fixtures/preaggregation/schema/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/preaggregation/schema/Orders.js
@@ -1,0 +1,33 @@
+cube(`Orders`, {
+  sql: `
+  select 1 as id, 100 as amount, 'new' status
+  UNION ALL
+  select 2 as id, 200 as amount, 'new' status
+  UNION ALL
+  select 3 as id, 300 as amount, 'processed' status
+  UNION ALL
+  select 4 as id, 500 as amount, 'processed' status
+  UNION ALL
+  select 5 as id, 600 as amount, 'shipped' status
+  `,
+
+  preAggregations: {
+    countByStatus: {
+      measures: [CUBE.count],
+      dimensions: [CUBE.status],
+    },
+  },
+
+  measures: {
+    count: {
+      type: `count`,
+    },
+  },
+
+  dimensions: {
+    status: {
+      sql: `status`,
+      type: `string`,
+    },
+  },
+});

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -48,6 +48,7 @@
     "smoke:athena:snapshot": "jest --verbose --updateSnapshot -i dist/test/smoke-athena.test.js",
     "smoke:bigquery": "jest --verbose -i dist/test/smoke-bigquery.test.js",
     "smoke:bigquery:snapshot": "jest --verbose --updateSnapshot -i dist/test/smoke-bigquery.test.js",
+    "smoke:config": "jest --verbose -i dist/test/smoke-config.test.js",
     "smoke:firebolt": "jest --verbose -i dist/test/smoke-firebolt.test.js",
     "smoke:firebolt:snapshot": "jest --updateSnapshot --verbose -i dist/test/smoke-firebolt.test.js",
     "smoke:materialize": "jest --verbose -i dist/test/smoke-materialize.test.js",

--- a/packages/cubejs-testing/test/smoke-config.test.ts
+++ b/packages/cubejs-testing/test/smoke-config.test.ts
@@ -1,0 +1,67 @@
+import { StartedTestContainer } from 'testcontainers';
+import { MysqlDBRunner, PostgresDBRunner } from '@cubejs-backend/testing-shared';
+import cubejs, { CubejsApi } from '@cubejs-client/core';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { afterAll, beforeAll, expect, jest } from '@jest/globals';
+import { BirdBox, getBirdbox } from '../src';
+import { DEFAULT_CONFIG } from './smoke-tests';
+
+describe('config manual refresh', () => {
+  jest.setTimeout(60 * 5 * 1000);
+  let db: StartedTestContainer;
+  let birdbox: BirdBox;
+  let client: CubejsApi;
+
+  beforeAll(async () => {
+    db = await PostgresDBRunner.startContainer({});
+    birdbox = await getBirdbox(
+      'postgres',
+      {
+        ...DEFAULT_CONFIG,
+
+        CUBEJS_DB_TYPE: 'postgres',
+        CUBEJS_DB_HOST: db.getHost(),
+        CUBEJS_DB_PORT: `${db.getMappedPort(5432)}`,
+        CUBEJS_DB_NAME: 'test',
+        CUBEJS_DB_USER: 'test',
+        CUBEJS_DB_PASS: 'test',
+
+        CUBEJS_ROLLUP_ONLY: 'true',
+        CUBEJS_REFRESH_WORKER: 'false',
+        CUBEJS_PRE_AGGREGATIONS_BUILDER: 'true',
+      },
+      {
+        schemaDir: 'preaggregation/schema',
+      }
+    );
+    client = cubejs(async () => 'test', {
+      apiUrl: birdbox.configuration.apiUrl,
+    });
+  });
+
+  afterAll(async () => {
+    await birdbox.stop();
+    await db.stop();
+  });
+
+  test('manual refresh', async () => {
+    const response = await client.load({
+      order: {
+        'Orders.status': 'asc',
+      },
+      measures: [
+        'Orders.count',
+      ],
+      dimensions: [
+        'Orders.status',
+      ],
+    });
+    expect(response.rawData()).toEqual(
+      [
+        { 'Orders.count': '2', 'Orders.status': 'new' },
+        { 'Orders.count': '2', 'Orders.status': 'processed' },
+        { 'Orders.count': '1', 'Orders.status': 'shipped' }
+      ]
+    );
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

N/A

**Description of Changes Made (if issue reference is not provided)**

Fixes configuration such that CUBEJS_PRE_AGGREGATIONS_BUILDER always enables preaggregation building. 

For example, the next configuration always builds preaggregations before answering a query, including on-the-fly if the necessary preaggregations are not built yet.

```
CUBEJS_ROLLUP_ONLY: 'true',
CUBEJS_REFRESH_WORKER: 'false',
CUBEJS_PRE_AGGREGATIONS_BUILDER: 'true',
```
