### PR TITLE
chore!(backend-shared): Remove deprecated npm proxy settings

### DIFF
--- a/packages/cubejs-backend-shared/package.json
+++ b/packages/cubejs-backend-shared/package.json
@@ -43,7 +43,6 @@
     "decompress": "^4.2.1",
     "env-var": "^6.3.0",
     "fs-extra": "^9.1.0",
-    "https-proxy-agent": "^7.0.6",
     "lru-cache": "^11.1.0",
     "moment-range": "^4.0.2",
     "moment-timezone": "^0.5.47",

--- a/packages/cubejs-backend-shared/src/proxy.ts
+++ b/packages/cubejs-backend-shared/src/proxy.ts
@@ -1,48 +1,8 @@
-import { exec } from 'child_process';
 import { ProxyAgent } from 'proxy-agent';
-import { HttpsProxyAgent } from 'https-proxy-agent';
-
-let npmProxy: string;
-let npmProxyInitialized = false;
-
-function getCommandOutput(command: string) {
-  return new Promise<string>((resolve, reject) => {
-    exec(command, (error, stdout) => {
-      if (error) {
-        reject(error.message);
-        return;
-      }
-
-      resolve(stdout);
-    });
-  });
-}
-
-/**
- * @deprecated
- * use ProxyAgent instead
- */
-export async function getProxySettings(): Promise<string> {
-  const [proxy] = (
-    await Promise.all([getCommandOutput('npm config -g get https-proxy'), getCommandOutput('npm config -g get proxy')])
-  )
-    .map((s) => s.trim())
-    .filter((s) => !['null', 'undefined', ''].includes(s));
-
-  npmProxyInitialized = true;
-
-  return proxy;
-}
 
 export async function getHttpAgentForProxySettings() {
-  if (!npmProxyInitialized) {
-    npmProxy = await getProxySettings();
+  if (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY) {
+    return undefined;
   }
-
-  if (npmProxy) {
-    console.warn('Npm proxy settings are deprecated. Please use HTTP_PROXY, HTTPS_PROXY environment variables instead.');
-    return new HttpsProxyAgent(npmProxy);
-  }
-
   return new ProxyAgent();
 }


### PR DESCRIPTION
This PR removes deprecated proxy settings obtained from npm settings. So only common HTTP_PROXY and/or HTTPS_PROXY env vars are used.

This probably fixes https://github.com/cube-js/cube/issues/9723

