### PR TITLE
fix(@cubejs-client/core): add missing Series.shortTitle typing

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -261,6 +261,7 @@ declare module '@cubejs-client/core' {
   export type Series<T> = {
     key: string;
     title: string;
+    shortTitle: string;
     series: T[];
   };
 


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Following update for https://github.com/cube-js/cube.js/pull/5836

**Description of Changes Made (if issue reference is not provided)**

Hello Cube team 👋 ,

When testing, I was using only the `.seriesNames` and didn't notice that the `.series` method had a separate return type, so I missed adding the `shortTitle` property typing in the Series.

This PR adds this missing type.

Thank you so much for reviewing the other PR, and sorry for the mistake.

I don't think this needs to be merged soon (`seriesNames` is enough on our side), this typing will solve the [other issue](https://github.com/cube-js/cube.js/issues/673) by exposing it correctly though.