### PR TITLE
feat(schema-compiler): Allow passing function that returns an array of time dimensions as pre-aggregation timeDimensions property

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -696,11 +696,19 @@ export class CubeEvaluator extends CubeSymbols {
         dimension: this.evaluateReferences(cube, aggregation.timeDimensionReference),
         granularity: aggregation.granularity
       });
-    } else if (aggregation.timeDimensionReferences) {
+    } else if (Array.isArray(aggregation.timeDimensionReferences)) {
       // eslint-disable-next-line guard-for-in
       for (const timeDimensionReference of aggregation.timeDimensionReferences) {
         timeDimensions.push({
           dimension: this.evaluateReferences(cube, timeDimensionReference.dimension),
+          granularity: timeDimensionReference.granularity
+        });
+      }
+    } else if (aggregation.timeDimensionReferences) {
+      const evaluatedRefs: any[] = this.evaluateReferences(cube, aggregation.timeDimensionReferences, { returnRaw: true });
+      for (const timeDimensionReference of evaluatedRefs) {
+        timeDimensions.push({
+          dimension: timeDimensionReference.dimension.toString(),
           granularity: timeDimensionReference.granularity
         });
       }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.js
@@ -515,6 +515,11 @@ export class CubeSymbols {
       cubeAliasFn: (cube) => cubeEvaluator.pathFromArray(fullPath(cubeEvaluator.joinHints(), [cube])),
       collectJoinHints: options.collectJoinHints,
     });
+
+    if (options.returnRaw) {
+      return arrayOrSingle;
+    }
+
     if (!Array.isArray(arrayOrSingle)) {
       return arrayOrSingle.toString();
     }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -473,10 +473,13 @@ const RollUpSchema = condition(
       // Rollup with multiple time dimensions
       inherit(BasePreAggregation, {
         type: Joi.any().valid('rollup').required(),
-        timeDimensions: Joi.array().items(Joi.object().keys({
-          dimension: Joi.func(),
-          granularity: GranularitySchema,
-        })),
+        timeDimensions: Joi.alternatives().try(
+          Joi.array().items(Joi.object().keys({
+            dimension: Joi.func(),
+            granularity: GranularitySchema,
+          })),
+          Joi.func(),
+        ),
         allowNonStrictDateRangeMatch: Joi.bool(),
         measures: Joi.func(),
         dimensions: Joi.func(),


### PR DESCRIPTION
This allows to pass a function as a pre-aggregation timeDimensions property like this:
```js
  cube(`Users`, {
    sql: `SELECT * FROM public.users`,

    preAggregations: {
      dynamicMultiple: {
        dimensions: [CUBE.status],
        measures: [CUBE.count],
        timeDimensions: (CUBE) => [
          {dimension: CUBE.createdAt, granularity: 'day'},
          {dimension: CUBE.modifiedAt, granularity: 'day'},
        ]
      },
    },
```

You can also use dynamicity inside concrete time dimension, like this:
```js
  cube(`Users`, {
    sql: `SELECT * FROM public.users`,

    preAggregations: {
      dynamicMultiple: {
        dimensions: [CUBE.status],
        measures: [CUBE.count],
        timeDimensions: [
          {dimension: (CUBE) => CUBE.createdAt, granularity: 'day'},
          {dimension: (CUBE) => CUBE.modifiedAt, granularity: 'day'},
        ]
      },
    },
```

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

