### PR TITLE
fix: ISSUE-5371 DruidQuery timezone MINUTES fix

### DIFF
--- a/packages/cubejs-druid-driver/src/DruidQuery.ts
+++ b/packages/cubejs-druid-driver/src/DruidQuery.ts
@@ -35,7 +35,7 @@ export class DruidQuery extends BaseQuery {
     const minutes = parseInt(hour, 10) * 60 + parseInt(minute, 10);
 
     if (minutes > 0) {
-      return `TIMESTAMPADD(MINUTES, ${minutes}, ${field})`;
+      return `TIMESTAMPADD(MINUTE, ${minutes}, ${field})`;
     }
 
     return field;

--- a/packages/cubejs-druid-driver/test/druid-query.test.ts
+++ b/packages/cubejs-druid-driver/test/druid-query.test.ts
@@ -28,8 +28,13 @@ describe('DruidQuery', () => {
         name: {
           type: 'string',
           sql: 'name'
+        },
+        createdAt: {
+            sql: \`created_at\`,
+            type: 'time',
         }
       }
+      
     })
     `,{});
 
@@ -53,4 +58,23 @@ describe('DruidQuery', () => {
       const queryAndParams = query.buildSqlAndParams();
       expect(queryAndParams[0]).toContain("LIKE CONCAT('%', ?, '%'))");
     }));
+
+    it('druid query timezone shift test',
+        () => compiler.compile().then(() => {
+            const query = new DruidQuery(
+                { joinGraph, cubeEvaluator, compiler },
+                {
+                    timeDimensions: [
+                        {
+                            dimension: "visitors.createdAt",
+                            granularity: 'day'
+                        }
+                    ],
+                    measures: [],
+                    timezone: 'Europe/Kiev'
+                }
+            );
+            const queryAndParams = query.buildSqlAndParams();
+            expect(queryAndParams[0]).toContain("DATE_TRUNC('day', TIMESTAMPADD(MINUTE, 180, \"visitors\".created_at)) \"visitors__created_at_day\"");
+        }));
 });


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[issue 5371](https://github.com/cube-js/cube.js/issues/5371)

**Description of Changes Made (if issue reference is not provided)**

`MINUTES` to `MINUTE` replacement
