### PR TITLE
fix(cubesql): Don't clone response, improve performance

### DIFF
--- a/packages/cubejs-backend-native/src/transport.rs
+++ b/packages/cubejs-backend-native/src/transport.rs
@@ -385,7 +385,7 @@ impl TransportService for NodeBridgeTransport {
             #[cfg(not(debug_assertions))]
             trace!("[transport] Request <- <hidden>");
 
-            if let Some(error_value) = response.as_object().map(|r| r.get("error")).flatten() {
+            if let Some(error_value) = response.get("error") {
                 match error_value {
                     serde_json::Value::String(error) => {
                         if error.to_lowercase() == *"continue wait" {


### PR DESCRIPTION
serde_json::from_value requires passing the own of the value; it's why we used `clone` here. The biggest problem is that we used it for successful responses, which is a large structure.

PR fixes that issue.