### PR TITLE
Move `@babel/runtime` from `devDependencies` to `dependencies`

### DIFF
--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -13,6 +13,7 @@
   "types": "index.d.ts",
   "author": "Cube Dev, Inc.",
   "dependencies": {
+    "@babel/runtime": "^7.1.2",
     "core-js": "^3.6.5",
     "cross-fetch": "^3.0.2",
     "dayjs": "^1.10.4",
@@ -35,7 +36,6 @@
   "devDependencies": {
     "@babel/core": "^7.3.3",
     "@babel/preset-env": "^7.3.1",
-    "@babel/runtime": "^7.1.2",
     "@types/jest": "^26.0.9",
     "@types/moment-range": "^4.0.0",
     "babel-jest": "^26.0.1",


### PR DESCRIPTION
`@babel/runtime` was moved to `devDependencies` in https://github.com/cube-js/cube.js/commit/e2c9b20d0420049b9b96608716a7f10212db2c36.

This PR moves it back to `dependencies` as it's required to use the package in scenarios where it's needed outside of the CubeJS server. 

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
