### PR TITLE
feat(docker): Alpine - migrate to 3.15 (3.14 was removed)

### DIFF
--- a/packages/cubejs-docker/DEVELOPMENT.md
+++ b/packages/cubejs-docker/DEVELOPMENT.md
@@ -4,21 +4,28 @@
 
 Release version
 
-Debian:
+### Debian:
 
 ```sh
 docker build -t cubejs/cube:latest -f latest.Dockerfile .
 docker buildx build --platform linux/amd64 -t cubejs/cube:latest -f latest.Dockerfile .
 ```
 
-Alpine
+### Alpine
 
 ```sh
 docker build -t cubejs/cube:alpine -f latest-alpine.Dockerfile .
 docker buildx build --platform linux/amd64 -t cubejs/cube:alpine -f latest-alpine.Dockerfile .
 ```
 
-Not released, development (from `cubejs-docker` directory)
+### JDK
+
+```sh
+docker build -t cubejs/cube:alpine-jdk -f latest-alpine-jdk.Dockerfile .
+docker build -t cubejs/cube:latest-jdk -f latest-debian-jdk.Dockerfile .
+```
+
+### Not released, development (from `cubejs-docker` directory)
 
 ```sh
 docker build -t cubejs/cube:dev -f dev.Dockerfile ../../

--- a/packages/cubejs-docker/dev-alpine.Dockerfile
+++ b/packages/cubejs-docker/dev-alpine.Dockerfile
@@ -1,6 +1,6 @@
 # This image has been deprecated!
 
-FROM node:14.21.1-alpine3.14
+FROM node:14.21.1-alpine3.15
 
 ARG IMAGE_VERSION=dev
 

--- a/packages/cubejs-docker/latest-alpine-jdk.Dockerfile
+++ b/packages/cubejs-docker/latest-alpine-jdk.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.21.1-alpine3.14
+FROM node:14.21.1-alpine3.15
 
 ARG IMAGE_VERSION=unknown
 

--- a/packages/cubejs-docker/latest-alpine.Dockerfile
+++ b/packages/cubejs-docker/latest-alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.21.1-alpine3.14
+FROM node:14.21.1-alpine3.15
 
 ARG IMAGE_VERSION=unknown
 


### PR DESCRIPTION
Hello!

https://github.com/cube-js/cube.js/actions/runs/3890140417/jobs/6639503153

There are no new docker images for Node.js and Alpine 3.14. Let's migrate to 3.15 (as nearest version).

Thanks