### PR TITLE
fix(cubesql): Improve SQL push down for Athena/Presto

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -157,8 +157,8 @@ export class PrestodbQuery extends BaseQuery {
     templates.expressions.timestamp_literal = 'from_iso8601_timestamp(\'{{ value }}\')';
     // Presto requires concat types to be VARCHAR
     templates.expressions.binary = '{% if op == \'||\' %}' +
-      'CAST({{ left }} AS VARCHAR) || CAST({{ right }} AS VARCHAR)' +
-      '{% else %}{{ left }} {{ op }} {{ right }}{% endif %}';
+      '(CAST({{ left }} AS VARCHAR) || CAST({{ right }} AS VARCHAR))' +
+      '{% else %}({{ left }} {{ op }} {{ right }}){% endif %}';
     delete templates.expressions.ilike;
     templates.types.string = 'VARCHAR';
     templates.types.float = 'REAL';

--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -140,7 +140,7 @@ pub trait QueryEngine {
 
         let optimizer_config = OptimizerConfig::new();
         let optimizers: Vec<Arc<dyn OptimizerRule + Sync + Send>> = vec![
-            Arc::new(PlanNormalize::new()),
+            Arc::new(PlanNormalize::new(&cube_ctx)),
             Arc::new(ProjectionDropOut::new()),
             Arc::new(FilterPushDown::new()),
             Arc::new(SortPushDown::new()),

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
@@ -409,6 +409,44 @@ impl RewriteRules for DateRules {
                     "?new_granularity",
                 ),
             ),
+            // AGE function seems to be a popular choice for this date arithmetic,
+            // but it is not supported in SQL push down by most dialects.
+            transforming_rewrite_with_root(
+                "thoughtspot-date-part-over-age-as-datediff-month",
+                binary_expr(
+                    binary_expr(
+                        self.fun_expr(
+                            "DatePart",
+                            vec![
+                                literal_string("year"),
+                                udf_expr("age", vec!["?newer_date", "?older_date"]),
+                            ],
+                        ),
+                        "*",
+                        literal_int(12),
+                    ),
+                    "+",
+                    self.fun_expr(
+                        "DatePart",
+                        vec![
+                            literal_string("month"),
+                            udf_expr("age", vec!["?newer_date", "?older_date"]),
+                        ],
+                    ),
+                ),
+                alias_expr(
+                    udf_expr(
+                        "datediff",
+                        vec![
+                            literal_string("month"),
+                            "?older_date".to_string(),
+                            "?newer_date".to_string(),
+                        ],
+                    ),
+                    "?alias",
+                ),
+                self.transform_root_alias("?alias"),
+            ),
         ]
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR improves compatibility of SQL push down with Athena/Presto dialects.
Changes include:
- Binary expression template is wrapped in brackets
- `DATE_PART` over `AGE` expressions are rewritten to `DATEDIFF` (most dialects lack `AGE` equivalent)
- `DATE - DATE` expressions are re-planned as `DATEDIFF('day', DATE, DATE)` as this produces a number but might yield interval in other dialects

Related tests are included.
