### PR TITLE
fix(base-driver, bigquery-driver, materialize-driver): Fix sort bug o…

### DIFF
--- a/packages/cubejs-base-driver/src/driver.interface.ts
+++ b/packages/cubejs-base-driver/src/driver.interface.ts
@@ -196,3 +196,15 @@ export interface DriverInterface {
 
   capabilities(): DriverCapabilities;
 }
+
+export interface InformationSchemaColumn {
+  // eslint-disable-next-line camelcase
+  table_schema: string;
+  // eslint-disable-next-line camelcase
+  table_name: string;
+  // eslint-disable-next-line camelcase
+  column_name: string;
+  // eslint-disable-next-line camelcase
+  data_type: string;
+  [key: string]: string
+}

--- a/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
+++ b/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
@@ -178,7 +178,7 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
 
       if (result.length) {
         return R.reduce(
-          this.informationColumnsSchemaReducer, {}, result[0]
+          this.informationColumnsSchemaReducer, {}, this.informationColumnsSchemaSorter(result[0])
         );
       }
 

--- a/packages/cubejs-materialize-driver/src/MaterializeDriver.ts
+++ b/packages/cubejs-materialize-driver/src/MaterializeDriver.ts
@@ -135,7 +135,11 @@ export class MaterializeDriver extends PostgresDriver {
     const version = await this.getMaterializeVersion();
     const query = this.informationSchemaQueryWithFilter(version);
 
-    return this.query(query, []).then(data => reduce(this.informationColumnsSchemaReducer, {}, data));
+    return this.query(query, []).then((data) => reduce(
+      this.informationColumnsSchemaReducer,
+      {},
+      this.informationColumnsSchemaSorter(data)
+    ));
   }
 
   protected async* asyncFetcher<R extends unknown>(conn: PoolClient, cursorId: string): AsyncGenerator<R> {


### PR DESCRIPTION
…n tablesSchema method

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

When we fetch a large schema `informationColumnsSchemaReducer` method is stuck because of not optimal sorting inside it. 
This PR fix the issue. 
