### PR TITLE
feat: Add x-request-name header to the default allowed ones

### DIFF
--- a/packages/cubejs-server/src/server.ts
+++ b/packages/cubejs-server/src/server.ts
@@ -70,7 +70,7 @@ export class CubejsServer {
       http: {
         ...config.http,
         cors: {
-          allowedHeaders: 'authorization,content-type,x-request-id',
+          allowedHeaders: 'authorization,content-type,x-request-id,x-request-name',
           ...config.http?.cors,
         },
       },

--- a/packages/cubejs-serverless/Handlers.js
+++ b/packages/cubejs-serverless/Handlers.js
@@ -87,7 +87,7 @@ class Handlers {
     if (!this.apiHandler) {
       const app = express();
       app.use(cors({
-        allowedHeaders: 'authorization,content-type,x-request-id',
+        allowedHeaders: 'authorization,content-type,x-request-id,x-request-name',
       }));
 
       this.serverCore.initApp(app);


### PR DESCRIPTION
**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Issue raised with CSM

**Description of Changes Made (if issue reference is not provided)**

This PR allows to send a logical name of a query that helps in debugging a web page that invokes several Cube APIs to display a bunch of widgets