### PR TITLE
feat(cubesql): Add `float8`, `bool` casts

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -12097,4 +12097,37 @@ ORDER BY \"COUNT(count)\" DESC"
             }
         );
     }
+
+    #[tokio::test]
+    async fn test_thoughtspot_casts() {
+        init_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT CAST("ta_4"."ca_3" AS FLOAT8), CAST("ta_4"."ca_3" AS INT2), CAST("ta_4"."ca_3" AS BOOL)
+            FROM (
+                SELECT sum("ta_1"."count") AS "ca_3"
+                FROM "db"."public"."KibanaSampleDataEcommerce" "ta_1"
+            ) AS "ta_4"
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
+                dimensions: Some(vec![]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+            }
+        )
+    }
 }

--- a/rust/cubesql/cubesql/src/sql/statement.rs
+++ b/rust/cubesql/cubesql/src/sql/statement.rs
@@ -765,7 +765,7 @@ impl<'ast> Visitor<'ast, ConnectionError> for CastReplacer {
         } = expr
         {
             match data_type {
-                ast::DataType::Custom(name) => match name.to_string().as_str() {
+                ast::DataType::Custom(name) => match name.to_string().to_lowercase().as_str() {
                     "name" | "oid" | "information_schema.cardinal_number" | "regproc" => {
                         self.visit_expr(&mut *cast_expr)?;
 
@@ -785,6 +785,16 @@ impl<'ast> Visitor<'ast, ConnectionError> for CastReplacer {
                         self.visit_expr(&mut *cast_expr)?;
 
                         *data_type = ast::DataType::BigInt(None)
+                    }
+                    "float8" => {
+                        self.visit_expr(&mut *cast_expr)?;
+
+                        *data_type = ast::DataType::Double;
+                    }
+                    "bool" => {
+                        self.visit_expr(&mut *cast_expr)?;
+
+                        *data_type = ast::DataType::Boolean;
                     }
                     "timestamptz" => {
                         self.visit_expr(&mut *cast_expr)?;


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `float8` and `bool` casts. Those are used by ThoughtSpot. It also fixes an issue when casts written in uppercase or mixed-case (as opposed to lowercase) would not be recognized. ThoughtSpot, for instance, issued `CAST(… AS INT2)` which resulted in an error.
A related test is also added.