### PR TITLE
feat(@cubejs-client/vue3): support logical operator filters (#2950)

### DIFF
--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -24,6 +24,50 @@ const toOrderMember = (member) => ({
 const reduceOrderMembers = (array) =>
   array.reduce((acc, { id, order }) => (order !== 'none' ? [...acc, [id, order]] : acc), []);
 
+const operators = [ 'and', 'or' ]
+
+const validateFilters = (filters) =>
+  filters.reduce((acc, raw) => {
+    if (raw.operator) {
+      return [...acc, raw];
+    }
+
+    const validBooleanFilter = operators.reduce((acc, operator) => {
+      const filters = raw[operator];
+
+      const booleanFilters = validateFilters(filters || []);
+
+      if (booleanFilters.length) {
+        return { ...acc, [operator]: booleanFilters };
+      }
+
+      return acc;
+    }, {});
+
+    if (operators.some((operator) => validBooleanFilter[operator])) {
+      return [...acc, validBooleanFilter];
+    }
+
+    return acc;
+  }, []);
+
+const getDimensionOrMeasure = (meta, m) => {
+  const memberName = m.member || m.dimension;
+  return memberName && meta.resolveMember(memberName, ['dimensions', 'measures']);
+};
+
+const resolveMembers = (meta, arr) =>
+  arr &&
+  arr.map((e, index) => {
+    return {
+      ...e,
+      member: getDimensionOrMeasure(meta, e),
+      index,
+      and: resolveMembers(meta, e.and),
+      or: resolveMembers(meta, e.or),
+    };
+  });
+
 export default {
   components: {
     QueryRenderer,
@@ -268,9 +312,11 @@ export default {
           });
         } else if (element === 'filters') {
           toQuery = (member) => ({
-            member: member.member.name,
+            member: member.member && member.member.name,
             operator: member.operator,
             values: member.values,
+            and: member.and && member.and.map(toQuery),
+            or: member.or && member.or.map(toQuery),
           });
         }
 
@@ -282,7 +328,7 @@ export default {
       });
 
       if (validatedQuery.filters) {
-        validatedQuery.filters = validatedQuery.filters.filter((f) => f.operator);
+        validatedQuery.filters = validateFilters(validatedQuery.filters)
       }
 
       // only set limit and offset if there are elements otherwise an invalid request with just limit/offset
@@ -396,15 +442,19 @@ export default {
         },
         index,
       }));
-      this.filters = filters.map((m, index) => ({
-        ...m,
-        member: this.meta.resolveMember(m.member || m.dimension, ['dimensions', 'measures']),
-        operators: this.meta.filterOperatorsForMember(m.member || m.dimension, [
-          'dimensions',
-          'measures',
-        ]),
-        index,
-      }));
+
+      const memberTypes = ['dimensions', 'measures'];
+      this.filters = filters.map((m, index) => {
+        const memberName = m.member || m.dimension;
+        return {
+          ...m,
+          member: memberName && this.meta.resolveMember(memberName, memberTypes),
+          operators: memberName && this.meta.filterOperatorsForMember(memberName, memberTypes),
+          and: resolveMembers(this.meta, m.and),
+          or: resolveMembers(this.meta, m.or),
+          index,
+        };
+      });
 
       this.availableMeasures = this.meta.membersForQuery({}, 'measures') || [];
       this.availableDimensions = this.meta.membersForQuery({}, 'dimensions') || [];
@@ -438,14 +488,12 @@ export default {
           };
         }
       } else if (element === 'filters') {
-        const filterMember = {
-          ...this.meta.resolveMember(member.member || member.dimension, ['dimensions', 'measures']),
-        };
-
         mem = {
           ...member,
-          member: filterMember,
-        };
+          and: resolveMembers(this.meta, member.and),
+          or: resolveMembers(this.meta, member.or),
+          member: getDimensionOrMeasure(this.meta, member),
+        }
       } else {
         mem = this[`available${name}`].find((m) => m.name === member);
       }
@@ -495,13 +543,11 @@ export default {
         }
       } else if (element === 'filters') {
         index = this[element].findIndex((x) => x.dimension === old);
-        const filterMember = {
-          ...this.meta.resolveMember(member.member || member.dimension, ['dimensions', 'measures']),
-        };
-
         mem = {
           ...member,
-          member: filterMember,
+          and: resolveMembers(this.meta, member.and),
+          or: resolveMembers(this.meta, member.or),
+          member: getDimensionOrMeasure(this.meta, member),
         };
       } else {
         index = this[element].findIndex((x) => x.name === old);
@@ -535,13 +581,11 @@ export default {
             };
           }
         } else if (element === 'filters') {
-          const member = {
-            ...this.meta.resolveMember(m.member || m.dimension, ['dimensions', 'measures']),
-          };
-
           mem = {
             ...m,
-            member,
+            and: resolveMembers(this.meta, m.and),
+            or: resolveMembers(this.meta, m.or),
+            member: getDimensionOrMeasure(this.meta, m),
           };
         } else {
           mem = this[`available${name}`].find((x) => x.name === m);


### PR DESCRIPTION
Signed-off-by: José Luis Di Biase <josx@interorganic.com.ar>

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**
> But for vue3
https://github.com/cube-js/cube.js/issues/2097
https://github.com/cube-js/cube.js/pull/2950

**Description of Changes Made (if issue reference is not provided)**

Support for filters containing [boolean logical operators](https://cube.dev/docs/query-format#boolean-logical-operators). Previously, fields and and or were discarded by validatedQuery watcher.
It is based on the last commits on vue cliente regarding this topic:

- https://github.com/cube-js/cube.js/commit/1313dad6a1f4b9da7e6ca194415b1a756e715692
- https://github.com/cube-js/cube.js/commit/8a3bb3dc8e427c30d2ac0cdd504662087dcf1e19
- https://github.com/cube-js/cube.js/commit/904171ee85185f1ba1fcf812ba58ae6bc11b8407
