### PR TITLE
fix: Catch exception from extendContext (unhandledRejection)

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -2278,9 +2278,17 @@ class ApiGateway {
   };
 
   protected requestContextMiddleware: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-    req.context = await this.contextByReq(req, req.securityContext, getRequestIdFromRequest(req));
-    if (next) {
-      next();
+    try {
+      req.context = await this.contextByReq(req, req.securityContext, getRequestIdFromRequest(req));
+      if (next) {
+        next();
+      }
+    } catch (e) {
+      if (next) {
+        next(e);
+      } else {
+        throw e;
+      }
     }
   };
 

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -123,6 +123,25 @@ describe('API Gateway', () => {
     );
   });
 
+  test('catch error requestContextMiddleware', async () => {
+    const { app } = createApiGateway(
+      new AdapterApiMock(),
+      new DataSourceStorageMock(),
+      {
+        extendContext: (_req) => {
+          throw new Error('Server should not crash');
+        }
+      }
+    );
+
+    const res = await request(app)
+      .get('/cubejs-api/v1/load?query={"measures":["Foo.bar"]}')
+      .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+      .expect(500);
+
+    expect(res.body && res.body.error).toStrictEqual('Error: Server should not crash');
+  });
+
   test('query transform with checkAuth', async () => {
     const queryRewrite = jest.fn(async (query: Query, context) => {
       expect(context.securityContext).toEqual({


### PR DESCRIPTION
Hello!

```js
export default {
  extendContext: (req) => {
    throw new Error("Should not crash");
  },
};
```

<img width="557" alt="image" src="https://user-images.githubusercontent.com/572096/223548157-0778027a-c4d8-4dcc-8459-6b5f2dacc7b3.png">

Thanks