### PR TITLE
feat(cubesql): Allow `EXTRACT` field to be parsed as a string

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=aac786a07fde784be70d4d738cf8f1986cc33dec#aac786a07fde784be70d4d738cf8f1986cc33dec"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
 dependencies = [
  "arrow",
  "chrono",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=aac786a07fde784be70d4d738cf8f1986cc33dec#aac786a07fde784be70d4d738cf8f1986cc33dec"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
 dependencies = [
  "ahash",
  "arrow",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=aac786a07fde784be70d4d738cf8f1986cc33dec#aac786a07fde784be70d4d738cf8f1986cc33dec"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=aac786a07fde784be70d4d738cf8f1986cc33dec#aac786a07fde784be70d4d738cf8f1986cc33dec"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=aac786a07fde784be70d4d738cf8f1986cc33dec#aac786a07fde784be70d4d738cf8f1986cc33dec"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
 dependencies = [
  "ahash",
  "arrow",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=aac786a07fde784be70d4d738cf8f1986cc33dec#aac786a07fde784be70d4d738cf8f1986cc33dec"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
 dependencies = [
  "ahash",
  "arrow",
@@ -3580,7 +3580,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "sqlparser"
 version = "0.16.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=13aff89fcbc3545c92a94ce771bafa739363fad5#13aff89fcbc3545c92a94ce771bafa739363fad5"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=ef389d81a7b787b424a43177e2e9d7ad8be3e6c5#ef389d81a7b787b424a43177e2e9d7ad8be3e6c5"
 dependencies = [
  "log",
 ]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,12 +9,12 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "aac786a07fde784be70d4d738cf8f1986cc33dec", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "f544f7e64dae8af51b04434c45d64bd34171fea7", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }
 pg-srv = { path = "../pg-srv" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "13aff89fcbc3545c92a94ce771bafa739363fad5" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ef389d81a7b787b424a43177e2e9d7ad8be3e6c5" }
 lazy_static = "1.4.0"
 base64 = "0.13.0"
 tokio = { version = "1.0", features = ["full", "rt", "tracing"] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -12545,4 +12545,19 @@ ORDER BY \"COUNT(count)\" DESC"
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_extract_string_field() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "test_extract_string_field",
+            execute_query(
+                "SELECT EXTRACT('YEAR' FROM CAST ('2020-12-25 22:48:48.000' AS timestamptz))"
+                    .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__test_extract_string_field.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__test_extract_string_field.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT EXTRACT('YEAR' FROM CAST ('2020-12-25 22:48:48.000' AS timestamptz))\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++-------------+
+| Int32(2020) |
++-------------+
+| 2020        |
++-------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR introduces a change that allows `EXTRACT` expression to accept date/time fields as strings, e.g. `EXTRACT('year' FROM column)`. PostgreSQL [allows those kinds of strings](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT).
It also adds a related test.
