### PR TITLE
feat(mssql-driver): Add column type mapping for bit

### DIFF
--- a/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
+++ b/packages/cubejs-mssql-driver/driver/MSSqlDriver.js
@@ -6,6 +6,7 @@ import {
 } from '@cubejs-backend/shared';
 
 const GenericTypeToMSSql = {
+  boolean: 'bit',
   string: 'nvarchar(max)',
   text: 'nvarchar(max)',
   timestamp: 'datetime2',
@@ -13,6 +14,7 @@ const GenericTypeToMSSql = {
 };
 
 const MSSqlToGenericType = {
+  bit: 'boolean',
   uniqueidentifier: 'uuid',
   datetime2: 'timestamp'
 }
@@ -33,11 +35,11 @@ class MSSqlDriver extends BaseDriver {
    */
   constructor(config = {}) {
     super();
-    
+
     const dataSource =
       config.dataSource ||
       assertDataSource('default');
-  
+
     this.config = {
       server: getEnv('dbHost', { dataSource }),
       database: getEnv('dbName', { dataSource }),


### PR DESCRIPTION
Hello!

https://stackoverflow.com/questions/57456939/what-is-the-difference-between-bit-and-boolean-why-we-can-use-boolean-in-sql-s

MSSQL server uses `bit` as an alias for the `boolean` type.

Thanks