### PR TITLE
Add CUBEJS_PG_SQL_PORT to cubejs helm chart env

### DIFF
--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -9,6 +9,10 @@
 - name: CUBEJS_SQL_PORT
   value: {{ .Values.config.sqlPort | quote }}
 {{- end }}
+{{- if .Values.config.pgSqlPort }}
+- name: CUBEJS_PG_SQL_PORT
+  value: {{ .Values.config.pgSqlPort | quote }}
+{{- end }}
 {{- if .Values.config.sqlUser }}
 - name: CUBEJS_SQL_USER
   value: {{ .Values.config.sqlUser | quote }}

--- a/examples/helm-charts/cubejs/templates/master/deployment.yaml
+++ b/examples/helm-charts/cubejs/templates/master/deployment.yaml
@@ -48,6 +48,11 @@ spec:
               containerPort: {{ .Values.config.sqlPort }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.config.pgSqlPort }}
+            - name: pgsql
+              containerPort: {{ .Values.config.pgSqlPort }}
+              protocol: TCP
+            {{- end }}
           env:
             {{- include "cubejs.common-env" . | nindent 12 }}
           {{- if .Values.master.livenessProbe.enabled }}

--- a/examples/helm-charts/cubejs/templates/master/service.yaml
+++ b/examples/helm-charts/cubejs/templates/master/service.yaml
@@ -22,6 +22,11 @@ spec:
       port: {{ .Values.config.sqlPort }}
       targetPort: sql
     {{- end}}
+    {{- if .Values.config.pgSqlPort }}
+    - name: pgsql
+      port: {{ .Values.config.pgSqlPort }}
+      targetPort: pgsql
+    {{- end}}
   selector:
     app.kubernetes.io/component: master
     {{- include "cubejs.selectorLabels" . | nindent 4 }}

--- a/examples/helm-charts/cubejs/values.yaml
+++ b/examples/helm-charts/cubejs/values.yaml
@@ -42,6 +42,10 @@ config:
   ##
   sqlPort:
 
+  ## The port for a Cube.js deployment to listen to Postgres SQL connections on
+  ##
+  pgSqlPort: 5432
+
   ## The username to access the SQL api
   ##
   sqlUser:

--- a/examples/helm-charts/cubejs/values.yaml
+++ b/examples/helm-charts/cubejs/values.yaml
@@ -44,7 +44,7 @@ config:
 
   ## The port for a Cube.js deployment to listen to Postgres SQL connections on
   ##
-  pgSqlPort: 5432
+  pgSqlPort:
 
   ## The username to access the SQL api
   ##


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

-

**Description of Changes Made (if issue reference is not provided)**

Helm chart, although had a doc entry for `config.pgSqlPort` doesn't really support it. This PR should add the correct env mapping for that config value
