### PR TITLE
chore(deps): Upgrade TypeScript to 4.9 (aligned)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.2",
     "rollup": "2.53.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "repository": {
     "type": "git",

--- a/packages/cubejs-api-gateway/package.json
+++ b/packages/cubejs-api-gateway/package.json
@@ -63,7 +63,7 @@
     "mysql": "^2.18.1",
     "should": "^13.2.3",
     "supertest": "^4.0.2",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-athena-driver/package.json
+++ b/packages/cubejs-athena-driver/package.json
@@ -39,7 +39,7 @@
     "@cubejs-backend/linter": "^0.31.0",
     "@cubejs-backend/testing-shared": "^0.31.59",
     "@types/ramda": "^0.27.40",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-backend-cloud/package.json
+++ b/packages/cubejs-backend-cloud/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.20",
     "@types/request-promise": "^4.1.46",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "dependencies": {
     "@cubejs-backend/dotenv": "^9.0.2",

--- a/packages/cubejs-backend-cloud/src/live-preview.ts
+++ b/packages/cubejs-backend-cloud/src/live-preview.ts
@@ -35,7 +35,7 @@ export class LivePreviewWatcher {
       };
 
       return this.auth;
-    } catch (e) {
+    } catch (e: any) {
       internalExceptions(e);
       throw new Error('Live-preview token is invalid');
     }
@@ -123,7 +123,7 @@ export class LivePreviewWatcher {
         this.uploading = true;
         await this.deploy();
       }
-    } catch (e) {
+    } catch (e: any) {
       if (e.response && e.response.statusCode === 302) {
         this.auth = null;
         this.stopWatch('token expired or invalid, please re-run live-preview mode');

--- a/packages/cubejs-backend-maven/package.json
+++ b/packages/cubejs-backend-maven/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^12",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-backend-maven/src/maven-resolve.ts
+++ b/packages/cubejs-backend-maven/src/maven-resolve.ts
@@ -8,7 +8,7 @@ import { resolveDependencies, getDependenciesFromPackage } from './maven';
     await resolveDependencies(getDependenciesFromPackage(), {
       showOutput: true,
     });
-  } catch (e) {
+  } catch (e: any) {
     await displayCLIError(e, 'Maven Installer');
   }
 })();

--- a/packages/cubejs-backend-native/package.json
+++ b/packages/cubejs-backend-native/package.json
@@ -35,7 +35,7 @@
     "cargo-cp-artifact": "^0.1",
     "jest": "^26",
     "mysql2": "^2.3.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "dependencies": {
     "@cubejs-backend/cubesql": "^0.31.59",

