### PR TITLE
fix(clickhouse-driver): Fix headers check

### DIFF
--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -268,7 +268,9 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
           abort_signal: signal,
         });
 
-        if (resultSet.response_headers['x-clickhouse-format'] !== format) {
+        // response_headers['x-clickhouse-format'] is optional, but if it exists,
+        // it should match the requested format.
+        if (resultSet.response_headers['x-clickhouse-format'] && resultSet.response_headers['x-clickhouse-format'] !== format) {
           throw new Error(`Unexpected x-clickhouse-format in response: expected ${format}, received ${resultSet.response_headers['x-clickhouse-format']}`);
         }
 


### PR DESCRIPTION
It seems that `response_headers['x-clickhouse-format']` is optional should not be checked strictly.

**Check List**
- [ ] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
