### PR TITLE
chore: Remove the reference to NODE_ENV=production

### DIFF
--- a/packages/cubejs-server-core/src/core/DevServer.ts
+++ b/packages/cubejs-server-core/src/core/DevServer.ts
@@ -52,7 +52,7 @@ export class DevServer {
     const cubejsToken = jwt.sign({}, options.apiSecret || 'secret', { expiresIn: '1d' });
 
     if (process.env.NODE_ENV !== 'production') {
-      console.log('🔓 Authentication checks are disabled in developer mode. Please use NODE_ENV=production to enable it.');
+      console.log('🔓 Authentication checks are disabled in development mode.');
     } else {
       console.log(`🔒 Your temporary cube.js token: ${cubejsToken}`);
     }


### PR DESCRIPTION
1. Remove the reference to `NODE_ENV=production`; it's obsolete since Cube is now run in Docker.
2. Fix wording: 'developer mode` → `development mode`; we have the latter in [docs](https://cube.dev/docs/product/configuration#development-mode).

For context — conversation in Slack: https://cube-js.slack.com/archives/C04NYBJP7RQ/p1699263331658569