### PR TITLE
fix: Allow to specify cubestore as cacheAndQueueDriver by config

### DIFF
--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -60,7 +60,7 @@ const schemaOptions = Joi.object().keys({
   externalDialectFactory: Joi.func(),
   externalDriverFactory: Joi.func(),
   //
-  cacheAndQueueDriver: Joi.string().valid('redis', 'memory'),
+  cacheAndQueueDriver: Joi.string().valid('cubestore', 'redis', 'memory'),
   contextToAppId: Joi.func(),
   contextToOrchestratorId: Joi.func(),
   contextToDataSourceId: Joi.func(),


### PR DESCRIPTION
Hello!

Fix #6279

Thanks