### PR TITLE
feat(cubesql): Thoughtspot improvements

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -26,24 +26,33 @@ pub fn parse_granularity(granularity: &ScalarValue, to_normalize: bool) -> Optio
     }
 }
 
-pub fn granularity_to_interval(granularity: &ScalarValue) -> Option<ScalarValue> {
+pub fn granularity_scalar_to_interval(granularity: &ScalarValue) -> Option<ScalarValue> {
     if let Some(granularity) = parse_granularity(granularity, false) {
-        let interval = match granularity.as_str() {
-            "second" => ScalarValue::IntervalDayTime(Some(1000)),
-            "minute" => ScalarValue::IntervalDayTime(Some(60000)),
-            "hour" => ScalarValue::IntervalDayTime(Some(3600000)),
-            "day" => ScalarValue::IntervalDayTime(Some(4294967296)),
-            "week" => ScalarValue::IntervalDayTime(Some(30064771072)),
-            "month" => ScalarValue::IntervalYearMonth(Some(1)),
-            "quarter" => ScalarValue::IntervalYearMonth(Some(3)),
-            "year" => ScalarValue::IntervalYearMonth(Some(12)),
-            _ => return None,
-        };
-
-        return Some(interval);
+        return granularity_to_interval(&granularity);
     }
-
     None
+}
+
+pub fn granularity_str_to_interval(granularity: &str) -> Option<ScalarValue> {
+    if let Some(granularity) = parse_granularity_string(granularity, false) {
+        return granularity_to_interval(&granularity);
+    }
+    None
+}
+
+fn granularity_to_interval(granularity: &str) -> Option<ScalarValue> {
+    let interval = match granularity.to_lowercase().as_str() {
+        "second" => ScalarValue::IntervalDayTime(Some(1000)),
+        "minute" => ScalarValue::IntervalDayTime(Some(60000)),
+        "hour" => ScalarValue::IntervalDayTime(Some(3600000)),
+        "day" => ScalarValue::IntervalDayTime(Some(4294967296)),
+        "week" => ScalarValue::IntervalDayTime(Some(30064771072)),
+        "month" => ScalarValue::IntervalYearMonth(Some(1)),
+        "quarter" => ScalarValue::IntervalYearMonth(Some(3)),
+        "year" => ScalarValue::IntervalYearMonth(Some(12)),
+        _ => return None,
+    };
+    Some(interval)
 }
 
 pub fn min_max_granularity(

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -75,7 +75,7 @@ pub fn min_max_granularity(
     granularity_int_order_to_str(result, week_as_day)
 }
 
-fn granularity_str_to_int_order(granularity: &str, week_as_day: Option<bool>) -> Option<i32> {
+pub fn granularity_str_to_int_order(granularity: &str, week_as_day: Option<bool>) -> Option<i32> {
     match granularity.to_lowercase().as_str() {
         "second" => Some(0),
         "minute" => Some(1),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR improves compatibility with Thoughtspot:

- Support `date_trunc` over column and a literal filter (`WHERE DATE_TRUNC('MONTH', time_dimension) </<=/>/>= literal_date`)
- Support double `date_trunc` with double `cast` (`DATE_TRUNC('MONTH', CAST(DATE_TRUNC('MONTH', CAST(time_dimension as TIMESTAMP)) as TIMESTAMP))`)

Related tests are included.
