### PR TITLE
chore(cubesql): Support `to_date` in `datediff`

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -788,6 +788,31 @@ pub fn create_dateadd_udf() -> ScalarUDF {
     )
 }
 
+pub fn create_to_date_udf() -> ScalarUDF {
+    let fun = make_scalar_function(move |args: &[ArrayRef]| {
+        assert!(args.len() == 2 || args.len() == 3);
+
+        return Err(DataFusionError::NotImplemented(format!(
+            "to_date is not implemented, it's stub"
+        )));
+    });
+
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Date32)));
+
+    ScalarUDF::new(
+        "to_date",
+        &Signature::one_of(
+            vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Boolean]),
+            ],
+            Volatility::Immutable,
+        ),
+        &return_type,
+        &fun,
+    )
+}
+
 pub fn create_time_format_udf() -> ScalarUDF {
     let fun = make_scalar_function(move |args: &[ArrayRef]| {
         assert!(args.len() == 2);

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
@@ -398,6 +398,14 @@ impl RewriteRules for DateRules {
                 ),
             ),
             rewrite(
+                "thoughtspot-to-date-to-timestamp",
+                udf_expr(
+                    "to_date",
+                    vec![literal_expr("?date"), literal_string("YYYY-MM-DD")],
+                ),
+                udf_expr("date_to_timestamp", vec![literal_expr("?date")]),
+            ),
+            rewrite(
                 "datastudio-dates",
                 fun_expr(
                     "DateTrunc",

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
@@ -1823,7 +1823,7 @@ impl RewriteRules for SplitRules {
                 alias_expr(
                     fun_expr(
                         "DateTrunc",
-                        vec![literal_string("month"), column_expr("?column")],
+                        vec![literal_string("day"), column_expr("?column")],
                     ),
                     "?alias",
                 ),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `to_date` expressions in `datediff` functions, used by Thoughtspot. `to_date` itself is a stub and cannot be used, but is effectively rewritten to another function.
A related PR is included.