### PR TITLE
feat: introduce a flag for casting numeric values

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1468,6 +1468,7 @@ class ApiGateway {
     },
     response: any,
     responseType?: ResultType,
+    castNumerics: boolean = false
   ) {
     return {
       query: normalizedQuery,
@@ -1482,6 +1483,7 @@ class ApiGateway {
         normalizedQuery,
         queryType,
         responseType,
+        castNumerics
       ),
       lastRefreshTime: response.lastRefreshTime?.toISOString(),
       ...(
@@ -1621,6 +1623,7 @@ class ApiGateway {
             annotation,
             response,
             resType,
+            normalizedQuery.castNumerics
           );
         })
       );
@@ -1690,11 +1693,13 @@ class ApiGateway {
 
       query = this.parseQueryParam(request.query);
       let resType: ResultType = ResultType.DEFAULT;
+      // let castNumerics = false;
 
       query = this.parseMemberExpressionsInQueries(query);
 
       if (!Array.isArray(query) && query.responseFormat) {
         resType = query.responseFormat;
+        // castNumerics = Boolean(query.castNumerics);
       }
 
       this.log({
@@ -1797,6 +1802,7 @@ class ApiGateway {
               annotation,
               response,
               resType,
+              // castNumerics
             );
           })
         );

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -111,6 +111,7 @@ const querySchema = Joi.object().keys({
   renewQuery: Joi.boolean(),
   ungrouped: Joi.boolean(),
   responseFormat: Joi.valid('default', 'compact'),
+  castNumerics: Joi.boolean(),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -10,7 +10,6 @@ import {
   TimeMember,
   FilterOperator,
   QueryTimeDimensionGranularity,
-  QueryOrderType,
 } from './strings';
 import { ResultType } from './enums';
 
@@ -74,6 +73,7 @@ interface Query {
   renewQuery?: boolean;
   ungrouped?: boolean;
   responseFormat?: ResultType;
+  castNumerics?: boolean;
 }
 
 /**


### PR DESCRIPTION
Currently, all values, including those of type 'number,' are returned as strings. The new `castNumerics` flag allows you to override this behavior.