### PR TITLE
feat(cubesql): Support cursors in stream mode

### DIFF
--- a/packages/cubejs-backend-native/src/stream.rs
+++ b/packages/cubejs-backend-native/src/stream.rs
@@ -312,10 +312,10 @@ pub async fn call_js_with_stream_as_callback(
     schema: SchemaRef,
     member_fields: Vec<MemberField>,
 ) -> Result<Receiver<Chunk>, CubeError> {
-    let channel_size = std::env::var("CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK")
-        .ok()
-        .map(|v| v.parse::<usize>().unwrap())
-        .unwrap_or(8192);
+    // Each chunk is a RecordBatch of up to CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK rows.
+    // Let's keep the size small to avoid memory issues and allow linear scaling
+    // of the buffer size depending on the env value.
+    let channel_size = 10;
 
     let (sender, receiver) = mpsc_channel::<Chunk>(channel_size);
     let (ready_sender, ready_receiver) = oneshot::channel();

--- a/rust/cubesql/cubesql/src/sql/postgres/extended.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/extended.rs
@@ -201,6 +201,7 @@ pub enum PortalFrom {
     Extended,
 }
 
+#[derive(Debug)]
 pub enum PortalBatch {
     Description(protocol::RowDescription),
     Rows(BatchWriter),

--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -1500,20 +1500,6 @@ impl AsyncPostgresShim {
                 sensitive,
                 hold,
             } => {
-                // TODO: move envs to config
-                let stream_mode = self.session.server.config_obj.stream_mode();
-                if stream_mode {
-                    return Err(ConnectionError::Protocol(
-                        protocol::ErrorResponse::error(
-                            protocol::ErrorCode::FeatureNotSupported,
-                            "DECLARE statement can not be used if CUBESQL_STREAM_MODE == true"
-                                .to_string(),
-                        )
-                        .into(),
-                        span_id.clone(),
-                    ));
-                }
-
                 // The default is to allow scrolling in some cases; this is not the same as specifying SCROLL.
                 if scroll.is_some() {
                     return Err(ConnectionError::Protocol(


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes an issue with streaming mode channel buffer scaling exponentially with `CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK` value instead of linearly, and removes the limitation disallowing usage of cursors in stream mode.