### PR TITLE
fix: cubejs-client - startsWith and endsWith to filterOperatorsForMember

### DIFF
--- a/packages/cubejs-client-core/src/Meta.js
+++ b/packages/cubejs-client-core/src/Meta.js
@@ -14,6 +14,8 @@ const operators = {
     { name: 'notEquals', title: 'does not equal' },
     { name: 'set', title: 'is set' },
     { name: 'notSet', title: 'is not set' },
+    { name: 'startsWith', title: 'starts with' },
+    { name: 'endsWith', title: 'ends with' },
   ],
   number: [
     { name: 'equals', title: 'equals' },


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made (if issue reference is not provided)**

`filterOperatorsForMember` should return operators `startsWith` and `endsWith` for string members