### PR TITLE
fix(cubesql): Push down projection to CubeScan with literals

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -314,7 +314,7 @@ crate::plan_to_language! {
         },
         OrderReplacer {
             sort_expr: Vec<LogicalPlan>,
-            column_name_to_member: Vec<(String, String)>,
+            column_name_to_member: Vec<(String, Option<String>)>,
         },
         InnerAggregateSplitReplacer {
             members: Vec<LogicalPlan>,
@@ -391,17 +391,29 @@ impl ExprRewriter for WithColumnRelation {
     }
 }
 
-fn column_name_to_member_vec(member_name_to_expr: Vec<(String, Expr)>) -> Vec<(String, String)> {
+fn column_name_to_member_vec(
+    member_name_to_expr: Vec<(Option<String>, Expr)>,
+) -> Vec<(String, Option<String>)> {
     let mut relation = WithColumnRelation(None);
     member_name_to_expr
         .into_iter()
         .map(|(member, expr)| {
             vec![
-                (expr_column_name(expr.clone(), &None), member.to_string()),
+                (expr_column_name(expr.clone(), &None), member.clone()),
                 (expr_column_name_with_relation(expr, &mut relation), member),
             ]
         })
         .flatten()
+        .collect::<Vec<_>>()
+}
+
+fn column_name_to_member_to_aliases(
+    column_name_to_member: Vec<(String, Option<String>)>,
+) -> Vec<(String, String)> {
+    column_name_to_member
+        .into_iter()
+        .filter(|(_, member)| member.is_some())
+        .map(|(column_name, member)| (column_name, member.unwrap()))
         .collect::<Vec<_>>()
 }
 
@@ -416,6 +428,7 @@ fn member_name_by_alias(
             .into_iter()
             .find(|(cn, _)| cn == alias)
             .map(|(_, member)| member)
+            .flatten()
     } else {
         None
     }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -3015,7 +3015,10 @@ impl FilterRules {
                 if let Some(member_name_to_expr) =
                     &egraph.index(subst[members_var]).data.member_name_to_expr
                 {
-                    if member_name_to_expr.iter().all(|(m, _)| m != &member) {
+                    if member_name_to_expr
+                        .iter()
+                        .all(|(m, _)| m.as_ref() != Some(&member))
+                    {
                         let date_range = var_iter!(
                             egraph[subst[time_dimension_date_range_var]],
                             TimeDimensionDateRangeReplacerDateRange
@@ -3078,7 +3081,10 @@ impl FilterRules {
                 if let Some(member_name_to_expr) =
                     &egraph.index(subst[members_var]).data.member_name_to_expr
                 {
-                    if member_name_to_expr.iter().any(|(m, _)| m == member) {
+                    if member_name_to_expr
+                        .iter()
+                        .any(|(m, _)| m.as_ref() == Some(member))
+                    {
                         return true;
                     }
                 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/order.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/order.rs
@@ -147,7 +147,7 @@ impl OrderRules {
                     egraph[subst[column_name_to_member_var]],
                     OrderReplacerColumnNameToMember
                 ) {
-                    if let Some((_, member_name)) = column_name_to_member
+                    if let Some((_, Some(member_name))) = column_name_to_member
                         .iter()
                         .find(|(c, _)| c == &column_name)
                     {


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue with projections not pushing down to CubeScan if any literal members are present. For instance, a simple query like `SELECT dimension, 1 lit FROM cube ORDER BY dimension ASC` would be missing the `order` clause. It also adds a related test.