--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -32,7 +32,7 @@
     "@types/shelljs": "^0.8.5",
     "@types/throttle-debounce": "^2.1.0",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "dependencies": {
     "@oclif/color": "^0.1.2",

--- a/packages/cubejs-backend-shared/src/http-utils.ts
+++ b/packages/cubejs-backend-shared/src/http-utils.ts
@@ -88,7 +88,7 @@ export async function downloadAndExtractFile(url: string, { cwd }: DownloadAndEx
 
   try {
     mkdirpSync(cwd);
-  } catch (e) {
+  } catch (e: any) {
     internalExceptions(e);
   }
 
@@ -103,7 +103,7 @@ export async function downloadAndExtractFile(url: string, { cwd }: DownloadAndEx
 
   try {
     fs.unlinkSync(savedFilePath);
-  } catch (e) {
+  } catch (e: any) {
     internalExceptions(e);
   }
 

--- a/packages/cubejs-backend-shared/src/promises.ts
+++ b/packages/cubejs-backend-shared/src/promises.ts
@@ -362,7 +362,7 @@ export const asyncMemoizeBackground = <Ret, Arguments>(
 
       bucket.item = item;
       bucket.lifetime = Date.now() + options.extractCacheLifetime(item);
-    } catch (e) {
+    } catch (e: any) {
       options.onBackgroundException(e);
     }
   };

--- a/packages/cubejs-backend-shared/src/track.ts
+++ b/packages/cubejs-backend-shared/src/track.ts
@@ -48,7 +48,7 @@ async function flush(toFlush?: Array<Event>, retries: number = 10): Promise<any>
     }
 
     // console.log(await result.json());
-  } catch (e) {
+  } catch (e: any) {
     if (retries > 0) {
       // eslint-disable-next-line consistent-return
       return flush(toFlush, retries - 1);
@@ -62,7 +62,7 @@ let anonymousId: string = 'unknown';
 
 try {
   anonymousId = machineIdSync();
-} catch (e) {
+} catch (e: any) {
   internalExceptions(e);
 }
 

--- a/packages/cubejs-backend-shared/test/promises.test.ts
+++ b/packages/cubejs-backend-shared/test/promises.test.ts
@@ -224,7 +224,7 @@ test('withTimeoutRace(timeout)', async () => {
     );
 
     throw new Error('Unexpected');
-  } catch (e) {
+  } catch (e: any) {
     expect(e.message).toEqual('Timeout reached after 250ms');
   }
 
@@ -442,7 +442,7 @@ describe('asyncRetry', () => {
       );
 
       throw new Error('should throw exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual('test');
       expect(called).toEqual(3);
     }

--- a/packages/cubejs-base-driver/package.json
+++ b/packages/cubejs-base-driver/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^12",
     "@types/ramda": "^0.27.32",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-bigquery-driver/package.json
+++ b/packages/cubejs-bigquery-driver/package.json
@@ -39,7 +39,7 @@
     "@cubejs-backend/testing-shared": "^0.31.59",
     "@types/dedent": "^0.7.0",
     "@types/ramda": "^0.27.40",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cubejs-cli/package.json
+++ b/packages/cubejs-cli/package.json
@@ -62,7 +62,7 @@
     "@types/semver": "^7.3.4",
     "husky": "^4.2.3",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-cli/src/command/proxy-command.ts
+++ b/packages/cubejs-cli/src/command/proxy-command.ts
@@ -49,7 +49,7 @@ export async function proxyCommand(program: CommanderStatic, command: string) {
             // eslint-disable-next-line new-cap
             const CommandInstance: Command = new OriginalCommandPackage.default(process.argv.slice(3));
             await CommandInstance.run();
-          } catch (e) {
+          } catch (e: any) {
             displayError(e.stack || e.message);
           }
         });

--- a/packages/cubejs-cli/src/command/typegen.ts
+++ b/packages/cubejs-cli/src/command/typegen.ts
@@ -71,7 +71,7 @@ const generateQueryTypes = async (apiUrl, { token }) => {
       url: `${apiUrl}/meta`,
       json: true,
     });
-  } catch (e) {
+  } catch (e: any) {
     await displayError(e.error.error);
   }
 

--- a/packages/cubejs-cli/src/utils.ts
+++ b/packages/cubejs-cli/src/utils.ts
@@ -44,7 +44,7 @@ export async function event(opts: BaseEvent) {
       ...opts,
       cliVersion: loadCliManifest().version,
     });
-  } catch (e) {
+  } catch (e: any) {
     internalExceptions(e);
   }
 }

--- a/packages/cubejs-clickhouse-driver/package.json
+++ b/packages/cubejs-clickhouse-driver/package.json
@@ -41,7 +41,7 @@
     "jest": "26.6.3",
     "stream-to-array": "^2.3.0",
     "testcontainers": "^8.12",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-client-ws-transport/package.json
+++ b/packages/cubejs-client-ws-transport/package.json
@@ -38,7 +38,7 @@
     "@types/ws": "^7.2.9",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-crate-driver/package.json
+++ b/packages/cubejs-crate-driver/package.json
@@ -37,7 +37,7 @@
     "@cubejs-backend/linter": "^0.31.0",
     "@cubejs-backend/testing-shared": "^0.31.59",
     "testcontainers": "^8.12",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-cubestore-driver/package.json
+++ b/packages/cubejs-cubestore-driver/package.json
@@ -46,7 +46,7 @@
     "@types/generic-pool": "^3.1.9",
     "@types/ws": "^7.4.0",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cubejs-databricks-jdbc-driver/package.json
+++ b/packages/cubejs-databricks-jdbc-driver/package.json
@@ -50,7 +50,7 @@
     "@types/ramda": "^0.27.34",
     "@types/uuid": "^8.3.4",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-databricks-jdbc-driver/src/post-install.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/post-install.ts
