### PR TITLE
fix(cubesql): Normalize error messsage

### DIFF
--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -694,7 +694,7 @@ impl PostgresIntegrationTestSuite {
 
         assert_eq!(
             err.to_string(),
-            "db error: ERROR: Internal(None): Unexpected panic. Reason: attempt to multiply with overflow None"
+            "db error: ERROR: Internal: Unexpected panic. Reason: attempt to multiply with overflow"
         );
 
         Ok(())

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -71,22 +71,12 @@ impl CubeError {
 
 impl fmt::Display for CubeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fn write_fmt(
-            cause: CubeErrorCauseType,
-            message: String,
-            f: &mut Formatter<'_>,
-        ) -> fmt::Result {
-            match &cause {
-                CubeErrorCauseType::User(meta) => {
-                    f.write_fmt(format_args!("{} {:?}", message, meta))
-                }
-                CubeErrorCauseType::Internal(meta) => {
-                    f.write_fmt(format_args!("{:?}: {} {:?}", cause, message, meta))
-                }
+        match self.cause {
+            CubeErrorCauseType::User(_) => f.write_fmt(format_args!("User: {}", self.message)),
+            CubeErrorCauseType::Internal(_) => {
+                f.write_fmt(format_args!("Internal: {}", self.message))
             }
         }
-
-        write_fmt(self.cause.clone(), self.message.clone(), f)
     }
 }
 


### PR DESCRIPTION
Before this PR, our error messages which clients saw were with debug information. `fmt::Display` trait should implement human-readable text without debug information.

<img width="862" alt="image" src="https://user-images.githubusercontent.com/572096/185911528-ef116645-7a79-4685-b74b-dd3092147b67.png">
