### PR TITLE
fix(clickhouse-driver): Parse Error: Header overflow due to X-ClickHo…

### DIFF
--- a/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
+++ b/packages/cubejs-clickhouse-driver/src/ClickHouseDriver.ts
@@ -173,6 +173,9 @@ export class ClickHouseDriver extends BaseDriver implements DriverInterface {
         request: getEnv('clickhouseCompression', { dataSource }),
       },
       clickhouseSettings: {
+        /// Default Node.js client has a limit for the max size of HTTP headers. In practise, such headers can be extremely large
+        /// Let's disable it, because we don't need them.
+        send_progress_in_http_headers: 0,
         // If ClickHouse user's permissions are restricted with "readonly = 1",
         // change settings queries are not allowed. Thus, "join_use_nulls" setting
         // can not be changed


### PR DESCRIPTION
To fix the issue with the headers overflowing:

```
Error: Parse Error: Header overflow
   at TLSSocket.socketOnData (node:_http_client:551:22)
   at TLSSocket.emit (node:events:519:28)
   at addChunk (node:internal/streams/readable:559:12)
   at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
```

More details in original repository of client library: https://github.com/ClickHouse/clickhouse-js/issues/448