### PR TITLE
Add possibility to define extra env in helm chart

### DIFF
--- a/examples/helm-charts/cubejs/templates/common-env.tpl
+++ b/examples/helm-charts/cubejs/templates/common-env.tpl
@@ -1,4 +1,15 @@
+{{/* User defined cubejs environment from */}}
+{{- define "custom_cubejs_environment_from" }}
+  {{- $Global := . }}
+  {{- with .Values.extraEnvFrom }}
+  {{- tpl . $Global | nindent 2 }}
+  {{- end }}
+{{- end }}
 {{- define "cubejs.common-env" -}}
+{{- $Global := . }}
+{{- with .Values.extraEnv }}
+{{- tpl . $Global }}
+{{- end }}
 - name: PORT
   value: {{ .Values.config.apiPort | quote }}
 {{- if .Values.config.debug }}

--- a/examples/helm-charts/cubejs/templates/master/deployment.yaml
+++ b/examples/helm-charts/cubejs/templates/master/deployment.yaml
@@ -51,11 +51,13 @@ spec:
               containerPort: {{ .Values.config.sqlPort }}
               protocol: TCP
             {{- end }}
-            {{- if .Values.config.pgSqlPort }}
+	    {{- if .Values.config.pgSqlPort }}
             - name: pgsql
               containerPort: {{ .Values.config.pgSqlPort }}
               protocol: TCP
             {{- end }}
+          envFrom:
+           {{- include "custom_cubejs_environment_from" . | default "\n  []" | indent 10 }}
           env:
             {{- include "cubejs.common-env" . | nindent 12 }}
           {{- if .Values.master.livenessProbe.enabled }}

--- a/examples/helm-charts/cubejs/templates/workers/deployment.yaml
+++ b/examples/helm-charts/cubejs/templates/workers/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             - name: http
               containerPort: {{ .Values.config.apiPort }}
               protocol: TCP
+          envFrom:
+           {{- include "custom_cubejs_environment_from" . | default "\n  []" | indent 10 }}          
           env:
             {{- include "cubejs.common-env" . | nindent 12 }}
             - name: CUBEJS_REFRESH_WORKER

--- a/examples/helm-charts/cubejs/values.yaml
+++ b/examples/helm-charts/cubejs/values.yaml
@@ -14,6 +14,23 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
+# Extra env 'items' that will be added to the definition of cubejs containers in every instance master and workers
+# a string is expected (can be templated).
+extraEnv: ~
+# eg:
+# extraEnv: |
+#   - name: PLATFORM
+#     value: FR
+
+# Extra envFrom 'items' that will be added to the definition of cubejs containers in every instance master and workers
+# A string is expected (can be templated).
+extraEnvFrom: ~
+# eg:
+# extraEnvFrom: |
+#   - secretRef:
+#       name: '{{ .Release.Name }}-cubejs-connections'
+#   - configMapRef:
+#       name: '{{ .Release.Name }}-cubejs-variables'
 image:
   ## Docker image repository
   ##


### PR DESCRIPTION
Hi,
could you please review this Pr.
With this PR users are enabled to define custom env vars and load env vars from k8s secrets using `envFrom` definition [example](https://kubernetes.io/docs/concepts/configuration/secret/#use-cases.). With this extension is possible to use it in k8s  [configuring-data-sources](https://cube.dev/docs/config/multiple-data-sources#configuring-data-sources-with-environment-variables
)
