### PR TITLE
docs(cloud): fix broken link in Developer Playground documentation

### DIFF
--- a/docs/content/Cube-Cloud/Developer-Tools/Developer-Playground.md
+++ b/docs/content/Cube-Cloud/Developer-Tools/Developer-Playground.md
@@ -26,4 +26,4 @@ API will restart and its status will be visible in the Playground:
   />
 </div>
 
-[ref-devtools-ide]: /cloud/cube-ide
+[ref-devtools-ide]: /cloud/dev-tools/cube-ide


### PR DESCRIPTION
Cube IDE link links to an unexisting page ("/cloud/cube-ide") rather than "/cloud/dev-tools/cube-ide"

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
