### PR TITLE
feat(cubesql): Support Thoughtspot starts/ends LIKE exprs

### DIFF
--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -14385,7 +14385,7 @@ ORDER BY \"COUNT(count)\" DESC"
     }
 
     #[tokio::test]
-    async fn test_thoughtspot_search_in_filter() {
+    async fn test_thoughtspot_like_with_escape() {
         init_logger();
 
         let logical_plan = convert_select_to_query_plan(
@@ -14432,6 +14432,106 @@ ORDER BY \"COUNT(count)\" DESC"
                     member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
                     operator: Some("contains".to_string()),
                     values: Some(vec!["male".to_string()]),
+                    or: None,
+                    and: None
+                }])
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT "ta_1"."customer_gender" "ca_1"
+            FROM "db"."public"."KibanaSampleDataEcommerce" "ta_1"
+            WHERE NOT(LOWER("ta_1"."customer_gender") LIKE (replace(
+                replace(
+                    replace(
+                        'test',
+                        '!',
+                        '!!'
+                    ),
+                    '%',
+                    '!%'
+                ),
+                '_',
+                '!_'
+            ) || '%') ESCAPE '!')
+            GROUP BY "ca_1"
+            ORDER BY "ca_1" ASC
+            LIMIT 1000
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: Some(vec![vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                    "asc".to_string(),
+                ]]),
+                limit: Some(1000),
+                offset: None,
+                filters: Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("notStartsWith".to_string()),
+                    values: Some(vec!["test".to_string()]),
+                    or: None,
+                    and: None
+                }])
+            }
+        );
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT "ta_1"."customer_gender" "ca_1"
+            FROM "db"."public"."KibanaSampleDataEcommerce" "ta_1"
+            WHERE NOT(LOWER("ta_1"."customer_gender") LIKE ('%' || replace(
+                replace(
+                    replace(
+                        'known',
+                        '!',
+                        '!!'
+                    ),
+                    '%',
+                    '!%'
+                ),
+                '_',
+                '!_'
+            )) ESCAPE '!')
+            GROUP BY "ca_1"
+            ORDER BY "ca_1" ASC
+            LIMIT 1000
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                time_dimensions: None,
+                order: Some(vec![vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                    "asc".to_string(),
+                ]]),
+                limit: Some(1000),
+                offset: None,
+                filters: Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("notEndsWith".to_string()),
+                    values: Some(vec!["known".to_string()]),
                     or: None,
                     and: None
                 }])

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -106,3 +106,30 @@ fn granularity_int_order_to_str(granularity: i32, week_as_day: Option<bool>) -> 
     }
     .map(|g| g.to_string())
 }
+
+pub fn negated_cube_filter_op(op: &str) -> Option<&'static str> {
+    macro_rules! define_op_eq {
+        ($($EXPR:expr => $NEG:expr,)*) => {
+            match op {
+                $(
+                    $EXPR => $NEG,
+                    $NEG => $EXPR,
+                )*
+                _ => return None,
+            }
+        }
+    }
+
+    let negated = define_op_eq![
+        "equals" => "notEquals",
+        "contains" => "notContains",
+        "startsWith" => "notStartsWith",
+        "endsWith" => "notEndsWith",
+        "gt" => "lte",
+        "lt" => "gte",
+        "set" => "notSet",
+        "inDateRange" => "notInDateRange",
+    ];
+
+    Some(negated)
+}


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for Thoughtspot `startsWith`/`endsWith` expressions using LIKE with ESCAPE symbol (re-encoding). Previously support for a similar expr `contains` was added; the changes here extend the support.
Related tests are included.
