### PR TITLE
fix: Delete `CUBEJS_DROP_PRE_AGG_WITHOUT_TOUCH` pre-aggregations only…

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.ts
@@ -399,4 +399,8 @@ export class QueryOrchestrator {
   public async unSubscribeQueueEvents(id) {
     return this.getQueueEventsBus().unsubscribe(id);
   }
+
+  public async updateRefreshEndReached() {
+    return this.preAggregations.updateRefreshEndReached();
+  }
 }

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -307,4 +307,8 @@ export class OrchestratorApi {
   public async unSubscribeQueueEvents(id) {
     return this.orchestrator.unSubscribeQueueEvents(id);
   }
+
+  public async updateRefreshEndReached() {
+    return this.orchestrator.updateRefreshEndReached();
+  }
 }

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -580,7 +580,7 @@ export class RefreshScheduler {
 
     const preAggregationsLoadCacheByDataSource = {};
     const queriesCache: { [key: string]: Promise<PreAggregationDescription[][]> } = {};
-    return Promise.all(R.range(0, concurrency)
+    await Promise.all(R.range(0, concurrency)
       .filter(workerIndex => workerIndices.indexOf(workerIndex) !== -1)
       .map(async workerIndex => {
         const queryIteratorStateKey = JSON.stringify({ ...securityContext, workerIndex });
@@ -603,6 +603,7 @@ export class RefreshScheduler {
           }
         }
       }));
+    await this.serverCore.getOrchestratorApi(context).updateRefreshEndReached();
   }
 
   public async buildPreAggregations(


### PR DESCRIPTION
… after refresh end to avoid cold start removals

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


