### PR TITLE
docs: use camelCase for the selector.dataSources parameter

### DIFF
--- a/docs/pages/product/apis-integrations/rest-api/reference.mdx
+++ b/docs/pages/product/apis-integrations/rest-api/reference.mdx
@@ -385,7 +385,7 @@ This endpoint is part of the [Orchestration API][ref-orchestration-api].
 | `action`                   | Use `post` to trigger jobs                                     | ✅       |
 | `selector.contexts`        | Array of objects, each containing a `securityContext`          | ✅       |
 | `selector.timezones`       | Array of timezones                                             | ✅       |
-| `selector.datasources`     | Array of data source names which have pre-aggregations defined | ❌       |
+| `selector.dataSources`     | Array of data source names which have pre-aggregations defined | ❌       |
 | `selector.cubes`           | Array of cube names which contain pre-aggregations             | ❌       |
 | `selector.preAggregations` | Array of pre-aggregation names                                 | ❌       |
 | `selector.dateRange`       | Date Range tuple ['range-date-start', 'range-date-end']        | ❌       |


### PR DESCRIPTION
**Check List**
- [N/A] Tests have been run in packages where changes made if available
- [N/A] Linter has been run for changed code
- [N/A] Tests for the changes have been added if not covered yet
- [/] Docs have been added / updated if required

I didn't create an issue, but the docs for the orchestrator API have an incorrect casing for dataSources. This PR fixes that so others don't have to work it out for themselves.

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
