### PR TITLE
feat(cubesql): Support `BOOL_AND`, `BOOL_OR` aggregate functions

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66fee4aec65da7cfe59174287ceb20f98d137b5d#66fee4aec65da7cfe59174287ceb20f98d137b5d"
 dependencies = [
  "arrow",
  "chrono",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66fee4aec65da7cfe59174287ceb20f98d137b5d#66fee4aec65da7cfe59174287ceb20f98d137b5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66fee4aec65da7cfe59174287ceb20f98d137b5d#66fee4aec65da7cfe59174287ceb20f98d137b5d"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66fee4aec65da7cfe59174287ceb20f98d137b5d#66fee4aec65da7cfe59174287ceb20f98d137b5d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66fee4aec65da7cfe59174287ceb20f98d137b5d#66fee4aec65da7cfe59174287ceb20f98d137b5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=59a2174f534abaf04574f66dfa886ffdd4e5635b#59a2174f534abaf04574f66dfa886ffdd4e5635b"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66fee4aec65da7cfe59174287ceb20f98d137b5d#66fee4aec65da7cfe59174287ceb20f98d137b5d"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "59a2174f534abaf04574f66dfa886ffdd4e5635b", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "66fee4aec65da7cfe59174287ceb20f98d137b5d", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -12563,6 +12563,37 @@ ORDER BY \"COUNT(count)\" DESC"
     }
 
     #[tokio::test]
+    async fn test_bool_and_or() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "test_bool_and_or",
+            execute_query(
+                "
+                SELECT
+                    bool_and(ttt) and_ttt, bool_or(ttt) or_ttt,
+                    bool_and(ttf) and_ttf, bool_or(ttf) or_ttf,
+                    bool_and(fff) and_fff, bool_or(fff) or_fff,
+                    bool_and(ttn) and_ttn, bool_or(ttn) or_ttn,
+                    bool_and(tfn) and_tfn, bool_or(tfn) or_tfn,
+                    bool_and(ffn) and_ffn, bool_or(ffn) or_ffn,
+                    bool_and(nnn) and_nnn, bool_or(nnn) or_nnn
+                FROM (
+                    SELECT true ttt, true  ttf, false fff, true ttn, true  tfn, false ffn, null::bool nnn
+                    UNION ALL
+                    SELECT true ttt, true  ttf, false fff, true ttn, false tfn, false ffn, null       nnn
+                    UNION ALL
+                    SELECT true ttt, false ttf, false fff, null ttn, null  tfn, null  ffn, null       nnn
+                ) tbl
+                "
+                    .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_select_is_null_is_not_null() {
         init_logger();
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/language.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/language.rs
@@ -290,6 +290,8 @@ macro_rules! variant_field_struct {
                 AggregateFunction::ApproxPercentileCont => "ApproxPercentileCont",
                 AggregateFunction::ApproxPercentileContWithWeight => "ApproxPercentileContWithWeight",
                 AggregateFunction::ApproxMedian => "ApproxMedian",
+                AggregateFunction::BoolAnd => "BoolAnd",
+                AggregateFunction::BoolOr => "BoolOr",
             }
         );
     };

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__test_bool_and_or.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__test_bool_and_or.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                SELECT\n                    bool_and(ttt) and_ttt, bool_or(ttt) or_ttt,\n                    bool_and(ttf) and_ttf, bool_or(ttf) or_ttf,\n                    bool_and(fff) and_fff, bool_or(fff) or_fff,\n                    bool_and(ttn) and_ttn, bool_or(ttn) or_ttn,\n                    bool_and(tfn) and_tfn, bool_or(tfn) or_tfn,\n                    bool_and(ffn) and_ffn, bool_or(ffn) or_ffn,\n                    bool_and(nnn) and_nnn, bool_or(nnn) or_nnn\n                FROM (\n                    SELECT true ttt, true  ttf, false fff, true ttn, true  tfn, false ffn, null::bool nnn\n                    UNION ALL\n                    SELECT true ttt, true  ttf, false fff, true ttn, false tfn, false ffn, null       nnn\n                    UNION ALL\n                    SELECT true ttt, false ttf, false fff, null ttn, null  tfn, null  ffn, null       nnn\n                ) tbl\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+
+| and_ttt | or_ttt | and_ttf | or_ttf | and_fff | or_fff | and_ttn | or_ttn | and_tfn | or_tfn | and_ffn | or_ffn | and_nnn | or_nnn |
++---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+
+| true    | true   | false   | true   | false   | false  | true    | true   | false   | true   | false   | false  | NULL    | NULL   |
++---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+---------+--------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@66fee4a, adding support for `BOOL_AND` and `BOOL_OR` aggregate functions. A related test is included.
