### PR TITLE
chore(cubesql): Reaggregation improvements

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1306,7 +1306,7 @@ impl MemberRules {
                     let column_name_to_alias = expr_to_alias
                         .clone()
                         .into_iter()
-                        .map(|(e, a)| (expr_column_name_with_relation(e, &mut relation), a))
+                        .map(|(e, a, _)| (expr_column_name_with_relation(e, &mut relation), a))
                         .collect::<Vec<_>>();
                     if let Some(member_name_to_expr) = egraph
                         .index(subst[members_var])

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 
-use datafusion::scalar::ScalarValue;
+use datafusion::{physical_plan::aggregates::AggregateFunction, scalar::ScalarValue};
 
 pub fn parse_granularity_string(granularity: &str, to_normalize: bool) -> Option<String> {
     if to_normalize {
@@ -141,4 +141,13 @@ pub fn negated_cube_filter_op(op: &str) -> Option<&'static str> {
     ];
 
     Some(negated)
+}
+
+pub fn reaggragate_fun(cube_fun: &str) -> Option<AggregateFunction> {
+    Some(match cube_fun {
+        "count" | "sum" => AggregateFunction::Sum,
+        "min" => AggregateFunction::Min,
+        "max" => AggregateFunction::Max,
+        _ => return None,
+    })
 }


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR improves compatibility regarding reaggregation:
- Allow unaliased expressions (`SELECT EXTRACT(YEAR FROM column) FROM cube`)
- Avoid direct mapping of values with `SUBSTRING` (except the Metabase case)

Related tests are included.
