### PR TITLE
fix(cubesql): Support `CAST` in `HAVING` clause

### DIFF
--- a/rust/cubesql/cubesql/src/sql/statement.rs
+++ b/rust/cubesql/cubesql/src/sql/statement.rs
@@ -315,6 +315,10 @@ trait Visitor<'ast, E: Error> {
             self.visit_table_with_joins(from)?;
         }
 
+        if let Some(having) = &mut select.having {
+            self.visit_expr(having)?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an issue with `CAST` expressions with custom names not being available within `HAVING` expressions. Such expressions are used by Thoughtspot. A related test is also added.
