### PR TITLE
fix(cubesql): Allow referencing CTEs in UNION

### DIFF
--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a5ad4c551998653bde8a33e72ba8f6198cc7326e#a5ad4c551998653bde8a33e72ba8f6198cc7326e"
 dependencies = [
  "arrow",
  "chrono",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a5ad4c551998653bde8a33e72ba8f6198cc7326e#a5ad4c551998653bde8a33e72ba8f6198cc7326e"
 dependencies = [
  "ahash",
  "arrow",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a5ad4c551998653bde8a33e72ba8f6198cc7326e#a5ad4c551998653bde8a33e72ba8f6198cc7326e"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a5ad4c551998653bde8a33e72ba8f6198cc7326e#a5ad4c551998653bde8a33e72ba8f6198cc7326e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a5ad4c551998653bde8a33e72ba8f6198cc7326e#a5ad4c551998653bde8a33e72ba8f6198cc7326e"
 dependencies = [
  "ahash",
  "arrow",
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=97c7336b56f53bdb833944354932ea45b08b91f5#97c7336b56f53bdb833944354932ea45b08b91f5"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=a5ad4c551998653bde8a33e72ba8f6198cc7326e#a5ad4c551998653bde8a33e72ba8f6198cc7326e"
 dependencies = [
  "ahash",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://cube.dev/docs"
 homepage = "https://cube.dev"
 
 [dependencies]
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "97c7336b56f53bdb833944354932ea45b08b91f5", default-features = false, features = ["unicode_expressions"] }
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "a5ad4c551998653bde8a33e72ba8f6198cc7326e", default-features = false, features = ["unicode_expressions"] }
 anyhow = "1.0"
 thiserror = "1.0"
 cubeclient = { path = "../cubeclient" }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -9873,6 +9873,26 @@ ORDER BY \"COUNT(count)\" DESC"
     }
 
     #[tokio::test]
+    async fn test_union_ctes() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "union_ctes",
+            execute_query(
+                "
+                WITH w AS (SELECT 1 l)
+                SELECT w.l
+                FROM w
+                UNION ALL (SELECT w.l FROM w)
+                ;"
+                .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_cast_decimal_default_precision() -> Result<(), CubeError> {
         insta::assert_snapshot!(
             "cast_decimal_default_precision",

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__union_ctes.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__union_ctes.snap
@@ -1,0 +1,10 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                WITH w AS (SELECT 1 l)\n                SELECT w.l\n                FROM w\n                UNION ALL (SELECT w.l FROM w)\n                ;\".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++---+
+| l |
++---+
+| 1 |
+| 1 |
++---+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@a5ad4c5, fixing an issue with UNION expressions failing to see referenced CTEs. This fixes queries like the one below:
```sql
WITH w AS (SELECT 1 l)
SELECT w.l
FROM w
UNION ALL (SELECT w.l FROM w)
```
Related test is included.
