### PR TITLE
fix(cubesql): Allow derived tables to have a dot in column name

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ba127294a6694ec4a90f62b3987df0d84637d432#ba127294a6694ec4a90f62b3987df0d84637d432"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=029c46ae53b6dbc097019428e4dc268f22b8cc41#029c46ae53b6dbc097019428e4dc268f22b8cc41"
 dependencies = [
  "arrow",
  "chrono",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ba127294a6694ec4a90f62b3987df0d84637d432#ba127294a6694ec4a90f62b3987df0d84637d432"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=029c46ae53b6dbc097019428e4dc268f22b8cc41#029c46ae53b6dbc097019428e4dc268f22b8cc41"
 dependencies = [
  "ahash",
  "arrow",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ba127294a6694ec4a90f62b3987df0d84637d432#ba127294a6694ec4a90f62b3987df0d84637d432"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=029c46ae53b6dbc097019428e4dc268f22b8cc41#029c46ae53b6dbc097019428e4dc268f22b8cc41"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ba127294a6694ec4a90f62b3987df0d84637d432#ba127294a6694ec4a90f62b3987df0d84637d432"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=029c46ae53b6dbc097019428e4dc268f22b8cc41#029c46ae53b6dbc097019428e4dc268f22b8cc41"
 dependencies = [
  "async-trait",
  "chrono",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ba127294a6694ec4a90f62b3987df0d84637d432#ba127294a6694ec4a90f62b3987df0d84637d432"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=029c46ae53b6dbc097019428e4dc268f22b8cc41#029c46ae53b6dbc097019428e4dc268f22b8cc41"
 dependencies = [
  "ahash",
  "arrow",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ba127294a6694ec4a90f62b3987df0d84637d432#ba127294a6694ec4a90f62b3987df0d84637d432"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=029c46ae53b6dbc097019428e4dc268f22b8cc41#029c46ae53b6dbc097019428e4dc268f22b8cc41"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "ba127294a6694ec4a90f62b3987df0d84637d432", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "029c46ae53b6dbc097019428e4dc268f22b8cc41", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -12162,4 +12162,62 @@ ORDER BY \"COUNT(count)\" DESC"
             }
         )
     }
+
+    #[tokio::test]
+    async fn test_thoughtspot_derived_dot_column() {
+        init_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            select
+                "_"."t1.agentCountApprox" as "agentCountApprox",
+                "_"."a0" as "a0"
+            from (
+                select
+                    sum(cast("rows"."t0.taxful_total_price" as decimal)) as "a0",
+                    "rows"."t1.agentCountApprox" as "t1.agentCountApprox"
+                from (
+                    select
+                        "$Outer"."t1.agentCountApprox",
+                        "$Inner"."t0.taxful_total_price"
+                    from (
+                        select
+                            "_"."agentCount" as "t1.agentCount",
+                            "_"."agentCountApprox" as "t1.agentCountApprox"
+                        from "public"."Logs" "_"
+                    ) "$Outer"
+                    left outer join (
+                        select
+                            "_"."taxful_total_price" as "t0.taxful_total_price",
+                            "_"."count" as "t0.count"
+                        from "public"."KibanaSampleDataEcommerce" "_"
+                    ) "$Inner" on ("$Outer"."t1.agentCount" = "$Inner"."t0.count")
+                ) "rows"
+                group by "t1.agentCountApprox"
+            ) "_"
+            where not "_"."a0" is null
+            limit 1000001
+            ;"#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec!["KibanaSampleDataEcommerce.count".to_string(),]),
+                dimensions: Some(vec![
+                    "KibanaSampleDataEcommerce.taxful_total_price".to_string(),
+                ]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+            }
+        )
+    }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps `datafusion` in order to fix an issue with derived tables where you could not have a dot in a column alias of a derived table. It also adds a related test with a query used by PowerBI.
