### PR TITLE
fix(schema-compiler): Use member expression definition as measure key

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2100,6 +2100,7 @@ export class BaseQuery {
         const cubeName = m.expressionCubeName ? `\`${m.expressionCubeName}\` ` : '';
         throw new UserError(`The query contains \`COUNT(*)\` expression but cube/view ${cubeName}is missing \`count\` measure`);
       }
+
       if (collectedMeasures.length === 0 && m.isMemberExpression) {
         // `m` is member expression measure, but does not reference any other measure
         // Consider this dimensions-only measure. This can happen at least in 2 cases:
@@ -2110,8 +2111,17 @@ export class BaseQuery {
         // TODO return measure object for every measure
         return this.dimensionOnlyMeasureToHierarchy(context, m);
       }
-      const measureName = typeof m.measure === 'string' ? m.measure : `${m.measure.cubeName}.${m.measure.name}`;
-      return [measureName, collectedMeasures];
+
+      let measureKey;
+      if (typeof m.measure === 'string') {
+        measureKey = m.measure;
+      } else if (m.isMemberExpression) {
+        // TODO expressionName vs definition?
+        measureKey = m.expressionName;
+      } else {
+        measureKey = `${m.measure.cubeName}.${m.measure.name}`;
+      }
+      return [measureKey, collectedMeasures];
     }));
   }
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Without this when measure was a member expression m.measure.name can be undefined, and different measures will have same key in collectRootMeasureToHieararchy