### PR TITLE
chore: plain error messages

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1161,6 +1161,8 @@ class ApiGateway {
   }: any) {
     const { requestId } = context ?? {};
     
+    const plainError = e.plainMessages;
+    
     if (e instanceof CubejsHandlerError) {
       this.log({
         type: e.type,
@@ -1168,7 +1170,7 @@ class ApiGateway {
         error: e.message,
         duration: this.duration(requestStarted)
       }, context);
-      res({ error: e.message, stack: e.stack, requestId }, { status: e.status });
+      res({ error: e.message, stack: e.stack, requestId, plainError }, { status: e.status });
     } else if (e.error === 'Continue wait') {
       this.log({
         type: 'Continue wait',
@@ -1196,6 +1198,7 @@ class ApiGateway {
         {
           type: e.type,
           error: e.message,
+          plainError,
           stack: e.stack,
           requestId
         },
@@ -1208,7 +1211,7 @@ class ApiGateway {
         error: e.stack || e.toString(),
         duration: this.duration(requestStarted)
       }, context);
-      res({ error: e.toString(), stack: e.stack, requestId }, { status: 500 });
+      res({ error: e.toString(), stack: e.stack, requestId, plainError, }, { status: 500 });
     }
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CompileError.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CompileError.ts
@@ -1,6 +1,7 @@
 export class CompileError extends Error {
   public constructor(
     protected readonly messages: string,
+    protected readonly plainMessages?: string,
   ) {
     super(`Compile errors:\n${messages}`);
   }

--- a/packages/cubejs-schema-compiler/src/compiler/ErrorReporter.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/ErrorReporter.ts
@@ -5,6 +5,7 @@ import { CompileError } from './CompileError';
 
 export interface CompilerErrorInterface {
   message: string;
+  plainMessage?: string
   fileName?: string;
   lineNumber?: string;
   position?: number;
@@ -12,6 +13,7 @@ export interface CompilerErrorInterface {
 
 export interface SyntaxErrorInterface {
   message: string;
+  plainMessage?: string
   loc: SourceLocation | null,
 }
 
@@ -54,7 +56,8 @@ export class ErrorReporter {
         message: e.message,
         highlightCode: true,
       });
-      const message = `Warning: ${e.message} in ${this.file.fileName}\n${codeFrame}`;
+      const plainMessage = `Warning: ${e.message} in ${this.file.fileName}`;
+      const message = `${plainMessage}\n${codeFrame}`;
 
       if (this.rootReporter().warnings.find(m => (m.message || m) === message)) {
         return;
@@ -62,6 +65,7 @@ export class ErrorReporter {
 
       this.rootReporter().warnings.push({
         message,
+        plainMessage,
         loc: e.loc,
       });
 
@@ -83,7 +87,8 @@ export class ErrorReporter {
         message: e.message,
         highlightCode: true,
       });
-      const message = `Syntax Error: ${e.message} in ${this.file.fileName}\n${codeFrame}`;
+      const plainMessage = `Syntax Error: ${e.message} in ${this.file.fileName}`;
+      const message = `${plainMessage}\n${codeFrame}`;
 
       if (this.rootReporter().errors.find(m => (m.message || m) === message)) {
         return;
@@ -91,6 +96,7 @@ export class ErrorReporter {
 
       this.rootReporter().errors.push({
         message,
+        plainMessage,
       });
     } else {
       if (this.rootReporter().errors.find(m => (m.message || m) === e.message)) {
@@ -125,7 +131,8 @@ export class ErrorReporter {
   public throwIfAny() {
     if (this.rootReporter().errors.length) {
       throw new CompileError(
-        this.rootReporter().errors.map((e) => e.message).join('\n')
+        this.rootReporter().errors.map((e) => e.message).join('\n'),
+        this.rootReporter().errors.map((e) => e.plainMessage).join('\n')
       );
     }
   }


### PR DESCRIPTION
Introduce `plainError` as an alternative to the error containing code frames