### PR TITLE
feat(cubestore): RocksStore - panic protection for RW loop

### DIFF
--- a/rust/cubestore/cubestore/src/lib.rs
+++ b/rust/cubestore/cubestore/src/lib.rs
@@ -27,6 +27,7 @@ use log::SetLoggerError;
 use parquet::errors::ParquetError;
 use serde_derive::{Deserialize, Serialize};
 use sqlparser::parser::ParserError;
+use std::any::Any;
 use std::backtrace::Backtrace;
 use std::fmt;
 use std::fmt::Display;
@@ -153,6 +154,16 @@ impl CubeError {
             message: format!("{:?}", error),
             backtrace: Backtrace::capture().to_string(),
             cause: CubeErrorCauseType::Internal,
+        }
+    }
+
+    pub fn from_panic_payload(payload: Box<dyn Any + Send>) -> Self {
+        if let Some(reason) = payload.downcast_ref::<&str>() {
+            CubeError::panic(format!("Reason: {}", reason))
+        } else if let Some(reason) = payload.downcast_ref::<String>() {
+            CubeError::panic(format!("Reason: {}", reason))
+        } else {
+            CubeError::panic("Without reason".to_string())
         }
     }
 }


### PR DESCRIPTION
Hello!

Issue: Single panic in the rw loop can break the whole processing

## Example:

![image](https://user-images.githubusercontent.com/572096/225135310-c1b264d9-ec3b-48d6-a94d-025220db4a77.png)

```
mysql> cache get “1”;
ERROR 1815 (HY000): channel closed

# another operation without panic will not be processed
mysql> cache set “1" “1”;
ERROR 1815 (HY000): channel closed
```

Thanks