### PR TITLE
chore(@cubejs-client/ngx): Align typescript to 4.3.5 with angular-dev…

### DIFF
--- a/packages/cubejs-client-ngx/package.json
+++ b/packages/cubejs-client-ngx/package.json
@@ -35,7 +35,7 @@
     "ng-packagr": "^12.1.2",
     "npm-watch": "^0.7.0",
     "tsickle": "^0.39.1",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.5"
   },
   "peerDependencies": {
     "@cubejs-client/core": ">=0.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27249,7 +27249,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.3.5:
+typescript@4.3.5, typescript@~4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
@@ -27263,11 +27263,6 @@ typescript@~4.1.5, typescript@~4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
   integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
-
-typescript@~4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
…kit/build-optimizer

Hello!

To reduce cache usage for `57.14MB`:


```
=> Found "@cubejs-client/ngx#typescript@4.2.4"
info This module exists because "_project_#@cubejs-client#ngx" depends on it.
info Disk size without dependencies: "57.14MB"
info Disk size with unique dependencies: "57.14MB"
info Disk size with transitive dependencies: "57.14MB"
info Number of shared dependencies: 0
=> Found "@angular-devkit/build-optimizer#typescript@4.3.5"
info This module exists because "_project_#@cubejs-client#ngx#@angular-devkit#build-angular#@angular-devkit#build-optimizer" depends on it.
```

Thanks