### PR TITLE
feat(cubesql): Increase limits for statements/portals/cursors

### DIFF
--- a/rust/cubesql/cubesql/src/sql/server_manager.rs
+++ b/rust/cubesql/cubesql/src/sql/server_manager.rs
@@ -26,9 +26,10 @@ pub struct ServerConfiguration {
 impl Default for ServerConfiguration {
     fn default() -> Self {
         Self {
-            connection_max_prepared_statements: 50,
-            connection_max_cursors: 15,
-            connection_max_portals: 15,
+            connection_max_prepared_statements: 128,
+            connection_max_portals: 64,
+            // by default cursor can be used only inside transaction
+            connection_max_cursors: 16,
         }
     }
 }


### PR DESCRIPTION
I've implemented these limits to protect possible memory leaks because at the begining, we didn't implement: discard/diallocate/transactions. Right now, it's safe to increase these limits.

- Prepared statements: 128, because some PG clients use the local map to parse statements once, and then it reuses them while a connection is still alive.
- Cursors: 16, because by default it lives inside a transaction. Some clients can use `WITH HOLD` to use it without a transaction.
- Portals: 64, because It's a too large object, and it should be closed after usage. Previously it was 15, but let's give it a try.