### PR TITLE
fix(cubesql): Allow `CAST` to be used with reaggregation

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf.rs
@@ -1450,7 +1450,7 @@ fn postgres_datetime_format_to_iso(format: String) -> String {
         .replace("mi", "%M")
         .replace("SS", "%S")
         .replace("ss", "%S")
-        .replace(".US", "%.f")
+        .replace(".US", "%.6f")
         .replace("MM", "%m")
         .replace(".MS", "%.3f")
 }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -9633,6 +9633,21 @@ ORDER BY \"COUNT(count)\" DESC"
             .await?
         );
 
+        insta::assert_snapshot!(
+            "to_char_3",
+            execute_query(
+                "
+                SELECT to_char(c, 'YYYY-MM-DD HH24:MI:SS.US') c2
+                FROM (
+                    SELECT str_to_date('2021-08-31 11:05', '%Y-%m-%d %H:%i') c
+                ) t
+                "
+                .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
         Ok(())
     }
 

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__to_char_3.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__to_char_3.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"\n                SELECT to_char(c, 'YYYY-MM-DD HH24:MI:SS.US') c2\n                FROM (\n                    SELECT str_to_date('2021-08-31 11:05', '%Y-%m-%d %H:%i') c\n                ) t\n                \".to_string(),\n            DatabaseProtocol::PostgreSQL).await?"
+---
++----------------------------+
+| c2                         |
++----------------------------+
+| 2021-08-31 11:05:00.000000 |
++----------------------------+


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes two issues with queries generated by Holistics.

The first issue is inability to use `CAST` with reaggregation. This would lead to expressions like `TO_CHAR(CAST ( "public_orders"."completedAt" AS timestamptz ), 'YYYY-MM-DD HH24:MI:SS.US')` erroring out if `GROUP BY` isn't in the query. Such expressions are now issued by Holistics for `timestamp`-type columns. This is now fixed.

The second issue is minor and is about formatting with `TO_CHAR`. Previously `.US` would imply `up to microseconds` but if the precision wasn't high enough (for example, .000000), the decimal part could have been cut in length or be entirely missing. This was inconsistent with PostgreSQL and is now resolved; `.US` will always convert to six decimal digits.

Related tests are included.
