### PR TITLE
feat(cubesql): Support Node.js 18.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
     name: Build native Linux ${{ matrix.node-version }} ${{ matrix.target }}
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [12, 14, 16, 17, 18]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
         include:
           - target: aarch64-unknown-linux-gnu
@@ -133,7 +133,7 @@ jobs:
     name: Build ${{ matrix.os-version }} ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
         os-version: [windows-2019, macos-11]
       fail-fast: false
 

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -125,7 +125,7 @@ jobs:
     name: Build Linux GNU ${{ matrix.node-version }}.x ${{ matrix.target }}
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [12, 14, 16, 17, 18]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
       fail-fast: false
     container:
@@ -193,7 +193,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
         os-version: [windows-2019, macos-11]
       fail-fast: false
 


### PR DESCRIPTION
This PR introduce support for @cubejs-backend/native (SQL API) for Node.js 18. In the October 2022, Node.js 18 will be flagged as LTS.