### PR TITLE
fix(cubesql): Correct Thoughtspot day in quarter offset

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split.rs
@@ -3082,16 +3082,20 @@ impl RewriteRules for SplitRules {
                     ),
                 )],
                 alias_expr(
-                    udf_expr(
-                        "datediff",
-                        vec![
-                            literal_string("day"),
-                            fun_expr(
-                                "DateTrunc",
-                                vec![literal_string("quarter"), column_expr("?outer_column")],
-                            ),
-                            column_expr("?outer_column"),
-                        ],
+                    binary_expr(
+                        udf_expr(
+                            "datediff",
+                            vec![
+                                literal_string("day"),
+                                fun_expr(
+                                    "DateTrunc",
+                                    vec![literal_string("quarter"), column_expr("?outer_column")],
+                                ),
+                                column_expr("?outer_column"),
+                            ],
+                        ),
+                        "+",
+                        literal_int(1),
                     ),
                     "?alias",
                 ),


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes an inconsistency with Thoughtspot's "day in quarter" expression which should yield numbers starting from 1 (with first day in quarter being 1 and last up to 92) instead of being zero-based as it was before the fix.
