### PR TITLE
feat(cubesql): Support DateTrunc qtr granularity for analytics queries

### DIFF
--- a/rust/cubesql/cubesql/src/compile/context.rs
+++ b/rust/cubesql/cubesql/src/compile/context.rs
@@ -287,8 +287,9 @@ impl QueryContext {
             [ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(ast::Expr::Value(ast::Value::SingleQuotedString(granularity)))), ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(ast::Expr::Identifier(column)))] => {
                 let possible_dimension_name = column.value.to_string();
 
-                match granularity.as_str() {
-                    "second" | "minute" | "hour" | "day" | "week" | "month" | "quarter" | "year" => (),
+                let granularity_value = match granularity.as_str() {
+                    "second" | "minute" | "hour" | "day" | "week" | "month" | "quarter" | "year" => granularity.clone(),
+                    "qtr" => "quarter".to_string(),
                     _ => {
                         return Err(CompilationError::user(format!(
                             "Unsupported granularity {:?}",
@@ -299,7 +300,7 @@ impl QueryContext {
 
                 if let Some(r) = self.find_dimension_for_identifier(&possible_dimension_name) {
                     if r.is_time() {
-                        Ok(Selection::TimeDimension(r, granularity.clone()))
+                        Ok(Selection::TimeDimension(r, granularity_value))
                     } else {
                         Err(CompilationError::user(format!(
                             "Unable to use non time dimension \"{}\" as a column in date_trunc, please specify time dimension",

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -1,3 +1,4 @@
+use super::utils;
 use crate::{
     compile::{
         engine::provider::CubeContext,
@@ -39,8 +40,6 @@ use datafusion::{
 };
 use egg::{EGraph, Rewrite, Subst, Var};
 use std::{fmt::Display, ops::Index, sync::Arc};
-
-use super::members::MemberRules;
 
 pub struct FilterRules {
     cube_context: Arc<CubeContext>,
@@ -1767,7 +1766,7 @@ impl FilterRules {
         let granularity_var = var!(granularity_var);
         move |egraph, subst| {
             for granularity in var_iter!(egraph[subst[granularity_var]], LiteralExprValue) {
-                match MemberRules::parse_granularity(granularity, false) {
+                match utils::parse_granularity(granularity, false) {
                     Some(granularity)
                         if granularity.to_lowercase() == target_granularity.to_lowercase() =>
                     {

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/mod.rs
@@ -6,6 +6,7 @@ pub mod filters;
 pub mod members;
 pub mod order;
 pub mod split;
+pub mod utils;
 
 pub fn replacer_push_down_node(
     name: &str,

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -1,0 +1,21 @@
+use datafusion::scalar::ScalarValue;
+
+pub fn parse_granularity(granularity: &ScalarValue, to_normalize: bool) -> Option<String> {
+    match granularity {
+        ScalarValue::Utf8(Some(granularity)) => {
+            if to_normalize {
+                match granularity.to_lowercase().as_str() {
+                    "dow" | "doy" => Some("day".to_string()),
+                    "qtr" => Some("quarter".to_string()),
+                    _ => Some(granularity.to_lowercase()),
+                }
+            } else {
+                match granularity.to_lowercase().as_str() {
+                    "qtr" => Some("quarter".to_string()),
+                    _ => Some(granularity.to_lowercase()),
+                }
+            }
+        }
+        _ => None,
+    }
+}


### PR DESCRIPTION
Hello!

Thought Spot uses `qtr` granularity for `DateTrunc` function, which is the same as `quarter`.

Thanks