### PR TITLE
feat(cubesql): Allow `char_length` function to be used with cubes

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -12066,6 +12066,38 @@ ORDER BY \"COUNT(count)\" DESC"
     }
 
     #[tokio::test]
+    async fn test_thoughtspot_char_length() {
+        init_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT char_length("ta_1"."customer_gender")
+            FROM "db"."public"."KibanaSampleDataEcommerce" "ta_1";
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                ]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+            }
+        )
+    }
+
+    #[tokio::test]
     async fn test_in_filter() {
         init_logger();
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
@@ -1265,6 +1265,20 @@ impl RewriteRules for SplitRules {
                     ],
                 ),
             ),
+            // CharacterLength
+            rewrite(
+                "split-push-down-char-length-inner-replacer",
+                inner_aggregate_split_replacer(fun_expr("CharacterLength", vec!["?expr"]), "?cube"),
+                inner_aggregate_split_replacer("?expr", "?cube"),
+            ),
+            rewrite(
+                "split-push-down-char-length-outer-aggr-replacer",
+                outer_aggregate_split_replacer(fun_expr("CharacterLength", vec!["?expr"]), "?cube"),
+                fun_expr(
+                    "CharacterLength",
+                    vec![outer_aggregate_split_replacer("?expr", "?cube")],
+                ),
+            ),
         ]
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `char_length` function to be used when querying cubes. This is used by ThoughtSpot. It also adds a related test.
