### PR TITLE
fix(cubesql): normalize column names in filter node

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -2964,9 +2964,23 @@ impl FilterRules {
                 } else if let Some((_, cube)) =
                     meta_context.find_cube_by_column(alias_to_cube, &column)
                 {
-                    return Some((format!("{}.{}", cube.name, column.name), cube));
+                    if let Some(original_name) = Self::original_member_name(&cube, &column.name) {
+                        return Some((original_name, cube));
+                    }
                 }
             }
+        }
+
+        None
+    }
+
+    fn original_member_name(cube: &V1CubeMeta, name: &String) -> Option<String> {
+        if let Some(measure) = cube.lookup_measure(name) {
+            return Some(measure.name.clone());
+        } else if let Some(dimension) = cube.lookup_dimension(name) {
+            return Some(dimension.name.clone());
+        } else if let Some(dimension) = cube.lookup_segment(name) {
+            return Some(dimension.name.clone());
         }
 
         None


### PR DESCRIPTION
`select * from cube where COLUMN > 0`

in case COLUMN is in a different register than in the cube schema, we caught the error