### PR TITLE
fix: Rollups are sorted by name in `rollups` params of pre-aggregations

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.js
@@ -445,7 +445,7 @@ export class CubeEvaluator extends CubeSymbols {
         aggregation.measureReferences && this.evaluateReferences(cube, aggregation.measureReferences) || [],
       timeDimensions,
       rollups:
-        aggregation.rollupReferences && this.evaluateReferences(cube, aggregation.rollupReferences) || [],
+        aggregation.rollupReferences && this.evaluateReferences(cube, aggregation.rollupReferences, { originalSorting: true }) || [],
     };
   }
 }

--- a/packages/cubejs-testing/birdbox-fixtures/lambda/schema/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/lambda/schema/Orders.js
@@ -10,7 +10,7 @@ cube(`Orders`, {
 
     ordersByCompletedAtLambda: {
       type: `rollupLambda`,
-      rollups: [ordersByCompletedAt, ordersByCompletedByDay],
+      rollups: [ordersByCompletedAt, ordersByCompletedByDay, AOrdersByCompletedByHour],
       unionWithSourceData: true,
     },
 
@@ -65,6 +65,23 @@ cube(`Orders`, {
       partitionGranularity: `day`,
       buildRangeStart: {
         sql: `SELECT DATE('2020-05-1')`,
+      },
+      buildRangeEnd: {
+        sql: `SELECT DATE('2020-05-5')`,
+      },
+      refreshKey: {
+        every: '1 day'
+      },
+    },
+
+    AOrdersByCompletedByHour: {
+      measures: [count],
+      dimensions: [status],
+      timeDimension: completedAt,
+      granularity: `day`,
+      partitionGranularity: `hour`,
+      buildRangeStart: {
+        sql: `SELECT DATE('2020-05-5')`,
       },
       buildRangeEnd: {
         sql: `SELECT DATE('2020-05-7')`,

--- a/packages/cubejs-testing/test/smoke-lambda.test.ts
+++ b/packages/cubejs-testing/test/smoke-lambda.test.ts
@@ -32,28 +32,27 @@ async function checkCubestoreState(cubestore: any) {
   expect(rows.slice(0, 4)).toEqual([
     {
       table_schema: 'dev_pre_aggregations',
-      table_name: 'orders_orders_by_completed_at20200201',
-      build_range_end: '2020-02-29T23:59:59.999Z',
+      table_name: 'orders__a_orders_by_completed_by_hour2020050500',
+      build_range_end: '2020-05-05T00:59:59.999Z',
     },
     {
       table_schema: 'dev_pre_aggregations',
-      table_name: 'orders_orders_by_completed_at20200301',
-      build_range_end: '2020-03-31T23:59:59.999Z',
+      table_name: 'orders__a_orders_by_completed_by_hour2020050501',
+      build_range_end: '2020-05-05T01:59:59.999Z',
     },
     {
       table_schema: 'dev_pre_aggregations',
-      table_name: 'orders_orders_by_completed_at20200401',
-      build_range_end: '2020-04-30T23:59:59.999Z',
+      table_name: 'orders__a_orders_by_completed_by_hour2020050502',
+      build_range_end: '2020-05-05T02:59:59.999Z',
     },
     {
       table_schema: 'dev_pre_aggregations',
-      table_name: 'orders_orders_by_completed_at20200501',
-      build_range_end: '2020-05-01T00:00:00.000Z',
+      table_name: 'orders__a_orders_by_completed_by_hour2020050503',
+      build_range_end: '2020-05-05T03:59:59.999Z',
     },
   ]);
-  expect(table.build_range_end).toEqual('2020-05-01T00:00:00.000Z');
   rows = await cubestore.query(`SELECT * FROM ${table.table_schema}.${table.table_name}`, []);
-  expect(rows.length).toEqual(0);
+  expect(rows.length).toEqual(1);
 }
 
 describe('lambda', () => {
@@ -140,7 +139,8 @@ describe('lambda', () => {
     // @ts-ignore
     expect(Object.keys(response.loadResponse.results[0].usedPreAggregations)).toEqual([
       'dev_pre_aggregations.orders_orders_by_completed_at',
-      'dev_pre_aggregations.orders_orders_by_completed_by_day'
+      'dev_pre_aggregations.orders_orders_by_completed_by_day',
+      'dev_pre_aggregations.orders__a_orders_by_completed_by_hour'
     ]);
 
     // With lambda-view we observe all 'fresh' data, with no partition/buildRange limit.


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