@@ -11,7 +11,7 @@ import { downloadJDBCDriver } from './installer';
     if (!fs.existsSync(path.join(__dirname, '..', 'download', 'SparkJDBC42.jar'))) {
       await downloadJDBCDriver();
     }
-  } catch (e) {
+  } catch (e: any) {
     await displayCLIError(e, 'Cube.js Databricks JDBC Installer');
   }
 })();

--- a/packages/cubejs-dbt-schema-extension/package.json
+++ b/packages/cubejs-dbt-schema-extension/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
     "stream-to-array": "^2.3.0",
-    "typescript": "~4.1.6"
+    "typescript": "~4.9.5"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-docker/package.json
+++ b/packages/cubejs-docker/package.json
@@ -35,7 +35,7 @@
     "@cubejs-backend/sqlite-driver": "^0.31.58",
     "@cubejs-backend/trino-driver": "^0.31.59",
     "cubejs-cli": "^0.31.59",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "resolutions": {
     "colors": "1.4.0"

--- a/packages/cubejs-druid-driver/package.json
+++ b/packages/cubejs-druid-driver/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^10.17.55",
     "jest": "^26.6.3",
     "testcontainers": "^8.12",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-druid-driver/src/DruidClient.ts
+++ b/packages/cubejs-druid-driver/src/DruidClient.ts
@@ -68,7 +68,7 @@ export class DruidClient {
         }
 
         return response.data;
-      } catch (e) {
+      } catch (e: any) {
         if (cancelled) {
           throw new Error('Query cancelled');
         }

--- a/packages/cubejs-firebolt-driver/package.json
+++ b/packages/cubejs-firebolt-driver/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
     "@cubejs-backend/testing-shared": "^0.31.59",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-jdbc-driver/package.json
+++ b/packages/cubejs-jdbc-driver/package.json
@@ -47,6 +47,6 @@
     "@types/generic-pool": "^3.1.9",
     "@types/node": "^12",
     "@types/sqlstring": "^2.3.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   }
 }

--- a/packages/cubejs-ksql-driver/package.json
+++ b/packages/cubejs-ksql-driver/package.json
@@ -42,6 +42,6 @@
   },
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   }
 }

--- a/packages/cubejs-materialize-driver/package.json
+++ b/packages/cubejs-materialize-driver/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
     "@cubejs-backend/testing": "^0.31.59",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-materialize-driver/test/MaterializeDriver.test.ts
+++ b/packages/cubejs-materialize-driver/test/MaterializeDriver.test.ts
@@ -143,7 +143,7 @@ describe('MaterializeDriver', () => {
       });
 
       throw new Error('stream must throw an exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual(
         'unknown catalog item \'test.random_name_for_table_that_doesnot_exist_sql_must_fail\''
       );

--- a/packages/cubejs-mongobi-driver/package.json
+++ b/packages/cubejs-mongobi-driver/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
     "@types/generic-pool": "^3.1.9",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-mysql-driver/package.json
+++ b/packages/cubejs-mysql-driver/package.json
@@ -41,7 +41,7 @@
     "jest": "^26.6.3",
     "stream-to-array": "^2.3.0",
     "testcontainers": "^8.12",
