### PR TITLE
fix(materialize-driver) schema inference 

### DIFF
--- a/packages/cubejs-materialize-driver/package.json
+++ b/packages/cubejs-materialize-driver/package.json
@@ -31,7 +31,9 @@
     "@cubejs-backend/postgres-driver": "^0.31.0",
     "@cubejs-backend/shared": "^0.31.0",
     "@types/pg": "^8.6.0",
-    "pg": "^8.6.0"
+    "pg": "^8.6.0",
+    "ramda": "0.27.2",
+    "semver": "7.3.7"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/cubejs-materialize-driver/src/MaterializeDriver.ts
+++ b/packages/cubejs-materialize-driver/src/MaterializeDriver.ts
@@ -1,13 +1,25 @@
 import { PostgresDriver, PostgresDriverConfiguration } from '@cubejs-backend/postgres-driver';
 import { BaseDriver, DownloadTableMemoryData, IndexesSQL, StreamOptions, StreamTableDataWithTypes, TableStructure } from '@cubejs-backend/base-driver';
 import { PoolClient, QueryResult } from 'pg';
+import { reduce } from 'ramda';
 import { Readable } from 'stream';
+import semver from 'semver';
 
 export type ReadableStreamTableDataWithTypes = StreamTableDataWithTypes & {
   /**
    * Compatibility with streamToArray method from '@cubejs-backend/shared'
    */
   rowStream: Readable;
+};
+
+export type SchemaResponse = {
+  [schema: string]: {
+    [schemaObject: string]: {
+      name: string;
+      type: string;
+      attributes: any[];
+  }[];
+  }
 };
 
 /**
@@ -53,7 +65,7 @@ export class MaterializeDriver extends PostgresDriver {
       `SHOW SCHEMAS WHERE name = '${schemaName}'`, []
     );
     if (schemas.length === 0) {
-      this.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`, []);
+      await this.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`, []);
     }
     return [];
   }
@@ -72,8 +84,9 @@ export class MaterializeDriver extends PostgresDriver {
    * Returns materialized sources, materialized views, and tables
    * @returns {string} schemaQuery
    */
-  public informationSchemaQuery(): string {
-    const materializationFilter = `
+  public informationSchemaQueryWithFilter(version: string): string {
+    console.log(version);
+    const materializationFilter = semver.lt(version, 'v0.27.0-alpha') ? `
         table_name IN (
           SELECT name
           FROM mz_catalog.mz_sources
@@ -85,9 +98,38 @@ export class MaterializeDriver extends PostgresDriver {
           UNION
           SELECT t.name
           FROM mz_catalog.mz_tables t
-        )`;
+        )` : `
+        table_name IN (
+          SELECT name
+          FROM mz_catalog.mz_sources
+          UNION
+          SELECT name
+          FROM mz_catalog.mz_tables t
+          UNION
+          SELECT name
+          FROM mz_catalog.mz_materialized_views t
+        )
+        `;
 
     return `${super.informationSchemaQuery()} AND ${materializationFilter}`;
+  }
+
+  /**
+   * Materialize instance version
+   * @returns {Promise<string>} version
+   */
+  public async getMaterializeVersion(): Promise<string> {
+    const [{ version }] = await this.query<{version: string}>('SELECT mz_version() as version;', []);
+
+    // Materialzie returns the version as follows: 'v0.24.3-alpha.5 (65778f520)'
+    return version.split(' ')[0];
+  }
+
+  public async tablesSchema(): Promise<SchemaResponse> {
+    const version = await this.getMaterializeVersion();
+    const query = this.informationSchemaQueryWithFilter(version);
+
+    return this.query(query, []).then(data => reduce(this.informationColumnsSchemaReducer, {}, data));
   }
 
   protected async* asyncFetcher<R extends unknown>(conn: PoolClient, cursorId: string): AsyncGenerator<R> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23338,15 +23338,15 @@ raf@^3.4.0, raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@0.27.2, ramda@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
+  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
+
 ramda@^0.27.0, ramda@^0.27.1, ramda@~0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
-
-ramda@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
-  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
 
 randomatic@^3.0.0:
   version "3.1.1"
@@ -25210,6 +25210,13 @@ semver@7.3.5, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

[Reference](https://github.com/cube-js/cube.js/pull/5148)

I had to create another branch due to a local main branch incompatibility (the PR got automatically closed.)
cc. @buntarb 

**Description of Changes Made (if issue reference is not provided)**

Newer versions of Materialize have a different way to query the schema.
This PR maintains backward compatibility with older versions too.

Added `semver` lib to calculate the versions.
Added `ramda` lib to keep the same mechanism to return the schema as BaseDriver in `tablesSchema`.
