### PR TITLE
fix(@cubejs-client/vue3): avoid setQuery Vue3 warnings (#5084)

### DIFF
--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -140,7 +140,6 @@ export default {
         order,
         orderMembers,
         setOrder: this.setOrder,
-        setQuery: this.setQuery,
         pivotConfig: this.pivotConfig,
         updateOrder: {
           set: (memberId, newOrder) => {


### PR DESCRIPTION
Signed-off-by: José Luis Di Biase <josx@interorganic.com.ar>

**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#5084 


**Description of Changes Made (if issue reference is not provided)**

Avoid annoying "[Vue warn]: Property "setQuery" was accessed during render but is not defined on instance"