-    "typescript": "~4.1.6"
+    "typescript": "~4.9.5"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-mysql-driver/test/MySqlDriverPool.disabled.ts
+++ b/packages/cubejs-mysql-driver/test/MySqlDriverPool.disabled.ts
@@ -28,7 +28,7 @@ describe('MySqlDriver Pool', () => {
         await poolErrorDriver.query('SELECT 1', []);
 
         throw new Error('Pool must throw an exception');
-      } catch (e) {
+      } catch (e: any) {
         console.log(e);
         expect(e.toString()).toContain('ResourceRequest timed out');
       }

--- a/packages/cubejs-playground/package.json
+++ b/packages/cubejs-playground/package.json
@@ -88,7 +88,7 @@
     "recursive-readdir": "^2.2.2",
     "styled-components": "5.2.0",
     "tslib": "^2.3.0",
-    "typescript": "4.8.2",
+    "typescript": "~4.9.5",
     "vite": "^3.1.0"
   },
   "peerDependencies": {

--- a/packages/cubejs-postgres-driver/package.json
+++ b/packages/cubejs-postgres-driver/package.json
@@ -40,7 +40,7 @@
     "@cubejs-backend/linter": "^0.31.0",
     "@cubejs-backend/testing-shared": "^0.31.59",
     "testcontainers": "^8.4.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
+++ b/packages/cubejs-postgres-driver/test/PostgresDriver.test.ts
@@ -109,7 +109,7 @@ describe('PostgresDriver', () => {
       });
 
       throw new Error('stream must throw an exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toEqual(
         'relation "test.random_name_for_table_that_doesnot_exist_sql_must_fail" does not exist'
       );

--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -42,7 +42,7 @@
     "jest": "^26.6.3",
     "should": "^13.2.3",
     "testcontainers": "^8.12",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "eslintConfig": {
     "extends": "../cubejs-linter"

--- a/packages/cubejs-query-orchestrator/package.json
+++ b/packages/cubejs-query-orchestrator/package.json
@@ -55,7 +55,7 @@
     "@types/redis": "^2.8.28",
     "@types/uuid": "^8.3.0",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-query-orchestrator/src/orchestrator/RedisQueueEventsBus.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/RedisQueueEventsBus.ts
@@ -28,7 +28,7 @@ export class RedisQueueEventsBus extends BaseQueueEventsBus {
       try {
         message = JSON.parse(message);
         await Promise.all(Object.values(this.subscribers).map(subscriber => subscriber.callback(message)));
-      } catch (error) {
+      } catch (error: any) {
         console.error(error.stack || error);
       }
     });

--- a/packages/cubejs-questdb-driver/package.json
+++ b/packages/cubejs-questdb-driver/package.json
@@ -40,7 +40,7 @@
     "@cubejs-backend/linter": "^0.31.0",
     "@cubejs-backend/testing-shared": "^0.31.59",
     "testcontainers": "^8.4.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-redshift-driver/package.json
+++ b/packages/cubejs-redshift-driver/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cubejs-schema-compiler/package.json
+++ b/packages/cubejs-schema-compiler/package.json
@@ -84,7 +84,7 @@
     "source-map-support": "^0.5.19",
     "sqlstring": "^2.3.1",
     "testcontainers": "^8.12",
-    "typescript": "~4.1.5",
+    "typescript": "~4.9.5",
     "uuid": "^8.3.2"
   },
   "license": "Apache-2.0",

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -185,7 +185,7 @@ export class YamlCompiler {
     try {
       const pythonParser = new PythonParser(codeString);
       return pythonParser.transpileToJs();
-    } catch (e) {
+    } catch (e: any) {
       errorsReport.error(`Can't parse python expression. Most likely this type of syntax isn't supported yet: ${e.message || e}`);
     }
     return t.nullLiteral();

--- a/packages/cubejs-schema-compiler/src/compiler/converters/CubeSchemaConverter.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/converters/CubeSchemaConverter.ts
@@ -74,7 +74,7 @@ export class CubeSchemaConverter {
         sourceType: 'module',
         plugins: ['objectRestSpread'],
       });
-    } catch (error) {
+    } catch (error: any) {
       if (error.toString().indexOf('SyntaxError') !== -1) {
         const line = file.content.split('\n')[error.loc.line - 1];
         const spaces = Array(error.loc.column).fill(' ').join('');

--- a/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
@@ -26,7 +26,7 @@ describe('Transpilers', () => {
       await compiler.compile();
 
       throw new Error('Compile should thrown an error');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toMatch(/Duplicate property parsing test1 in main.js/);
     }
   });

--- a/packages/cubejs-server-core/package.json
+++ b/packages/cubejs-server-core/package.json
@@ -73,7 +73,7 @@
     "@types/ramda": "^0.27.34",
     "@types/uuid": "^8.3.0",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-server-core/src/core/agentCollect.ts
+++ b/packages/cubejs-server-core/src/core/agentCollect.ts
@@ -62,7 +62,7 @@ class WebSocketTransport implements AgentTransport {
         if (method === 'callback' && this.callbacks[params.callbackId]) {
           this.callbacks[params.callbackId](params.result);
         }
-      } catch (e) {
+      } catch (e: any) {
         this.logger('Agent Error', { error: (e.stack || e).toString() });
       }
     });
