### PR TITLE
fix(cubesql): Failed printing to stdout: Resource temporarily unavailable

### DIFF
--- a/packages/cubejs-backend-native/src/transport.rs
+++ b/packages/cubejs-backend-native/src/transport.rs
@@ -89,7 +89,10 @@ impl TransportService for NodeBridgeTransport {
             Some(extra),
         )
         .await?;
+        #[cfg(debug_assertions)]
         trace!("[transport] Meta <- {:?}", response);
+        #[cfg(not(debug_assertions))]
+        trace!("[transport] Meta <- <hidden>", response);
 
         Ok(Arc::new(MetaContext::new(
             response.cubes.unwrap_or_default(),
@@ -131,7 +134,10 @@ impl TransportService for NodeBridgeTransport {
                 Some(extra),
             )
             .await?;
+            #[cfg(debug_assertions)]
             trace!("[transport] Request <- {:?}", response);
+            #[cfg(not(debug_assertions))]
+            trace!("[transport] Request <- <hidden>", response);
 
             let load_err = match serde_json::from_value::<V1LoadResponse>(response.clone()) {
                 Ok(r) => {


### PR DESCRIPTION
Hello!

The root cause is a non-blocking STDOUT set by the Node.js at startup. I don't think that it's a correct idea to set up O_NONBLOCK for STDOUT, let's hide some trace logs as a workaround for this issue. 

Thanks!
