### PR TITLE
refactor(query-orchestrator): Re-use cacheDriver from QueryCache

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import csvWriter from 'csv-write-stream';
 import LRUCache from 'lru-cache';
-import { pipeline } from 'stream';
 import { MaybeCancelablePromise, streamToArray } from '@cubejs-backend/shared';
 
 import { BaseDriver, InlineTables } from '@cubejs-backend/base-driver';


### PR DESCRIPTION
Hello!

I've found a strange moment, that PreAggregation creates a new instance of a CacheDriver instead of using the driver from QueryCache.

Thanks