### PR TITLE
feat: Re-use connection to Cube Store from externalDriver

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -117,7 +117,7 @@ export interface QueryCacheOptions {
     heartBeatInterval?: number;
   }>;
   redisPool?: any;
-  cubeStoreDriver?: CubeStoreDriver,
+  cubeStoreDriverFactory?: () => Promise<CubeStoreDriver>,
   continueWaitTimeout?: number;
   cacheAndQueueDriver?: CacheAndQueryDriverType;
   maxInMemoryCacheEntries?: number;
@@ -148,7 +148,7 @@ export class QueryCache {
         break;
       case 'cubestore':
         this.cacheDriver = new CubeStoreCacheDriver(
-          options.cubeStoreDriver || new CubeStoreDriver({})
+          options.cubeStoreDriverFactory || (async () => new CubeStoreDriver({}))
         );
         break;
       default:

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryOrchestrator.ts
@@ -60,19 +60,19 @@ export class QueryOrchestrator {
       throw new Error('Only \'redis\', \'memory\' or \'cubestore\' are supported for cacheAndQueueDriver option');
     }
 
+    const { externalDriverFactory, continueWaitTimeout, skipExternalCacheAndQueue } = options;
+
     const redisPool = cacheAndQueueDriver === 'redis' ? new RedisPool(options.redisPoolOptions) : undefined;
     this.redisPool = redisPool;
 
-    const { externalDriverFactory, continueWaitTimeout, skipExternalCacheAndQueue } = options;
-
-    const cubeStoreDriverFactory = async () => {
+    const cubeStoreDriverFactory = cacheAndQueueDriver === 'cubestore' ? async () => {
       const externalDriver = await externalDriverFactory();
       if (externalDriver instanceof CubeStoreDriver) {
         return externalDriver;
       }
 
       throw new Error('It`s not possible to use CubeStore as queue & cache driver without using it as external');
-    };
+    } : undefined;
 
     this.queryCache = new QueryCache(
       this.redisPrefix,

--- a/packages/cubejs-query-orchestrator/test/integration/cubestore/QueryCacheCubestore.test.ts
+++ b/packages/cubejs-query-orchestrator/test/integration/cubestore/QueryCacheCubestore.test.ts
@@ -3,7 +3,7 @@ import { QueryCacheTest } from '../../unit/QueryCache.abstract';
 
 let beforeAll;
 let afterAll;
-let cubeStoreDriver = new CubeStoreDriver({});
+let cubeStoreDriverFactory = async () => new CubeStoreDriver({});
 
 if ((process.env.CUBEJS_TESTING_CUBESTORE_AUTO_PROVISIONING || 'true') === 'true') {
   const cubeStoreHandler = new CubeStoreHandler({
@@ -22,14 +22,14 @@ if ((process.env.CUBEJS_TESTING_CUBESTORE_AUTO_PROVISIONING || 'true') === 'true
     await cubeStoreHandler.acquire();
   };
   afterAll = async () => cubeStoreHandler.release(true);
-  cubeStoreDriver = new CubeStoreDevDriver(cubeStoreHandler);
+  cubeStoreDriverFactory = async () => new CubeStoreDevDriver(cubeStoreHandler);
 }
 
 QueryCacheTest(
   'CubeStore Cache Driver',
   {
     cacheAndQueueDriver: 'cubestore',
-    cubeStoreDriver,
+    cubeStoreDriverFactory,
     beforeAll,
     afterAll
   }


### PR DESCRIPTION
Hello!

Cube Store is used as the default external database; let's reuse the connection from external driver for caching.

Thanks