### PR TITLE
feat(cubesql): Support `LOCALTIMESTAMP`

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -1226,7 +1226,7 @@ pub fn create_str_to_date_udf() -> ScalarUDF {
     )
 }
 
-pub fn create_current_timestamp_udf() -> ScalarUDF {
+pub fn create_current_timestamp_udf(name: &str) -> ScalarUDF {
     let fun: Arc<dyn Fn(&[ColumnarValue]) -> Result<ColumnarValue> + Send + Sync> =
         Arc::new(move |_| panic!("Should be rewritten with UtcTimestamp function"));
 
@@ -1234,7 +1234,7 @@ pub fn create_current_timestamp_udf() -> ScalarUDF {
         Arc::new(move |_| Ok(Arc::new(DataType::Timestamp(TimeUnit::Nanosecond, None))));
 
     ScalarUDF::new(
-        "current_timestamp",
+        name,
         &Signature::exact(vec![], Volatility::Immutable),
         &return_type,
         &fun,

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -2449,7 +2449,8 @@ WHERE `TABLE_SCHEMA` = '{}'",
         ctx.register_udf(create_date_sub_udf());
         ctx.register_udf(create_date_add_udf());
         ctx.register_udf(create_str_to_date_udf());
-        ctx.register_udf(create_current_timestamp_udf());
+        ctx.register_udf(create_current_timestamp_udf("current_timestamp"));
+        ctx.register_udf(create_current_timestamp_udf("localtimestamp"));
         ctx.register_udf(create_current_schema_udf());
         ctx.register_udf(create_current_schemas_udf());
         ctx.register_udf(create_format_type_udf());
@@ -10682,6 +10683,21 @@ ORDER BY \"COUNT(count)\" DESC"
                     key_seq
                 "
                 .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_localtimestamp() -> Result<(), CubeError> {
+        // TODO: the value will be different with the introduction of TZ support
+        insta::assert_snapshot!(
+            "localtimestamp",
+            execute_query(
+                "SELECT localtimestamp = current_timestamp".to_string(),
                 DatabaseProtocol::PostgreSQL
             )
             .await?

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
@@ -242,6 +242,11 @@ impl RewriteRules for DateRules {
                 fun_expr("UtcTimestamp", Vec::<String>::new()),
             ),
             rewrite(
+                "localtimestamp-to-now",
+                udf_expr("localtimestamp", Vec::<String>::new()),
+                fun_expr("UtcTimestamp", Vec::<String>::new()),
+            ),
+            rewrite(
                 "tableau-week",
                 binary_expr(
                     fun_expr(

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__localtimestamp.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__localtimestamp.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT localtimestamp = current_timestamp\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---------------+
+| Boolean(true) |
++---------------+
+| true          |
++---------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR adds support for `LOCALTIMESTAMP` function, which is currently equivalent to `CURRENT_TIMESTAMP`. It also adds a related test.