### PR TITLE
Fix a type inference failure

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -815,7 +815,7 @@ declare module '@cubejs-client/core' {
 
   type QueryArrayRecordType<T extends DeeplyReadonly<Query[]>> =
     T extends readonly [infer First, ...infer Rest]
-      ? SingleQueryRecordType<First> | QueryArrayRecordType<Rest>
+      ? SingleQueryRecordType<First> | QueryArrayRecordType<Rest & DeeplyReadonly<Query[]>>
       : never;
 
   // If we can't infer any members at all, then return any.


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet (n/a)
- [x] Docs have been added / updated if required (n/a)

#5065

The compiler was complaining about:

```ts
  type QueryArrayRecordType<T extends DeeplyReadonly<Query[]>> =
    T extends readonly [infer First, ...infer Rest]
      ? SingleQueryRecordType<First> | QueryArrayRecordType<Rest>
      : never;
```

`Rest` must be `DeeplyReadonly<Query[]>`, but apparently the compiler isn't inferring that, so it's complaining. This PR adds adds a union that actually does nothing, but give tsc the confidence to succeed.