### PR TITLE
refactor(cubestore): Introduce RocksMetaStore via BaseMetaStore

### DIFF
--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -41,7 +41,7 @@ use rocksdb::{Options, DB};
 use simple_logger::SimpleLogger;
 use std::fmt::Display;
 use std::future::Future;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -1102,9 +1102,14 @@ impl Config {
                         let config = i.get_service_typed::<dyn ConfigObj>().await;
                         let metastore_fs = i.get_service_typed::<dyn MetaStoreFs>().await;
                         let meta_store = if let Some(dump_dir) = config.clone().dump_dir() {
-                            RocksMetaStore::load_from_dump(&path, dump_dir, metastore_fs, config)
-                                .await
-                                .unwrap()
+                            RocksMetaStore::load_from_dump(
+                                &Path::new(&path),
+                                dump_dir,
+                                metastore_fs,
+                                config,
+                            )
+                            .await
+                            .unwrap()
                         } else {
                             metastore_fs.load_from_remote(&path, config).await.unwrap()
                         };

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -3299,7 +3299,6 @@ impl MetaStore for RocksMetaStore {
         multi_partition_id: u64,
     ) -> Result<(IdRow<MultiIndex>, IdRow<MultiPartition>, Vec<PartitionData>), CubeError> {
         let (mi, mp, pds) = self
-            .store
             .read_operation(move |db| {
                 let mindex = MultiIndexRocksTable::new(db.clone());
                 let mpartition = MultiPartitionRocksTable::new(db.clone());

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -20,12 +20,10 @@ use log::info;
 use rocksdb::{MergeOperands, Options, DB};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
-use std::{env, io::Cursor, sync::Arc, time};
-use tokio::fs;
-use tokio::sync::{oneshot, Notify, RwLock};
+use std::{io::Cursor, sync::Arc};
 
 use crate::config::injection::DIService;
-use crate::config::{Config, ConfigObj};
+use crate::config::ConfigObj;
 use crate::metastore::chunks::{ChunkIndexKey, ChunkRocksIndex};
 use crate::metastore::index::IndexIndexKey;
 use crate::metastore::job::{Job, JobIndexKey, JobRocksIndex, JobRocksTable, JobStatus, JobType};
@@ -39,10 +37,9 @@ use crate::metastore::source::{
 };
 use crate::metastore::table::{AggregateColumnIndex, TableIndexKey, TablePath};
 use crate::metastore::wal::{WALIndexKey, WALRocksIndex};
-use crate::remotefs::LocalDirRemoteFs;
+
 use crate::table::{Row, TableValue};
-use crate::util::aborting_join_handle::AbortingJoinHandle;
-use crate::util::time_span::warn_long;
+
 use crate::util::WorkerLoop;
 use crate::{meta_store_table_impl, CubeError};
 use arrow::datatypes::TimeUnit::Microsecond;
@@ -50,7 +47,7 @@ use arrow::datatypes::{DataType, Field};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use chrono::{DateTime, Utc};
 use chunks::ChunkRocksTable;
-use core::{fmt, mem};
+use core::fmt;
 use cubehll::HllSketch;
 use cubezetasketch::HyperLogLogPlusPlus;
 use datafusion::cube_ext;
@@ -58,24 +55,26 @@ use futures_timer::Delay;
 use index::{IndexRocksIndex, IndexRocksTable};
 use itertools::Itertools;
 use log::trace;
-use metastore_fs::{MetaStoreFs, RocksMetaStoreFs};
+use metastore_fs::MetaStoreFs;
 use multi_index::{MultiIndex, MultiIndexRocksIndex, MultiIndexRocksTable};
 use parquet::basic::{ConvertedType, Repetition};
 use parquet::{basic::Type, schema::types};
 use partition::{PartitionRocksIndex, PartitionRocksTable};
 use regex::Regex;
 use rocksdb::backup::BackupEngineOptions;
-use rocksdb::checkpoint::Checkpoint;
+
 use schema::{SchemaRocksIndex, SchemaRocksTable};
 use smallvec::alloc::fmt::Formatter;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::mem::take;
-use std::path::{Path, PathBuf};
+
+use std::path::Path;
 use std::str::FromStr;
-use std::sync::Mutex;
-use std::time::{Duration, SystemTime};
+
+use crate::remotefs::LocalDirRemoteFs;
+use std::time::Duration;
 use table::Table;
 use table::{TableRocksIndex, TableRocksTable};
 use tokio::sync::broadcast::Sender;
@@ -965,40 +964,6 @@ pub enum MetaStoreEvent {
     DeleteMultiPartition(IdRow<MultiPartition>),
 }
 
-fn check_indexes_for_all_tables<'a>(table_ref: DbTableRef<'a>) -> Result<(), CubeError> {
-    SchemaRocksTable::new(table_ref.clone()).check_indexes()?;
-    TableRocksTable::new(table_ref.clone()).check_indexes()?;
-    IndexRocksTable::new(table_ref.clone()).check_indexes()?;
-    PartitionRocksTable::new(table_ref.clone()).check_indexes()?;
-    ChunkRocksTable::new(table_ref.clone()).check_indexes()?;
-    WALRocksTable::new(table_ref.clone()).check_indexes()?;
-    JobRocksTable::new(table_ref.clone()).check_indexes()?;
-    SourceRocksTable::new(table_ref.clone()).check_indexes()?;
-    MultiIndexRocksTable::new(table_ref.clone()).check_indexes()?;
-    MultiPartitionRocksTable::new(table_ref.clone()).check_indexes()?;
-    Ok(())
-}
-
-#[derive(Clone)]
-pub struct RocksMetaStore {
-    pub db: Arc<DB>,
-    seq_store: Arc<Mutex<HashMap<TableId, u64>>>,
-    listeners: Arc<RwLock<Vec<Sender<MetaStoreEvent>>>>,
-    metastore_fs: Arc<dyn MetaStoreFs>,
-    last_checkpoint_time: Arc<RwLock<SystemTime>>,
-    write_notify: Arc<Notify>,
-    write_completed_notify: Arc<Notify>,
-    last_upload_seq: Arc<RwLock<u64>>,
-    last_check_seq: Arc<RwLock<u64>>,
-    upload_loop: Arc<WorkerLoop>,
-    config: Arc<dyn ConfigObj>,
-    cached_tables: Arc<Mutex<Option<Arc<Vec<TablePath>>>>>,
-    rw_loop_tx: std::sync::mpsc::SyncSender<
-        Box<dyn FnOnce() -> Result<(), CubeError> + Send + Sync + 'static>,
-    >,
-    _rw_loop_join_handle: Arc<AbortingJoinHandle<()>>,
-}
-
 fn meta_store_merge(
     _new_key: &[u8],
     existing_val: Option<&[u8]>,
@@ -1015,208 +980,95 @@ fn meta_store_merge(
     Some(result)
 }
 
-impl RocksMetaStore {
-    pub fn with_listener(
-        path: impl AsRef<Path>,
-        listeners: Vec<Sender<MetaStoreEvent>>,
-        metastore_fs: Arc<dyn MetaStoreFs>,
-        config: Arc<dyn ConfigObj>,
-    ) -> Arc<RocksMetaStore> {
-        let meta_store = RocksMetaStore::with_listener_impl(path, listeners, metastore_fs, config);
-        Arc::new(meta_store)
-    }
+pub struct RocksMetaStoreDetails {}
 
-    pub fn with_listener_impl(
-        path: impl AsRef<Path>,
-        listeners: Vec<Sender<MetaStoreEvent>>,
-        metastore_fs: Arc<dyn MetaStoreFs>,
-        config: Arc<dyn ConfigObj>,
-    ) -> RocksMetaStore {
+impl RocksStoreDetails for RocksMetaStoreDetails {
+    fn open_db(&self, path: &Path) -> Result<DB, CubeError> {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(13));
         opts.set_merge_operator_associative("meta_store merge", meta_store_merge);
 
-        let db = DB::open(&opts, path).unwrap();
-        let db_arc = Arc::new(db);
-
-        let (rw_loop_tx, rw_loop_rx) = std::sync::mpsc::sync_channel::<
-            Box<dyn FnOnce() -> Result<(), CubeError> + Send + Sync + 'static>,
-        >(32_768);
-
-        let join_handle = cube_ext::spawn_blocking(move || loop {
-            match rw_loop_rx.recv() {
-                Ok(fun) => {
-                    if let Err(e) = fun() {
-                        log::error!("Error during read write loop execution: {}", e);
-                    }
-                }
-                Err(_) => {
-                    return;
-                }
-            }
-        });
-
-        let meta_store = RocksMetaStore {
-            db: db_arc.clone(),
-            seq_store: Arc::new(Mutex::new(HashMap::new())),
-            listeners: Arc::new(RwLock::new(listeners)),
-            metastore_fs,
-            last_checkpoint_time: Arc::new(RwLock::new(SystemTime::now())),
-            write_notify: Arc::new(Notify::new()),
-            write_completed_notify: Arc::new(Notify::new()),
-            last_upload_seq: Arc::new(RwLock::new(db_arc.latest_sequence_number())),
-            last_check_seq: Arc::new(RwLock::new(db_arc.latest_sequence_number())),
-            upload_loop: Arc::new(WorkerLoop::new("Meta Store Upload")),
-            config,
-            cached_tables: Arc::new(Mutex::new(None)),
-            rw_loop_tx,
-            _rw_loop_join_handle: Arc::new(AbortingJoinHandle::new(join_handle)),
-        };
-        meta_store
+        Ok(DB::open(&opts, path).unwrap())
     }
 
-    pub fn new(
-        path: impl AsRef<Path>,
-        metastore_fs: Arc<dyn MetaStoreFs>,
-        config: Arc<dyn ConfigObj>,
-    ) -> Arc<RocksMetaStore> {
-        Self::with_listener(path, vec![], metastore_fs, config)
-    }
-
-    pub async fn load_from_dump(
-        path: impl AsRef<Path>,
-        dump_path: impl AsRef<Path>,
-        metastore_fs: Arc<dyn MetaStoreFs>,
-        config: Arc<dyn ConfigObj>,
-    ) -> Result<Arc<RocksMetaStore>, CubeError> {
-        if !fs::metadata(path.as_ref()).await.is_ok() {
-            let mut backup =
-                rocksdb::backup::BackupEngine::open(&BackupEngineOptions::default(), dump_path)?;
-            backup.restore_from_latest_backup(
-                &path,
-                &path,
-                &rocksdb::backup::RestoreOptions::default(),
-            )?;
-        } else {
-            info!(
-                "Using existing metastore in {}",
-                path.as_ref().as_os_str().to_string_lossy()
-            );
-        }
-
-        let meta_store = Self::new(path, metastore_fs, config);
-
-        RocksMetaStore::check_all_indexes(&meta_store).await?;
-
-        Ok(meta_store)
-    }
-
-    pub async fn check_all_indexes(meta_store: &Arc<RocksMetaStore>) -> Result<(), CubeError> {
-        let meta_store_to_move = meta_store.clone();
-
-        cube_ext::spawn_blocking(move || {
-            let table_ref = DbTableRef {
-                db: &meta_store_to_move.db,
-                snapshot: &meta_store_to_move.db.snapshot(),
-                mem_seq: MemorySequence::new(meta_store_to_move.seq_store.clone()),
-            };
-
-            if let Err(e) = check_indexes_for_all_tables(table_ref) {
-                log::error!("Error during checking indexes: {}", e);
-            }
-        })
-        .await?;
+    fn migrate<'a>(&self, table_ref: DbTableRef<'a>) -> Result<(), CubeError> {
+        SchemaRocksTable::new(table_ref.clone()).check_indexes()?;
+        TableRocksTable::new(table_ref.clone()).check_indexes()?;
+        IndexRocksTable::new(table_ref.clone()).check_indexes()?;
+        PartitionRocksTable::new(table_ref.clone()).check_indexes()?;
+        ChunkRocksTable::new(table_ref.clone()).check_indexes()?;
+        WALRocksTable::new(table_ref.clone()).check_indexes()?;
+        JobRocksTable::new(table_ref.clone()).check_indexes()?;
+        SourceRocksTable::new(table_ref.clone()).check_indexes()?;
+        MultiIndexRocksTable::new(table_ref.clone()).check_indexes()?;
+        MultiPartitionRocksTable::new(table_ref.clone()).check_indexes()?;
 
         Ok(())
     }
 
-    pub async fn add_listener(&self, listener: Sender<MetaStoreEvent>) {
-        self.listeners.write().await.push(listener);
+    fn get_name(&self) -> &'static str {
+        "metastore"
+    }
+}
+
+pub struct RocksMetaStore {
+    store: Arc<RocksStore>,
+    upload_loop: Arc<WorkerLoop>,
+}
+
+impl RocksMetaStore {
+    pub fn new(
+        path: &Path,
+        metastore_fs: Arc<dyn MetaStoreFs>,
+        config: Arc<dyn ConfigObj>,
+    ) -> Arc<RocksMetaStore> {
+        Arc::new(RocksMetaStore {
+            store: RocksStore::with_listener(
+                path,
+                vec![],
+                metastore_fs,
+                config,
+                Arc::new(RocksMetaStoreDetails {}),
+            ),
+            upload_loop: Arc::new(WorkerLoop::new("Metastore upload")),
+        })
     }
 
-    async fn write_operation<F, R>(&self, f: F) -> Result<R, CubeError>
-    where
-        F: for<'a> FnOnce(DbTableRef<'a>, &'a mut BatchPipe) -> Result<R, CubeError>
-            + Send
-            + Sync
-            + 'static,
-        R: Send + Sync + 'static,
-    {
-        let db = self.db.clone();
-        let mem_seq = MemorySequence::new(self.seq_store.clone());
-        let db_to_send = db.clone();
-        let cached_tables = self.cached_tables.clone();
-        let rw_loop_sender = self.rw_loop_tx.clone();
-        let (tx, rx) = oneshot::channel::<Result<(R, Vec<MetaStoreEvent>), CubeError>>();
-        cube_ext::spawn_blocking(move || {
-            let res = rw_loop_sender.send(Box::new(move || {
-                let db_span = warn_long("metastore write operation", Duration::from_millis(100));
-
-                let mut batch = BatchPipe::new(db_to_send.as_ref());
-                let snapshot = db_to_send.snapshot();
-                let res = f(
-                    DbTableRef {
-                        db: db_to_send.as_ref(),
-                        snapshot: &snapshot,
-                        mem_seq,
-                    },
-                    &mut batch,
-                );
-                match res {
-                    Ok(res) => {
-                        if batch.invalidate_tables_cache {
-                            *cached_tables.lock().unwrap() = None;
-                        }
-                        let write_result = batch.batch_write_rows()?;
-                        tx.send(Ok((res, write_result))).map_err(|_| {
-                            CubeError::internal(
-                                "Write operation result receiver has been dropped".to_string(),
-                            )
-                        })?;
-                    }
-                    Err(e) => {
-                        tx.send(Err(e)).map_err(|_| {
-                            CubeError::internal(
-                                "Write operation result receiver has been dropped".to_string(),
-                            )
-                        })?;
-                    }
-                }
-
-                mem::drop(db_span);
-
-                Ok(())
-            }));
-            if let Err(e) = res {
-                log::error!("Error during read write loop send: {}", e);
-            }
-        })
+    pub async fn load_from_dump(
+        path: &Path,
+        dump_path: &Path,
+        metastore_fs: Arc<dyn MetaStoreFs>,
+        config: Arc<dyn ConfigObj>,
+    ) -> Result<Arc<RocksMetaStore>, CubeError> {
+        let store = RocksStore::load_from_dump(
+            path,
+            dump_path,
+            metastore_fs,
+            config,
+            Arc::new(RocksMetaStoreDetails {}),
+        )
         .await?;
-        let (spawn_res, events) = rx.await??;
 
-        self.write_notify.notify_waiters();
-
-        for listener in self.listeners.read().await.clone().iter_mut() {
-            for event in events.iter() {
-                listener.send(event.clone())?;
-            }
-        }
-        Ok(spawn_res)
+        Ok(Arc::new(RocksMetaStore {
+            store,
+            upload_loop: Arc::new(WorkerLoop::new("Metastore upload")),
+        }))
     }
 
     pub async fn wait_upload_loop(meta_store: Arc<Self>) {
-        if !meta_store.config.upload_to_remote() {
+        if !meta_store.store.config.upload_to_remote() {
             log::info!("Not running metastore upload loop");
             return;
         }
-        let upload_interval = meta_store.config.meta_store_log_upload_interval();
+
+        let upload_interval = meta_store.store.config.meta_store_log_upload_interval();
         meta_store
             .upload_loop
             .process(
                 meta_store.clone(),
                 async move |_| Ok(Delay::new(Duration::from_secs(upload_interval)).await),
-                async move |m, _| m.run_upload().await,
+                async move |m, _| m.store.run_upload().await,
             )
             .await;
     }
@@ -1225,234 +1077,67 @@ impl RocksMetaStore {
         self.upload_loop.stop();
     }
 
-    pub async fn run_upload(&self) -> Result<(), CubeError> {
-        let time = SystemTime::now();
-        trace!("Persisting meta store snapshot");
-        let last_check_seq = self.last_check_seq().await;
-        let last_db_seq = self.db.latest_sequence_number();
-        if last_check_seq == last_db_seq {
-            trace!("Persisting meta store snapshot: nothing to update");
-            return Ok(());
-        }
-        let last_upload_seq = self.last_upload_seq().await;
-        let (serializer, min, max) = {
-            let updates = self.db.get_updates_since(last_upload_seq)?;
-            let mut serializer = WriteBatchContainer::new();
-
-            let mut seq_numbers = Vec::new();
-
-            updates.into_iter().for_each(|(n, write_batch)| {
-                seq_numbers.push(n);
-                write_batch.iterate(&mut serializer);
-            });
-            (
-                serializer,
-                seq_numbers.iter().min().map(|v| *v),
-                seq_numbers.iter().max().map(|v| *v),
-            )
-        };
-
-        if max.is_some() {
-            let checkpoint_time = self.last_checkpoint_time.read().await;
-            let log_name = format!(
-                "{}-logs/{}.flex",
-                RocksMetaStore::meta_store_path(&checkpoint_time),
-                min.unwrap()
-            );
-            self.metastore_fs.upload_log(&log_name, &serializer).await?;
-            let mut seq = self.last_upload_seq.write().await;
-            *seq = max.unwrap();
-            self.write_completed_notify.notify_waiters();
-        }
-
-        let last_checkpoint_time: SystemTime = self.last_checkpoint_time.read().await.clone();
-        if last_checkpoint_time
-            + time::Duration::from_secs(self.config.meta_store_snapshot_interval())
-            < SystemTime::now()
-        {
-            info!("Uploading meta store check point");
-            self.upload_check_point().await?;
-        }
-
-        let mut check_seq = self.last_check_seq.write().await;
-        *check_seq = last_db_seq;
-
-        info!(
-            "Persisting meta store snapshot: done ({:?})",
-            time.elapsed()?
-        );
-
-        Ok(())
+    pub async fn add_listener(&self, listener: Sender<MetaStoreEvent>) {
+        self.store.add_listener(listener).await;
     }
 
-    pub async fn upload_check_point(&self) -> Result<(), CubeError> {
-        let mut check_point_time = self.last_checkpoint_time.write().await;
-
-        let (remote_path, checkpoint_path) = {
-            let db = self.db.clone();
-            *check_point_time = SystemTime::now();
-            RocksMetaStore::prepare_checkpoint(db, &check_point_time).await?
-        };
-
-        self.metastore_fs
-            .upload_checkpoint(remote_path, checkpoint_path)
-            .await?;
-        self.write_completed_notify.notify_waiters();
-        Ok(())
-    }
-
-    async fn last_upload_seq(&self) -> u64 {
-        *self.last_upload_seq.read().await
-    }
-
-    async fn last_check_seq(&self) -> u64 {
-        *self.last_check_seq.read().await
-    }
-
-    async fn prepare_checkpoint(
-        db: Arc<DB>,
-        checkpoint_time: &SystemTime,
-    ) -> Result<(String, PathBuf), CubeError> {
-        let remote_path = RocksMetaStore::meta_store_path(checkpoint_time);
-        let checkpoint_path = db.path().join("..").join(remote_path.clone());
-        let path_to_move = checkpoint_path.clone();
-        cube_ext::spawn_blocking(move || -> Result<(), CubeError> {
-            let checkpoint = Checkpoint::new(db.as_ref())?;
-            checkpoint.create_checkpoint(path_to_move.as_path())?;
-            Ok(())
-        })
-        .await??;
-        Ok((remote_path, checkpoint_path))
-    }
-
-    fn meta_store_path(checkpoint_time: &SystemTime) -> String {
-        format!(
-            "metastore-{}",
-            checkpoint_time
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_millis()
+    pub fn prepare_test_metastore(test_name: &str) -> (Arc<LocalDirRemoteFs>, Arc<Self>) {
+        let (local_dir, store) =
+            RocksStore::prepare_test_metastore(test_name, Arc::new(RocksMetaStoreDetails {}));
+        (
+            local_dir,
+            Arc::new(RocksMetaStore {
+                store,
+                upload_loop: Arc::new(WorkerLoop::new("Metastore upload")),
+            }),
         )
     }
 
-    async fn read_operation<F, R>(&self, f: F) -> Result<R, CubeError>
-    where
-        F: for<'a> FnOnce(DbTableRef<'a>) -> Result<R, CubeError> + Send + Sync + 'static,
-        R: Send + Sync + 'static,
-    {
-        let mem_seq = MemorySequence::new(self.seq_store.clone());
-        let db_to_send = self.db.clone();
-
-        let rw_loop_sender = self.rw_loop_tx.clone();
-        let (tx, rx) = oneshot::channel::<Result<R, CubeError>>();
-        cube_ext::spawn_blocking(move || {
-            let res = rw_loop_sender.send(Box::new(move || {
-                let db_span = warn_long("metastore read operation", Duration::from_millis(100));
-
-                let snapshot = db_to_send.snapshot();
-                let res = f(DbTableRef {
-                    db: db_to_send.as_ref(),
-                    snapshot: &snapshot,
-                    mem_seq,
-                });
-
-                tx.send(res).map_err(|_| {
-                    CubeError::internal(
-                        "Read operation result receiver has been dropped".to_string(),
-                    )
-                })?;
-
-                mem::drop(db_span);
-
-                Ok(())
-            }));
-            if let Err(e) = res {
-                log::error!("Error during read write loop send: {}", e);
-            }
-        })
-        .await?;
-
-        rx.await?
-    }
-
-    async fn read_operation_out_of_queue<F, R>(&self, f: F) -> Result<R, CubeError>
-    where
-        F: for<'a> FnOnce(DbTableRef<'a>) -> Result<R, CubeError> + Send + Sync + 'static,
-        R: Send + Sync + 'static,
-    {
-        let mem_seq = MemorySequence::new(self.seq_store.clone());
-        let db_to_send = self.db.clone();
-
-        cube_ext::spawn_blocking(move || {
-            let db_span = warn_long(
-                "metastore read operation out of queue",
-                Duration::from_millis(100),
-            );
-
-            let snapshot = db_to_send.snapshot();
-            let res = f(DbTableRef {
-                db: db_to_send.as_ref(),
-                snapshot: &snapshot,
-                mem_seq,
-            });
-
-            mem::drop(db_span);
-
-            res
-        })
-        .await?
-    }
-
-    fn check_if_exists(name: &String, existing_keys_len: usize) -> Result<(), CubeError> {
-        if existing_keys_len > 1 {
-            let e = CubeError::user(format!(
-                "Schema with name '{}' has more than one id. Something went wrong.",
-                name
-            ));
-            return Err(e);
-        } else if existing_keys_len == 0 {
-            let e = CubeError::user(format!("Schema with name '{}' does not exist.", name));
-            return Err(e);
-        }
-        Ok(())
-    }
-
-    pub fn prepare_test_metastore(test_name: &str) -> (Arc<LocalDirRemoteFs>, Arc<RocksMetaStore>) {
-        let config = Config::test(test_name);
-        let store_path = env::current_dir()
-            .unwrap()
-            .join(format!("test-{}-local", test_name));
-        let remote_store_path = env::current_dir()
-            .unwrap()
-            .join(format!("test-{}-remote", test_name));
-        let _ = std::fs::remove_dir_all(store_path.clone());
-        let _ = std::fs::remove_dir_all(remote_store_path.clone());
-        let remote_fs = LocalDirRemoteFs::new(Some(remote_store_path.clone()), store_path.clone());
-        let meta_store = RocksMetaStore::new(
-            store_path.clone().join("metastore").as_path(),
-            RocksMetaStoreFs::new(remote_fs.clone()),
-            config.config_obj(),
-        );
-        (remote_fs, meta_store)
-    }
-
     pub fn cleanup_test_metastore(test_name: &str) {
-        let store_path = env::current_dir()
-            .unwrap()
-            .join(format!("test-{}-local", test_name));
-        let remote_store_path = env::current_dir()
-            .unwrap()
-            .join(format!("test-{}-remote", test_name));
-        let _ = std::fs::remove_dir_all(store_path.clone());
-        let _ = std::fs::remove_dir_all(remote_store_path.clone());
+        RocksStore::cleanup_test_metastore(test_name)
     }
 
-    async fn has_pending_changes(&self) -> Result<bool, CubeError> {
-        let db = self.db.clone();
-        Ok(db
-            .get_updates_since(self.last_upload_seq().await)?
-            .next()
-            .is_some())
+    pub async fn run_upload(&self) -> Result<(), CubeError> {
+        self.store.run_upload().await
+    }
+
+    pub async fn upload_check_point(&self) -> Result<(), CubeError> {
+        self.store.upload_check_point().await
+    }
+
+    pub async fn has_pending_changes(&self) -> Result<bool, CubeError> {
+        self.store.has_pending_changes().await
+    }
+
+    pub async fn check_all_indexes(&self) -> Result<(), CubeError> {
+        RocksStore::check_all_indexes(&self.store).await
+    }
+
+    pub async fn read_operation<F, R>(&self, f: F) -> Result<R, CubeError>
+    where
+        F: for<'a> FnOnce(DbTableRef<'a>) -> Result<R, CubeError> + Send + Sync + 'static,
+        R: Send + Sync + 'static,
+    {
+        self.store.read_operation(f).await
+    }
+
+    pub async fn read_operation_out_of_queue<F, R>(&self, f: F) -> Result<R, CubeError>
+    where
+        F: for<'a> FnOnce(DbTableRef<'a>) -> Result<R, CubeError> + Send + Sync + 'static,
+        R: Send + Sync + 'static,
+    {
+        self.store.read_operation_out_of_queue(f).await
+    }
+
+    pub async fn write_operation<F, R>(&self, f: F) -> Result<R, CubeError>
+    where
+        F: for<'a> FnOnce(DbTableRef<'a>, &'a mut BatchPipe) -> Result<R, CubeError>
+            + Send
+            + Sync
+            + 'static,
+        R: Send + Sync + 'static,
+    {
+        self.store.write_operation(f).await
     }
 }
 
@@ -1597,7 +1282,7 @@ impl RocksMetaStore {
                 if l.get_column_type() != &r.column_type {
                     return Err(CubeError::user(
                         format!("Type of table column '{}'({}) is different from type of partitioned index column '{}'({}). Index name is '{}'",
-                            l.name, l.column_type, r.name, r.column_type, mi.name()
+                                l.name, l.column_type, r.name, r.column_type, mi.name()
                         )
                     ));
                 }
@@ -1661,9 +1346,9 @@ impl RocksMetaStore {
         let aggregate_columns = table_id.get_row().aggregate_columns();
         if aggregate_columns.is_empty() {
             return Err(CubeError::user(format!(
-                    "Can't create aggregate index for table '{}' because aggregate columns (`AGGREGATIONS`) not specified for the table",
-                    table_id.get_row().get_table_name()
-                )));
+                "Can't create aggregate index for table '{}' because aggregate columns (`AGGREGATIONS`) not specified for the table",
+                table_id.get_row().get_table_name()
+            )));
         }
         if let Some(col_in_aggreations) = index_def.columns.iter().find(|dc| {
             aggregate_columns
@@ -1671,17 +1356,17 @@ impl RocksMetaStore {
                 .any(|c| c.column().name == dc.as_str())
         }) {
             return Err(CubeError::user(format!(
-                    "Column '{}' in aggregate index '{}' is in aggregations list for table '{}'. Aggregate index columns must be outside of aggregations list.",
-                    col_in_aggreations,
-                    index_def.name,
-                    table_id.get_row().get_table_name()
-                )));
+                "Column '{}' in aggregate index '{}' is in aggregations list for table '{}'. Aggregate index columns must be outside of aggregations list.",
+                col_in_aggreations,
+                index_def.name,
+                table_id.get_row().get_table_name()
+            )));
         }
         let unique_key_columns = table_id.get_row().unique_key_columns();
         if unique_key_columns.is_some() {
             return Err(CubeError::user(format!(
-                    "Can't create aggregate index for table '{}' because aggregate index for the table with unique key is not supported yet",
-                    table_id.get_row().get_table_name())));
+                "Can't create aggregate index for table '{}' because aggregate index for the table with unique key is not supported yet",
+                table_id.get_row().get_table_name())));
         }
 
         // First put the columns from the sort key.
@@ -1782,15 +1467,15 @@ impl RocksMetaStore {
 #[async_trait]
 impl MetaStore for RocksMetaStore {
     async fn wait_for_current_seq_to_sync(&self) -> Result<(), CubeError> {
-        if !self.config.upload_to_remote() {
+        if !self.store.config.upload_to_remote() {
             return Err(CubeError::internal(
                 "waiting for metastore to upload in noupload mode".to_string(),
             ));
         }
-        while self.has_pending_changes().await? {
+        while self.store.has_pending_changes().await? {
             tokio::time::timeout(
                 Duration::from_secs(30),
-                self.write_completed_notify.notified(),
+                self.store.write_completed_notify.notified(),
             )
             .await?;
         }
@@ -1799,7 +1484,7 @@ impl MetaStore for RocksMetaStore {
 
     fn schemas_table(&self) -> SchemaMetaStoreTable {
         SchemaMetaStoreTable {
-            rocks_meta_store: self.clone(),
+            rocks_meta_store: self.store.clone(),
         }
     }
 
@@ -1843,7 +1528,7 @@ impl MetaStore for RocksMetaStore {
             let table = SchemaRocksTable::new(db_ref);
             let existing_keys =
                 table.get_row_ids_by_index(&schema_name, &SchemaRocksIndex::Name)?;
-            RocksMetaStore::check_if_exists(&schema_name, existing_keys.len())?;
+            check_if_exists(&schema_name, existing_keys.len())?;
             Ok(existing_keys[0])
         })
         .await
@@ -1867,7 +1552,7 @@ impl MetaStore for RocksMetaStore {
             let table = SchemaRocksTable::new(db_ref.clone());
             let existing_keys =
                 table.get_row_ids_by_index(&old_schema_name, &SchemaRocksIndex::Name)?;
-            RocksMetaStore::check_if_exists(&old_schema_name, existing_keys.len())?;
+            check_if_exists(&old_schema_name, existing_keys.len())?;
 
             let schema_id = existing_keys[0];
 
@@ -1905,7 +1590,7 @@ impl MetaStore for RocksMetaStore {
             let table = SchemaRocksTable::new(db_ref.clone());
             let existing_keys =
                 table.get_row_ids_by_index(&schema_name, &SchemaRocksIndex::Name)?;
-            RocksMetaStore::check_if_exists(&schema_name, existing_keys.len())?;
+            check_if_exists(&schema_name, existing_keys.len())?;
             let schema_id = existing_keys[0];
 
             let tables = TableRocksTable::new(db_ref.clone()).all_rows()?;
@@ -1948,7 +1633,7 @@ impl MetaStore for RocksMetaStore {
 
     fn tables_table(&self) -> TableMetaStoreTable {
         TableMetaStoreTable {
-            rocks_meta_store: self.clone(),
+            rocks_meta_store: self.store.clone(),
         }
     }
 
@@ -2212,14 +1897,14 @@ impl MetaStore for RocksMetaStore {
             })
             .await
         } else {
-            let cache = self.cached_tables.clone();
+            let cache = self.store.cached_tables.clone();
 
             if let Some(t) = cube_ext::spawn_blocking(move || cache.lock().unwrap().clone()).await?
             {
                 return Ok(t);
             }
 
-            let cache = self.cached_tables.clone();
+            let cache = self.store.cached_tables.clone();
             // Can't do read_operation_out_of_queue as we need to update cache on the same thread where it's dropped
             self.read_operation(move |db_ref| {
                 let table_rocks_table = TableRocksTable::new(db_ref.clone());
@@ -2295,7 +1980,7 @@ impl MetaStore for RocksMetaStore {
 
     fn partition_table(&self) -> PartitionMetaStoreTable {
         PartitionMetaStoreTable {
-            rocks_meta_store: self.clone(),
+            rocks_meta_store: self.store.clone(),
         }
     }
 
@@ -2762,7 +2447,7 @@ impl MetaStore for RocksMetaStore {
 
     fn index_table(&self) -> IndexMetaStoreTable {
         IndexMetaStoreTable {
-            rocks_meta_store: self.clone(),
+            rocks_meta_store: self.store.clone(),
         }
     }
 
@@ -3269,7 +2954,7 @@ impl MetaStore for RocksMetaStore {
 
     fn chunks_table(&self) -> ChunkMetaStoreTable {
         ChunkMetaStoreTable {
-            rocks_meta_store: self.clone(),
+            rocks_meta_store: self.store.clone(),
         }
     }
 
@@ -3614,6 +3299,7 @@ impl MetaStore for RocksMetaStore {
         multi_partition_id: u64,
     ) -> Result<(IdRow<MultiIndex>, IdRow<MultiPartition>, Vec<PartitionData>), CubeError> {
         let (mi, mp, pds) = self
+            .store
             .read_operation(move |db| {
                 let mindex = MultiIndexRocksTable::new(db.clone());
                 let mpartition = MultiPartitionRocksTable::new(db.clone());
@@ -4074,6 +3760,7 @@ mod tests {
     use super::table::AggregateColumn;
     use super::*;
     use crate::config::Config;
+    use crate::metastore::metastore_fs::RocksMetaStoreFs;
     use crate::remotefs::LocalDirRemoteFs;
     use futures_timer::Delay;
     use rocksdb::IteratorMode;
@@ -4374,6 +4061,7 @@ mod tests {
                 .unwrap();
 
             meta_store
+                .store
                 .db
                 .delete(RowKey::Table(TableId::Schemas, 1).to_bytes())
                 .unwrap();
@@ -4382,7 +4070,7 @@ mod tests {
             println!("{:?}", result);
             assert_eq!(result.is_err(), true);
 
-            let iterator = meta_store.db.iterator(IteratorMode::Start);
+            let iterator = meta_store.store.db.iterator(IteratorMode::Start);
 
             println!("Keys in db");
             for (key, _) in iterator {

--- a/rust/cubestore/cubestore/src/metastore/rocks_store.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_store.rs
@@ -1,14 +1,33 @@
+use crate::config::{Config, ConfigObj};
+use crate::metastore::metastore_fs::{MetaStoreFs, RocksMetaStoreFs};
+use crate::metastore::table::TablePath;
 use crate::metastore::MetaStoreEvent;
+use crate::remotefs::LocalDirRemoteFs;
+use crate::util::aborting_join_handle::AbortingJoinHandle;
+use crate::util::time_span::warn_long;
+
 use crate::CubeError;
 use async_trait::async_trait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use datafusion::cube_ext;
+
+use log::{info, trace};
+use rocksdb::backup::BackupEngineOptions;
+use rocksdb::checkpoint::Checkpoint;
 use rocksdb::{Snapshot, WriteBatch, WriteBatchIterator, DB};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::Cursor;
+
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+use std::{env, mem, time};
+use tokio::fs;
 use tokio::fs::File;
+use tokio::sync::broadcast::Sender;
+use tokio::sync::{oneshot, Notify, RwLock};
 
 macro_rules! enum_from_primitive_impl {
     ($name:ident, $( $variant:ident )*) => {
@@ -296,7 +315,7 @@ pub trait MetaStoreTable: Send + Sync {
 macro_rules! meta_store_table_impl {
     ($name: ident, $table: ty, $rocks_table: ident) => {
         pub struct $name {
-            rocks_meta_store: RocksMetaStore,
+            rocks_meta_store: Arc<RocksStore>,
         }
 
         impl $name {
@@ -330,4 +349,471 @@ macro_rules! meta_store_table_impl {
             }
         }
     };
+}
+
+pub trait RocksStoreDetails: Send + Sync {
+    fn open_db(&self, path: &Path) -> Result<DB, CubeError>;
+
+    fn migrate(&self, table_ref: DbTableRef) -> Result<(), CubeError>;
+
+    fn get_name(&self) -> &'static str;
+}
+
+#[derive(Clone)]
+pub struct RocksStore {
+    pub db: Arc<DB>,
+    pub config: Arc<dyn ConfigObj>,
+    seq_store: Arc<Mutex<HashMap<TableId, u64>>>,
+    listeners: Arc<RwLock<Vec<Sender<MetaStoreEvent>>>>,
+    metastore_fs: Arc<dyn MetaStoreFs>,
+    last_checkpoint_time: Arc<RwLock<SystemTime>>,
+    write_notify: Arc<Notify>,
+    pub(crate) write_completed_notify: Arc<Notify>,
+    last_upload_seq: Arc<RwLock<u64>>,
+    last_check_seq: Arc<RwLock<u64>>,
+    pub(crate) cached_tables: Arc<Mutex<Option<Arc<Vec<TablePath>>>>>,
+    rw_loop_tx: std::sync::mpsc::SyncSender<
+        Box<dyn FnOnce() -> Result<(), CubeError> + Send + Sync + 'static>,
+    >,
+    _rw_loop_join_handle: Arc<AbortingJoinHandle<()>>,
+    details: Arc<dyn RocksStoreDetails>,
+}
+
+pub fn check_if_exists(name: &String, existing_keys_len: usize) -> Result<(), CubeError> {
+    if existing_keys_len > 1 {
+        let e = CubeError::user(format!(
+            "Schema with name '{}' has more than one id. Something went wrong.",
+            name
+        ));
+        return Err(e);
+    } else if existing_keys_len == 0 {
+        let e = CubeError::user(format!("Schema with name '{}' does not exist.", name));
+        return Err(e);
+    }
+    Ok(())
+}
+
+impl RocksStore {
+    pub fn with_listener(
+        path: &Path,
+        listeners: Vec<Sender<MetaStoreEvent>>,
+        metastore_fs: Arc<dyn MetaStoreFs>,
+        config: Arc<dyn ConfigObj>,
+        details: Arc<dyn RocksStoreDetails>,
+    ) -> Arc<RocksStore> {
+        let meta_store =
+            RocksStore::with_listener_impl(path, listeners, metastore_fs, config, details);
+        Arc::new(meta_store)
+    }
+
+    pub fn with_listener_impl(
+        path: &Path,
+        listeners: Vec<Sender<MetaStoreEvent>>,
+        metastore_fs: Arc<dyn MetaStoreFs>,
+        config: Arc<dyn ConfigObj>,
+        details: Arc<dyn RocksStoreDetails>,
+    ) -> RocksStore {
+        let db = details.open_db(path).unwrap();
+        let db_arc = Arc::new(db);
+
+        let (rw_loop_tx, rw_loop_rx) = std::sync::mpsc::sync_channel::<
+            Box<dyn FnOnce() -> Result<(), CubeError> + Send + Sync + 'static>,
+        >(32_768);
+
+        let join_handle = cube_ext::spawn_blocking(move || loop {
+            match rw_loop_rx.recv() {
+                Ok(fun) => {
+                    if let Err(e) = fun() {
+                        log::error!("Error during read write loop execution: {}", e);
+                    }
+                }
+                Err(_) => {
+                    return;
+                }
+            }
+        });
+
+        let meta_store = RocksStore {
+            db: db_arc.clone(),
+            seq_store: Arc::new(Mutex::new(HashMap::new())),
+            listeners: Arc::new(RwLock::new(listeners)),
+            metastore_fs,
+            last_checkpoint_time: Arc::new(RwLock::new(SystemTime::now())),
+            write_notify: Arc::new(Notify::new()),
+            write_completed_notify: Arc::new(Notify::new()),
+            last_upload_seq: Arc::new(RwLock::new(db_arc.latest_sequence_number())),
+            last_check_seq: Arc::new(RwLock::new(db_arc.latest_sequence_number())),
+            config,
+            cached_tables: Arc::new(Mutex::new(None)),
+            rw_loop_tx,
+            _rw_loop_join_handle: Arc::new(AbortingJoinHandle::new(join_handle)),
+            details,
+        };
+
+        meta_store
+    }
+
+    pub fn new(
+        path: &Path,
+        metastore_fs: Arc<dyn MetaStoreFs>,
+        config: Arc<dyn ConfigObj>,
+        details: Arc<dyn RocksStoreDetails>,
+    ) -> Arc<RocksStore> {
+        Self::with_listener(path, vec![], metastore_fs, config, details)
+    }
+
+    pub async fn load_from_dump(
+        path: &Path,
+        dump_path: &Path,
+        metastore_fs: Arc<dyn MetaStoreFs>,
+        config: Arc<dyn ConfigObj>,
+        details: Arc<dyn RocksStoreDetails>,
+    ) -> Result<Arc<RocksStore>, CubeError> {
+        if !fs::metadata(path).await.is_ok() {
+            let mut backup =
+                rocksdb::backup::BackupEngine::open(&BackupEngineOptions::default(), dump_path)?;
+            backup.restore_from_latest_backup(
+                &path,
+                &path,
+                &rocksdb::backup::RestoreOptions::default(),
+            )?;
+        } else {
+            info!(
+                "Using existing {} in {}",
+                details.get_name(),
+                path.as_os_str().to_string_lossy()
+            );
+        }
+
+        let meta_store = Self::new(path, metastore_fs, config, details);
+        Self::check_all_indexes(&meta_store).await?;
+
+        Ok(meta_store)
+    }
+
+    pub async fn check_all_indexes(meta_store: &Arc<Self>) -> Result<(), CubeError> {
+        let meta_store_to_move = meta_store.clone();
+
+        cube_ext::spawn_blocking(move || {
+            let table_ref = DbTableRef {
+                db: &meta_store_to_move.db,
+                snapshot: &meta_store_to_move.db.snapshot(),
+                mem_seq: MemorySequence::new(meta_store_to_move.seq_store.clone()),
+            };
+
+            if let Err(e) = meta_store_to_move.details.migrate(table_ref) {
+                log::error!("Error during checking indexes: {}", e);
+            }
+        })
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn add_listener(&self, listener: Sender<MetaStoreEvent>) {
+        self.listeners.write().await.push(listener);
+    }
+
+    pub async fn write_operation<F, R>(&self, f: F) -> Result<R, CubeError>
+    where
+        F: for<'a> FnOnce(DbTableRef<'a>, &'a mut BatchPipe) -> Result<R, CubeError>
+            + Send
+            + Sync
+            + 'static,
+        R: Send + Sync + 'static,
+    {
+        let db = self.db.clone();
+        let mem_seq = MemorySequence::new(self.seq_store.clone());
+        let db_to_send = db.clone();
+        let cached_tables = self.cached_tables.clone();
+        let store_name = self.details.get_name();
+
+        let rw_loop_sender = self.rw_loop_tx.clone();
+        let (tx, rx) = oneshot::channel::<Result<(R, Vec<MetaStoreEvent>), CubeError>>();
+
+        cube_ext::spawn_blocking(move || {
+            let res = rw_loop_sender.send(Box::new(move || {
+                let db_span = warn_long("metastore write operation", Duration::from_millis(100));
+
+                let mut batch = BatchPipe::new(db_to_send.as_ref());
+                let snapshot = db_to_send.snapshot();
+                let res = f(
+                    DbTableRef {
+                        db: db_to_send.as_ref(),
+                        snapshot: &snapshot,
+                        mem_seq,
+                    },
+                    &mut batch,
+                );
+                match res {
+                    Ok(res) => {
+                        if batch.invalidate_tables_cache {
+                            *cached_tables.lock().unwrap() = None;
+                        }
+                        let write_result = batch.batch_write_rows()?;
+                        tx.send(Ok((res, write_result))).map_err(|_| {
+                            CubeError::internal(format!(
+                                "[{}] Write operation result receiver has been dropped",
+                                store_name
+                            ))
+                        })?;
+                    }
+                    Err(e) => {
+                        tx.send(Err(e)).map_err(|_| {
+                            CubeError::internal(format!(
+                                "[{}] Write operation result receiver has been dropped",
+                                store_name
+                            ))
+                        })?;
+                    }
+                }
+
+                mem::drop(db_span);
+
+                Ok(())
+            }));
+            if let Err(e) = res {
+                log::error!("[{}] Error during read write loop send: {}", store_name, e);
+            }
+        })
+        .await?;
+        let (spawn_res, events) = rx.await??;
+
+        self.write_notify.notify_waiters();
+
+        for listener in self.listeners.read().await.clone().iter_mut() {
+            for event in events.iter() {
+                listener.send(event.clone())?;
+            }
+        }
+        Ok(spawn_res)
+    }
+
+    pub async fn run_upload(&self) -> Result<(), CubeError> {
+        let time = SystemTime::now();
+        trace!("Persisting meta store snapshot");
+        let last_check_seq = self.last_check_seq().await;
+        let last_db_seq = self.db.latest_sequence_number();
+        if last_check_seq == last_db_seq {
+            trace!("Persisting meta store snapshot: nothing to update");
+            return Ok(());
+        }
+        let last_upload_seq = self.last_upload_seq().await;
+        let (serializer, min, max) = {
+            let updates = self.db.get_updates_since(last_upload_seq)?;
+            let mut serializer = WriteBatchContainer::new();
+
+            let mut seq_numbers = Vec::new();
+
+            updates.into_iter().for_each(|(n, write_batch)| {
+                seq_numbers.push(n);
+                write_batch.iterate(&mut serializer);
+            });
+            (
+                serializer,
+                seq_numbers.iter().min().map(|v| *v),
+                seq_numbers.iter().max().map(|v| *v),
+            )
+        };
+
+        if max.is_some() {
+            let checkpoint_time = self.last_checkpoint_time.read().await;
+            let log_name = format!(
+                "{}-logs/{}.flex",
+                self.get_store_path(&checkpoint_time),
+                min.unwrap()
+            );
+            self.metastore_fs.upload_log(&log_name, &serializer).await?;
+            let mut seq = self.last_upload_seq.write().await;
+            *seq = max.unwrap();
+            self.write_completed_notify.notify_waiters();
+        }
+
+        let last_checkpoint_time: SystemTime = self.last_checkpoint_time.read().await.clone();
+        if last_checkpoint_time
+            + time::Duration::from_secs(self.config.meta_store_snapshot_interval())
+            < SystemTime::now()
+        {
+            info!("Uploading meta store check point");
+            self.upload_check_point().await?;
+        }
+
+        let mut check_seq = self.last_check_seq.write().await;
+        *check_seq = last_db_seq;
+
+        info!(
+            "Persisting meta store snapshot: done ({:?})",
+            time.elapsed()?
+        );
+
+        Ok(())
+    }
+
+    pub async fn upload_check_point(&self) -> Result<(), CubeError> {
+        let mut check_point_time = self.last_checkpoint_time.write().await;
+
+        let (remote_path, checkpoint_path) = {
+            let _db = self.db.clone();
+            *check_point_time = SystemTime::now();
+            self.prepare_checkpoint(&check_point_time).await?
+        };
+
+        self.metastore_fs
+            .upload_checkpoint(remote_path, checkpoint_path)
+            .await?;
+        self.write_completed_notify.notify_waiters();
+        Ok(())
+    }
+
+    async fn last_upload_seq(&self) -> u64 {
+        *self.last_upload_seq.read().await
+    }
+
+    async fn last_check_seq(&self) -> u64 {
+        *self.last_check_seq.read().await
+    }
+
+    fn get_store_path(&self, checkpoint_time: &SystemTime) -> String {
+        format!(
+            "{}-{}",
+            self.details.get_name(),
+            checkpoint_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        )
+    }
+
+    async fn prepare_checkpoint(
+        &self,
+        checkpoint_time: &SystemTime,
+    ) -> Result<(String, PathBuf), CubeError> {
+        let remote_path = self.get_store_path(checkpoint_time);
+        let checkpoint_path = self.db.path().join("..").join(remote_path.clone());
+
+        let path_to_move = checkpoint_path.clone();
+        let db_to_move = self.db.clone();
+
+        cube_ext::spawn_blocking(move || -> Result<(), CubeError> {
+            let checkpoint = Checkpoint::new(db_to_move.as_ref())?;
+            checkpoint.create_checkpoint(path_to_move.as_path())?;
+            Ok(())
+        })
+        .await??;
+
+        Ok((remote_path, checkpoint_path))
+    }
+
+    pub async fn read_operation<F, R>(&self, f: F) -> Result<R, CubeError>
+    where
+        F: for<'a> FnOnce(DbTableRef<'a>) -> Result<R, CubeError> + Send + Sync + 'static,
+        R: Send + Sync + 'static,
+    {
+        let mem_seq = MemorySequence::new(self.seq_store.clone());
+        let db_to_send = self.db.clone();
+        let store_name = self.details.get_name();
+
+        let rw_loop_sender = self.rw_loop_tx.clone();
+        let (tx, rx) = oneshot::channel::<Result<R, CubeError>>();
+
+        cube_ext::spawn_blocking(move || {
+            let res = rw_loop_sender.send(Box::new(move || {
+                let db_span = warn_long("metastore read operation", Duration::from_millis(100));
+
+                let snapshot = db_to_send.snapshot();
+                let res = f(DbTableRef {
+                    db: db_to_send.as_ref(),
+                    snapshot: &snapshot,
+                    mem_seq,
+                });
+
+                tx.send(res).map_err(|_| {
+                    CubeError::internal(format!(
+                        "[{}] Read operation result receiver has been dropped",
+                        store_name
+                    ))
+                })?;
+
+                mem::drop(db_span);
+
+                Ok(())
+            }));
+            if let Err(e) = res {
+                log::error!("Error during read write loop send: {}", e);
+            }
+        })
+        .await?;
+
+        rx.await?
+    }
+
+    pub async fn read_operation_out_of_queue<F, R>(&self, f: F) -> Result<R, CubeError>
+    where
+        F: for<'a> FnOnce(DbTableRef<'a>) -> Result<R, CubeError> + Send + Sync + 'static,
+        R: Send + Sync + 'static,
+    {
+        let mem_seq = MemorySequence::new(self.seq_store.clone());
+        let db_to_send = self.db.clone();
+
+        cube_ext::spawn_blocking(move || {
+            let db_span = warn_long(
+                "metastore read operation out of queue",
+                Duration::from_millis(100),
+            );
+
+            let snapshot = db_to_send.snapshot();
+            let res = f(DbTableRef {
+                db: db_to_send.as_ref(),
+                snapshot: &snapshot,
+                mem_seq,
+            });
+
+            mem::drop(db_span);
+
+            res
+        })
+        .await?
+    }
+
+    pub fn prepare_test_metastore(
+        test_name: &str,
+        details: Arc<dyn RocksStoreDetails>,
+    ) -> (Arc<LocalDirRemoteFs>, Arc<RocksStore>) {
+        let config = Config::test(test_name);
+        let store_path = env::current_dir()
+            .unwrap()
+            .join(format!("test-{}-local", test_name));
+        let remote_store_path = env::current_dir()
+            .unwrap()
+            .join(format!("test-{}-remote", test_name));
+        let _ = std::fs::remove_dir_all(store_path.clone());
+        let _ = std::fs::remove_dir_all(remote_store_path.clone());
+        let remote_fs = LocalDirRemoteFs::new(Some(remote_store_path.clone()), store_path.clone());
+        let meta_store = RocksStore::new(
+            store_path.clone().join(details.get_name()).as_path(),
+            RocksMetaStoreFs::new(remote_fs.clone()),
+            config.config_obj(),
+            details,
+        );
+        (remote_fs, meta_store)
+    }
+
+    pub fn cleanup_test_metastore(test_name: &str) {
+        let store_path = env::current_dir()
+            .unwrap()
+            .join(format!("test-{}-local", test_name));
+        let remote_store_path = env::current_dir()
+            .unwrap()
+            .join(format!("test-{}-remote", test_name));
+        let _ = std::fs::remove_dir_all(store_path.clone());
+        let _ = std::fs::remove_dir_all(remote_store_path.clone());
+    }
+
+    pub async fn has_pending_changes(&self) -> Result<bool, CubeError> {
+        let db = self.db.clone();
+        Ok(db
+            .get_updates_since(self.last_upload_seq().await)?
+            .next()
+            .is_some())
+    }
 }

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -1720,7 +1720,7 @@ mod tests {
                 PathBuf::from(store_path.clone()),
             );
             let meta_store = RocksMetaStore::new(
-                path,
+                Path::new(path),
                 RocksMetaStoreFs::new(remote_fs.clone()),
                 config.config_obj(),
             );
@@ -1778,7 +1778,7 @@ mod tests {
                 PathBuf::from(store_path.clone()),
             );
             let meta_store = RocksMetaStore::new(
-                path,
+                Path::new(path),
                 RocksMetaStoreFs::new(remote_fs.clone()),
                 config.config_obj(),
             );
@@ -1864,7 +1864,7 @@ mod tests {
                 PathBuf::from(store_path.clone()),
             );
             let meta_store = RocksMetaStore::new(
-                path,
+                Path::new(path),
                 RocksMetaStoreFs::new(remote_fs.clone()),
                 config.config_obj(),
             );

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -1227,7 +1227,7 @@ mod tests {
     use datafusion::physical_plan::collect;
     use rocksdb::{Options, DB};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     #[tokio::test]
     async fn compaction() {
@@ -1579,7 +1579,7 @@ mod tests {
             PathBuf::from(chunk_store_path.clone()),
         );
         let metastore = RocksMetaStore::new(
-            path,
+            Path::new(path),
             RocksMetaStoreFs::new(remote_fs.clone()),
             config.config_obj(),
         );

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -582,7 +582,7 @@ mod tests {
     use arrow::array::{Int64Array, StringArray};
     use rocksdb::{Options, DB};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     #[tokio::test]
     async fn create_wal_test() {
@@ -601,7 +601,7 @@ mod tests {
             );
             let store = WALStore::new(
                 RocksMetaStore::new(
-                    path,
+                    Path::new(path),
                     RocksMetaStoreFs::new(remote_fs.clone()),
                     config.config_obj(),
                 ),
@@ -691,7 +691,7 @@ mod tests {
                 PathBuf::from(chunk_store_path.clone()),
             );
             let meta_store = RocksMetaStore::new(
-                path,
+                Path::new(path),
                 RocksMetaStoreFs::new(remote_fs.clone()),
                 config.config_obj(),
             );
@@ -788,7 +788,7 @@ mod tests {
                 PathBuf::from(chunk_store_path.clone()),
             );
             let meta_store = RocksMetaStore::new(
-                path,
+                Path::new(path),
                 RocksMetaStoreFs::new(remote_fs.clone()),
                 config.config_obj(),
             );


### PR DESCRIPTION
Hello!

This PR introduces an initial ability to build a new type of store. In this PR `MetaStore` uses the new API `RocksStore`. Next PR (https://github.com/cube-js/cube.js/pull/5607) will use the same functionality to build `CacheStore`

Thanks