### PR TITLE
Handle async errors by passing the error to next middleware

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -177,23 +177,31 @@ class ApiGateway {
       })(req, res);
     });
 
-    app.get(`${this.basePath}/v1/load`, userMiddlewares, (async (req, res) => {
-      await this.load({
-        query: req.query.query,
-        context: req.context,
-        res: this.resToResultFn(res),
-        queryType: req.query.queryType,
-      });
+    app.get(`${this.basePath}/v1/load`, userMiddlewares, (async (req, res, next) => {
+      try {
+        await this.load({
+          query: req.query.query,
+          context: req.context,
+          res: this.resToResultFn(res),
+          queryType: req.query.queryType,
+        });
+      } catch (err) {
+        next(err);
+      }
     }));
 
     const jsonParser = bodyParser.json({ limit: '1mb' });
-    app.post(`${this.basePath}/v1/load`, jsonParser, userMiddlewares, (async (req, res) => {
-      await this.load({
-        query: req.body.query,
-        context: req.context,
-        res: this.resToResultFn(res),
-        queryType: req.body.queryType
-      });
+    app.post(`${this.basePath}/v1/load`, jsonParser, userMiddlewares, (async (req, res, next) => {
+      try {
+        await this.load({
+          query: req.body.query,
+          context: req.context,
+          res: this.resToResultFn(res),
+          queryType: req.body.queryType
+        });
+      } catch (err) {
+        next(err);
+      }
     }));
 
     app.get(`${this.basePath}/v1/subscribe`, userMiddlewares, (async (req, res) => {

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 
-import { ApiGateway, ApiGatewayOptions, Query, Request } from '../src';
+import { ApiGateway, ApiGatewayOptions, CubejsHandlerError, Query, Request } from '../src';
 import { generateAuthToken } from './utils';
 import {
   preAggregationsResultFactory,
@@ -165,6 +165,34 @@ describe('API Gateway', () => {
     expect(res.body && res.body.data).toStrictEqual([{ 'Foo.bar': 42 }]);
 
     expect(queryRewrite.mock.calls.length).toEqual(1);
+  });
+
+  test('Ensure async errors passed on to error handling middleware ', async () => {
+    const queryRewrite = jest.fn(async () => {
+      throw new CubejsHandlerError(403, 'Forbidden', 'Unauthorized Access');
+    });
+
+    const { app } = createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {
+        checkAuth: (req: Request, authorization) => {
+          if (authorization) {
+            req.authInfo = jwt.verify(authorization, API_SECRET);
+          }
+        },
+        queryRewrite
+      }
+    );
+
+    await request(app)
+      .get(
+        '/cubejs-api/v1/load?query={"measures":["Foo.bar"],"filters":[{"dimension":"Foo.id","operator":"equals","values":[null]}]}'
+      )
+      .set('Authorization', 'Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjUsImlhdCI6MTYxMTg1NzcwNSwiZXhwIjoyNDc1ODU3NzA1fQ.tTieqdIcxDLG8fHv8YWwfvg_rPVe1XpZKUvrCdzVn3g')
+      .expect(403);
+
+    expect(queryRewrite).toHaveBeenCalledTimes(1);
   });
 
   test('query transform with checkAuth (return securityContext as string)', async () => {
@@ -571,8 +599,6 @@ describe('API Gateway', () => {
           this.$testConnectionsDone = true;
 
           throw new Error('It\'s expected exception for testing');
-
-          return [];
         }
       }
 
@@ -596,8 +622,6 @@ describe('API Gateway', () => {
           this.$testConnectionsDone = true;
 
           throw new Error('It\'s expected exception for testing');
-
-          return [];
         }
       }
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet

**Description of Changes Made (if issue reference is not provided)**
If express route handlers/middleware return async errors/rejected promise, they aren't passed on to next automatically but it's passed on for sync errors/uncaught exceptions.

I believe this is changing as a part of express 5 but I think this is a worthwhile addition until express 5 final release is out and we migrate to express 5.