### PR TITLE
feat(client-core): Add loadResponse and loadResponses to ResultSet

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -306,6 +306,9 @@ declare module '@cubejs-client/core' {
    * Provides a convenient interface for data manipulation.
    */
   export class ResultSet<T = any> {
+
+    loadResponse: LoadResponse<T>;
+    loadResponses: LoadResponse<T>[];
     /**
      * @hidden
      */


### PR DESCRIPTION
The loadResponse(s) that are set on the ResultSet allow determining some
useful metadata on a query. These attributes should be included in the
typing so that users writing in Typescript can access their information
without running into errors from the missing attributes.

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required