### PR TITLE
Helm chart : export commons labels at pod level

### DIFF
--- a/examples/helm-charts/cubejs/templates/master/deployment.yaml
+++ b/examples/helm-charts/cubejs/templates/master/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         app.kubernetes.io/component: master
         {{- include "cubejs.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- toYaml .Values.commonLabels | nindent 8 }}
+        {{- end }}
       {{- if .Values.commonAnnotations }}
       annotations:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}

--- a/examples/helm-charts/cubejs/templates/workers/deployment.yaml
+++ b/examples/helm-charts/cubejs/templates/workers/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app.kubernetes.io/component: workers
         {{- include "cubejs.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- toYaml .Values.commonLabels | nindent 8 }}
+        {{- end }}
       {{- if .Values.commonAnnotations }}
       annotations:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}

--- a/examples/helm-charts/cubestore/templates/router/statefulset.yaml
+++ b/examples/helm-charts/cubestore/templates/router/statefulset.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app.kubernetes.io/component: router
         {{- include "cubestore.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- toYaml .Values.commonLabels | nindent 8 }}
+        {{- end }}
       {{- if .Values.commonAnnotations }}
       annotations:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}

--- a/examples/helm-charts/cubestore/templates/workers/statefulset.yaml
+++ b/examples/helm-charts/cubestore/templates/workers/statefulset.yaml
@@ -24,6 +24,9 @@ spec:
       labels:
         app.kubernetes.io/component: workers
         {{- include "cubestore.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- toYaml .Values.commonLabels | nindent 8 }}
+        {{- end }}
       {{- if .Values.commonAnnotations }}
       annotations:
       {{- toYaml .Values.commonAnnotations | nindent 8 }}


### PR DESCRIPTION
At the moment of writing is not possible to add custom labels to add pod level. This change can be useful cause a lot of 
network policy frameworks like `Cilium` use labels at the pod level to apply a particular rule
 