### PR TITLE
manage BQkeyFile and CubeStore telemetry

### DIFF
--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -286,6 +286,10 @@ CUBEJS_REDIS_PASSWORD.
       name: {{ .Values.database.bigquery.credentialsFromSecret.name | required "database.bigquery.credentialsFromSecret.name is required" }}
       key: {{ .Values.database.bigquery.credentialsFromSecret.key | required "database.bigquery.credentialsFromSecret.key is required" }}
 {{- end }}
+{{- if .Values.database.bigquery.KeyFile }}
+- name: CUBEJS_DB_BQ_KEY_FILE
+  value: {{ .Values.database.bigquery.KeyFile }}
+{{- end }}
 {{- if .Values.exportBucket.name }}
 - name: CUBEJS_DB_EXPORT_BUCKET
   value: {{ .Values.exportBucket.name | quote }}

--- a/examples/helm-charts/cubestore/templates/common-env.tpl
+++ b/examples/helm-charts/cubestore/templates/common-env.tpl
@@ -7,6 +7,8 @@
 - name: CUBESTORE_NO_UPLOAD
   value: {{ .Values.config.noUpload | quote }}
 {{- end }}
+- name: CUBESTORE_TELEMETRY
+  value: {{ .Values.config.telemetry | quote }}
 {{- if .Values.config.jobRunners }}
 - name: CUBESTORE_JOB_RUNNERS
   value: {{ .Values.config.jobRunners | quote }}


### PR DESCRIPTION
Hi,
please review this PR. Enable char to define 
`CUBEJS_DB_BQ_KEY_FILE` and `CUBESTORE_TELEMETRY` in cubestore chart
