### PR TITLE
docs(sql): fix incorrect "Not Equals" example and description

### DIFF
--- a/docs/content/SQL-API/SQL-Functions-and-Operators.mdx
+++ b/docs/content/SQL-API/SQL-Functions-and-Operators.mdx
@@ -202,10 +202,10 @@ WHERE orders.status = 'completed';
 ### <--{"id" : "Comparison Functions and Operators"}--> Not equal
 
 ```sql
-datatype = datatype
+datatype != datatype
 ```
 
-Returns true if the first `datatype` is equal to the second.
+Returns true if the first `datatype` is not equal to the second.
 
 Within a Cube Query Rewrite, this operator may behave differently. Use the table
 below for support:


### PR DESCRIPTION
Fixed two small typos with regards to the "not equal" operator.

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
