### PR TITLE
fix: Wrong cast to string in cubestore driver, UNIQUE KEY brackets missing  

### DIFF
--- a/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreDriver.ts
@@ -94,7 +94,7 @@ export class CubeStoreDriver extends BaseDriver implements DriverInterface {
       sql = `${sql} WITH (${withEntries.join(', ')})`;
     }
     if (options.uniqueKey) {
-      sql = `${sql} UNIQUE KEY ${options.uniqueKey}`;
+      sql = `${sql} UNIQUE KEY (${options.uniqueKey})`;
     }
     if (options.aggregations) {
       sql = `${sql} ${options.aggregations}`;

--- a/packages/cubejs-cubestore-driver/src/CubeStoreQuery.ts
+++ b/packages/cubejs-cubestore-driver/src/CubeStoreQuery.ts
@@ -98,6 +98,10 @@ export class CubeStoreQuery extends BaseQuery {
     return `cardinality(${sql})`;
   }
 
+  public castToString(sql) {
+    return `CAST(${sql} as VARCHAR)`;
+  }
+
   public countDistinctApprox(sql) {
     // TODO: We should throw an error, but this gets called even when only `hllMerge` result is used.
     return `approx_distinct_is_unsupported_in_cubestore(${sql}))`;


### PR DESCRIPTION
Fixed cast to string on count() with unique keys. Also fixed the unique key definition.

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/5086936/186690193-8810f438-3fac-43d3-a454-2105febd5d96.png">

<img width="1593" alt="image" src="https://user-images.githubusercontent.com/5086936/186692556-3d5312b4-fd24-411a-bca9-aa0ef880dd2d.png">

<img width="449" alt="image" src="https://user-images.githubusercontent.com/5086936/186692645-a2e89f9e-d33f-4b45-aa38-ad7e83b60f78.png">
