### PR TITLE
Add auth token even if provided via env vars

### DIFF
--- a/packages/cubejs-cli/src/command/deploy.ts
+++ b/packages/cubejs-cli/src/command/deploy.ts
@@ -14,7 +14,7 @@ const deploy = async ({ directory, auth, uploadEnv, token }: any) => {
     );
   }
 
-  token = token || process.env.CUBE_CLOUD_DEPLOY_AUTH;
+  token ??= process.env.CUBE_CLOUD_DEPLOY_AUTH;
 
   if (token) {
     const config = new Config();

--- a/packages/cubejs-cli/src/command/deploy.ts
+++ b/packages/cubejs-cli/src/command/deploy.ts
@@ -14,6 +14,8 @@ const deploy = async ({ directory, auth, uploadEnv, token }: any) => {
     );
   }
 
+  token = token || process.env.CUBE_CLOUD_DEPLOY_AUTH;
+
   if (token) {
     const config = new Config();
     await config.addAuthToken(token);


### PR DESCRIPTION
**Check List**
- [x] Tests has been run in packages where changes made if available: See test results below
- [X] Linter has been run for changed code
- [?] Tests for the changes have been added if not covered yet: Not sure how to do this
- [x] Docs have been added / updated if required: No docs need to be updated

**Issue Reference this PR resolves**

Resolves #7146

**Description of Changes Made (if issue reference is not provided)**

Register token from env variable (if provided) earlier in the command lifecycle.

**Test result in local**

Not sure if I ran the test properly. I just ran `npm test` as indicated in the README file. I followed the instruction in the contribution guide. That's what I got :thinking: 

```
> cubejs-cli@0.33.58 test
> npm run unit


> cubejs-cli@0.33.58 unit
> jest dist/test

No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In /home/mathieu/projects/cube/packages/cubejs-cli
  19 files checked.
  testMatch: **/__tests__/**/*.[jt]s?(x), **/?(*.)+(spec|test).[tj]s?(x) - 2 matches
  testPathIgnorePatterns: /node_modules/ - 19 matches
  testRegex:  - 0 matches
Pattern: dist/test - 0 matches
npm ERR! Lifecycle script `unit` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: cubejs-cli@0.33.58 
npm ERR!   at location: /home/mathieu/projects/cube/packages/cubejs-cli 
npm ERR! Lifecycle script `test` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: cubejs-cli@0.33.58 
npm ERR!   at location: /home/mathieu/projects/cube/packages/cubejs-cli
```