### PR TITLE
fix(tesseract): param casting in presto

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
@@ -860,25 +860,6 @@ SELECT 1 AS revenue,  cast('2024-01-01' AS timestamp) as time UNION ALL
         includes: ['count']
       }]
     })
-
-    cube('boolean_dimension', {
-      sql: \`
-        SELECT
-          'true' AS dim
-      \`,
-      dimensions: {
-        dim: {
-          sql: \`dim\`,
-          type: 'boolean',
-          primaryKey: true
-        }
-      },
-      measures: {
-        count: {
-          type: 'count',
-        }
-      }
-    });
     `);
 
   it('simple join', async () => {
@@ -2012,31 +1993,6 @@ SELECT 1 AS revenue,  cast('2024-01-01' AS timestamp) as time UNION ALL
     console.log(query.buildSqlAndParams());
 
     expect(query.buildSqlAndParams()[0]).toMatch(/OFFSET (\d)\s+LIMIT (\d)/);
-  });
-
-  it('bool param cast (PrestoQuery)', async () => {
-    await compiler.compile();
-
-    const query = new PrestodbQuery({ joinGraph, cubeEvaluator, compiler }, {
-      measures: [
-        'boolean_dimension.count',
-      ],
-      timeDimensions: [{
-        dimension: 'boolean_dimension.dim',
-      }],
-      filters: [
-        {
-          member: 'boolean_dimension.dim',
-          operator: 'equals',
-          values: ['true'],
-        },
-      ],
-    });
-
-    const queryAndParams = query.buildSqlAndParams();
-    console.log(queryAndParams);
-
-    expect(queryAndParams[0]).toContain('"boolean_dimension".dim = CAST(? AS BOOLEAN)');
   });
 
   it('calculated join', async () => {

--- a/packages/cubejs-schema-compiler/test/unit/prestodb-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/prestodb-query.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-restricted-syntax */
+import { PrestodbQuery } from '../../src/adapter/PrestodbQuery';
+import { prepareJsCompiler } from './PrepareCompiler';
+
+describe('PrestodbQuery', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+    cube('boolean_dimension', {
+      sql: \`
+        SELECT
+          'true' AS dim
+      \`,
+      dimensions: {
+        dim: {
+          sql: \`dim\`,
+          type: 'boolean',
+          primaryKey: true
+        }
+      },
+      measures: {
+        count: {
+          type: 'count',
+        }
+      }
+    });
+    `);
+
+  it('bool param cast (PrestoQuery)', async () => {
+    await compiler.compile();
+
+    const query = new PrestodbQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: [
+        'boolean_dimension.count',
+      ],
+      timeDimensions: [{
+        dimension: 'boolean_dimension.dim',
+      }],
+      filters: [
+        {
+          member: 'boolean_dimension.dim',
+          operator: 'equals',
+          values: ['true'],
+        },
+      ],
+    });
+
+    const queryAndParams = query.buildSqlAndParams();
+    console.log(queryAndParams);
+
+    expect(queryAndParams[0]).toContain('"boolean_dimension".dim = CAST(? AS BOOLEAN)');
+  });
+});


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#9875 

**Description of Changes Made (if issue reference is not provided)**

With tesseract on, Cube doesn’t cast boolean and number parameters for Presto SQL, resulting in invalid SQL being generated. Updated PrestoDBQuery to do this, and added a short for test casting booleans. 
