### PR TITLE
chore(cubesql): Helpers for checking Arrows's DataType

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -507,12 +507,15 @@ macro_rules! variant_field_struct {
                     let typed_str = s.strip_prefix(&prefix).ok_or(CubeError::internal(format!("Can't convert {}. Should start with '{}'", s, prefix)))?;
 
                     match typed_str {
+                        "Float32" => Ok([<$variant $var_field:camel>](DataType::Float32)),
+                        "Float64" => Ok([<$variant $var_field:camel>](DataType::Float64)),
                         "Int32" => Ok([<$variant $var_field:camel>](DataType::Int32)),
                         "Int64" => Ok([<$variant $var_field:camel>](DataType::Int64)),
                         "Boolean" => Ok([<$variant $var_field:camel>](DataType::Boolean)),
                         "Utf8" => Ok([<$variant $var_field:camel>](DataType::Utf8)),
                         "Date32" => Ok([<$variant $var_field:camel>](DataType::Date32)),
-                        _ => Err(CubeError::internal(format!("Can't convert {}. Should contains type type, actual: {}", s, typed_str))),
+                        "Date64" => Ok([<$variant $var_field:camel>](DataType::Date64)),
+                        _ => Err(CubeError::internal(format!("Can't convert {}. Should contain a valid type, actual: {}", s, typed_str))),
                     }
                 }
             }

--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -495,6 +495,36 @@ macro_rules! variant_field_struct {
         }
     };
 
+    ($variant:ident, $var_field:ident, DataType) => {
+        paste::item! {
+            #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+            pub struct [<$variant $var_field:camel>](DataType);
+
+            impl FromStr for [<$variant $var_field:camel>] {
+                type Err = CubeError;
+                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                    let prefix = format!("{}:", std::stringify!([<$variant $var_field:camel>]));
+                    let typed_str = s.strip_prefix(&prefix).ok_or(CubeError::internal(format!("Can't convert {}. Should start with '{}'", s, prefix)))?;
+
+                    match typed_str {
+                        "Int32" => Ok([<$variant $var_field:camel>](DataType::Int32)),
+                        "Int64" => Ok([<$variant $var_field:camel>](DataType::Int64)),
+                        "Boolean" => Ok([<$variant $var_field:camel>](DataType::Boolean)),
+                        "Utf8" => Ok([<$variant $var_field:camel>](DataType::Utf8)),
+                        "Date32" => Ok([<$variant $var_field:camel>](DataType::Date32)),
+                        _ => Err(CubeError::internal(format!("Can't convert {}. Should contains type type, actual: {}", s, typed_str))),
+                    }
+                }
+            }
+
+            impl std::fmt::Display for [<$variant $var_field:camel>] {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{}", self.0)
+                }
+            }
+        }
+    };
+
     ($variant:ident, $var_field:ident, ScalarValue) => {
         paste::item! {
             #[derive(Debug, PartialOrd, Clone)]

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -641,6 +641,10 @@ fn cast_expr(expr: impl Display, data_type: impl Display) -> String {
     format!("(CastExpr {} {})", expr, data_type)
 }
 
+fn cast_expr_explicit(expr: impl Display, data_type: DataType) -> String {
+    format!("(CastExpr {} (CastExprDataType:{}))", expr, data_type)
+}
+
 fn alias_expr(column: impl Display, alias: impl Display) -> String {
     format!("(AliasExpr {} {})", column, alias)
 }


### PR DESCRIPTION
This PR allows us to check `DataType` in any place where we want. It allows us to write more safety rules with casting.