### PR TITLE
feat(cubesql): Support `LEFT`, `RIGHT` in projection

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -15869,4 +15869,45 @@ ORDER BY \"COUNT(count)\" DESC"
             }
         )
     }
+
+    #[tokio::test]
+    async fn test_thoughtspot_left_right() {
+        init_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT
+                "ta_1"."customer_gender" "ca_1",
+                LEFT("ta_1"."customer_gender", 2) "ca_2",
+                RIGHT("ta_1"."customer_gender", 2) "ca_3"
+            FROM KibanaSampleDataEcommerce "ta_1"
+            GROUP BY
+                "ca_1",
+                "ca_2",
+                "ca_3"
+            ORDER BY
+                "ca_1" ASC,
+                "ca_2" ASC,
+                "ca_3" ASC
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: None,
+                limit: None,
+                offset: None,
+                filters: None,
+            }
+        )
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
@@ -2141,6 +2141,30 @@ impl RewriteRules for SplitRules {
                 inner_aggregate_split_replacer(fun_expr("CharacterLength", vec!["?expr"]), "?cube"),
                 inner_aggregate_split_replacer("?expr", "?cube"),
             ),
+            // Left
+            rewrite(
+                "split-push-down-left-inner-replacer",
+                inner_aggregate_split_replacer(
+                    fun_expr(
+                        "Left",
+                        vec!["?expr".to_string(), literal_expr("?length")],
+                    ),
+                    "?cube",
+                ),
+                inner_aggregate_split_replacer("?expr", "?cube"),
+            ),
+            // Right
+            rewrite(
+                "split-push-down-right-inner-replacer",
+                inner_aggregate_split_replacer(
+                    fun_expr(
+                        "Right",
+                        vec!["?expr".to_string(), literal_expr("?length")],
+                    ),
+                    "?cube",
+                ),
+                inner_aggregate_split_replacer("?expr", "?cube"),
+            ),
             // IS NULL, IS NOT NULL
             rewrite(
                 "split-push-down-is-null-inner-replacer",
@@ -3660,6 +3684,62 @@ impl RewriteRules for SplitRules {
                     fun_expr(
                         "CharacterLength",
                         vec![split_replacer("?expr".to_string(), "?cube")],
+                    )
+                },
+                |_, _| true,
+                false,
+                false,
+                true,
+                Some(vec![("?expr", column_expr("?column"))]),
+            )
+            .into_iter(),
+        );
+        // Left
+        rules.extend(
+            self.outer_aggr_group_expr_aggr_combinator_rewrite(
+                "split-push-down-left-replacer",
+                |split_replacer| {
+                    split_replacer(
+                        fun_expr("Left", vec!["?expr".to_string(), literal_expr("?length")]),
+                        "?cube",
+                    )
+                },
+                |_| vec![],
+                |split_replacer| {
+                    fun_expr(
+                        "Left",
+                        vec![
+                            split_replacer("?expr".to_string(), "?cube"),
+                            literal_expr("?length"),
+                        ],
+                    )
+                },
+                |_, _| true,
+                false,
+                false,
+                true,
+                Some(vec![("?expr", column_expr("?column"))]),
+            )
+            .into_iter(),
+        );
+        // Right
+        rules.extend(
+            self.outer_aggr_group_expr_aggr_combinator_rewrite(
+                "split-push-down-right-replacer",
+                |split_replacer| {
+                    split_replacer(
+                        fun_expr("Right", vec!["?expr".to_string(), literal_expr("?length")]),
+                        "?cube",
+                    )
+                },
+                |_| vec![],
+                |split_replacer| {
+                    fun_expr(
+                        "Right",
+                        vec![
+                            split_replacer("?expr".to_string(), "?cube"),
+                            literal_expr("?length"),
+                        ],
                     )
                 },
                 |_, _| true,


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `LEFT` and `RIGHT` post-processing functions to be used in projections. This improves compatibility with Thoughtspot. Test suite is included.
