### PR TITLE
feat(cubesql): Support `date_trunc` over column filter with `<=`

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -1445,6 +1445,7 @@ pub async fn convert_sql_to_cube_query(
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
+    use chrono::Datelike;
     use cubeclient::models::{
         V1LoadRequestQueryFilterItem, V1LoadRequestQueryTimeDimension, V1LoadResponse,
     };
@@ -11348,6 +11349,8 @@ ORDER BY \"COUNT(count)\" DESC"
         .await
         .as_logical_plan();
 
+        let now = chrono::Utc::now();
+        let current_year = now.naive_utc().date().year();
         assert_eq!(
             logical_plan.find_cube_scan().request,
             V1LoadRequestQuery {
@@ -11358,9 +11361,9 @@ ORDER BY \"COUNT(count)\" DESC"
                     dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
                     granularity: Some("day".to_string()),
                     date_range: Some(json!(vec![
-                        "2017-01-01T00:00:00.000Z".to_string(),
-                        "2021-12-31T23:59:59.999Z".to_string()
-                    ]))
+                        format!("{}-01-01T00:00:00.000Z", current_year - 5),
+                        format!("{}-12-31T23:59:59.999Z", current_year - 1),
+                    ])),
                 }]),
                 order: Some(vec![vec![
                     "KibanaSampleDataEcommerce.order_date".to_string(),

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -23,3 +23,23 @@ pub fn parse_granularity(granularity: &ScalarValue, to_normalize: bool) -> Optio
         _ => None,
     }
 }
+
+pub fn granularity_to_interval(granularity: &ScalarValue) -> Option<ScalarValue> {
+    if let Some(granularity) = parse_granularity(granularity, false) {
+        let interval = match granularity.as_str() {
+            "second" => ScalarValue::IntervalDayTime(Some(1000)),
+            "minute" => ScalarValue::IntervalDayTime(Some(60000)),
+            "hour" => ScalarValue::IntervalDayTime(Some(3600000)),
+            "day" => ScalarValue::IntervalDayTime(Some(4294967296)),
+            "week" => ScalarValue::IntervalDayTime(Some(30064771072)),
+            "month" => ScalarValue::IntervalYearMonth(Some(1)),
+            "quarter" => ScalarValue::IntervalYearMonth(Some(3)),
+            "year" => ScalarValue::IntervalYearMonth(Some(12)),
+            _ => return None,
+        };
+
+        return Some(interval);
+    }
+
+    None
+}


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

This PR adds support for filters where the left side of an expression is a `date_trunc` over a column, the right side is a `date_trunc` with literal expression, the condition between expression is *less than* (`<=`), and granularities match.
Example: `date_trunc('day', column) <= date_trunc('day', literal_date)`
This expression is effectively the same as `column < date_trunc('day', literal_date) + interval '1 day'`.
A special case is considered for *excluding N weeks* expression used by QuickSight.
Related tests are included.
The PR also contains a fix for `interval_mul` test, fixing `LOCALTIMESTAMP` usage result which made the test break over time.
