### PR TITLE
feat(cubesql): Support Sigma Computing string filters

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
 dependencies = [
  "arrow",
  "chrono",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
 dependencies = [
  "ahash",
  "arrow",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
 dependencies = [
  "ahash",
  "arrow",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=f544f7e64dae8af51b04434c45d64bd34171fea7#f544f7e64dae8af51b04434c45d64bd34171fea7"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
 dependencies = [
  "ahash",
  "arrow",
@@ -3580,7 +3580,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "sqlparser"
 version = "0.16.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=ef389d81a7b787b424a43177e2e9d7ad8be3e6c5#ef389d81a7b787b424a43177e2e9d7ad8be3e6c5"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=2b18e22a179770f1297896d52ae384f00949ab2a#2b18e22a179770f1297896d52ae384f00949ab2a"
 dependencies = [
  "log",
 ]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,12 +9,12 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "f544f7e64dae8af51b04434c45d64bd34171fea7", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "59a2174f534abaf04574f66dfa886ffdd4e5635b", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }
 pg-srv = { path = "../pg-srv" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ef389d81a7b787b424a43177e2e9d7ad8be3e6c5" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "2b18e22a179770f1297896d52ae384f00949ab2a" }
 lazy_static = "1.4.0"
 base64 = "0.13.0"
 tokio = { version = "1.0", features = ["full", "rt", "tracing"] }

--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -2779,3 +2779,22 @@ pub fn create_regexp_substr_udf() -> ScalarUDF {
         &fun,
     )
 }
+
+pub fn create_position_udf() -> ScalarUDF {
+    let fun = make_scalar_function(move |args: &[ArrayRef]| {
+        assert!(args.len() == 2);
+
+        return Err(DataFusionError::NotImplemented(format!(
+            "POSITION is not implemented, it's a stub"
+        )));
+    });
+
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Int32)));
+
+    ScalarUDF::new(
+        "position",
+        &Signature::exact(vec![DataType::Utf8, DataType::Utf8], Volatility::Immutable),
+        &return_type,
+        &fun,
+    )
+}

--- a/rust/cubesql/cubesql/src/sql/statement.rs
+++ b/rust/cubesql/cubesql/src/sql/statement.rs
@@ -201,6 +201,10 @@ trait Visitor<'ast, E: Error> {
             }
             Expr::TypedString { .. } => (),
             Expr::AtTimeZone { timestamp, .. } => self.visit_expr(timestamp)?,
+            Expr::Position { expr, r#in } => {
+                self.visit_expr(expr)?;
+                self.visit_expr(r#in)?;
+            }
         };
 
         Ok(())


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for string filters used by Sigma Computing. `notStartsWith` and `notEndsWith` are currently ignored as those are not supported by Cube. Related tests are included.
