### PR TITLE
feat(cubesql): Support DEALLOCATE in pg-wire

### DIFF
--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -657,6 +657,30 @@ impl PostgresIntegrationTestSuite {
 
         Ok(())
     }
+
+    async fn test_simple_query_deallocate_specific(&self) -> RunResult<()> {
+        self.test_simple_query("PREPARE simple_query AS SELECT 1".to_string(), |_| {})
+            .await?;
+
+        self.test_simple_query("DEALLOCATE simple_query".to_string(), |_| {})
+            .await?;
+
+        // TODO: Check select * from pg_catalog.pg_prepared_statements
+
+        Ok(())
+    }
+
+    async fn test_simple_query_deallocate_all(&self) -> RunResult<()> {
+        self.test_simple_query("PREPARE simple_query AS SELECT 1".to_string(), |_| {})
+            .await?;
+
+        self.test_simple_query("DEALLOCATE ALL".to_string(), |_| {})
+            .await?;
+
+        // TODO: Check select * from pg_catalog.pg_prepared_statements
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -685,6 +709,8 @@ impl AsyncTestSuite for PostgresIntegrationTestSuite {
             false,
         )
         .await?;
+        self.test_simple_query_deallocate_specific().await?;
+        self.test_simple_query_deallocate_all().await?;
 
         // PostgreSQL doesn't support unsigned integers in the protocol, it's a constraint only
         self.test_snapshot_execute_query(

--- a/rust/cubesql/cubesql/src/sql/types.rs
+++ b/rust/cubesql/cubesql/src/sql/types.rs
@@ -104,6 +104,8 @@ pub enum CommandCompletion {
     DeclareCursor,
     CloseCursor,
     CloseCursorAll,
+    Deallocate,
+    DeallocateAll,
     Discard(String),
 }
 
@@ -123,6 +125,10 @@ impl CommandCompletion {
             CommandCompletion::CloseCursor => CommandComplete::Plain("CLOSE CURSOR".to_string()),
             CommandCompletion::CloseCursorAll => {
                 CommandComplete::Plain("CLOSE CURSOR ALL".to_string())
+            }
+            CommandCompletion::Deallocate => CommandComplete::Plain("DEALLOCATE".to_string()),
+            CommandCompletion::DeallocateAll => {
+                CommandComplete::Plain("DEALLOCATE ALL".to_string())
             }
             CommandCompletion::Discard(tp) => CommandComplete::Plain(format!("DISCARD {}", tp)),
             // ROWS COUNT


### PR DESCRIPTION
Hello!

> DEALLOCATE — deallocate a prepared statement

https://www.postgresql.org/docs/current/sql-deallocate.html

Thanks