### PR TITLE
feat(cubesql): Support Node.js 18/19

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
     name: Build native Linux ${{ matrix.node-version }} ${{ matrix.target }}
     strategy:
       matrix:
-        node-version: [14, 16, 17]
+        node-version: 14
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
         include:
           - target: aarch64-unknown-linux-gnu
@@ -153,7 +153,7 @@ jobs:
     name: Build ${{ matrix.os-version }} ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: 14.x
         os-version: [windows-2019, macos-11]
       fail-fast: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,7 @@ jobs:
             package_target_libc: glibc
       fail-fast: false
     container:
-      image: cubejs/rust-cross:${{ matrix.target }}-10052021
+      image: cubejs/rust-cross:${{ matrix.target }}-02012023
 
     steps:
       - name: Checkout

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -126,7 +126,7 @@ jobs:
     name: Build Linux GNU ${{ matrix.node-version }}.x ${{ matrix.target }}
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [12, 14, 16, 18]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
       fail-fast: false
     container:
@@ -202,7 +202,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        # We dont need to test under all versions, we do it under linux
+        node-version: [14.x]
         os-version: [windows-2019, macos-11]
       fail-fast: false
 

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -130,7 +130,7 @@ jobs:
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
       fail-fast: false
     container:
-      image: cubejs/rust-cross:${{ matrix.target }}-10052021
+      image: cubejs/rust-cross:${{ matrix.target }}-02012023
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust-cubesql.yml
+++ b/.github/workflows/rust-cubesql.yml
@@ -126,7 +126,7 @@ jobs:
     name: Build Linux GNU ${{ matrix.node-version }}.x ${{ matrix.target }}
     strategy:
       matrix:
-        node-version: [12, 14, 16, 18]
+        node-version: [14, 16, 18]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
       fail-fast: false
     container:

--- a/packages/cubejs-backend-native/package.json
+++ b/packages/cubejs-backend-native/package.json
@@ -45,7 +45,7 @@
     "module_name": "index",
     "host": "https://github.com/cube-js/cube.js/releases/download/",
     "remote_path": "v{version}",
-    "package_name": "native-{node_abi}-{platform}-{arch}-{libc}.tar.gz",
+    "package_name": "native-{platform}-{arch}-{libc}.tar.gz",
     "module_path": "native",
     "pkg_path": "."
   },

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -48,7 +48,7 @@
     "driver:databricks:snap": "jest --verbose --updateSnapshot -i dist/test/driver-databricks.test.js",
     "integration:cubestore": "jest --verbose --updateSnapshot -i dist/test/driver-cubestore.test.js",
     "rest:postgres": "yarn tsc && clear && jest --verbose -i dist/test/rest-postgres.test.js",
-    "smoke": "jest --verbose -i 'dist/test/smoke-(?!.*?(redshift|bigquery|firebolt))'",
+    "smoke": "jest --verbose -i 'dist/test/smoke-(?!.*?(redshift|bigquery|firebolt|cubesql))'",
     "smoke:athena": "jest --verbose -i dist/test/smoke-athena.test.js",
     "smoke:athena:snapshot": "jest --verbose --updateSnapshot -i dist/test/smoke-athena.test.js",
     "smoke:bigquery": "jest --verbose -i dist/test/smoke-bigquery.test.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6616,30 +6616,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@^12", "@types/node@^12.12.17":
+"@types/node@*", "@types/node@12.12.50", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^10.17.55", "@types/node@^10.17.60", "@types/node@^12", "@types/node@^12.12.17", "@types/node@^14.14.35":
   version "12.20.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.41.tgz#81d7734c5257da9f04354bd9084a6ebbdd5198a5"
   integrity sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q==
-
-"@types/node@12.12.50":
-  version "12.12.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.50.tgz#e9b2e85fafc15f2a8aa8fdd41091b983da5fd6ee"
-  integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
-
-"@types/node@>=13.7.0":
-  version "18.11.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.11.tgz#1d455ac0211549a8409d3cdb371cd55cc971e8dc"
-  integrity sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==
-
-"@types/node@^10.17.55", "@types/node@^10.17.60":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
-
-"@types/node@^14.14.35":
-  version "14.18.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.34.tgz#cd2e6fa0dbfb08a62582a7b967558e73c32061ec"
-  integrity sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -6688,7 +6668,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
+"@types/ramda@0.27.40", "@types/ramda@^0.27.32", "@types/ramda@^0.27.34", "@types/ramda@^0.27.40":
   version "0.27.40"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.40.tgz#99f307356fe553095ee4d3c2af2b0eb3af7a8413"
   integrity sha512-V99ZfTH2tqVYdLDAlgh2uT+N074HPgqnAsMjALKSBqogYd0HbuuGMqNukJ6fk9Ml/Htaus76fsc4Yh3p7q1VdQ==
@@ -23435,21 +23415,10 @@ rc-tree-select@~4.3.0:
     rc-tree "^4.0.0"
     rc-util "^5.0.5"
 
-rc-tree@^4.0.0:
+rc-tree@4.1.5, rc-tree@^4.0.0, rc-tree@~4.2.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.1.5.tgz#734ab1bfe835e78791be41442ca0e571147ab6fa"
   integrity sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "2.x"
-    rc-motion "^2.0.1"
-    rc-util "^5.0.0"
-    rc-virtual-list "^3.0.1"
-
-rc-tree@~4.2.1:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-4.2.2.tgz#4429187cbbfbecbe989714a607e3de8b3ab7763f"
-  integrity sha512-V1hkJt092VrOVjNyfj5IYbZKRMHxWihZarvA5hPL/eqm7o2+0SNkeidFYm7LVVBrAKBpOpa0l8xt04uiqOd+6w==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11744,9 +11744,9 @@ de-indent@^1.0.2:
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
 deasync@^0.1.15:
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.24.tgz#6ecc9c6ff9eba64a4f4572ae3c4db77fed09268a"
-  integrity sha512-i98vg42xNfRZCymummMAN0rIcQ1gZFinSe3btvPIvy6JFTaeHcumeKybRo2HTv86nasfmT0nEgAn2ggLZhOCVA==
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.28.tgz#9b447b79b3f822432f0ab6a8614c0062808b5ad2"
+  integrity sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"


### PR DESCRIPTION
Hello!

`@cubejs-backend/native` uses <= NAPI-6 (not Node.js's ABI), which allows us to use a single artifact for each platform-libc.

Thanks