### PR TITLE
Added initial Teradata JDBC driver implementation

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -205,6 +205,14 @@ const variables: Record<string, (...args: any) => any> = {
     .asString(),
   databrickAcceptPolicy: () => get('CUBEJS_DB_DATABRICKS_ACCEPT_POLICY')
     .asString(),
+  // TERADATA
+  teradataDbName: () => get('CUBEJS_DB_TERADATA_NAME')
+    .asString(),
+  teradataUrl: () => get('CUBEJS_DB_TERADATA_URL')
+    .asString(),
+  teradataAcceptPolicy: () => get('CUBEJS_DB_TERADATA_ACCEPT_POLICY')
+    .required()
+    .asString(),
   // Redis
   redisPoolMin: () => get('CUBEJS_REDIS_POOL_MIN')
     .default('2')

--- a/packages/cubejs-docker/dev.Dockerfile
+++ b/packages/cubejs-docker/dev.Dockerfile
@@ -96,6 +96,7 @@ RUN yarn install --prod
 FROM prod_base_dependencies as prod_dependencies
 COPY packages/cubejs-databricks-jdbc-driver/package.json packages/cubejs-databricks-jdbc-driver/package.json
 COPY packages/cubejs-databricks-jdbc-driver/bin packages/cubejs-databricks-jdbc-driver/bin
+COPY packages/cubejs-teradata-jdbc-driver/package.json packages/cubejs-teradata-jdbc-driver/package.json
 RUN yarn install --prod --ignore-scripts
 
 FROM base as build
@@ -140,6 +141,8 @@ COPY packages/cubejs-ksql-driver/ packages/cubejs-ksql-driver/
 COPY packages/cubejs-dbt-schema-extension/ packages/cubejs-dbt-schema-extension/
 COPY packages/cubejs-jdbc-driver/ packages/cubejs-jdbc-driver/
 COPY packages/cubejs-databricks-jdbc-driver/ packages/cubejs-databricks-jdbc-driver/
+COPY packages/cubejs-teradata-jdbc-driver/ packages/cubejs-teradata-jdbc-driver/
+
 # Skip
 # COPY packages/cubejs-testing/ packages/cubejs-testing/
 # COPY packages/cubejs-docker/ packages/cubejs-docker/

--- a/packages/cubejs-server-core/src/core/DriverDependencies.js
+++ b/packages/cubejs-server-core/src/core/DriverDependencies.js
@@ -26,4 +26,5 @@ module.exports = {
   materialize: '@cubejs-backend/materialize-driver',
   // List for JDBC drivers
   'databricks-jdbc': '@cubejs-backend/databricks-jdbc-driver',
+  teradata: '@cubejs-backend/teradata-jdbc-driver',
 };

--- a/packages/cubejs-server/src/server/container.ts
+++ b/packages/cubejs-server/src/server/container.ts
@@ -174,6 +174,7 @@ export class ServerContainer {
 
     const deepsToIgnore = [
       '@cubejs-backend/databricks-jdbc-driver',
+      '@cubejs-backend/teradata-jdbc-driver',
     ];
 
     if (manifest.dependencies) {

--- a/packages/cubejs-teradata-jdbc-driver/.gitignore
+++ b/packages/cubejs-teradata-jdbc-driver/.gitignore
@@ -1,0 +1,3 @@
+dist/
+download/
+bin/

--- a/packages/cubejs-teradata-jdbc-driver/LICENSE
+++ b/packages/cubejs-teradata-jdbc-driver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Cube Dev, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cubejs-teradata-jdbc-driver/README.md
+++ b/packages/cubejs-teradata-jdbc-driver/README.md
@@ -1,0 +1,68 @@
+# IN DEVELOPEMENT
+## Install Teradata VM (tested on version 17.10)
+- [Link to download the VM](https://downloads.teradata.com/download/database/teradata-express-for-vmware-player?_gl=1*9gfmgq*_ga*NTM5NzI5MzkuMTY1ODgyMjQzMA..*_ga_7PE2TMW3FE*MTY1OTMzNjk5NC43LjEuMTY1OTMzNzI5OS4w)
+
+### When you are the VM check the following:
+#### Check that you are connect to the internet
+`$ ip a`
+
+#### Check that your DB is connected
+1. `pdestate -a`
+2. a) You DB is online if you have the following output :
+```
+PDE state is RUN/STARTED.
+DBS state is 5: Lofons are enabled - The system is quiescent
+```
+
+2. b) If you don't get the output in point (1).
+try to delete the following file:
+- `$ rm /var/opt/teradata/tdtemp/PanicLoop`
+- Click on the **Start Teradata** executable file on your Desktop and wait a few minutes. Check if you DB is now online with (1)
+
+# Make sure to follow these steps after forking the repo:
+1. Run `yarn install` in the root directory.
+2. Run `yarn build` in the root directory to build the frontend dependent packages. 
+3. Run `yarn build` in `packages/cubejs-playground` to build the frontend.
+4. Run `yarn tsc:watch` to start the TypeScript compiler in watch mode.
+5. Run `yarn link` in `packages/cubejs-<pkg>` for the drivers and dependent packages you intend to modify. 
+- yarn link in "cubejs-schema-compiler" package
+- yarn link in "cubejs-backend-shared" package
+- yarn link in "cubejs-jdbc-driver" package
+
+6. Run `yarn install` in `packages/cubejs-<pkg>` to install dependencies for drivers and dependent packages.
+- yarn install in "cubejs-schema-compiler" package
+- yarn install in "cubejs-backend-shared" package
+- yarn install in "cubejs-jdbc-driver" package
+
+7. Run `yarn link @cubejs-backend/<pkg>` in `packages/cubejs-teradata-jdbc-driver` to link drivers and dependent packages.
+- yarn link "@cubejs-backend/shared"
+- yarn link "@cubejs-backend/jdbc-driver"
+- yarn link "@cubejs-backend/schema-compiler"
+
+8. Run `yarn install` in `packages/cubejs-teradata-jdbc-driver` to install the rest of the dependencies and install the terajdbc4.jar 
+
+9. Run `yarn build` in `packages/cubejs-teradata-jdbc-driver`
+
+10. To make sure that all packages will build correctly in the container, run `yarn lerna run build` in the root of the repo.
+- If you build successfuly, you're ready to build your own docker image
+
+# Build a docker image
+
+0. (optional) Run `yarn lerna run build` in the root of the repo to check all dependencies are satisfied.
+
+**All the following steps are done in `packages/cubejs-docker`.**
+
+1. Run the following command to build your image.
+- `docker build -t cubejs/cube:dev -f dev.Dockerfile ../../`
+
+2. Once the image is built (it will take time), fill in the `docker-compose.yml` file.
+Make sure that the following environement variables are filled.
+- `CUBEJS_DB_TYPE=<db_type>` # should be `teradata` to connect to teradata DB.
+- `CUBEJS_DB_NAME=<dbName>` 
+- `CUBEJS_DB_HOST=<host>` #should be `host.docker.internal` for localhost
+- `CUBEJS_DB_TERADATA_URL=jdbc:teradata://<teradata_db_ip>/USER=<teradata_user>,PASSWORD=<teradata_user_pwd>`
+- `CUBEJS_DB_TERADATA_ACCEPT_POLICY=true` #accept the Terms and Conditions of Teradata
+
+3. To start the container `docker compose up`
+
+4. Once is live, visit [http://localhost:4000/](http://localhost:4000/) to access the cube playground.

--- a/packages/cubejs-teradata-jdbc-driver/bin/post-install
+++ b/packages/cubejs-teradata-jdbc-driver/bin/post-install
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+if (!fs.existsSync(path.join(__dirname, '..', 'dist', 'src', 'post-install.js')) && fs.existsSync(path.join(__dirname, '..', 'tsconfig.json'))) {
+  console.log('Skipping post-install because it was not compiled');
+  return;
+}
+
+require('./post-install.js');

--- a/packages/cubejs-teradata-jdbc-driver/package.json
+++ b/packages/cubejs-teradata-jdbc-driver/package.json
@@ -1,0 +1,58 @@
+{
+    "name": "@cubejs-backend/teradata-jdbc-driver",
+    "description": "Cube.js Teradata database driver",
+    "author": "Cube Dev, Inc.",
+    "version": "0.30.42",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cube-js/cube.js.git",
+        "directory": "packages/cubejs-teradata-driver"
+    },
+    "engines": {
+        "node": ">=10.8.0"
+    },
+    "main": "dist/src/index.js",
+    "typings": "dist/src/index.d.ts",
+    "scripts": {
+        "build": "rm -rf dist && npm run tsc",
+        "tsc": "tsc",
+        "watch": "tsc -w",
+        "lint": "eslint src/* --ext .ts",
+        "lint:fix": "eslint --fix src/* --ext .ts"
+    },
+    "files": [
+        "README.md",
+        "dist/src/*",
+        "bin"
+    ],
+    "dependencies": {
+        "@cubejs-backend/jdbc-driver": "^0.30.39",
+        "@cubejs-backend/query-orchestrator": "^0.30.39",
+        "@cubejs-backend/schema-compiler": "^0.30.39",
+        "@cubejs-backend/shared": "^0.30.34",
+        "inquirer": "^8.0.0",
+        "source-map-support": "^0.5.19",
+        "node-fetch": "^2.6.1",
+        "uuid": "^8.3.2",
+        "@types/uuid": "^8.3.4",
+        "ramda":"^0.28.0"
+    },
+    "devDependencies": {
+        "@cubejs-backend/linter": "^0.26.74",
+        "@types/inquirer": "^7.3.1",
+        "@types/jest": "^26.0.20",
+        "@types/node": "^10.17.55",
+        "jest": "^26.6.3",
+        "typescript": "~4.1.5"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "eslintConfig": {
+        "extends": "../cubejs-linter"
+    },
+    "jest": {
+        "testEnvironment": "node"
+    }
+}

--- a/packages/cubejs-teradata-jdbc-driver/src/TeradataDriver.ts
+++ b/packages/cubejs-teradata-jdbc-driver/src/TeradataDriver.ts
@@ -1,0 +1,267 @@
+/* eslint-disable no-restricted-syntax */
+import { JDBCDriver, JDBCDriverConfiguration } from '@cubejs-backend/jdbc-driver';
+import { getEnv } from '@cubejs-backend/shared';
+import fs from 'fs';
+import path from 'path';
+import { TeradataQuery } from './TeradataQuery';
+
+export type TeradataDriverConfiguration = JDBCDriverConfiguration & {
+  readOnly?: boolean,
+};
+
+async function fileExistsOr(fsPath: string, fn: () => Promise<string>): Promise<string> {
+  if (fs.existsSync(fsPath)) {
+    return fsPath;
+  }
+
+  return fn();
+}
+
+const jdbcDriverResolver: Promise<string> | null = null;
+
+async function resolveJDBCDriver(): Promise<string> {
+  if (jdbcDriverResolver) {
+    return jdbcDriverResolver;
+  }
+
+  return fileExistsOr(
+    path.join(process.cwd(), 'terajdbc4.jar'),
+    async () => fileExistsOr(path.join(__dirname, '..', '..', 'download', 'terajdbc4.jar'), async () => {
+      throw new Error('Please place terajdbc4.jar inside the container in /cubejs/packages/cubejs-teradata-jdbc-driver/download');
+    })
+  );
+}
+
+type ShowTableRow = {
+  database: string,
+  tableName: string,
+};
+
+const TeradataToGenericType: Record<string, string> = {
+  AT: 'TIME',
+  CF: 'string',
+  CV: 'VARCHAR',
+  D: 'DECIMAL',
+  DA: 'DATE',
+  DH: 'INTERVAL DAY TO HOUR',
+  DM: 'INTERVAL DAY TO MINUTE',
+  DS: 'INTERVAL DAY TO SECOND',
+  DY: 'INTERVAL DAY',
+  F: 'FLOAT',
+  HM: 'INTERVAL HOUR TO MINUTE',
+  HS: 'INTERVAL HOUR TO SECOND',
+  HR: 'INTERVAL HOUR',
+  I: 'INTEGER',
+  I1: 'BYTEINT',
+  I2: 'SMALLINT',
+  I8: 'bigint',
+  JN: 'JSON',
+  MI: 'INTERVAL MINUTE',
+  MO: 'INTERVAL MONTH',
+  MS: 'INTERVAL MINUTE TO SECOND',
+  N: 'NUMBER',
+  PD: 'PERIOD(DATE)',
+  PM: 'PERIOD(TIMESTAMP WITH TIME ZONE)',
+  PS: 'PERIOD(TIMESTAMP)',
+  PT: 'PERIOD(TIME)',
+  PZ: 'PERIOD(TIME WITH TIME ZONE)',
+  SC: 'INTERVAL SECOND',
+  SZ: 'TIMESTAMP WITH TIME ZONE',
+  TS: 'TIMESTAMP',
+  TZ: 'TIME WITH TIME ZONE',
+  UT: 'UDT Type',
+  XM: 'XML',
+  YM: 'INTERVAL YEAR TO MONTH',
+  YR: 'INTERVAL YEAR',
+  '++': 'TD_ANYTYPE'
+};
+
+const TeradataToAllowedCubeNumbersType: Record<string, string> = {
+  FLOAT: 'numb',
+  DECIMAL: 'dec',
+  INTEGER: 'int',
+  BYTEINT: 'int',
+  SMALLINT: 'int',
+  BIGINT: 'int',
+  NUMBER: 'numb',
+};
+
+export class TeradataDriver extends JDBCDriver {
+  protected readonly config: TeradataDriverConfiguration;
+
+  public static dialectClass() {
+    return TeradataQuery;
+  }
+
+  public constructor(configuration: Partial<TeradataDriverConfiguration>) {
+    const config: TeradataDriverConfiguration = {
+      drivername: 'com.teradata.jdbc.TeraDriver',
+      database: getEnv('teradataDbName', { required: false }),
+      dbType: 'teradata',
+      url: getEnv('teradataUrl'),
+      customClassPath: undefined,
+      properties: {},
+      ...configuration
+    };
+
+    super(config);
+    this.config = config;
+  }
+
+  public readOnly() {
+    return !!this.config.readOnly;
+  }
+
+  protected async getCustomClassPath() {
+    return resolveJDBCDriver();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async createSchemaIfNotExists(schemaName: string): Promise<any> {
+    // do nothing for the moment.
+  }
+
+  public quoteIdentifier(identifier: string): string {
+    return `"${identifier}"`;
+  }
+
+  private lettersNumbersSpacesDashes(str: string) {
+    return /^[A-Za-z0-9 _]*$/.test(str);
+  }
+
+  public async tableColumnTypes(table: string) {
+    const [databaseName, tableName] = table.split('.');
+    
+    try {
+      let columns = await this.query(`HELP COLUMN * FROM ${tableName}`, []);
+      
+      if (!columns.length) {
+        return [];
+      }
+
+      columns = columns.map((c: any, index) => {
+        const { 'Column Name': columnName, Type: dataType, 'Primary?': keyType } = c;
+        let name = columnName.trim();
+
+        if (!columnName || !dataType) {
+          return null;
+        }
+
+        if (!this.lettersNumbersSpacesDashes(name)) {
+          name = `unknown_${index}_${name}`;
+        }
+
+        const genericType = this.toGenericType(dataType.trim());
+        const columnType = this.toAllowdedNumber(genericType) || genericType;
+        const isPrimaryKey = keyType?.trim() === 'P';
+
+        return { name, type: columnType, attributes: isPrimaryKey ? ['primaryKey'] : [] };
+      }).filter(x => x !== null);
+      return columns;
+    } catch (error) {
+      // TODO: handle errors.
+      console.log(error);
+    }
+    return [];
+  }
+
+  public async getTablesQuery(databaseName: string) {
+    try {
+      // Only SELECT VIEWS (tabkeKind=V)
+      // TODO: handle also tables, not only table views.
+      const response = await this.query(`SELECT 
+                                          DATABASENAME AS "database",
+                                          TABLENAME AS "tableName",
+                                          FROM dbc.tables
+                                          WHERE tableKind='V' AND databasename='${databaseName}'
+                                              `, []);
+      return response.map((row: any) => ({
+        table_name: row.tableName.trim(),
+      }));
+    } catch (error) {
+      // TODO: handle errors.
+      console.log(error);
+      return [];
+    }
+  }
+
+  protected async getTables(): Promise<ShowTableRow[]> {
+    const databaseName = this.config.database;
+    const allTables: ShowTableRow[] = [];
+
+    const results: any = await this.query(`SELECT 
+                                          DATABASENAME AS "database",
+                                          TABLENAME AS "tableName"
+                                          FROM dbc.tables
+                                          WHERE tableKind='V' AND databasename='${databaseName}'
+                                              `, []);
+    
+    for (let index = 0; index < results.length; index++) {
+      const { database, tableName } = results[index];
+      if (database && tableName) {
+        allTables.push({ database: database.trim(), tableName: tableName.trim() });
+      }
+    }
+    
+    return allTables.flat();
+  }
+
+  public toGenericType(columnType: string): string {
+    return TeradataToGenericType[columnType] || super.toGenericType(columnType);
+  }
+
+  public toAllowdedNumber(columnType: string): string {
+    return TeradataToAllowedCubeNumbersType[columnType];
+  }
+
+  public async tablesSchema() {
+    const tables = await this.getTables();
+
+    const metadata: Record<string, Record<string, object>> = {};
+
+    if (!tables.length) {
+      return metadata;
+    }
+
+    for (const table of tables) {
+      if (table) {
+        const { database, tableName } = table;
+        if (!(database in metadata) || !database || !tableName) {
+          metadata[database] = {};
+        }
+        console.log(`Request start: ${database}.${tableName}`);
+        const columns = await this.tableColumnTypes(`${database}.${tableName}`);
+        console.log('Request finish:', table);
+        if (columns.length) {
+          metadata[database][tableName] = columns;
+        }
+      }
+    }
+    
+    return metadata;
+  }
+
+  protected async queryPromised(query: any, cancelObj: any, options: any) {
+    options = options || {};
+    try {
+      const conn = await this.pool.acquire();
+      
+      try {
+        const prepareConnectionQueries = options.prepareConnectionQueries || [];
+        for (let i = 0; i < prepareConnectionQueries.length; i++) {
+          await this.executeStatement(conn, prepareConnectionQueries[i], null);
+        }
+        return await this.executeStatement(conn, query, cancelObj);
+      } finally {
+        // TODO: we should release the pool.
+        // await this.pool.release(conn);
+      }
+    } catch (ex: any) {
+      if (ex.cause) {
+        throw new Error(ex.cause.getMessageSync());
+      } else {
+        throw ex;
+      }
+    }
+  }
+}

--- a/packages/cubejs-teradata-jdbc-driver/src/TeradataQuery.ts
+++ b/packages/cubejs-teradata-jdbc-driver/src/TeradataQuery.ts
@@ -1,0 +1,140 @@
+import { BaseFilter, BaseQuery } from '@cubejs-backend/schema-compiler';
+import R, { concat } from 'ramda';
+
+const GRANULARITY_TO_INTERVAL: Record<string, string> = {
+  day: 'DD',
+  hour: 'HH',
+  minute: 'MI',
+  second: 'second',
+  month: 'MONTH',
+  year: 'YEAR'
+};
+
+class TeradataFilter extends BaseFilter {
+  public likeIgnoreCase(column: any, not: any, param: any, type: string) {
+    const p = (!type || type === 'contains' || type === 'ends') ? '%' : '';
+    const s = (!type || type === 'contains' || type === 'starts') ? '%' : '';
+    return `${column}${not ? ' NOT' : ''} LIKE CONCAT('${p}', ${this.allocateParam(param)}, '${s}')`;
+  }
+}
+
+export class TeradataQuery extends BaseQuery {
+  public newFilter(filter: any) {
+    return new TeradataFilter(this, filter);
+  }
+
+  public concatStringsSql(strings: string[]) {
+    return `CONCAT(${strings.join(', ')})`;
+  }
+
+  public convertTz(field: string) {
+    return `${field}`;
+  }
+
+  public timeStampCast(value: string) {
+    return `CAST(OREPLACE(OREPLACE(${value}, 'T', ' '), 'Z', '') AS TIMESTAMP(3))`;
+  }
+
+  public dateTimeCast(value: string) {
+    return `CAST(OREPLACE(OREPLACE(${value}, 'T', ' '), 'Z', '') AS TIMESTAMP(3))`;
+  }
+
+  public subtractInterval(date: string, interval: string) {
+    const [number, type] = this.parseInterval(interval);
+    console.log(`(${date} - INTERVAL '${number}' ${type})`);
+    return `(${date} - INTERVAL '${number}' ${type})`;
+  }
+
+  public addInterval(date: string, interval: string) {
+    const [number, type] = this.parseInterval(interval);
+    console.log(`(${date} + INTERVAL '${number}' ${type})`);
+    return `(${date} + INTERVAL '${number}' ${type})`;
+  }
+
+  public timeGroupedColumn(granularity: string, dimension: string): string {
+    console.log(`TRUNC(CAST(${dimension} AS TIMESTAMP(6)), '${GRANULARITY_TO_INTERVAL[granularity]}')`);
+    return `TRUNC(CAST(${dimension} AS TIMESTAMP(6)), '${GRANULARITY_TO_INTERVAL[granularity]}')`;
+  }
+
+  public rowNumberColumn() {
+    return ', ROW_NUMBER() OVER (ORDER BY 1) AS RowNum_ ';
+  }
+
+  public groupByDimensionLimit() {
+    const RADIX = 10;
+    let startWindow = 0;
+    let endWindow = 1000;
+    if (this.offset && parseInt(this.offset, RADIX)) {
+      startWindow = this.rowLimit === null ? 0 : (this.rowLimit && parseInt(this.rowLimit, 10) || 0);
+      endWindow = startWindow + parseInt(this.offset, RADIX);
+    } else {
+      endWindow = this.rowLimit === null ? 0 : (this.rowLimit && parseInt(this.rowLimit, 10) || 1000);
+    }
+
+    return ` QUALIFY RowNum_ BETWEEN ${startWindow} AND ${endWindow}`;
+  }
+
+  public commonQuery() {
+    return `
+      SELECT
+      ${this.baseSelect()}
+      ${this.rowNumberColumn()}
+      FROM
+      ${this.query()}
+      ${this.groupByClause()}
+      ${this.baseHaving(this.measureFilters)}
+      ${this.groupByDimensionLimit()}`;
+  }
+
+  public simpleQuery() {
+    // eslint-disable-next-line prefer-template
+    const inlineWhereConditions: any[] = [];
+    const commonQuery = this.rewriteInlineWhere(() => this.commonQuery(), inlineWhereConditions);
+    const aliases = this.baseSelect()
+      .split(' ')
+      .map(word => word.replace(',', ''))
+      .filter((word) => word.includes('__'))
+      .toString();
+    // eslint-disable-next-line prefer-template
+    return `
+        WITH WINDOW_TABLE AS  (
+        ${commonQuery} 
+        ${this.baseWhere(this.allFilters.concat(inlineWhereConditions))}`
+       + `) SELECT ${aliases} FROM WINDOW_TABLE`
+       + this.orderBy();
+  }
+  
+  public escapeColumnName(name: string) {
+    return `"${name}"`;
+  }
+
+  public renderDimensionCaseLabel(label: any, cubeName: any) {
+    if (typeof label === 'object' && label.sql) {
+      return this.evaluateSql(cubeName, label.sql, null);
+    }
+    return `"${label}"`;
+  }
+
+  public getFieldIndex(id: string) {
+    const dimension = this.dimensionsForSelect().find((d: any) => d.dimension === id);
+    if (dimension) {
+      return super.getFieldIndex(id);
+    }
+    return this.escapeColumnName(this.aliasName(id, false));
+  }
+
+  public seriesSql(timeDimension: any) {
+    const values = timeDimension.timeSeries().map(
+      ([from, to]: [string, string]) => `select '${from}' f, '${to}' t`
+    ).join(' UNION ALL ');
+    return `SELECT ${this.timeStampCast('dates.f')} date_from, ${this.timeStampCast('dates.t')} date_to FROM (${values}) AS dates`;
+  }
+
+  public defaultRefreshKeyRenewalThreshold() {
+    return 120;
+  }
+
+  public castToString(sql: any): string {
+    return `CAST(${sql} as VARCHAR(1024))`;
+  }
+}

--- a/packages/cubejs-teradata-jdbc-driver/src/index.ts
+++ b/packages/cubejs-teradata-jdbc-driver/src/index.ts
@@ -1,0 +1,3 @@
+import { TeradataDriver } from './TeradataDriver';
+
+export default TeradataDriver;

--- a/packages/cubejs-teradata-jdbc-driver/src/installer.ts
+++ b/packages/cubejs-teradata-jdbc-driver/src/installer.ts
@@ -1,0 +1,64 @@
+import path from 'path';
+import inquirer from 'inquirer';
+import { displayCLIWarning, downloadAndExtractFile, getEnv } from '@cubejs-backend/shared';
+
+function acceptedByEnv() {
+  const acceptStatus = getEnv('teradataAcceptPolicy');
+  if (acceptStatus) {
+    console.log('You accepted Terms & Conditions for JDBC driver from Teradata by CUBEJS_DB_TERADATA_ACCEPT_POLICY');
+  }
+
+  if (acceptStatus === false) {
+    console.log('You declined Terms & Conditions for JDBC driver from Teradata by CUBEJS_DB_TERADATA_ACCEPT_POLICY');
+    console.log('Installation will be skipped');
+  }
+
+  return acceptStatus;
+}
+
+async function cliAcceptVerify() {
+  console.log('Teradata driver is using JDBC driver from Teradata');
+  console.log('By downloading the driver, you agree to the Terms & Conditions');
+  console.log('link to insert');
+  console.log('More info: say no more');
+
+  if (process.stdout.isTTY) {
+    const { licenseAccepted } = await inquirer.prompt([{
+      type: 'confirm',
+      name: 'licenseAccepted',
+      message: 'You read & agree to the Terms & Conditions',
+    }]);
+
+    return licenseAccepted;
+  }
+
+  displayCLIWarning('Your stdout is not interactive, you can accept it via CUBEJS_DB_DATABRICKS_ACCEPT_POLICY=true');
+
+  return false;
+}
+
+export async function downloadJDBCDriver(isCli: boolean = false): Promise<string | null> {
+  let driverAccepted = acceptedByEnv();
+
+  if (driverAccepted === undefined && isCli) {
+    driverAccepted = await cliAcceptVerify();
+  }
+
+  if (driverAccepted) {
+    console.log('Downloading terajdbc4');
+
+    await downloadAndExtractFile(
+      'https://drive.google.com/uc?export=download&id=11HlWnmzCJ7S5zFRYA_FWHFdz0gfs5Isj',
+      {
+        showProgress: true,
+        cwd: path.resolve(path.join(__dirname, '..', '..', 'download')),
+      }
+    );
+
+    console.log('Teradata jdbc file has been download and unzip');
+
+    return path.resolve(path.join(__dirname, '..', '..', 'download', 'terajdbc4.jar'));
+  }
+
+  return null;
+}

--- a/packages/cubejs-teradata-jdbc-driver/src/post-install.ts
+++ b/packages/cubejs-teradata-jdbc-driver/src/post-install.ts
@@ -1,0 +1,11 @@
+import { displayCLIError } from '@cubejs-backend/shared';
+
+import { downloadJDBCDriver } from './installer';
+
+(async () => {
+  try {
+    await downloadJDBCDriver(true);
+  } catch (e: any) {
+    await displayCLIError(e, 'Cube.js Teradata JDBC Installer');
+  }
+})();

--- a/packages/cubejs-teradata-jdbc-driver/tsconfig.json
+++ b/packages/cubejs-teradata-jdbc-driver/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src",
+    "test"
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,9 @@
       "path": "packages/cubejs-databricks-jdbc-driver"
     },
     {
+      "path": "packages/cubejs-teradata-jdbc-driver"
+    },
+    {
       "path": "rust/cubestore"
     },
     {


### PR DESCRIPTION
This patch introduces initial Teradata JDBC driver implementation.

Introducing the following env vars:
CUBEJS_DB_TERADATA_NAME - optional, name of the database to connect to CUBEJS_DB_TERADATA_URL - mandatory, e.g.
                         jdbc:teradata://<teradata_db_ip>/USER=<teradata_user>,PASSWORD=<teradata_user_pwd>
CUBEJS_DB_TERADATA_ACCEPT_POLICY - optional, true/false to accept terms and conditions

As part of the Docker build we fetch an external dependency, namely the Teradata JDBC jar file into:
/cubejs/packages/cubejs-teradata-jdbc-driver/download/terajdbc4.jar

More information on setting up a server and using this driver is documented here:
packages/cubejs-teradata-jdbc-driver/README.md
We tested it with an on-prem Teradata server as well as Teradata Express.
Known limitations include:
1) Max 15 transactions per cursor
   https://docs.teradata.com/r/GVKfXcemJFkTJh_89R34UQ/YB_t1rB9boiHUNbSQlvLRA (Error 3130).

2) Cursor limitations
   After 15 transactions we get the 3130 error from the cursor.
   Temporary workaround: doing a Cube pre-processing step where we manually
   generate the schemas outside of Cube using Teradata SQL CLI client (bteq).

3) Only handling table views
   Handling tables (in addition to table views)
   Currently we only support table views (tableKind=‘V’) and not tables.
   Need to implement and test it.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
