### PR TITLE
feat(cubesql): Add support for `current_catalog` function for pg-wire

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -4346,13 +4346,6 @@ pub fn register_fun_stubs(mut ctx: SessionContext) -> SessionContext {
     register_fun_stub!(udf, "cosh", tsig = [Float64], rettyp = Float64);
     register_fun_stub!(udf, "cot", tsig = [Float64], rettyp = Float64);
     register_fun_stub!(udf, "cotd", tsig = [Float64], rettyp = Float64);
-    register_fun_stub!(
-        udf,
-        "current_catalog",
-        argc = 0,
-        rettyp = Utf8,
-        vol = Stable
-    );
     register_fun_stub!(udf, "current_query", argc = 0, rettyp = Utf8, vol = Stable);
     register_fun_stub!(udf, "current_role", argc = 0, rettyp = Utf8, vol = Stable);
     register_fun_stub!(

--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -436,6 +436,7 @@ impl QueryEngine for SqlQueryEngine {
                 "PostgreSQL 14.2 on x86_64-cubesql".to_string(),
             ));
             ctx.register_udf(create_db_udf("current_database".to_string(), state.clone()));
+            ctx.register_udf(create_db_udf("current_catalog".to_string(), state.clone()));
             ctx.register_udf(create_db_udf("current_schema".to_string(), state.clone()));
             ctx.register_udf(create_current_user_udf(
                 state.clone(),

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__datagrip_introspection.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_introspection__datagrip_introspection.snap
@@ -1,9 +1,9 @@
 ---
 source: cubesql/src/compile/test/test_introspection.rs
-expression: "execute_query(\"select current_database(), current_schema(), current_user;\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
+expression: "execute_query(\"select current_database(), current_catalog, current_schema(), current_user;\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
 ---
-+------------------+----------------+--------------+
-| current_database | current_schema | current_user |
-+------------------+----------------+--------------+
-| cubedb           | public         | ovr          |
-+------------------+----------------+--------------+
++------------------+-----------------+----------------+--------------+
+| current_database | current_catalog | current_schema | current_user |
++------------------+-----------------+----------------+--------------+
+| cubedb           | cubedb          | public         | ovr          |
++------------------+-----------------+----------------+--------------+

--- a/rust/cubesql/cubesql/src/compile/test/test_introspection.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_introspection.rs
@@ -842,7 +842,8 @@ async fn datagrip_introspection() -> Result<(), CubeError> {
     insta::assert_snapshot!(
         "datagrip_introspection",
         execute_query(
-            "select current_database(), current_schema(), current_user;".to_string(),
+            "select current_database(), current_catalog, current_schema(), current_user;"
+                .to_string(),
             DatabaseProtocol::PostgreSQL
         )
         .await?


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#9833

**Description of Changes Made**

These changes add support for the `current_catalog` function to cubesql for postgresql protocol.

The initial issue was encountered while using Metabase with version 0.55.10.1 and upwards, and prevents all queries made from Metabase from executing correctly.
Upon investigation, this issue is not limited to Metabase, as it comes from an update of PostgreSQL JDBC Driver from version 42.7.6+, specifically from this PR https://github.com/pgjdbc/pgjdbc/pull/3565.

Proposed changes are inspired from previous commit [a18f68c - feat(cubesql): Support current_database(), current_schema(), current_user for pg-wire](https://github.com/cube-js/cube.js/commit/a18f68c8a6538c38c8985b512996a9fec2292da2).

The `current_catalog` function is only registered for postgresql protocol, as it does not seem to have a strict equivalent in mysql dialect.

Finally, `current_catalog` function is called in the test without any parenthesis as these are not supported, as stated in [postgresql documentation](https://www.postgresql.org/docs/current/functions-info.html) : 
> current_catalog, current_role, current_schema, current_user, session_user, and user have special syntactic status in SQL: they must be called without trailing parentheses. In PostgreSQL, parentheses can optionally be used with current_schema, but not with the others.
