### PR TITLE
feat(cubestore): Add metastore benchmarks for get_tables_with_path pe…

### DIFF
--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -126,6 +126,10 @@ md5 = "0.8.0"
 name = "cachestore_queue"
 harness = false
 
+[[bench]]
+name = "metastore"
+harness = false
+
 [features]
 # When enabled, child processes will die whenever parent process exits.
 # Highly recomended for production, available only on Linux with prctl system call.

--- a/rust/cubestore/cubestore/benches/metastore.rs
+++ b/rust/cubestore/cubestore/benches/metastore.rs
@@ -1,0 +1,214 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use cubestore::config::Config;
+use cubestore::metastore::{BaseRocksStoreFs, Column, ColumnType, MetaStore, RocksMetaStore};
+use cubestore::remotefs::LocalDirRemoteFs;
+use cubestore::CubeError;
+use std::env;
+use std::fs;
+use std::sync::Arc;
+use tokio::runtime::{Builder, Runtime};
+
+fn prepare_metastore(name: &str) -> Result<Arc<RocksMetaStore>, CubeError> {
+    let config = Config::test(name);
+
+    let store_path = env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("bench")
+        .join(format!("test-local-{}", name));
+    let remote_store_path = env::current_dir()
+        .unwrap()
+        .join("target")
+        .join("bench")
+        .join(format!("test-remote-{}", name));
+
+    let _ = fs::remove_dir_all(store_path.clone());
+    let _ = fs::remove_dir_all(remote_store_path.clone());
+
+    let remote_fs = LocalDirRemoteFs::new(Some(remote_store_path.clone()), store_path.clone());
+
+    RocksMetaStore::new(
+        store_path.join("metastore").as_path(),
+        BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+        config.config_obj(),
+    )
+}
+
+async fn populate_metastore(
+    metastore: &Arc<RocksMetaStore>,
+    num_schemas: usize,
+    tables_per_schema: usize,
+) -> Result<(), CubeError> {
+    for schema_idx in 0..num_schemas {
+        let schema_name = format!("schema_{}", schema_idx);
+        metastore.create_schema(schema_name.clone(), false).await?;
+
+        for table_idx in 0..tables_per_schema {
+            let table_name = format!("table_{}_{}", schema_idx, table_idx);
+            let global_table_id = schema_idx * tables_per_schema + table_idx;
+            let columns = vec![
+                Column::new("name".to_string(), ColumnType::String, 1),
+                Column::new("timestamp".to_string(), ColumnType::Timestamp, 2),
+                Column::new("float_measure".to_string(), ColumnType::Float, 3),
+                Column::new("int_measure".to_string(), ColumnType::Int, 4),
+            ];
+
+            let table_id = metastore
+                .create_table(
+                    schema_name.clone(),
+                    table_name,
+                    columns,
+                    None,   // locations
+                    None,   // import_format
+                    vec![], // indexes
+                    false,  // is_ready
+                    None,   // build_range_end
+                    None,   // seal_at
+                    None,   // select_statement
+                    None,   // source_columns
+                    None,   // stream_offset
+                    None,   // unique_key_column_names
+                    None,   // aggregates
+                    None,   // partition_split_threshold
+                    None,   // trace_obj
+                    false,  // drop_if_exists
+                    None,   // extension
+                )
+                .await?;
+
+            // Make some tables ready and some not ready for realistic testing
+            if global_table_id % 4 != 3 {
+                metastore.table_ready(table_id.get_id(), true).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn bench_get_tables_with_path(
+    metastore: &Arc<RocksMetaStore>,
+    include_non_ready: bool,
+    iterations: usize,
+) {
+    for _ in 0..iterations {
+        let result = metastore.get_tables_with_path(include_non_ready).await;
+        assert!(result.is_ok());
+    }
+}
+
+fn benchmark_get_tables_with_path_small(c: &mut Criterion, runtime: &Runtime) {
+    let metastore = runtime.block_on(async {
+        let metastore = prepare_metastore("get_tables_with_path_small").unwrap();
+        populate_metastore(&metastore, 10, 10).await.unwrap(); // 100 tables
+        metastore
+    });
+
+    c.bench_with_input(
+        BenchmarkId::new("get_tables_with_path_small_include_non_ready_true", 100),
+        &100,
+        |b, &iterations| {
+            b.to_async(runtime)
+                .iter(|| bench_get_tables_with_path(&metastore, true, iterations));
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("get_tables_with_path_small_include_non_ready_false", 100),
+        &100,
+        |b, &iterations| {
+            b.to_async(runtime)
+                .iter(|| bench_get_tables_with_path(&metastore, false, iterations));
+        },
+    );
+}
+
+fn benchmark_get_tables_with_path_medium(c: &mut Criterion, runtime: &Runtime) {
+    let metastore = runtime.block_on(async {
+        let metastore = prepare_metastore("get_tables_with_path_medium").unwrap();
+        populate_metastore(&metastore, 50, 20).await.unwrap(); // 1,000 tables
+        metastore
+    });
+
+    c.bench_with_input(
+        BenchmarkId::new("get_tables_with_path_medium_include_non_ready_true", 50),
+        &50,
+        |b, &iterations| {
+            b.to_async(runtime)
+                .iter(|| bench_get_tables_with_path(&metastore, true, iterations));
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("get_tables_with_path_medium_include_non_ready_false", 50),
+        &50,
+        |b, &iterations| {
+            b.to_async(runtime)
+                .iter(|| bench_get_tables_with_path(&metastore, false, iterations));
+        },
+    );
+}
+
+fn benchmark_get_tables_with_path_large(c: &mut Criterion, runtime: &Runtime) {
+    let metastore = runtime.block_on(async {
+        let metastore = prepare_metastore("get_tables_with_path_large").unwrap();
+        populate_metastore(&metastore, 25, 1000).await.unwrap(); // 25,000 tables
+        metastore
+    });
+
+    c.bench_with_input(
+        BenchmarkId::new("get_tables_with_path_large_include_non_ready_true", 10),
+        &10,
+        |b, &iterations| {
+            b.to_async(runtime)
+                .iter(|| bench_get_tables_with_path(&metastore, true, iterations));
+        },
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("get_tables_with_path_large_include_non_ready_false", 10),
+        &10,
+        |b, &iterations| {
+            b.to_async(runtime)
+                .iter(|| bench_get_tables_with_path(&metastore, false, iterations));
+        },
+    );
+}
+
+fn cold_vs_warm_cache_benchmark(c: &mut Criterion, runtime: &Runtime) {
+    let metastore = runtime.block_on(async {
+        let metastore = prepare_metastore("cold_warm_cache").unwrap();
+        populate_metastore(&metastore, 20, 50).await.unwrap(); // 1,000 tables
+        metastore
+    });
+
+    // Cold cache benchmark (first call)
+    c.bench_function("get_tables_with_path_cold_cache", |b| {
+        b.to_async(runtime).iter(|| async {
+            let fresh_metastore = prepare_metastore("cold_cache_fresh").unwrap();
+            populate_metastore(&fresh_metastore, 20, 50).await.unwrap();
+            let result = fresh_metastore.get_tables_with_path(false).await;
+            assert!(result.is_ok());
+        });
+    });
+
+    // Warm cache benchmark (subsequent calls)
+    c.bench_function("get_tables_with_path_warm_cache", |b| {
+        b.to_async(runtime).iter(|| async {
+            let result = metastore.get_tables_with_path(false).await;
+            assert!(result.is_ok());
+        });
+    });
+}
+
+fn do_benches(c: &mut Criterion) {
+    let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
+
+    benchmark_get_tables_with_path_small(c, &runtime);
+    benchmark_get_tables_with_path_medium(c, &runtime);
+    benchmark_get_tables_with_path_large(c, &runtime);
+    cold_vs_warm_cache_benchmark(c, &runtime);
+}
+
+criterion_group!(benches, do_benches);
+criterion_main!(benches);


### PR DESCRIPTION
…rformance testing

- Add comprehensive benchmarks for small (100), medium (1K), and large (25K) table datasets
- Test both cached and non-cached execution paths
- Include cold vs warm cache comparison benchmarks
