### PR TITLE
fix(cubesql): Keep CubeScan literal values relation

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -13321,4 +13321,39 @@ ORDER BY \"COUNT(count)\" DESC"
             )
         }
     }
+
+    #[tokio::test]
+    async fn test_sigma_literal_relation() {
+        init_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT l1.*
+            FROM (
+                SELECT
+                    "customer_gender",
+                    1 as error
+                FROM "KibanaSampleDataEcommerce"
+            ) as l1
+            ;"#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+            }
+        )
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -11,13 +11,13 @@ use crate::{
             ColumnExprColumn, CubeScanAliases, CubeScanLimit, CubeScanOffset, DimensionName,
             EmptyRelationProduceOneRow, FilterMemberMember, FilterMemberOp, FilterMemberValues,
             FilterOpOp, InListExprNegated, JoinJoinConstraint, JoinJoinType, JoinLeftOn,
-            JoinRightOn, LimitFetch, LimitSkip, LiteralExprValue, LiteralMemberValue,
-            LogicalPlanLanguage, MeasureName, MemberErrorError, OrderAsc, OrderMember,
-            OuterColumnExprColumn, OuterColumnExprDataType, ProjectionAlias, ScalarFunctionExprFun,
-            ScalarUDFExprFun, ScalarVariableExprDataType, ScalarVariableExprVariable,
-            SegmentMemberMember, SortExprAsc, SortExprNullsFirst, TableScanFetch,
-            TableScanProjection, TableScanSourceTableName, TableScanTableName, TableUDFExprFun,
-            TimeDimensionDateRange, TimeDimensionGranularity, TimeDimensionName,
+            JoinRightOn, LimitFetch, LimitSkip, LiteralExprValue, LiteralMemberRelation,
+            LiteralMemberValue, LogicalPlanLanguage, MeasureName, MemberErrorError, OrderAsc,
+            OrderMember, OuterColumnExprColumn, OuterColumnExprDataType, ProjectionAlias,
+            ScalarFunctionExprFun, ScalarUDFExprFun, ScalarVariableExprDataType,
+            ScalarVariableExprVariable, SegmentMemberMember, SortExprAsc, SortExprNullsFirst,
+            TableScanFetch, TableScanProjection, TableScanSourceTableName, TableScanTableName,
+            TableUDFExprFun, TimeDimensionDateRange, TimeDimensionGranularity, TimeDimensionName,
             TryCastExprDataType, UnionAlias, WindowFunctionExprFun, WindowFunctionExprWindowFrame,
         },
     },
@@ -1189,9 +1189,14 @@ impl LanguageToLogicalPlanConverter {
                                     let value =
                                         match_data_node!(node_by_id, params[0], LiteralMemberValue);
                                     let expr = self.to_expr(params[1])?;
+                                    let relation = match_data_node!(
+                                        node_by_id,
+                                        params[2],
+                                        LiteralMemberRelation
+                                    );
                                     fields.push((
                                         DFField::new(
-                                            expr_relation(&expr),
+                                            relation.as_deref(),
                                             &expr_name(&expr)?,
                                             value.get_datatype(),
                                             true,

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -237,6 +237,7 @@ crate::plan_to_language! {
         LiteralMember {
             value: ScalarValue,
             expr: Arc<Expr>,
+            relation: Option<String>,
         },
         Order {
             member: String,
@@ -892,8 +893,8 @@ fn change_user_expr(cube: impl Display, expr: impl Display) -> String {
     format!("(ChangeUser {} {})", cube, expr)
 }
 
-fn literal_member(value: impl Display, expr: impl Display) -> String {
-    format!("(LiteralMember {} {})", value, expr)
+fn literal_member(value: impl Display, expr: impl Display, relation: impl Display) -> String {
+    format!("(LiteralMember {} {} {})", value, expr, relation)
 }
 
 fn time_dimension_expr(


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue with CubeScans missing relations for literal values, which prevented referencing them from outer query. For instance, this query was broken before the proposed fix:
```sql
SELECT t.* FROM (
  SELECT "column", 'literal' AS literal
  FROM table
) t
```
Related test is included.