### PR TITLE
chore: Remove the length check for pre-aggregation table name

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -146,14 +146,6 @@ export class MysqlQuery extends BaseQuery {
     return `IF(${sql}, 1, 0)`;
   }
 
-  public preAggregationTableName(cube, preAggregationName, skipSchema) {
-    const name = super.preAggregationTableName(cube, preAggregationName, skipSchema);
-    if (name.length > 64) {
-      throw new UserError(`MySQL can not work with table names that longer than 64 symbols. Consider using the 'sqlAlias' attribute in your cube and in your pre-aggregation definition for ${name}.`);
-    }
-    return name;
-  }
-
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.quotes.identifiers = '`';

--- a/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
@@ -97,12 +97,4 @@ export class OracleQuery extends BaseQuery {
     // eslint-disable-next-line quotes
     return `((cast (systimestamp at time zone 'UTC' as date) - date '1970-01-01') * 86400)`;
   }
-
-  public preAggregationTableName(cube, preAggregationName, skipSchema) {
-    const name = super.preAggregationTableName(cube, preAggregationName, skipSchema);
-    if (name.length > 128) {
-      throw new UserError(`Oracle can not work with table names that longer than 64 symbols. Consider using the 'sqlAlias' attribute in your cube and in your pre-aggregation definition for ${name}.`);
-    }
-    return name;
-  }
 }


### PR DESCRIPTION
Remove the length check for pre-aggregation table name (including schema) as redundant since external pre-aggregations in Cube Store don't need a low length limit

**Check List**
- [ ] Tests has been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required
