### PR TITLE
chore: add test for limit

### DIFF
--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -47,6 +47,28 @@ describe('SQL Generation', () => {
     });
   });
 
+  describe('Common - JS - limit', () => {
+    const compilers = /** @type Compilers */ prepareCompiler(
+      createCubeSchema({
+        name: 'cards',
+        sqlTable: 'card_tbl'
+      })
+    );
+
+    it('Query with limit', async () => {
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: [
+          'cards.count'
+        ],
+        limit: 5
+      });
+      const queryAndParams = query.buildSqlAndParams();
+      expect(queryAndParams[0]).toContain('LIMIT 5');
+    });
+  });
+
   describe('Common - JS', () => {
     const compilers = /** @type Compilers */ prepareCompiler(
       createCubeSchema({


### PR DESCRIPTION
`limit` is no more recognized in the query. For some reason, only `rowLimit` works. This is a breaking, backwards-incompatible change.

I've written a test that fails.