@@ -166,7 +166,7 @@ export default async (event: Record<string, any>, endpointUrl: string, logger: a
       if (!result && retries > 0) return flush(toFlush, retries - 1);
   
       return true;
-    } catch (e) {
+    } catch (e: any) {
       if (retries > 0) return flush(toFlush, retries - 1);
       logger('Agent Error', { error: (e.stack || e).toString() });
     }

--- a/packages/cubejs-server/package.json
+++ b/packages/cubejs-server/package.json
@@ -71,7 +71,7 @@
     "@types/ws": "^7.2.9",
     "@types/yarnpkg__lockfile": "^1.1.4",
     "jest": "^26.0.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "license": "Apache-2.0",
   "eslintConfig": {

--- a/packages/cubejs-server/src/server/container.ts
+++ b/packages/cubejs-server/src/server/container.ts
@@ -239,7 +239,7 @@ export class ServerContainer {
         const { version, port } = await server.listen();
 
         console.log(`🚀 Cube API server (${version}) is listening on ${port}`);
-      } catch (e) {
+      } catch (e: any) {
         console.error('Fatal error during server start: ');
         console.error(e.stack || e);
 

--- a/packages/cubejs-server/src/server/utils.ts
+++ b/packages/cubejs-server/src/server/utils.ts
@@ -74,7 +74,7 @@ export function parseNpmLock(): ProjectLock | null {
         return null;
       },
     };
-  } catch (e) {
+  } catch (e: any) {
     internalExceptions(e);
 
     return null;

--- a/packages/cubejs-snowflake-driver/package.json
+++ b/packages/cubejs-snowflake-driver/package.json
@@ -43,6 +43,6 @@
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
     "@types/snowflake-sdk": "^1.6.8",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   }
 }

--- a/packages/cubejs-templates/package.json
+++ b/packages/cubejs-templates/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "@cubejs-backend/linter": "^0.31.0",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   }
 }

