### PR TITLE
chore(cubesql): Push down `WHERE`, `ORDER`, `LIMIT`

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/mod.rs
@@ -1,4 +1,5 @@
 pub mod coerce;
 pub mod columar;
+pub mod optimizers;
 pub mod planner;
 pub mod scan;

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/filter_push_down.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/filter_push_down.rs
@@ -1,0 +1,1051 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use datafusion::{
+    error::{DataFusionError, Result},
+    logical_plan::{
+        plan::{
+            Aggregate, CrossJoin, Distinct, Join, Limit, Projection, Repartition, Sort, Subquery,
+            Union, Window,
+        },
+        Column, DFSchema, Expr, Filter, LogicalPlan, Operator,
+    },
+    optimizer::optimizer::{OptimizerConfig, OptimizerRule},
+};
+
+use super::utils::{
+    get_expr_columns, get_schema_columns, is_column_expr, is_const_expr, is_plan_yielding_one_row,
+    plan_has_projections, rewrite,
+};
+
+/// Filter Push Down optimizer rule pushes WHERE clauses consisting of specific,
+/// mostly simple, expressions down the plan, all the way to the Projection
+/// closest to TableScan. This is beneficial for CubeScans when some of the Projections
+/// on the way contain post-processing operations and cannot be pushed down.
+#[derive(Default)]
+pub struct FilterPushDown {}
+
+impl FilterPushDown {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for FilterPushDown {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        optimizer_config: &OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        filter_push_down(self, plan, vec![], optimizer_config)
+    }
+
+    fn name(&self) -> &str {
+        "__cube__filter_push_down"
+    }
+}
+
+/// Recursively optimizes plan, collecting the filters that can possibly be pushed down.
+/// Several filters will be concatenated to one Filter node joined with AND operator.
+fn filter_push_down(
+    optimizer: &FilterPushDown,
+    plan: &LogicalPlan,
+    predicates: Vec<Expr>,
+    optimizer_config: &OptimizerConfig,
+) -> Result<LogicalPlan> {
+    match plan {
+        LogicalPlan::Projection(Projection {
+            expr,
+            input,
+            schema,
+            alias,
+        }) => {
+            // Filter can be pushed down to projection, however we only map specific expressions.
+            // Complex predicates will not be pushed down, and get issued before the projection.
+            // As for the simple predicates, push down optimization is continued with those.
+            if predicates.is_empty() || !plan_has_projections(input) {
+                return issue_filter(
+                    predicates,
+                    LogicalPlan::Projection(Projection {
+                        expr: expr.clone(),
+                        input: Arc::new(filter_push_down(
+                            optimizer,
+                            input,
+                            vec![],
+                            optimizer_config,
+                        )?),
+                        schema: schema.clone(),
+                        alias: alias.clone(),
+                    }),
+                );
+            }
+
+            let rewrite_map = rewrite_map_for_projection(expr, schema);
+            let mut rewritten_predicates = vec![];
+            let mut non_rewrittable_predicates = vec![];
+            for predicate in predicates {
+                let new_predicate = rewrite(&predicate, &rewrite_map)?;
+                if let Some(predicate) = new_predicate {
+                    rewritten_predicates.push(predicate);
+                    continue;
+                }
+                non_rewrittable_predicates.push(predicate);
+            }
+
+            issue_filter(
+                non_rewrittable_predicates,
+                LogicalPlan::Projection(Projection {
+                    expr: expr.clone(),
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        rewritten_predicates,
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Filter(Filter { predicate, input }) => {
+            // When encountering a filter, collect it to our list of predicates,
+            // remove the filter from the plan and continue down the plan.
+
+            // TODO: splitting predicates by AND doesn't break anything per se,
+            // but does alter how rewrites work with date ranges, generating filters
+            // instead of a date range. Add a single predicate for the time being.
+            // let predicates = split_predicates(predicate)
+            let predicates = vec![predicate.clone()]
+                .into_iter()
+                .chain(predicates.into_iter())
+                .collect::<Vec<_>>();
+            let mut pushable_predicates = vec![];
+            let mut non_pushable_predicates = vec![];
+            for predicate in predicates {
+                if is_predicate_pushable(&predicate) {
+                    pushable_predicates.push(predicate);
+                    continue;
+                }
+                non_pushable_predicates.push(predicate);
+            }
+
+            issue_filter(
+                non_pushable_predicates,
+                filter_push_down(optimizer, input, pushable_predicates, optimizer_config)?,
+            )
+        }
+        LogicalPlan::Window(Window {
+            input,
+            window_expr,
+            schema,
+        }) => {
+            // Filter can't be pushed down Window.
+            issue_filter(
+                predicates,
+                LogicalPlan::Window(Window {
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    window_expr: window_expr.clone(),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Aggregate(Aggregate {
+            input,
+            group_expr,
+            aggr_expr,
+            schema,
+        }) => {
+            // Filters can be pushed down Aggregate if the predicate only references
+            // columns in `group_expr`. Issue the rest of the filters and continue
+            // down the plan.
+            if predicates.is_empty() {
+                return Ok(LogicalPlan::Aggregate(Aggregate {
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    group_expr: group_expr.clone(),
+                    aggr_expr: aggr_expr.clone(),
+                    schema: schema.clone(),
+                }));
+            }
+
+            let group_expr_exprs = group_expr.iter().collect::<HashSet<_>>();
+            let mut pushable_predicates = vec![];
+            let mut non_pushable_predicates = vec![];
+            for predicate in predicates {
+                let predicate_column_exprs = get_expr_columns(&predicate)
+                    .into_iter()
+                    .map(|column| Expr::Column(column))
+                    .collect::<Vec<_>>();
+                let all_columns_in_group_expr = predicate_column_exprs
+                    .iter()
+                    .all(|column| group_expr_exprs.contains(column));
+                if all_columns_in_group_expr {
+                    pushable_predicates.push(predicate);
+                    continue;
+                }
+                non_pushable_predicates.push(predicate);
+            }
+
+            issue_filter(
+                non_pushable_predicates,
+                LogicalPlan::Aggregate(Aggregate {
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        pushable_predicates,
+                        optimizer_config,
+                    )?),
+                    group_expr: group_expr.clone(),
+                    aggr_expr: aggr_expr.clone(),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Sort(Sort { expr, input }) => {
+            // Filtering won't affect the sorting; on the contrary, filtering before sorting
+            // may be beneficial for sorting performance.
+            Ok(LogicalPlan::Sort(Sort {
+                expr: expr.clone(),
+                input: Arc::new(filter_push_down(
+                    optimizer,
+                    input,
+                    predicates,
+                    optimizer_config,
+                )?),
+            }))
+        }
+        LogicalPlan::Join(Join {
+            left,
+            right,
+            on,
+            join_type,
+            join_constraint,
+            schema,
+            null_equals_null,
+        }) => {
+            // Joins are tricky since whether pushing filters to each side is allowed depends
+            // on the join type, since some joins would issue NULLs with no matches, hence
+            // affect the result. Additionally, Cube joins are always LEFT JOINs.
+            // It is unknown whether the join will be pushed down CubeScan or post-processed.
+            // Taking the above into account, the safest option is to push down filter only
+            // the left side of a JOIN, and only when both conditions are true:
+            // - `join_type` must be an INNER JOIN or LEFT JOIN
+            // - All columns in predicate must reference columns in left side of JOIN
+
+            // TODO: Nested joins with filters between will behave incorrectly with rewrites,
+            // so this code is disabled for the time being. Only join inputs are optimized.
+            /*
+            let pushable_join_type = match join_type {
+                JoinType::Inner | JoinType::Left => true,
+                _ => false,
+            };
+            if predicates.is_empty() || !pushable_join_type {
+                return issue_filter(
+                    predicates,
+                    LogicalPlan::Join(Join {
+                        left: Arc::new(filter_push_down(
+                            optimizer,
+                            left,
+                            vec![],
+                            optimizer_config,
+                        )?),
+                        right: Arc::new(filter_push_down(
+                            optimizer,
+                            right,
+                            vec![],
+                            optimizer_config,
+                        )?),
+                        on: on.clone(),
+                        join_type: join_type.clone(),
+                        join_constraint: join_constraint.clone(),
+                        schema: schema.clone(),
+                        null_equals_null: null_equals_null.clone(),
+                    }),
+                );
+            }
+
+            let left_columns = get_schema_columns(left.schema());
+            let mut pushable_predicates = vec![];
+            let mut non_pushable_predicates = vec![];
+            for predicate in predicates {
+                let predicate_column_exprs = get_expr_columns(&predicate);
+                let all_columns_in_schema = predicate_column_exprs
+                    .iter()
+                    .all(|column| left_columns.contains(column));
+                if all_columns_in_schema {
+                    pushable_predicates.push(predicate);
+                    continue;
+                }
+                non_pushable_predicates.push(predicate);
+            }
+
+            issue_filter(
+                non_pushable_predicates,
+                LogicalPlan::Join(Join {
+                    left: Arc::new(filter_push_down(
+                        optimizer,
+                        left,
+                        pushable_predicates,
+                        optimizer_config,
+                    )?),
+                    right: Arc::new(filter_push_down(
+                        optimizer,
+                        right,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    on: on.clone(),
+                    join_type: join_type.clone(),
+                    join_constraint: join_constraint.clone(),
+                    schema: schema.clone(),
+                    null_equals_null: null_equals_null.clone(),
+                }),
+            )
+            */
+
+            issue_filter(
+                predicates,
+                LogicalPlan::Join(Join {
+                    left: Arc::new(filter_push_down(optimizer, left, vec![], optimizer_config)?),
+                    right: Arc::new(filter_push_down(
+                        optimizer,
+                        right,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    on: on.clone(),
+                    join_type: join_type.clone(),
+                    join_constraint: join_constraint.clone(),
+                    schema: schema.clone(),
+                    null_equals_null: null_equals_null.clone(),
+                }),
+            )
+        }
+        LogicalPlan::CrossJoin(CrossJoin {
+            left,
+            right,
+            schema,
+        }) => {
+            // CROSS JOINs have the same limitations as JOINs (read above), yet they never
+            // produce NULLs, so it's always safe to push to the left side if the predicate
+            // only reference left side columns.
+
+            // TODO: Nested joins with filters between will behave incorrectly with rewrites,
+            // so this code should be disabled for the time being. There is, however,
+            // at least one specific case that should be supported regardless:
+            // if the right side always produces exactly one row (we know this if the first
+            // meaningful input of a plan is an Aggregate with no `group_expr` and one or more
+            // `aggr_expr`s), push filters down the left input.
+            if predicates.is_empty() || !is_plan_yielding_one_row(right) {
+                return issue_filter(
+                    predicates,
+                    LogicalPlan::CrossJoin(CrossJoin {
+                        left: Arc::new(filter_push_down(
+                            optimizer,
+                            left,
+                            vec![],
+                            optimizer_config,
+                        )?),
+                        right: Arc::new(filter_push_down(
+                            optimizer,
+                            right,
+                            vec![],
+                            optimizer_config,
+                        )?),
+                        schema: schema.clone(),
+                    }),
+                );
+            }
+
+            let left_columns = get_schema_columns(left.schema());
+            let mut pushable_predicates = vec![];
+            let mut non_pushable_predicates = vec![];
+            for predicate in predicates {
+                let predicate_column_exprs = get_expr_columns(&predicate);
+                let all_columns_in_schema = predicate_column_exprs
+                    .iter()
+                    .all(|column| left_columns.contains(column));
+                if all_columns_in_schema {
+                    pushable_predicates.push(predicate);
+                    continue;
+                }
+                non_pushable_predicates.push(predicate);
+            }
+
+            issue_filter(
+                non_pushable_predicates,
+                LogicalPlan::CrossJoin(CrossJoin {
+                    left: Arc::new(filter_push_down(
+                        optimizer,
+                        left,
+                        pushable_predicates,
+                        optimizer_config,
+                    )?),
+                    right: Arc::new(filter_push_down(
+                        optimizer,
+                        right,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Repartition(Repartition {
+            input,
+            partitioning_scheme,
+        }) => {
+            // TODO: figure out if Filter and Repartition can be swapped around
+            issue_filter(
+                predicates,
+                LogicalPlan::Repartition(Repartition {
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    partitioning_scheme: partitioning_scheme.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Union(Union {
+            inputs,
+            schema,
+            alias,
+        }) => {
+            // It's safe to push filters down UNION inputs with a simple rewrite.
+
+            // TODO: However, Projection schema duplicates UNION schema, so rewriting is impossible.
+            /*
+            if predicates.is_empty() {
+                return Ok(LogicalPlan::Union(Union {
+                    inputs: inputs
+                        .iter()
+                        .map(|plan| filter_push_down(optimizer, plan, vec![], optimizer_config))
+                        .collect::<Result<_>>()?,
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }));
+            }
+
+            Ok(LogicalPlan::Union(Union {
+                inputs: inputs
+                    .iter()
+                    .map(|plan| {
+                        let rewrite_map = rewrite_map_for_union_input(schema, plan.schema());
+                        let new_predicates = predicates
+                            .iter()
+                            .map(|predicate| rewrite(predicate, &rewrite_map))
+                            .collect::<Result<Option<_>>>()?
+                            .ok_or(DataFusionError::Internal(
+                                "Unable to optimize plan: union schema doesn't match input schema"
+                                    .to_string(),
+                            ))?;
+                        filter_push_down(optimizer, plan, new_predicates, optimizer_config)
+                    })
+                    .collect::<Result<_>>()?,
+                schema: schema.clone(),
+                alias: alias.clone(),
+            }))
+            */
+
+            issue_filter(
+                predicates,
+                LogicalPlan::Union(Union {
+                    inputs: inputs
+                        .iter()
+                        .map(|plan| filter_push_down(optimizer, plan, vec![], optimizer_config))
+                        .collect::<Result<_>>()?,
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }),
+            )
+        }
+        plan @ LogicalPlan::TableScan(_) | plan @ LogicalPlan::EmptyRelation(_) => {
+            // TableScan or EmptyRelation's as far as we can push our filters.
+            issue_filter(predicates, plan.clone())
+        }
+        LogicalPlan::Limit(Limit { skip, fetch, input }) => {
+            // Swapping Limit and Filter affects the final result.
+            issue_filter(
+                predicates,
+                LogicalPlan::Limit(Limit {
+                    skip: skip.clone(),
+                    fetch: fetch.clone(),
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                }),
+            )
+        }
+        LogicalPlan::Subquery(Subquery {
+            subqueries,
+            input,
+            schema,
+        }) => {
+            // TODO: Push Filter down Subquery
+            issue_filter(
+                predicates,
+                LogicalPlan::Subquery(Subquery {
+                    subqueries: subqueries
+                        .iter()
+                        .map(|subquery| {
+                            filter_push_down(optimizer, subquery, vec![], optimizer_config)
+                        })
+                        .collect::<Result<_>>()?,
+                    input: Arc::new(filter_push_down(
+                        optimizer,
+                        input,
+                        vec![],
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Distinct(Distinct { input }) => {
+            // Distinct removes duplicate rows, so it is safe to keep pushing the filters down.
+            Ok(LogicalPlan::Distinct(Distinct {
+                input: Arc::new(filter_push_down(
+                    optimizer,
+                    input,
+                    predicates,
+                    optimizer_config,
+                )?),
+            }))
+        }
+        other => {
+            // The rest of the plans have no inputs to optimize, can't have the filters
+            // be pushed down them, or it makes no sense to optimize them.
+            issue_filter(predicates, other.clone())
+        }
+    }
+}
+
+/// Generates a rewrite map for projection, taking qualified and unqualified fields into account.
+/// Only simple realiasing expressions are mapped; more complex projection expressions might
+/// produce complex filters which cannot be pushed down to CubeScan, and will block other nodes:
+/// those are mapped as `None` to explicitly mark them as non-mappable.
+/// Extend this on case-by-case basis.
+fn rewrite_map_for_projection(
+    exprs: &Vec<Expr>,
+    schema: &Arc<DFSchema>,
+) -> HashMap<Column, Option<Expr>> {
+    schema
+        .fields()
+        .iter()
+        .zip(exprs)
+        .flat_map(|(field, expr)| {
+            // Aliases are never part of WHERE clause so they must be removed
+            let expr = match expr {
+                Expr::Alias(expr, _) => expr,
+                expr @ _ => expr,
+            };
+
+            let expr = match expr {
+                // We only expand simple realiasing expressions
+                expr @ Expr::Column(_) => Some(expr.clone()),
+                _ => None,
+            };
+
+            // Duplicate fields for projections without an alias
+            // will be dropped while collecting as HashMap
+            vec![
+                (field.qualified_column(), expr.clone()),
+                (field.unqualified_column(), expr),
+            ]
+        })
+        .collect()
+}
+
+/// Generates a rewrite map for union inputs, taking UNION's schema and one of the input's schema.
+/// These expressions can't be more complex than simple column references by definition.
+///
+/// TODO: see `LogicalPlan::Union` above
+/*
+fn rewrite_map_for_union_input(
+    union_schema: &DFSchema,
+    input_schema: &DFSchema,
+) -> HashMap<Column, Option<Expr>> {
+    union_schema
+        .fields()
+        .iter()
+        .zip(input_schema.fields().iter())
+        .flat_map(|(union_field, input_field)| {
+            vec![
+                (
+                    union_field.qualified_column(),
+                    Some(Expr::Column(input_field.unqualified_column())),
+                ),
+                (
+                    union_field.unqualified_column(),
+                    Some(Expr::Column(input_field.unqualified_column())),
+                ),
+            ]
+        })
+        .collect()
+}
+*/
+
+/// Recursively concatenates several filter predicates into one binary AND expression.
+/// `predicates` must contain at least one expression.
+fn concatenate_predicates(predicates: Vec<Expr>) -> Result<Expr> {
+    predicates
+        .into_iter()
+        .reduce(|acc, el| Expr::BinaryExpr {
+            left: Box::new(acc),
+            op: Operator::And,
+            right: Box::new(el),
+        })
+        .ok_or(DataFusionError::Internal(
+            "Unable to optimize plan: can't concatenate predicates, vec is unexpectedly empty"
+                .to_string(),
+        ))
+}
+
+/// Recursively splits filter predicate from binary AND expressions into a flat vec of predicates.
+///
+/// TODO: see `LogicalPlan::Filter` above
+/*
+fn split_predicates(predicate: &Expr) -> Vec<Expr> {
+    match predicate {
+        Expr::BinaryExpr {
+            left,
+            op: Operator::And,
+            right,
+        } => split_predicates(left)
+            .into_iter()
+            .chain(split_predicates(right).into_iter())
+            .collect(),
+        expr => vec![expr.clone()],
+    }
+}
+*/
+
+/// Recursively checks if the passed expr is a filter predicate that can be pushed down.
+/// The predicate should be pushed down the plan if it can ultimately be pushed down to CubeScan.
+/// Extend this on case-by-case basis.
+fn is_predicate_pushable(predicate: &Expr) -> bool {
+    match predicate {
+        Expr::Column(_) => true,
+        Expr::BinaryExpr { left, op, right } => match op {
+            Operator::Eq
+            | Operator::NotEq
+            | Operator::Lt
+            | Operator::LtEq
+            | Operator::Gt
+            | Operator::GtEq => {
+                (is_column_expr(left) && is_const_expr(right))
+                    || (is_const_expr(left) && is_column_expr(right))
+            }
+            Operator::And | Operator::Or => {
+                is_predicate_pushable(left) && is_predicate_pushable(right)
+            }
+            Operator::Like | Operator::NotLike | Operator::ILike | Operator::NotILike => {
+                is_column_expr(left) && is_const_expr(right)
+            }
+            _ => false,
+        },
+        Expr::Like(like) | Expr::ILike(like) | Expr::SimilarTo(like) => {
+            like.escape_char.is_none() && is_column_expr(&like.expr) && is_const_expr(&like.pattern)
+        }
+        Expr::Not(expr) => is_predicate_pushable(expr),
+        Expr::IsNotNull(expr) | Expr::IsNull(expr) => is_column_expr(expr),
+        Expr::InList { expr, list, .. } => {
+            is_column_expr(expr) && list.iter().all(|item| is_const_expr(item))
+        }
+        _ => false,
+    }
+}
+
+/// Issues a Filter containing the provided input if the provided vec contains predicates;
+/// otherwise, issues the provided input instead.
+fn issue_filter(predicates: Vec<Expr>, input: LogicalPlan) -> Result<LogicalPlan> {
+    if predicates.is_empty() {
+        return Ok(input);
+    }
+    Ok(LogicalPlan::Filter(Filter {
+        predicate: concatenate_predicates(predicates)?,
+        input: Arc::new(input),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::utils::{make_sample_table, sample_table},
+        *,
+    };
+    use datafusion::logical_plan::{binary_expr, col, count, lit, sum, LogicalPlanBuilder};
+
+    fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
+        let rule = FilterPushDown::new();
+        rule.optimize(plan, &OptimizerConfig::new())
+    }
+
+    fn assert_optimized_plan_eq(plan: LogicalPlan, expected: &str) {
+        let optimized_plan = optimize(&plan).expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    #[test]
+    fn test_filter_down_projection() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c3")])?
+            .project_with_alias(
+                vec![col("c1").alias("n1"), col("c3").alias("n2")],
+                Some("t2".to_string()),
+            )?
+            .filter(col("t2.n2").gt(lit(5i32)))?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1 AS n1, #t1.c3 AS n2, alias=t2\
+            \n  Filter: #t1.c3 > Int32(5)\
+            \n    Projection: #t1.c1, #t1.c3\
+            \n      TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_filters_down_projections() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project_with_alias(
+                vec![
+                    col("c1").alias("c4"),
+                    col("c2").alias("c5"),
+                    col("c3").alias("c6"),
+                ],
+                Some("t2".to_string()),
+            )?
+            .filter(col("t2.c5").gt(lit(5i32)))?
+            .project_with_alias(
+                vec![
+                    col("t2.c4").alias("c7"),
+                    col("t2.c5"),
+                    col("t2.c6").alias("c8"),
+                ],
+                Some("t3".to_string()),
+            )?
+            .filter(col("t3.c5").lt_eq(lit(10i32)).and(col("c8").eq(lit(0i32))))?
+            .project(vec![col("t3.c7"), col("c5"), col("t3.c8").alias("c9")])?
+            .filter(col("c7").lt(lit(0i32)).not())?
+            .project(vec![col("c7"), col("c5"), col("c9")])?
+            .build()?;
+
+        let expected = "\
+              Projection: #t3.c7, #t3.c5, #c9\
+            \n  Projection: #t3.c7, #t3.c5, #t3.c8 AS c9\
+            \n    Projection: #t2.c4 AS c7, #t2.c5, #t2.c6 AS c8, alias=t3\
+            \n      Projection: #t1.c1 AS c4, #t1.c2 AS c5, #t1.c3 AS c6, alias=t2\
+            \n        Filter: #t1.c2 > Int32(5) AND #t1.c2 <= Int32(10) AND #t1.c3 = Int32(0) AND NOT #t1.c1 < Int32(0)\
+            \n          Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n            TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_filters_down_projections_with_post_processing() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project(vec![
+                col("c1"),
+                binary_expr(col("c2"), Operator::Plus, lit(5i32)).alias("c2"),
+                col("c3"),
+            ])?
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .filter(col("c1").gt(col("c3")))?
+            .filter(col("c2").eq(lit(5i32)))?
+            .filter(col("c3").lt(lit(5i32)))?
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1, #c2, #t1.c3\
+            \n  Filter: #t1.c1 > #t1.c3\
+            \n    Projection: #t1.c1, #c2, #t1.c3\
+            \n      Filter: #c2 = Int32(5)\
+            \n        Projection: #t1.c1, #t1.c2 + Int32(5) AS c2, #t1.c3\
+            \n          Filter: #t1.c3 < Int32(5)\
+            \n            Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n              TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    // TODO: see `LogicalPlan::Filter` above
+    /*
+    #[test]
+    fn test_complex_filters_down_projections_with_post_processing() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project(vec![
+                col("c1"),
+                binary_expr(col("c2"), Operator::Plus, lit(5i32)).alias("c2"),
+                col("c3"),
+            ])?
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .filter(
+                col("c1")
+                    .gt(col("c3"))
+                    .and(col("c2").eq(lit(5i32)).and(col("c3").lt(lit(5i32)))),
+            )?
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1, #c2, #t1.c3\
+            \n  Filter: #t1.c1 > #t1.c3\
+            \n    Projection: #t1.c1, #c2, #t1.c3\
+            \n      Filter: #c2 = Int32(5)\
+            \n        Projection: #t1.c1, #t1.c2 + Int32(5) AS c2, #t1.c3\
+            \n          Filter: #t1.c3 < Int32(5)\
+            \n            Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n              TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+    */
+
+    #[test]
+    fn test_filters_down_aggregate() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .aggregate(vec![col("c1"), col("c3")], vec![sum(col("c2"))])?
+            .project(vec![
+                col("c1"),
+                col("SUM(t1.c2)").alias("c2_sum"),
+                col("c3"),
+            ])?
+            .filter(col("c2_sum").gt(lit(10i32)))?
+            .filter(col("c3").eq(lit(0i32)))?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1, #SUM(t1.c2) AS c2_sum, #t1.c3\
+            \n  Filter: #SUM(t1.c2) > Int32(10)\
+            \n    Aggregate: groupBy=[[#t1.c1, #t1.c3]], aggr=[[SUM(#t1.c2)]]\
+            \n      Filter: #t1.c3 = Int32(0)\
+            \n        Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n          TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    // TODO: see `LogicalPlan::Filter` above
+    /*
+    #[test]
+    fn test_complex_filters_down_aggregate() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .aggregate(vec![col("c1"), col("c3")], vec![sum(col("c2"))])?
+            .project(vec![
+                col("c1"),
+                col("SUM(t1.c2)").alias("c2_sum"),
+                col("c3"),
+            ])?
+            .filter(col("c2_sum").gt(lit(10i32)).and(col("c3").eq(lit(0i32))))?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1, #SUM(t1.c2) AS c2_sum, #t1.c3\
+            \n  Filter: #SUM(t1.c2) > Int32(10)\
+            \n    Aggregate: groupBy=[[#t1.c1, #t1.c3]], aggr=[[SUM(#t1.c2)]]\
+            \n      Filter: #t1.c3 = Int32(0)\
+            \n        Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n          TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+    */
+
+    #[test]
+    fn test_filter_down_sort() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .sort(vec![col("c2")])?
+            .filter(col("c3").eq(lit(5i32)))?
+            .build()?;
+
+        let expected = "\
+              Sort: #t1.c2\
+            \n  Filter: #t1.c3 = Int32(5)\
+            \n    Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n      TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    // TODO: see `LogicalPlan::Join` above
+    /*
+    #[test]
+    fn test_filter_down_join() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+                LogicalPlanBuilder::from(make_sample_table("j1", vec!["key", "c1"])?)
+                    .project(vec![col("key"), col("c1")])?
+                    .build()?
+            )
+            .join(
+                &LogicalPlanBuilder::from(make_sample_table("j2", vec!["key", "c2"])?)
+                    .project(vec![col("key"), col("c2")])?
+                    .build()?,
+                JoinType::Inner,
+                (
+                    vec![Column::from_name("key")],
+                    vec![Column::from_name("key")],
+                ),
+            )?
+            .filter(col("c1").eq(lit(5i32)).and(col("c2").eq(lit(10i32))))?
+            .build()?;
+
+        let expected = "\
+              Filter: #j2.c2 = Int32(10)\
+            \n  Inner Join: #j1.key = #j2.key\
+            \n    Filter: #j1.c1 = Int32(5)\
+            \n      Projection: #j1.key, #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n    Projection: #j2.key, #j2.c2\
+            \n      TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+    */
+
+    // TODO: see `LogicalPlan::CrossJoin` above
+    /*
+    #[test]
+    fn test_filter_down_cross_join() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["c1"])?)
+                .project(vec![col("c1")])?
+                .build()?,
+        )
+        .cross_join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["c2"])?)
+                .project(vec![col("c2")])?
+                .build()?,
+        )?
+        .filter(col("c1").eq(lit(5i32)).and(col("c2").eq(lit(10i32))))?
+        .build()?;
+
+        let expected = "\
+              Filter: #j2.c2 = Int32(10)\
+            \n  CrossJoin:\
+            \n    Filter: #j1.c1 = Int32(5)\
+            \n      Projection: #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n    Projection: #j2.c2\
+            \n      TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+    */
+
+    #[test]
+    fn test_filter_down_cross_join_right_one_row() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["c1"])?)
+                .project(vec![col("c1")])?
+                .build()?,
+        )
+        .cross_join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["c2"])?)
+                .project(vec![col("c2")])?
+                .aggregate(vec![] as Vec<Expr>, vec![count(lit(1u8))])?
+                .project_with_alias(
+                    vec![col("COUNT(UInt8(1))").alias("c2")],
+                    Some("j2".to_string()),
+                )?
+                .build()?,
+        )?
+        .filter(col("c1").eq(lit(5i32)))?
+        .filter(col("c2").eq(lit(10i32)))?
+        .build()?;
+
+        let expected = "\
+              Filter: #j2.c2 = Int32(10)\
+            \n  CrossJoin:\
+            \n    Filter: #j1.c1 = Int32(5)\
+            \n      Projection: #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n    Projection: #COUNT(UInt8(1)) AS c2, alias=j2\
+            \n      Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
+            \n        Projection: #j2.c2\
+            \n          TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    // TODO: see `LogicalPlan::Union` above
+    /*
+    #[test]
+    fn test_filter_down_union_distinct() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+                LogicalPlanBuilder::from(make_sample_table("u1", vec!["c1"])?)
+                    .project(vec![col("c1")])?
+                    .build()?
+            )
+            .union_distinct(
+                LogicalPlanBuilder::from(make_sample_table("u2", vec!["c2"])?)
+                    .project(vec![col("c2")])?
+                    .build()?
+            )?
+            .filter(col("c1").gt(lit(10i32)))?
+            .build()?;
+
+        let expected = "\
+              Distinct:\
+            \n  Union\
+            \n    Filter: #c1 > Int32(10)\
+            \n      Projection: #u1.c1\
+            \n        TableScan: u1 projection=None\
+            \n    Filter: #c2 > Int32(10)\
+            \n      Projection: #u2.c2\
+            \n        TableScan: u2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+    */
+}

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/limit_push_down.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/limit_push_down.rs
@@ -1,0 +1,538 @@
+use std::{cmp::min, sync::Arc};
+
+use datafusion::{
+    error::Result,
+    logical_plan::{
+        plan::{
+            Aggregate, CrossJoin, Distinct, Join, Limit, Projection, Sort, Subquery, Union, Window,
+        },
+        Filter, LogicalPlan,
+    },
+    optimizer::optimizer::{OptimizerConfig, OptimizerRule},
+};
+
+use super::utils::{is_plan_yielding_one_row, plan_has_projections};
+
+/// Limit Push Down optimizer rule pushes LIMIT/OFFSET clauses  down the plan,
+/// all the way to the Projection closest to TableScan.
+/// This is beneficial for CubeScans when some of the Projections on the way
+/// contain post-processing operations and cannot be pushed down.
+#[derive(Default)]
+pub struct LimitPushDown {}
+
+impl LimitPushDown {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for LimitPushDown {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        optimizer_config: &OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        limit_push_down(self, plan, None, None, optimizer_config)
+    }
+
+    fn name(&self) -> &str {
+        "__cube__limit_push_down"
+    }
+}
+
+/// Recursively optimizes plan, collecting limit clauses that can possibly be pushed down.
+/// Some limit clauses may be combined; those are handled accordingly.
+fn limit_push_down(
+    optimizer: &LimitPushDown,
+    plan: &LogicalPlan,
+    skip: Option<usize>,
+    fetch: Option<usize>,
+    optimizer_config: &OptimizerConfig,
+) -> Result<LogicalPlan> {
+    match plan {
+        LogicalPlan::Projection(Projection {
+            expr,
+            input,
+            schema,
+            alias,
+        }) => {
+            // Limit can be pushed down Projections with no restrictions, unless
+            // it's the Projection closest to TableScan.
+            if plan_has_projections(input) {
+                return Ok(LogicalPlan::Projection(Projection {
+                    expr: expr.clone(),
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        skip,
+                        fetch,
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }));
+            }
+
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Projection(Projection {
+                    expr: expr.clone(),
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Filter(Filter { predicate, input }) => {
+            // Pushing Limit down Filter will affect results; issue limit and continue
+            // down the plan.
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Filter(Filter {
+                    predicate: predicate.clone(),
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                }),
+            )
+        }
+        LogicalPlan::Window(Window {
+            input,
+            window_expr,
+            schema,
+        }) => {
+            // Pushing Limit down Window will affect results; issue limit and continue
+            // down the plan.
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Window(Window {
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    window_expr: window_expr.clone(),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Aggregate(Aggregate {
+            input,
+            group_expr,
+            aggr_expr,
+            schema,
+        }) => {
+            // Pushing Limit down Aggregate will affect results.
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Aggregate(Aggregate {
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    group_expr: group_expr.clone(),
+                    aggr_expr: aggr_expr.clone(),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Sort(Sort { expr, input }) => {
+            // Sort must run before Limit.
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Sort(Sort {
+                    expr: expr.clone(),
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                }),
+            )
+        }
+        LogicalPlan::Join(Join {
+            left,
+            right,
+            on,
+            join_type,
+            join_constraint,
+            schema,
+            null_equals_null,
+        }) => {
+            // TODO: It is unsafe to push LIMIT down most JOIN clauses.
+            // Optimize only the plans for the time being.
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Join(Join {
+                    left: Arc::new(limit_push_down(
+                        optimizer,
+                        left,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    right: Arc::new(limit_push_down(
+                        optimizer,
+                        right,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    on: on.clone(),
+                    join_type: join_type.clone(),
+                    join_constraint: join_constraint.clone(),
+                    schema: schema.clone(),
+                    null_equals_null: null_equals_null.clone(),
+                }),
+            )
+        }
+        LogicalPlan::CrossJoin(CrossJoin {
+            left,
+            right,
+            schema,
+        }) => {
+            // There is one case where it's allowed to push LIMIT down a CROSS JOIN side;
+            // If one of the sides is guaranteed to always produce one row (aggregates
+            // with no `group_expr`), the other side will yield the exact number of rows
+            // CROSS JOIN would. Taking into consideration that Cube's joins are LEFT JOINs,
+            // this is only safe to do with left side of a CROSS JOIN.
+            if is_plan_yielding_one_row(right) {
+                return Ok(LogicalPlan::CrossJoin(CrossJoin {
+                    left: Arc::new(limit_push_down(
+                        optimizer,
+                        left,
+                        skip,
+                        fetch,
+                        optimizer_config,
+                    )?),
+                    right: Arc::new(limit_push_down(
+                        optimizer,
+                        right,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                }));
+            }
+
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::CrossJoin(CrossJoin {
+                    left: Arc::new(limit_push_down(
+                        optimizer,
+                        left,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    right: Arc::new(limit_push_down(
+                        optimizer,
+                        right,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Union(Union {
+            inputs,
+            schema,
+            alias,
+        }) => {
+            // TODO: push Limit down Union?
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Union(Union {
+                    inputs: inputs
+                        .iter()
+                        .map(|input| {
+                            limit_push_down(optimizer, input, None, None, optimizer_config)
+                        })
+                        .collect::<Result<_>>()?,
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }),
+            )
+        }
+        plan @ LogicalPlan::TableScan(_) | plan @ LogicalPlan::EmptyRelation(_) => {
+            // TableScan or EmptyRelation's as far as we can push our limit.
+            issue_limit(skip, fetch, plan.clone())
+        }
+        LogicalPlan::Limit(limit) => {
+            // Consume the Limit from the plan.
+            // Depending on the situation, limit clauses may be combined.
+            match (skip, fetch) {
+                (None, None) => limit_push_down(
+                    optimizer,
+                    &limit.input,
+                    limit.skip,
+                    limit.fetch,
+                    optimizer_config,
+                ),
+                (None, Some(fetch)) => {
+                    // `limit`s can be combined by taking min value
+                    limit_push_down(
+                        optimizer,
+                        &limit.input,
+                        limit.skip,
+                        Some(min(fetch, limit.fetch.unwrap_or(fetch))),
+                        optimizer_config,
+                    )
+                }
+                (Some(skip), _) => {
+                    if limit.fetch.is_some() {
+                        // `skip` can't be added to LIMIT with `fetch`, as this will remove rows
+                        issue_limit(
+                            Some(skip),
+                            fetch,
+                            limit_push_down(
+                                optimizer,
+                                &limit.input,
+                                limit.skip,
+                                limit.fetch,
+                                optimizer_config,
+                            )?,
+                        )
+                    } else {
+                        // `skip`s can be added together when no `fetch` is present
+                        limit_push_down(
+                            optimizer,
+                            &limit.input,
+                            Some(skip + limit.skip.unwrap_or(0)),
+                            fetch,
+                            optimizer_config,
+                        )
+                    }
+                }
+            }
+        }
+        LogicalPlan::Subquery(Subquery {
+            subqueries,
+            input,
+            schema,
+        }) => {
+            // TODO: Pushing Limit down Subquery?
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Subquery(Subquery {
+                    subqueries: subqueries
+                        .iter()
+                        .map(|subquery| {
+                            limit_push_down(optimizer, subquery, None, None, optimizer_config)
+                        })
+                        .collect::<Result<_>>()?,
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Distinct(Distinct { input }) => {
+            // Distinct itself removes rows, so pushing Limit down the plan isn't possible.
+            issue_limit(
+                skip,
+                fetch,
+                LogicalPlan::Distinct(Distinct {
+                    input: Arc::new(limit_push_down(
+                        optimizer,
+                        input,
+                        None,
+                        None,
+                        optimizer_config,
+                    )?),
+                }),
+            )
+        }
+        other => {
+            // The rest of the plans have no inputs to optimize, can't have limit expressions
+            // be pushed down them, or it makes no sense to optimize them.
+            issue_limit(skip, fetch, other.clone())
+        }
+    }
+}
+
+/// Issues a Limit containing the provided `skip` and `fetch` if any of those are `Some`;
+/// otherwise, issues the provided input instead.
+fn issue_limit(
+    skip: Option<usize>,
+    fetch: Option<usize>,
+    input: LogicalPlan,
+) -> Result<LogicalPlan> {
+    if skip.is_some() || fetch.is_some() {
+        return Ok(LogicalPlan::Limit(Limit {
+            skip,
+            fetch,
+            input: Arc::new(input),
+        }));
+    }
+    Ok(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::utils::{make_sample_table, sample_table},
+        *,
+    };
+    use datafusion::logical_plan::{col, count, lit, Expr, LogicalPlanBuilder};
+
+    fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
+        let rule = LimitPushDown::new();
+        rule.optimize(plan, &OptimizerConfig::new())
+    }
+
+    fn assert_optimized_plan_eq(plan: LogicalPlan, expected: &str) {
+        let optimized_plan = optimize(&plan).expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    #[test]
+    fn test_limit_down_projection() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project_with_alias(
+                vec![col("c1").alias("n1"), col("c2"), col("c3").alias("n2")],
+                Some("t2".to_string()),
+            )?
+            .limit(Some(5), Some(10))?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2\
+            \n  Limit: skip=5, fetch=10\
+            \n    Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n      TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_limit_down_cross_join_right_one_row() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["c1"])?)
+                .project(vec![col("c1")])?
+                .build()?,
+        )
+        .cross_join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["c2"])?)
+                .project(vec![col("c2")])?
+                .aggregate(vec![] as Vec<Expr>, vec![count(lit(1u8))])?
+                .project_with_alias(
+                    vec![col("COUNT(UInt8(1))").alias("c2")],
+                    Some("j2".to_string()),
+                )?
+                .build()?,
+        )?
+        .limit(None, Some(10))?
+        .build()?;
+
+        let expected = "\
+              CrossJoin:\
+            \n  Limit: skip=None, fetch=10\
+            \n    Projection: #j1.c1\
+            \n      TableScan: j1 projection=None\
+            \n  Projection: #COUNT(UInt8(1)) AS c2, alias=j2\
+            \n    Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
+            \n      Projection: #j2.c2\
+            \n        TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_limit_down_limit() -> Result<()> {
+        // OFFSET then OFFSET
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1")])?
+            .limit(Some(5), None)?
+            .project(vec![col("c1")])?
+            .limit(Some(5), None)?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1\
+            \n  Limit: skip=10, fetch=None\
+            \n    Projection: #t1.c1\
+            \n      TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        // LIMIT then OFFSET
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1")])?
+            .limit(None, Some(5))?
+            .project(vec![col("c1")])?
+            .limit(Some(5), None)?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1\
+            \n  Limit: skip=5, fetch=None\
+            \n    Limit: skip=None, fetch=5\
+            \n      Projection: #t1.c1\
+            \n        TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        // LIMIT OFFSET then LIMIT
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1")])?
+            .limit(Some(10), Some(15))?
+            .project(vec![col("c1")])?
+            .limit(None, Some(5))?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1\
+            \n  Limit: skip=10, fetch=5\
+            \n    Projection: #t1.c1\
+            \n      TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        Ok(())
+    }
+}

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/mod.rs
@@ -1,0 +1,9 @@
+pub mod utils;
+
+mod filter_push_down;
+mod limit_push_down;
+mod sort_push_down;
+
+pub use filter_push_down::FilterPushDown;
+pub use limit_push_down::LimitPushDown;
+pub use sort_push_down::SortPushDown;

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/sort_push_down.rs
@@ -1,0 +1,624 @@
+use std::{collections::HashMap, sync::Arc};
+
+use datafusion::{
+    error::{DataFusionError, Result},
+    logical_plan::{
+        plan::{
+            Aggregate, CrossJoin, Distinct, Join, Limit, Projection, Sort, Subquery, Union, Window,
+        },
+        Column, DFSchema, Expr, Filter, LogicalPlan,
+    },
+    optimizer::optimizer::{OptimizerConfig, OptimizerRule},
+};
+
+use super::utils::{get_schema_columns, is_column_expr, plan_has_projections, rewrite};
+
+/// Sort Push Down optimizer rule pushes ORDER BY clauses consisting of specific,
+/// mostly simple, expressions down the plan, all the way to the Projection
+/// closest to TableScan. This is beneficial for CubeScans when some of the Projections
+/// on the way contain post-processing operations and cannot be pushed down.
+#[derive(Default)]
+pub struct SortPushDown {}
+
+impl SortPushDown {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for SortPushDown {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        optimizer_config: &OptimizerConfig,
+    ) -> Result<LogicalPlan> {
+        sort_push_down(self, plan, None, optimizer_config)
+    }
+
+    fn name(&self) -> &str {
+        "__cube__sort_push_down"
+    }
+}
+
+/// Recursively optimizes plan, collecting sort expressions that can possibly be pushed down.
+/// Only the topmost sort expression is kept when one pushes through another.
+fn sort_push_down(
+    optimizer: &SortPushDown,
+    plan: &LogicalPlan,
+    sort_expr: Option<Vec<Expr>>,
+    optimizer_config: &OptimizerConfig,
+) -> Result<LogicalPlan> {
+    match plan {
+        LogicalPlan::Projection(Projection {
+            expr,
+            input,
+            schema,
+            alias,
+        }) => {
+            // Sort can be pushed down to projection, however we only map specific expressions.
+            // Complex expressions can't be pushed down, so if there are any, Sort is issued
+            // before the projection.
+            if plan_has_projections(input) {
+                if let Some(sort_expr) = &sort_expr {
+                    let rewrite_map = rewrite_map_for_projection(expr, schema);
+                    if let Some(new_sort_expr) = sort_expr
+                        .iter()
+                        .map(|expr| match expr {
+                            Expr::Sort {
+                                expr,
+                                asc,
+                                nulls_first,
+                            } => Ok(if is_column_expr(expr) {
+                                rewrite(expr, &rewrite_map)?.map(|expr| Expr::Sort {
+                                    expr: Box::new(expr),
+                                    asc: asc.clone(),
+                                    nulls_first: nulls_first.clone(),
+                                })
+                            } else {
+                                None
+                            }),
+                            _ => Err(DataFusionError::Internal(
+                                "Unable to optimize plan: sort contains non-sort expressions"
+                                    .to_string(),
+                            )),
+                        })
+                        .collect::<Result<Option<_>>>()?
+                    {
+                        return Ok(LogicalPlan::Projection(Projection {
+                            expr: expr.clone(),
+                            input: Arc::new(sort_push_down(
+                                optimizer,
+                                input,
+                                Some(new_sort_expr),
+                                optimizer_config,
+                            )?),
+                            schema: schema.clone(),
+                            alias: alias.clone(),
+                        }));
+                    }
+                }
+            }
+
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Projection(Projection {
+                    expr: expr.clone(),
+                    input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Filter(Filter { predicate, input }) => {
+            // Sort can be pushed down Filter, and while it may seem weird to do that
+            // after doing the exact opposite in `FilterPushDown`, this may allow the sort
+            // to push through some complex filters, ultimately reaching CubeScan.
+            Ok(LogicalPlan::Filter(Filter {
+                predicate: predicate.clone(),
+                input: Arc::new(sort_push_down(
+                    optimizer,
+                    input,
+                    sort_expr,
+                    optimizer_config,
+                )?),
+            }))
+        }
+        LogicalPlan::Window(Window {
+            input,
+            window_expr,
+            schema,
+        }) => {
+            // Sort can't be pushed down Window, but we can optimize its input.
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Window(Window {
+                    input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                    window_expr: window_expr.clone(),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Aggregate(Aggregate {
+            input,
+            group_expr,
+            aggr_expr,
+            schema,
+        }) => {
+            // It may be unsafe to push Sort down Aggregate; optimize just the input.
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Aggregate(Aggregate {
+                    input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                    group_expr: group_expr.clone(),
+                    aggr_expr: aggr_expr.clone(),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Sort(Sort { expr, input }) => {
+            // When encountering Sort, drop it from the plan, keeping the expr.
+            // If we already have an expr, however, then there was a sort above which
+            // would override this sort expression; drop the new one in such case.
+            sort_push_down(
+                optimizer,
+                input,
+                Some(sort_expr.unwrap_or(expr.clone())),
+                optimizer_config,
+            )
+        }
+        LogicalPlan::Join(Join {
+            left,
+            right,
+            on,
+            join_type,
+            join_constraint,
+            schema,
+            null_equals_null,
+        }) => {
+            // DataFusion preserves the sorting of the joined plans, prioritizing left side.
+            // Taking this into account, we can push Sort down the left plan if Sort references
+            // columns just from the left side.
+            // TODO: check if this is still the case with multiple target partitions
+            if let Some(some_sort_expr) = &sort_expr {
+                let left_columns = get_schema_columns(left.schema());
+                if some_sort_expr.iter().all(|expr| {
+                    if let Expr::Sort { expr, .. } = expr {
+                        if let Expr::Column(column) = expr.as_ref() {
+                            return left_columns.contains(column);
+                        }
+                    }
+                    false
+                }) {
+                    return Ok(LogicalPlan::Join(Join {
+                        left: Arc::new(sort_push_down(
+                            optimizer,
+                            left,
+                            sort_expr,
+                            optimizer_config,
+                        )?),
+                        right: Arc::new(sort_push_down(optimizer, right, None, optimizer_config)?),
+                        on: on.clone(),
+                        join_type: join_type.clone(),
+                        join_constraint: join_constraint.clone(),
+                        schema: schema.clone(),
+                        null_equals_null: null_equals_null.clone(),
+                    }));
+                }
+            }
+
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Join(Join {
+                    left: Arc::new(sort_push_down(optimizer, left, None, optimizer_config)?),
+                    right: Arc::new(sort_push_down(optimizer, right, None, optimizer_config)?),
+                    on: on.clone(),
+                    join_type: join_type.clone(),
+                    join_constraint: join_constraint.clone(),
+                    schema: schema.clone(),
+                    null_equals_null: null_equals_null.clone(),
+                }),
+            )
+        }
+        LogicalPlan::CrossJoin(CrossJoin {
+            left,
+            right,
+            schema,
+        }) => {
+            // See `LogicalPlan::Join` notes above.
+            if let Some(some_sort_expr) = &sort_expr {
+                let left_columns = get_schema_columns(left.schema());
+                if some_sort_expr.iter().all(|expr| {
+                    if let Expr::Sort { expr, .. } = expr {
+                        if let Expr::Column(column) = expr.as_ref() {
+                            return left_columns.contains(column);
+                        }
+                    }
+                    false
+                }) {
+                    return Ok(LogicalPlan::CrossJoin(CrossJoin {
+                        left: Arc::new(sort_push_down(
+                            optimizer,
+                            left,
+                            sort_expr,
+                            optimizer_config,
+                        )?),
+                        right: Arc::new(sort_push_down(optimizer, right, None, optimizer_config)?),
+                        schema: schema.clone(),
+                    }));
+                }
+            }
+
+            issue_sort(
+                sort_expr,
+                LogicalPlan::CrossJoin(CrossJoin {
+                    left: Arc::new(sort_push_down(optimizer, left, None, optimizer_config)?),
+                    right: Arc::new(sort_push_down(optimizer, right, None, optimizer_config)?),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Union(Union {
+            inputs,
+            schema,
+            alias,
+        }) => {
+            // Union randomizes sorting, so Sort can't be pushed down.
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Union(Union {
+                    inputs: inputs
+                        .iter()
+                        .map(|input| sort_push_down(optimizer, input, None, optimizer_config))
+                        .collect::<Result<_>>()?,
+                    schema: schema.clone(),
+                    alias: alias.clone(),
+                }),
+            )
+        }
+        plan @ LogicalPlan::TableScan(_) | plan @ LogicalPlan::EmptyRelation(_) => {
+            // TableScan or EmptyRelation's as far as we can push our sort expression.
+            issue_sort(sort_expr, plan.clone())
+        }
+        LogicalPlan::Limit(Limit { skip, fetch, input }) => {
+            // Pushing down Sort to Limit will affect the results; issue the sort expression.
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Limit(Limit {
+                    skip: skip.clone(),
+                    fetch: fetch.clone(),
+                    input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                }),
+            )
+        }
+        LogicalPlan::Subquery(Subquery {
+            subqueries,
+            input,
+            schema,
+        }) => {
+            // TODO: Pushing Sort down Subquery?
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Subquery(Subquery {
+                    subqueries: subqueries
+                        .iter()
+                        .map(|subquery| sort_push_down(optimizer, subquery, None, optimizer_config))
+                        .collect::<Result<_>>()?,
+                    input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                    schema: schema.clone(),
+                }),
+            )
+        }
+        LogicalPlan::Distinct(Distinct { input }) => {
+            // Distinct randomizes the sorting; issue the sort expression.
+            issue_sort(
+                sort_expr,
+                LogicalPlan::Distinct(Distinct {
+                    input: Arc::new(sort_push_down(optimizer, input, None, optimizer_config)?),
+                }),
+            )
+        }
+        other => {
+            // The rest of the plans have no inputs to optimize, can't have sort expressions
+            // be pushed down them, or it makes no sense to optimize them.
+            issue_sort(sort_expr, other.clone())
+        }
+    }
+}
+
+/// Generates a rewrite map for projection, taking qualified and unqualified fields into account.
+/// Only simple realiasing expressions are mapped, with specific exceptions; more complex
+/// projection expressions might produce complex sort expressions which cannot be pushed down to CubeScan,
+/// and will block other nodes: those are mapped as `None` to explicitly mark them as non-mappable.
+/// Extend this on case-by-case basis.
+fn rewrite_map_for_projection(
+    exprs: &Vec<Expr>,
+    schema: &Arc<DFSchema>,
+) -> HashMap<Column, Option<Expr>> {
+    schema
+        .fields()
+        .iter()
+        .zip(exprs)
+        .flat_map(|(field, expr)| {
+            // Aliases are never part of ORDER BY clause so they must be removed
+            let expr = match expr {
+                Expr::Alias(expr, _) => expr,
+                expr @ _ => expr,
+            };
+
+            let expr = match expr {
+                // We always expand simple realiasing expressions
+                expr @ Expr::Column(_) => Some(expr.clone()),
+                _ => None,
+            };
+
+            // Duplicate fields for projections without an alias
+            // will be dropped while collecting as HashMap
+            vec![
+                (field.qualified_column(), expr.clone()),
+                (field.unqualified_column(), expr),
+            ]
+        })
+        .collect()
+}
+
+/// Issues a Sort containing the provided input if the provided `sort_expr` is `Some`;
+/// otherwise, issues the provided input instead.
+fn issue_sort(sort_expr: Option<Vec<Expr>>, input: LogicalPlan) -> Result<LogicalPlan> {
+    if let Some(sort_expr) = sort_expr {
+        return Ok(LogicalPlan::Sort(Sort {
+            expr: sort_expr,
+            input: Arc::new(input),
+        }));
+    }
+    Ok(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::utils::{make_sample_table, sample_table},
+        *,
+    };
+    use datafusion::logical_plan::{col, JoinType, LogicalPlanBuilder};
+
+    fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
+        let rule = SortPushDown::new();
+        rule.optimize(plan, &OptimizerConfig::new())
+    }
+
+    fn assert_optimized_plan_eq(plan: LogicalPlan, expected: &str) {
+        let optimized_plan = optimize(&plan).expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    fn sort(expr: Expr, asc: bool, nulls_first: bool) -> Expr {
+        Expr::Sort {
+            expr: Box::new(expr),
+            asc,
+            nulls_first,
+        }
+    }
+
+    #[test]
+    fn test_sort_down_projection() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project_with_alias(
+                vec![col("c1").alias("n1"), col("c2"), col("c3").alias("n2")],
+                Some("t2".to_string()),
+            )?
+            .sort(vec![
+                sort(col("t2.c2"), true, false),
+                sort(col("t2.n2"), false, true),
+            ])?
+            .build()?;
+
+        let expected = "\
+              Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2\
+            \n  Sort: #t1.c2 ASC NULLS LAST, #t1.c3 DESC NULLS FIRST\
+            \n    Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n      TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_sort_down_multiple_projections() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project_with_alias(
+                vec![col("c1").alias("n1"), col("c2"), col("c3").alias("n2")],
+                Some("t2".to_string()),
+            )?
+            .project_with_alias(
+                vec![col("n1").alias("n3"), col("c2").alias("n4"), col("n2")],
+                Some("t3".to_string()),
+            )?
+            .project_with_alias(
+                vec![col("n3"), col("n4"), col("n2")],
+                Some("t4".to_string()),
+            )?
+            .sort(vec![
+                sort(col("t4.n4"), true, false),
+                sort(col("t4.n2"), false, true),
+            ])?
+            .build()?;
+
+        let expected = "\
+              Projection: #t3.n3, #t3.n4, #t3.n2, alias=t4\
+            \n  Projection: #t2.n1 AS n3, #t2.c2 AS n4, #t2.n2, alias=t3\
+            \n    Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2\
+            \n      Sort: #t1.c2 ASC NULLS LAST, #t1.c3 DESC NULLS FIRST\
+            \n        Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n          TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_sort_down_sort() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(sample_table()?)
+            .project(vec![col("c1"), col("c2"), col("c3")])?
+            .project_with_alias(
+                vec![col("c1").alias("n1"), col("c2"), col("c3").alias("n2")],
+                Some("t2".to_string()),
+            )?
+            .sort(vec![sort(col("t2.n1"), false, false)])?
+            .project_with_alias(
+                vec![col("n1").alias("n3"), col("c2").alias("n4"), col("n2")],
+                Some("t3".to_string()),
+            )?
+            .sort(vec![sort(col("t3.n2"), true, true)])?
+            .project_with_alias(
+                vec![col("n3"), col("n4"), col("n2")],
+                Some("t4".to_string()),
+            )?
+            .sort(vec![
+                sort(col("t4.n4"), true, false),
+                sort(col("t4.n2"), false, true),
+            ])?
+            .build()?;
+
+        let expected = "\
+              Projection: #t3.n3, #t3.n4, #t3.n2, alias=t4\
+            \n  Projection: #t2.n1 AS n3, #t2.c2 AS n4, #t2.n2, alias=t3\
+            \n    Projection: #t1.c1 AS n1, #t1.c2, #t1.c3 AS n2, alias=t2\
+            \n      Sort: #t1.c2 ASC NULLS LAST, #t1.c3 DESC NULLS FIRST\
+            \n        Projection: #t1.c1, #t1.c2, #t1.c3\
+            \n          TableScan: t1 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_sort_down_join() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["key", "c1"])?)
+                .project(vec![col("key"), col("c1")])?
+                .build()?,
+        )
+        .join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["key", "c2"])?)
+                .project(vec![col("key"), col("c2")])?
+                .build()?,
+            JoinType::Inner,
+            (
+                vec![Column::from_name("key")],
+                vec![Column::from_name("key")],
+            ),
+        )?
+        .project(vec![col("j1.c1"), col("j2.c2")])?
+        .sort(vec![sort(col("j1.c1"), true, false)])?
+        .build()?;
+
+        let expected = "\
+              Projection: #j1.c1, #j2.c2\
+            \n  Inner Join: #j1.key = #j2.key\
+            \n    Sort: #j1.c1 ASC NULLS LAST\
+            \n      Projection: #j1.key, #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n    Projection: #j2.key, #j2.c2\
+            \n      TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["key", "c1"])?)
+                .project(vec![col("key"), col("c1")])?
+                .build()?,
+        )
+        .join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["key", "c2"])?)
+                .project(vec![col("key"), col("c2")])?
+                .build()?,
+            JoinType::Inner,
+            (
+                vec![Column::from_name("key")],
+                vec![Column::from_name("key")],
+            ),
+        )?
+        .project(vec![col("j1.c1"), col("j2.c2")])?
+        .sort(vec![sort(col("j2.c2"), true, false)])?
+        .build()?;
+
+        let expected = "\
+              Projection: #j1.c1, #j2.c2\
+            \n  Sort: #j2.c2 ASC NULLS LAST\
+            \n    Inner Join: #j1.key = #j2.key\
+            \n      Projection: #j1.key, #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n      Projection: #j2.key, #j2.c2\
+            \n        TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_sort_down_cross_join() -> Result<()> {
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["key", "c1"])?)
+                .project(vec![col("key"), col("c1")])?
+                .build()?,
+        )
+        .cross_join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["key", "c2"])?)
+                .project(vec![col("key"), col("c2")])?
+                .build()?,
+        )?
+        .project(vec![col("j1.c1"), col("j2.c2")])?
+        .sort(vec![sort(col("j1.c1"), true, false)])?
+        .build()?;
+
+        let expected = "\
+              Projection: #j1.c1, #j2.c2\
+            \n  CrossJoin:\
+            \n    Sort: #j1.c1 ASC NULLS LAST\
+            \n      Projection: #j1.key, #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n    Projection: #j2.key, #j2.c2\
+            \n      TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        let plan = LogicalPlanBuilder::from(
+            LogicalPlanBuilder::from(make_sample_table("j1", vec!["key", "c1"])?)
+                .project(vec![col("key"), col("c1")])?
+                .build()?,
+        )
+        .cross_join(
+            &LogicalPlanBuilder::from(make_sample_table("j2", vec!["key", "c2"])?)
+                .project(vec![col("key"), col("c2")])?
+                .build()?,
+        )?
+        .project(vec![col("j1.c1"), col("j2.c2")])?
+        .sort(vec![sort(col("j2.c2"), true, false)])?
+        .build()?;
+
+        let expected = "\
+              Projection: #j1.c1, #j2.c2\
+            \n  Sort: #j2.c2 ASC NULLS LAST\
+            \n    CrossJoin:\
+            \n      Projection: #j1.key, #j1.c1\
+            \n        TableScan: j1 projection=None\
+            \n      Projection: #j2.key, #j2.c2\
+            \n        TableScan: j2 projection=None\
+        ";
+
+        assert_optimized_plan_eq(plan, expected);
+
+        Ok(())
+    }
+}

--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/utils.rs
@@ -1,0 +1,547 @@
+use std::collections::{HashMap, HashSet};
+
+use datafusion::{
+    error::{DataFusionError, Result},
+    logical_plan::{
+        plan::{
+            Aggregate, Analyze, CrossJoin, Distinct, Explain, Filter, Join, Limit, Projection,
+            Repartition, Sort, Subquery, TableUDFs, Union, Window,
+        },
+        Column, DFSchema, Expr, Like, LogicalPlan,
+    },
+    physical_plan::functions::Volatility,
+};
+
+#[cfg(test)]
+use datafusion::{
+    arrow::datatypes::{DataType, Field, Schema},
+    logical_plan::LogicalPlanBuilder,
+};
+
+/// Recursively rewrites an expression using the provided rewrite map. If the expression is explicitly
+/// marked as non-rewrittable (maps to `None`), returns `None`, otherwise returns the expression.
+/// If the provided rewrite map lacks the key for an expression, returns an error.
+pub fn rewrite(expr: &Expr, map: &HashMap<Column, Option<Expr>>) -> Result<Option<Expr>> {
+    Ok(match expr {
+        Expr::Alias(expr, name) => {
+            rewrite(expr, map)?.map(|expr| Expr::Alias(Box::new(expr), name.clone()))
+        }
+        // Outer columns may be missing from the rewrite map, so no rewrite is assumed
+        Expr::OuterColumn(_, _) => None,
+        Expr::Column(column) => map
+            .get(column)
+            .ok_or(DataFusionError::Internal(format!(
+                "Unable to optimize expression: {:?} missing in rewrite map",
+                column,
+            )))
+            .cloned()?,
+        expr @ Expr::ScalarVariable(_, _) => Some(expr.clone()),
+        expr @ Expr::Literal(_) => Some(expr.clone()),
+        Expr::BinaryExpr { left, op, right } => {
+            let rewrites = match (rewrite(left, map)?, rewrite(right, map)?) {
+                (Some(left), Some(right)) => Some((left, right)),
+                _ => None,
+            };
+            rewrites.map(|(left, right)| Expr::BinaryExpr {
+                left: Box::new(left),
+                op: op.clone(),
+                right: Box::new(right),
+            })
+        }
+        Expr::AnyExpr { left, op, right } => {
+            let rewrites = match (rewrite(left, map)?, rewrite(right, map)?) {
+                (Some(left), Some(right)) => Some((left, right)),
+                _ => None,
+            };
+            rewrites.map(|(left, right)| Expr::AnyExpr {
+                left: Box::new(left),
+                op: op.clone(),
+                right: Box::new(right),
+            })
+        }
+        Expr::Like(Like {
+            negated,
+            expr,
+            pattern,
+            escape_char,
+        }) => {
+            let rewrites = match (rewrite(expr, map)?, rewrite(pattern, map)?) {
+                (Some(expr), Some(pattern)) => Some((expr, pattern)),
+                _ => None,
+            };
+            rewrites.map(|(expr, pattern)| {
+                Expr::Like(Like {
+                    negated: negated.clone(),
+                    expr: Box::new(expr),
+                    pattern: Box::new(pattern),
+                    escape_char: escape_char.clone(),
+                })
+            })
+        }
+        Expr::ILike(Like {
+            negated,
+            expr,
+            pattern,
+            escape_char,
+        }) => {
+            let rewrites = match (rewrite(expr, map)?, rewrite(pattern, map)?) {
+                (Some(expr), Some(pattern)) => Some((expr, pattern)),
+                _ => None,
+            };
+            rewrites.map(|(expr, pattern)| {
+                Expr::ILike(Like {
+                    negated: negated.clone(),
+                    expr: Box::new(expr),
+                    pattern: Box::new(pattern),
+                    escape_char: escape_char.clone(),
+                })
+            })
+        }
+        Expr::SimilarTo(Like {
+            negated,
+            expr,
+            pattern,
+            escape_char,
+        }) => {
+            let rewrites = match (rewrite(expr, map)?, rewrite(pattern, map)?) {
+                (Some(expr), Some(pattern)) => Some((expr, pattern)),
+                _ => None,
+            };
+            rewrites.map(|(expr, pattern)| {
+                Expr::SimilarTo(Like {
+                    negated: negated.clone(),
+                    expr: Box::new(expr),
+                    pattern: Box::new(pattern),
+                    escape_char: escape_char.clone(),
+                })
+            })
+        }
+        Expr::Not(expr) => rewrite(expr, map)?.map(|expr| Expr::Not(Box::new(expr))),
+        Expr::IsNotNull(expr) => rewrite(expr, map)?.map(|expr| Expr::IsNotNull(Box::new(expr))),
+        Expr::IsNull(expr) => rewrite(expr, map)?.map(|expr| Expr::IsNull(Box::new(expr))),
+        Expr::Negative(expr) => rewrite(expr, map)?.map(|expr| Expr::Negative(Box::new(expr))),
+        Expr::GetIndexedField { expr, key } => {
+            let rewrites = match (rewrite(expr, map)?, rewrite(key, map)?) {
+                (Some(expr), Some(key)) => Some((expr, key)),
+                _ => None,
+            };
+            rewrites.map(|(expr, key)| Expr::GetIndexedField {
+                expr: Box::new(expr),
+                key: Box::new(key),
+            })
+        }
+        Expr::Between {
+            expr,
+            negated,
+            low,
+            high,
+        } => {
+            let rewrites = match (rewrite(expr, map)?, rewrite(low, map)?, rewrite(high, map)?) {
+                (Some(expr), Some(low), Some(high)) => Some((expr, low, high)),
+                _ => None,
+            };
+            rewrites.map(|(expr, low, high)| Expr::Between {
+                expr: Box::new(expr),
+                negated: negated.clone(),
+                low: Box::new(low),
+                high: Box::new(high),
+            })
+        }
+        Expr::Case {
+            expr,
+            when_then_expr,
+            else_expr,
+        } => {
+            let expr = match expr {
+                Some(expr) => match rewrite(expr, map)? {
+                    Some(expr) => Some(expr),
+                    _ => return Ok(None),
+                },
+                _ => None,
+            };
+            let when_then_expr = when_then_expr
+                .iter()
+                .map(
+                    |(when, then)| match (rewrite(when, map), rewrite(then, map)) {
+                        (Err(err), _) | (Ok(_), Err(err)) => Err(err),
+                        (Ok(when), Ok(then)) => Ok(match (when, then) {
+                            (Some(when), Some(then)) => Some((when, then)),
+                            _ => None,
+                        }),
+                    },
+                )
+                .collect::<Result<Option<Vec<_>>>>()?;
+            if when_then_expr.is_none() {
+                return Ok(None);
+            }
+            let when_then_expr = when_then_expr.unwrap();
+            let else_expr = match else_expr {
+                Some(else_expr) => match rewrite(else_expr, map)? {
+                    Some(else_expr) => Some(else_expr),
+                    _ => return Ok(None),
+                },
+                _ => None,
+            };
+            Some(Expr::Case {
+                expr: expr.map(|expr| Box::new(expr)),
+                when_then_expr: when_then_expr
+                    .iter()
+                    .map(|(when, then)| (Box::new(when.clone()), Box::new(then.clone())))
+                    .collect(),
+                else_expr: else_expr.map(|else_expr| Box::new(else_expr)),
+            })
+        }
+        Expr::Cast { expr, data_type } => rewrite(expr, map)?.map(|expr| Expr::Cast {
+            expr: Box::new(expr),
+            data_type: data_type.clone(),
+        }),
+        Expr::TryCast { expr, data_type } => rewrite(expr, map)?.map(|expr| Expr::TryCast {
+            expr: Box::new(expr),
+            data_type: data_type.clone(),
+        }),
+        Expr::Sort {
+            expr,
+            asc,
+            nulls_first,
+        } => rewrite(expr, map)?.map(|expr| Expr::Sort {
+            expr: Box::new(expr),
+            asc: asc.clone(),
+            nulls_first: nulls_first.clone(),
+        }),
+        Expr::ScalarFunction { fun, args } => args
+            .iter()
+            .map(|arg| rewrite(arg, map))
+            .collect::<Result<Option<Vec<_>>>>()?
+            .map(|args| Expr::ScalarFunction {
+                fun: fun.clone(),
+                args,
+            }),
+        Expr::ScalarUDF { fun, args } => args
+            .iter()
+            .map(|arg| rewrite(arg, map))
+            .collect::<Result<Option<Vec<_>>>>()?
+            .map(|args| Expr::ScalarUDF {
+                fun: fun.clone(),
+                args,
+            }),
+        Expr::TableUDF { fun, args } => args
+            .iter()
+            .map(|arg| rewrite(arg, map))
+            .collect::<Result<Option<Vec<_>>>>()?
+            .map(|args| Expr::TableUDF {
+                fun: fun.clone(),
+                args,
+            }),
+        Expr::AggregateFunction {
+            fun,
+            args,
+            distinct,
+        } => args
+            .iter()
+            .map(|arg| rewrite(arg, map))
+            .collect::<Result<Option<Vec<_>>>>()?
+            .map(|args| Expr::AggregateFunction {
+                fun: fun.clone(),
+                args,
+                distinct: distinct.clone(),
+            }),
+        Expr::WindowFunction {
+            fun,
+            args,
+            partition_by,
+            order_by,
+            window_frame,
+        } => {
+            let args = args
+                .iter()
+                .map(|arg| rewrite(arg, map))
+                .collect::<Result<Option<Vec<_>>>>()?;
+            if args.is_none() {
+                return Ok(None);
+            }
+            let args = args.unwrap();
+            let partition_by = partition_by
+                .iter()
+                .map(|partition_by| rewrite(partition_by, map))
+                .collect::<Result<Option<Vec<_>>>>()?;
+            if partition_by.is_none() {
+                return Ok(None);
+            }
+            let partition_by = partition_by.unwrap();
+            order_by
+                .iter()
+                .map(|order_by| rewrite(order_by, map))
+                .collect::<Result<Option<Vec<_>>>>()?
+                .map(|order_by| Expr::WindowFunction {
+                    fun: fun.clone(),
+                    args,
+                    partition_by,
+                    order_by,
+                    window_frame: window_frame.clone(),
+                })
+        }
+        Expr::AggregateUDF { fun, args } => args
+            .iter()
+            .map(|arg| rewrite(arg, map))
+            .collect::<Result<Option<Vec<_>>>>()?
+            .map(|args| Expr::AggregateUDF {
+                fun: fun.clone(),
+                args,
+            }),
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            let expr = rewrite(expr, map)?;
+            if expr.is_none() {
+                return Ok(None);
+            }
+            let expr = expr.unwrap();
+            list.iter()
+                .map(|item| rewrite(item, map))
+                .collect::<Result<Option<Vec<_>>>>()?
+                .map(|list| Expr::InList {
+                    expr: Box::new(expr),
+                    list,
+                    negated: negated.clone(),
+                })
+        }
+        // As rewrites are used to push things down or up the plan, wildcards
+        // might change the selection and should be marked as non-rewrittable
+        Expr::Wildcard | Expr::QualifiedWildcard { .. } => None,
+    })
+}
+
+/// Recursively checks if the passed expr is a constant (always evaluates to the same result).
+pub fn is_const_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Alias(expr, _)
+        | Expr::Not(expr)
+        | Expr::IsNotNull(expr)
+        | Expr::IsNull(expr)
+        | Expr::Negative(expr)
+        | Expr::Cast { expr, .. }
+        | Expr::TryCast { expr, .. }
+        | Expr::Sort { expr, .. } => is_const_expr(expr),
+        Expr::Literal(_) => true,
+        Expr::BinaryExpr { left, right, .. } | Expr::AnyExpr { left, right, .. } => {
+            is_const_expr(left) && is_const_expr(right)
+        }
+        Expr::Like(Like { expr, pattern, .. })
+        | Expr::ILike(Like { expr, pattern, .. })
+        | Expr::SimilarTo(Like { expr, pattern, .. }) => {
+            is_const_expr(expr) && is_const_expr(pattern)
+        }
+        Expr::GetIndexedField { expr, key } => is_const_expr(expr) && is_const_expr(key),
+        Expr::Between {
+            expr, low, high, ..
+        } => is_const_expr(expr) && is_const_expr(low) && is_const_expr(high),
+        Expr::Case {
+            expr,
+            when_then_expr,
+            else_expr,
+        } => expr
+            .iter()
+            .map(|expr| is_const_expr(expr))
+            .chain(
+                when_then_expr
+                    .iter()
+                    .map(|(when, then)| is_const_expr(when) && is_const_expr(then)),
+            )
+            .chain(else_expr.iter().map(|else_expr| is_const_expr(else_expr)))
+            .all(|is_const| is_const),
+        Expr::ScalarFunction { fun, args } => match fun.volatility() {
+            Volatility::Immutable | Volatility::Stable => args.iter().all(|arg| is_const_expr(arg)),
+            _ => false,
+        },
+        Expr::ScalarUDF { fun, args } => match fun.signature.volatility {
+            Volatility::Immutable | Volatility::Stable => args.iter().all(|arg| is_const_expr(arg)),
+            _ => false,
+        },
+        Expr::TableUDF { fun, args } => match fun.signature.volatility {
+            Volatility::Immutable | Volatility::Stable => args.iter().all(|arg| is_const_expr(arg)),
+            _ => false,
+        },
+        Expr::InList { expr, list, .. } => {
+            is_const_expr(expr) && list.iter().map(|item| is_const_expr(item)).all(|item| item)
+        }
+        _ => false,
+    }
+}
+
+/// Checks if the passed expr is a column.
+pub fn is_column_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Column(_) => true,
+        _ => false,
+    }
+}
+
+/// Recursively extracts `Column`s from an expr.
+pub fn get_expr_columns(expr: &Expr) -> Vec<Column> {
+    match expr {
+        Expr::Alias(expr, _)
+        | Expr::Not(expr)
+        | Expr::IsNotNull(expr)
+        | Expr::IsNull(expr)
+        | Expr::Negative(expr)
+        | Expr::Cast { expr, .. }
+        | Expr::TryCast { expr, .. }
+        | Expr::Sort { expr, .. } => get_expr_columns(expr),
+        Expr::Column(column) => vec![column.clone()],
+        Expr::BinaryExpr { left, right, .. } | Expr::AnyExpr { left, right, .. } => {
+            get_expr_columns(left)
+                .into_iter()
+                .chain(get_expr_columns(right).into_iter())
+                .collect()
+        }
+        Expr::Like(Like { expr, pattern, .. })
+        | Expr::ILike(Like { expr, pattern, .. })
+        | Expr::SimilarTo(Like { expr, pattern, .. }) => get_expr_columns(expr)
+            .into_iter()
+            .chain(get_expr_columns(pattern).into_iter())
+            .collect(),
+        Expr::GetIndexedField { expr, key } => get_expr_columns(expr)
+            .into_iter()
+            .chain(get_expr_columns(key).into_iter())
+            .collect(),
+        Expr::Between {
+            expr, low, high, ..
+        } => get_expr_columns(expr)
+            .into_iter()
+            .chain(get_expr_columns(low).into_iter())
+            .chain(get_expr_columns(high).into_iter())
+            .collect(),
+        Expr::Case {
+            expr,
+            when_then_expr,
+            else_expr,
+        } => expr
+            .as_ref()
+            .map(|expr| get_expr_columns(expr))
+            .unwrap_or(vec![])
+            .into_iter()
+            .chain(when_then_expr.iter().flat_map(|(when, then)| {
+                get_expr_columns(when)
+                    .into_iter()
+                    .chain(get_expr_columns(then).into_iter())
+                    .collect::<Vec<_>>()
+            }))
+            .chain(
+                else_expr
+                    .as_ref()
+                    .map(|else_expr| get_expr_columns(else_expr))
+                    .unwrap_or(vec![])
+                    .into_iter(),
+            )
+            .collect(),
+        Expr::ScalarFunction { args, .. }
+        | Expr::ScalarUDF { args, .. }
+        | Expr::TableUDF { args, .. }
+        | Expr::AggregateFunction { args, .. }
+        | Expr::AggregateUDF { args, .. } => {
+            args.iter().flat_map(|arg| get_expr_columns(arg)).collect()
+        }
+        Expr::WindowFunction {
+            args,
+            partition_by,
+            order_by,
+            ..
+        } => args
+            .iter()
+            .flat_map(|arg| get_expr_columns(arg))
+            .chain(
+                partition_by
+                    .iter()
+                    .flat_map(|partition_by| get_expr_columns(partition_by)),
+            )
+            .chain(
+                order_by
+                    .iter()
+                    .flat_map(|order_by| get_expr_columns(order_by)),
+            )
+            .collect(),
+        Expr::InList { expr, list, .. } => get_expr_columns(expr)
+            .into_iter()
+            .chain(list.iter().flat_map(|item| get_expr_columns(item)))
+            .collect(),
+        _ => vec![],
+    }
+}
+
+/// Provides a list of `Column`s the schema has, both qualified and unqualified.
+pub fn get_schema_columns(schema: &DFSchema) -> HashSet<Column> {
+    schema
+        .fields()
+        .iter()
+        .flat_map(|field| vec![field.qualified_column(), field.unqualified_column()])
+        .collect()
+}
+
+/// Recursively determines whether the plan yields exactly one row.
+pub fn is_plan_yielding_one_row(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::Projection(Projection { input, .. })
+        | LogicalPlan::Sort(Sort { input, .. })
+        | LogicalPlan::Distinct(Distinct { input }) => is_plan_yielding_one_row(input),
+        LogicalPlan::Aggregate(Aggregate {
+            group_expr,
+            aggr_expr,
+            ..
+        }) => group_expr.is_empty() && !aggr_expr.is_empty(),
+        LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {
+            is_plan_yielding_one_row(left) && is_plan_yielding_one_row(right)
+        }
+        _ => false,
+    }
+}
+
+/// Recursively determines whether the plan has Projections. This is useful for determining
+/// whether or not the Projection in question is closest to TableScan.
+/// If there are several inputs, returns `true` when all of the inputs have projections.
+pub fn plan_has_projections(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::Projection(_) => true,
+        LogicalPlan::Filter(Filter { input, .. })
+        | LogicalPlan::Window(Window { input, .. })
+        | LogicalPlan::Aggregate(Aggregate { input, .. })
+        | LogicalPlan::Sort(Sort { input, .. })
+        | LogicalPlan::Repartition(Repartition { input, .. })
+        | LogicalPlan::Limit(Limit { input, .. })
+        | LogicalPlan::Explain(Explain { plan: input, .. })
+        | LogicalPlan::Analyze(Analyze { input, .. })
+        | LogicalPlan::TableUDFs(TableUDFs { input, .. })
+        | LogicalPlan::Distinct(Distinct { input }) => plan_has_projections(input),
+        LogicalPlan::Join(Join { left, right, .. })
+        | LogicalPlan::CrossJoin(CrossJoin { left, right, .. }) => {
+            plan_has_projections(left) && plan_has_projections(right)
+        }
+        LogicalPlan::Union(Union { inputs, .. }) => {
+            inputs.iter().all(|input| plan_has_projections(input))
+        }
+        LogicalPlan::Subquery(Subquery {
+            subqueries, input, ..
+        }) => {
+            subqueries.iter().all(|input| plan_has_projections(input))
+                && plan_has_projections(input)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+pub fn make_sample_table(name: &str, fields: Vec<&str>) -> Result<LogicalPlan> {
+    let schema = Schema::new(
+        fields
+            .into_iter()
+            .map(|field| Field::new(field, DataType::Int32, true))
+            .collect(),
+    );
+    LogicalPlanBuilder::scan_empty(Some(name), &schema, None)?.build()
+}
+
+#[cfg(test)]
+pub fn sample_table() -> Result<LogicalPlan> {
+    make_sample_table("t1", vec!["c1", "c2", "c3"])
+}


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds optimizers to push down `Filter`, `Sort`, and `Limit` in logical plan. This benefits queries with CubeScan that have projections with post-processing. Related tests are included.