### PR TITLE
chore(cubestore): Improve safety on compaction

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/rocks_table.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_table.rs
@@ -808,7 +808,7 @@ pub trait RocksTable: Debug + Send + Sync {
                 }
 
                 let (hash, expire) =
-                    match RocksSecondaryIndexValue::from_bytes(&*value, index.value_version()) {
+                    match RocksSecondaryIndexValue::from_bytes(&*value, index.value_version())? {
                         RocksSecondaryIndexValue::Hash(h) => (h, None),
                         RocksSecondaryIndexValue::HashAndTTL(h, expire) => (h, expire),
                     };


### PR DESCRIPTION
Hello!

Any kind of migration doesn't remove old values from the database; it's why compaction should remove them.

Thanks