--- a/packages/cubejs-templates/src/PackageFetcher.ts
+++ b/packages/cubejs-templates/src/PackageFetcher.ts
@@ -28,7 +28,7 @@ export class PackageFetcher {
     try {
       // Folder node_modules does not exist by default inside docker in /cube/conf without sharing volume for it
       fs.mkdirpSync(this.tmpFolderPath);
-    } catch (err) {
+    } catch (err: any) {
       if (err.code === 'EEXIST') {
         this.cleanup();
         fs.mkdirSync(this.tmpFolderPath);

--- a/packages/cubejs-testing-shared/package.json
+++ b/packages/cubejs-testing-shared/package.json
@@ -35,7 +35,7 @@
     "@types/jest": "^26.0.22",
     "@types/node": "^10.17.55",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "jest": {
     "coveragePathIgnorePatterns": [

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -118,7 +118,7 @@
     "jsonwebtoken": "^8.5.1",
     "jwt-decode": "^3.1.2",
     "pg": "^8.7.3",
-    "typescript": "~4.1.5",
+    "typescript": "~4.9.5",
     "yaml": "^1.10.2"
   },
   "jest": {

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -97,7 +97,7 @@ describe('SQL API', () => {
         await createPostgresClient('admin', 'wrong_password');
 
         throw new Error('Code must thrown auth error, something wrong...');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toContain('password authentication failed for user "admin"');
       }
     });
@@ -137,7 +137,7 @@ describe('SQL API', () => {
         await conn.query('SELECT "user", "uid" FROM SecurityContextTest WHERE __user = \'usr2\'');
 
         throw new Error('Code must thrown auth error, something wrong...');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toContain('You cannot change security context via __user from moderator to usr2, because it\'s not allowed');
       } finally {
         await conn.end();
@@ -151,7 +151,7 @@ describe('SQL API', () => {
         await conn.query('SELECT "user", "uid" FROM SecurityContextTest WHERE __user = \'moderator\'');
 
         throw new Error('Code must thrown auth error, something wrong...');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toContain('You cannot change security context via __user from usr1 to moderator, because it\'s not allowed');
       } finally {
         await conn.end();

--- a/rust/cubestore/js-wrapper/src/post-install.ts
+++ b/rust/cubestore/js-wrapper/src/post-install.ts
@@ -16,7 +16,7 @@ import { isCubeStoreSupported } from './utils';
         'which is not supported by Cube Store. Installation will be skipped.'
       );
     }
-  } catch (e) {
+  } catch (e: any) {
     await displayCLIError(e, 'Cube Store Installer');
   }
 })();

--- a/rust/cubestore/js-wrapper/src/utils.ts
+++ b/rust/cubestore/js-wrapper/src/utils.ts
@@ -16,7 +16,7 @@ export function detectLibc() {
     if (status === 0) {
       return 'gnu';
     }
-  } catch (e) {
+  } catch (e: any) {
     internalExceptions(e);
   }
 

--- a/rust/cubestore/package.json
+++ b/rust/cubestore/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^26.0.22",
     "@types/node": "^12",
     "jest": "^26.6.3",
-    "typescript": "~4.1.5"
+    "typescript": "~4.9.5"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27503,15 +27503,10 @@ typescript@4.3.5, typescript@~4.3.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
-typescript@4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
-
-typescript@~4.1.5, typescript@~4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
-  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+typescript@~4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
```
=> Found "typescript@4.9.5"
info Has been hoisted to "typescript"
info Reasons this module exists
   - "workspace-aggregator-6578b4dc-a8c7-4bb6-8b5f-87d47d2e3433" depends on it
   - Specified in "devDependencies"
   - Hoisted from "_project_#typescript"
   - Hoisted from "_project_#@cubejs-backend#cubestore#typescript"
   - Hoisted from "_project_#@cubejs-backend#api-gateway#typescript"
   - Hoisted from "_project_#@cubejs-backend#athena-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#cloud#typescript"
   - Hoisted from "_project_#@cubejs-backend#maven#typescript"
   - Hoisted from "_project_#@cubejs-backend#native#typescript"
   - Hoisted from "_project_#@cubejs-backend#shared#typescript"
   - Hoisted from "_project_#@cubejs-backend#base-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#bigquery-driver#typescript"
   - Hoisted from "_project_#cubejs-cli#typescript"
   - Hoisted from "_project_#@cubejs-backend#clickhouse-driver#typescript"
   - Hoisted from "_project_#@cubejs-client#ws-transport#typescript"
   - Hoisted from "_project_#@cubejs-backend#crate-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#cubestore-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#databricks-jdbc-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#dbt-schema-extension#typescript"
   - Hoisted from "_project_#@cubejs-backend#docker#typescript"
   - Hoisted from "_project_#@cubejs-backend#druid-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#firebolt-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#jdbc-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#ksql-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#materialize-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#mongobi-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#mysql-driver#typescript"
   - Hoisted from "_project_#@cubejs-client#playground#typescript"
   - Hoisted from "_project_#@cubejs-backend#postgres-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#prestodb-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#query-orchestrator#typescript"
   - Hoisted from "_project_#@cubejs-backend#questdb-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#redshift-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#schema-compiler#typescript"
   - Hoisted from "_project_#@cubejs-backend#server-core#typescript"
   - Hoisted from "_project_#@cubejs-backend#server#typescript"
   - Hoisted from "_project_#@cubejs-backend#snowflake-driver#typescript"
   - Hoisted from "_project_#@cubejs-backend#templates#typescript"
   - Hoisted from "_project_#@cubejs-backend#testing-shared#typescript"
   - Hoisted from "_project_#@cubejs-backend#testing#typescript"
info Disk size without dependencies: "64.06MB"
info Disk size with unique dependencies: "64.06MB"
info Disk size with transitive dependencies: "64.06MB"
info Number of shared dependencies: 0
=> Found "@cubejs-client/ngx#typescript@4.3.5"
info This module exists because "_project_#@cubejs-client#ngx" depends on it.
info Disk size without dependencies: "58.62MB"
info Disk size with unique dependencies: "58.62MB"
info Disk size with transitive dependencies: "58.62MB"
info Number of shared dependencies: 0
=> Found "@angular-devkit/build-optimizer#typescript@4.3.5"
info This module exists because "_project_#@cubejs-client#ngx#@angular-devkit#build-angular#@angular-devkit#build-optimizer" depends on it.
```