### PR TITLE
docs(examples): add note on how to configure Redis URL in helm chart `README`

### DIFF
--- a/examples/helm-charts/cubejs/README.md
+++ b/examples/helm-charts/cubejs/README.md
@@ -206,7 +206,7 @@ cubestore:
 
 | Name                            | Description                                                                                                                                              | Value |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| `redis.url`                     | The host URL for a Redis server                                                                                                                          |       |
+| `redis.url`                     | The host URL for a Redis server. Note that this must include the `redis://` protocol prefix.                                                              |       |
 | `redis.password`                | The password used to connect to the Redis server                                                                                                         |       |
 | `redis.passwordFromSecret.name` | The password used to connect to the Redis server (using secret)                                                                                          |       |
 | `redis.passwordFromSecret.key`  | The password used to connect to the Redis server (using secret)                                                                                          |       |


### PR DESCRIPTION
Not having an understanding of how redis expects URLs to be constructed, it would be helpful to have this note saying that you can't just use the IP or hostname, you have to include the protocol prefix as well.

**Check List**
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Just a small README.md addition.
