### PR TITLE
docs: fix connect to db link refereneces

### DIFF
--- a/docs/content/Cube-Cloud/Getting-Started/Create-new.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Create-new.mdx
@@ -129,4 +129,4 @@ application to Cube Cloud API.
   />
 </div>
 
-[link-connecting-to-databases]: /cloud/configuration/connecting-to-databases
+[link-connecting-to-databases]: /cloud/configuration/connecting-to-the-database

--- a/docs/content/Cube-Cloud/Getting-Started/Import-Bitbucket-repository-via-SSH.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Import-Bitbucket-repository-via-SSH.mdx
@@ -195,4 +195,4 @@ application to the Cube Cloud API.
 </div>
 
 [bitbucket]: https://bitbucket.org/
-[link-connecting-to-databases]: /cloud/configuration/connecting-to-databases
+[link-connecting-to-databases]: /cloud/configuration/connecting-to-the-database

--- a/docs/content/Cube-Cloud/Getting-Started/Import-Git-repository-via-SSH.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Import-Git-repository-via-SSH.mdx
@@ -157,4 +157,4 @@ application to the Cube Cloud API.
   />
 </div>
 
-[link-connecting-to-databases]: /cloud/configuration/connecting-to-databases
+[link-connecting-to-databases]: /cloud/configuration/connecting-to-the-database

--- a/docs/content/Cube-Cloud/Getting-Started/Import-GitHub-repository.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Import-GitHub-repository.mdx
@@ -136,4 +136,4 @@ application to Cube Cloud API.
   />
 </div>
 
-[link-connecting-to-databases]: /cloud/configuration/connecting-to-databases
+[link-connecting-to-databases]: /cloud/configuration/connecting-to-the-database

--- a/docs/content/Cube-Cloud/Getting-Started/Import-GitLab-repository-via-SSH.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Import-GitLab-repository-via-SSH.mdx
@@ -194,4 +194,4 @@ application to the Cube Cloud API.
 </div>
 
 [gitlab]: https://gitlab.com/
-[link-connecting-to-databases]: /cloud/configuration/connecting-to-databases
+[link-connecting-to-databases]: /cloud/configuration/connecting-to-the-database

--- a/docs/content/Cube-Cloud/Getting-Started/Upload-with-CLI.mdx
+++ b/docs/content/Cube-Cloud/Getting-Started/Upload-with-CLI.mdx
@@ -88,5 +88,5 @@ queries or connect your application to Cube Cloud API.
 </div>
 
 [ref-cloud-connecting-to-databases]:
-  /cloud/configuration/connecting-to-databases
+  /cloud/configuration/connecting-to-the-database
 [ref-cloud-playground]: /cloud/dev-tools/dev-playground


### PR DESCRIPTION
[`Connecting to the Database`](https://cube.dev/docs/cloud/configuration/connecting-to-the-database) page was moved from `/cloud/configuration/connecting-to-databases` to `/cloud/configuration/connecting-to-the-database`, but we had some references to the old url, causing 404 errors

https://github.com/cube-js/cube.js/blob/master/docs/content/Cube-Cloud/Configuration/Connecting-to-Databases.mdx?plain=1#L6-L7
