### PR TITLE
feat(cubesql): Simplify filter for true literal

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -2748,7 +2748,7 @@ mod tests {
     use cubeclient::models::{
         V1CubeMeta, V1CubeMetaDimension, V1CubeMetaMeasure, V1CubeMetaSegment, V1LoadResponse,
     };
-    use datafusion::dataframe::DataFrame as DFDataFrame;
+    use datafusion::{dataframe::DataFrame as DFDataFrame, logical_plan::plan::Filter};
     use pretty_assertions::assert_eq;
     use regex::Regex;
 
@@ -2982,6 +2982,27 @@ mod tests {
         fn find_projection_schema(&self) -> DFSchemaRef;
 
         fn find_cube_scan(&self) -> CubeScanNode;
+
+        fn find_filter(&self) -> Option<Filter>;
+    }
+
+    fn find_filter_deep_search(parent: Arc<LogicalPlan>) -> Option<Filter> {
+        pub struct FindFilterNodeVisitor(Option<Filter>);
+
+        impl PlanVisitor for FindFilterNodeVisitor {
+            type Error = CubeError;
+
+            fn pre_visit(&mut self, plan: &LogicalPlan) -> Result<bool, Self::Error> {
+                if let LogicalPlan::Filter(filter) = plan {
+                    self.0 = Some(filter.clone());
+                }
+                Ok(true)
+            }
+        }
+
+        let mut visitor = FindFilterNodeVisitor(None);
+        parent.accept(&mut visitor).unwrap();
+        visitor.0
     }
 
     impl LogicalPlanTestUtils for LogicalPlan {
@@ -2994,6 +3015,10 @@ mod tests {
 
         fn find_cube_scan(&self) -> CubeScanNode {
             find_cube_scan_deep_search(Arc::new(self.clone()))
+        }
+
+        fn find_filter(&self) -> Option<Filter> {
+            find_filter_deep_search(Arc::new(self.clone()))
         }
     }
 
@@ -6062,6 +6087,78 @@ ORDER BY \"COUNT(count)\" DESC"
                 DatabaseProtocol::PostgreSQL
             )
             .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_literal_filter_simplify() -> Result<(), CubeError> {
+        init_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            "
+                SELECT
+                  \"customer_gender\"
+                FROM \"KibanaSampleDataEcommerce\"
+                WHERE TRUE = TRUE
+                LIMIT 1000;"
+                .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                segments: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                time_dimensions: None,
+                order: None,
+                limit: Some(1000),
+                offset: None,
+                filters: None,
+            }
+        );
+        assert_eq!(
+            logical_plan.find_filter().is_none(),
+            true,
+            "Filter must be eliminated"
+        );
+
+        let query_plan = convert_select_to_query_plan(
+            "
+                SELECT
+                  \"customer_gender\"
+                FROM \"KibanaSampleDataEcommerce\"
+                WHERE TRUE = TRUE AND customer_gender = 'male'
+                LIMIT 1000;"
+                .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                segments: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                time_dimensions: None,
+                order: None,
+                limit: Some(1000),
+                offset: None,
+                filters: Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("equals".to_string()),
+                    values: Some(vec!["male".to_string()]),
+                    or: None,
+                    and: None,
+                }]),
+            }
         );
 
         Ok(())

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -5,11 +5,12 @@ use crate::{
         rewrite::{
             analysis::{ConstantFolding, LogicalPlanAnalysis},
             between_expr, binary_expr, case_expr, case_expr_var_arg, cast_expr, change_user_member,
-            column_expr, cube_scan, cube_scan_filters, cube_scan_members, dimension_expr,
-            expr_column_name, filter, filter_cast_unwrap_replacer, filter_member, filter_op,
-            filter_op_filters, filter_replacer, fun_expr, fun_expr_var_arg, inlist_expr,
-            is_not_null_expr, is_null_expr, limit, literal_expr, literal_string, measure_expr,
-            member_name_by_alias, not_expr, projection, rewrite,
+            column_expr, cube_scan, cube_scan_filters, cube_scan_filters_empty_tail,
+            cube_scan_members, dimension_expr, expr_column_name, filter,
+            filter_cast_unwrap_replacer, filter_member, filter_op, filter_op_filters,
+            filter_replacer, fun_expr, fun_expr_var_arg, inlist_expr, is_not_null_expr,
+            is_null_expr, limit, literal_expr, literal_string, measure_expr, member_name_by_alias,
+            not_expr, projection, rewrite,
             rewriter::RewriteRules,
             scalar_fun_expr_args, scalar_fun_expr_args_empty_tail, segment_member,
             time_dimension_date_range_replacer, time_dimension_expr, transforming_rewrite,
@@ -82,6 +83,7 @@ impl RewriteRules for FilterRules {
                 ),
                 self.push_down_filter("?alias_to_cube", "?expr", "?filter_alias_to_cube"),
             ),
+            // Transform Filter: Boolean(False)
             transforming_rewrite(
                 "push-down-limit-filter",
                 filter(
@@ -183,6 +185,13 @@ impl RewriteRules for FilterRules {
                         "?alias",
                     ),
                 ),
+            ),
+            // Transform Filter: Boolean(True) same as TRUE = TRUE, which is useless
+            transforming_rewrite(
+                "filter-truncate-true",
+                filter_replacer(literal_expr("?literal"), "?alias_to_cube", "?members"),
+                cube_scan_filters_empty_tail(),
+                self.truncate_filter_literal_true("?literal"),
             ),
             transforming_rewrite(
                 "filter-replacer",
@@ -989,6 +998,22 @@ impl FilterRules {
                         new_limit_n_var,
                         egraph.add(LogicalPlanLanguage::LimitN(LimitN(0))),
                     );
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
+    fn truncate_filter_literal_true(
+        &self,
+        literal_var: &'static str,
+    ) -> impl Fn(&mut EGraph<LogicalPlanLanguage, LogicalPlanAnalysis>, &mut Subst) -> bool {
+        let literal_var = var!(literal_var);
+
+        move |egraph, subst| {
+            for literal_value in var_iter!(egraph[subst[literal_var]], LiteralExprValue) {
+                if let ScalarValue::Boolean(Some(true)) = literal_value {
                     return true;
                 }
             }


### PR DESCRIPTION
There is a problem with `Filter: True` which we didn't truncate before this PR. Filter node is a limitation for implementation of limit push down through projections for queries which contain `Filter` or `Aggregation` nodes.