### PR TITLE
perf(schema-compiler): Improve yaml compilation speed

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -23,7 +23,6 @@ import { CompilerInterface } from './PrepareCompiler';
 import { YamlCompiler } from './YamlCompiler';
 import { CubeDictionary } from './CubeDictionary';
 import { CompilerCache } from './CompilerCache';
-import { perfTracker } from './PerfTracker';
 
 const ctxFileStorage = new AsyncLocalStorage<FileContent>();
 
@@ -212,11 +211,7 @@ export class DataSchemaCompiler {
   }
 
   protected async doCompile() {
-    const compileTimer = perfTracker.start('doCompile', true);
-
     const files = await this.repository.dataSchemaFiles();
-
-    console.log(`Compiling ${files.length} files...`);
 
     this.pythonContext = await this.loadPythonContext(files, 'globals.py');
     this.yamlCompiler.initFromPythonContext(this.pythonContext);
@@ -240,8 +235,6 @@ export class DataSchemaCompiler {
     }
 
     const transpile = async (stage: CompileStage): Promise<FileContent[]> => {
-      const transpileTimer = perfTracker.start(`transpilation-stage-${stage}`);
-
       let cubeNames: string[] = [];
       let cubeSymbols: Record<string, Record<string, boolean>> = {};
       let transpilerNames: string[] = [];
@@ -307,8 +300,6 @@ export class DataSchemaCompiler {
       } else {
         results = await Promise.all(toCompile.map(f => this.transpileFile(f, errorsReport, {})));
       }
-
-      transpileTimer.end();
 
       return results.filter(f => !!f) as FileContent[];
     };
@@ -407,8 +398,6 @@ export class DataSchemaCompiler {
     });
 
     const compilePhase = async (compilers: CompileCubeFilesCompilers, stage: 0 | 1 | 2 | 3) => {
-      const compilePhaseTimer = perfTracker.start(`compilation-phase-${stage}`);
-
       // clear the objects for the next phase
       cubes = [];
       exports = {};
@@ -417,9 +406,7 @@ export class DataSchemaCompiler {
       asyncModules = [];
       transpiledFiles = await transpile(stage);
 
-      const res = this.compileCubeFiles(cubes, contexts, compiledFiles, asyncModules, compilers, transpiledFiles, errorsReport);
-      compilePhaseTimer.end();
-      return res;
+      return this.compileCubeFiles(cubes, contexts, compiledFiles, asyncModules, compilers, transpiledFiles, errorsReport);
     };
 
     return compilePhase({ cubeCompilers: this.cubeNameCompilers }, 0)
@@ -455,12 +442,6 @@ export class DataSchemaCompiler {
         } else if (transpilationWorkerThreads && this.workerPool) {
           this.workerPool.terminate();
         }
-
-        // End overall compilation timing and print performance report
-        compileTimer.end();
-        setImmediate(() => {
-          perfTracker.printReport();
-        });
       });
   }
 
@@ -659,9 +640,7 @@ export class DataSchemaCompiler {
           asyncModules
         );
       });
-    const asyncModulesTimer = perfTracker.start('asyncModules.reduce (jinja)');
     await asyncModules.reduce((a: Promise<void>, b: CallableFunction) => a.then(() => b()), Promise.resolve());
-    asyncModulesTimer.end();
     return this.compileObjects(compilers.cubeCompilers || [], cubes, errorsReport)
       .then(() => this.compileObjects(compilers.contextCompilers || [], contexts, errorsReport));
   }
@@ -684,9 +663,7 @@ export class DataSchemaCompiler {
     compiledFiles[file.fileName] = true;
 
     if (file.fileName.endsWith('.js')) {
-      const compileJsFileTimer = perfTracker.start('compileJsFile');
       this.compileJsFile(file, errorsReport, { doSyntaxCheck });
-      compileJsFileTimer.end();
     } else if (file.fileName.endsWith('.yml.jinja') || file.fileName.endsWith('.yaml.jinja') ||
       (
         file.fileName.endsWith('.yml') || file.fileName.endsWith('.yaml')
@@ -700,9 +677,7 @@ export class DataSchemaCompiler {
         this.pythonContext!
       ));
     } else if (file.fileName.endsWith('.yml') || file.fileName.endsWith('.yaml')) {
-      const compileYamlFileTimer = perfTracker.start('compileYamlFile');
       this.yamlCompiler.compileYamlFile(file, errorsReport);
-      compileYamlFileTimer.end();
     }
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/PerfTracker.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/PerfTracker.ts
@@ -1,0 +1,88 @@
+import { performance, PerformanceObserver } from 'perf_hooks';
+
+interface PerfMetric {
+  count: number;
+  totalTime: number;
+  avgTime: number;
+}
+
+interface PerfStats {
+  [key: string]: PerfMetric;
+}
+
+class PerfTracker {
+  private metrics: PerfStats = {};
+
+  private globalMetric: string | null = null;
+
+  public constructor() {
+    const obs = new PerformanceObserver((items) => {
+      for (const entry of items.getEntries()) {
+        const { name } = entry;
+        if (!this.metrics[name]) {
+          this.metrics[name] = { count: 0, totalTime: 0, avgTime: 0 };
+        }
+        const m = this.metrics[name];
+        m.count++;
+        m.totalTime += entry.duration;
+        m.avgTime = m.totalTime / m.count;
+      }
+    });
+    obs.observe({ entryTypes: ['measure'] });
+  }
+
+  public start(name: string, global: boolean = false): { end: () => void } {
+    const uid = `${name}-${performance.now()}`;
+    const startMark = `${uid}-start`;
+    const endMark = `${uid}-end`;
+    performance.mark(startMark);
+
+    if (global && !this.globalMetric) {
+      this.globalMetric = name;
+    }
+
+    let ended = false;
+
+    return {
+      end: () => {
+        if (ended) return;
+        performance.mark(endMark);
+        performance.measure(name, startMark, endMark);
+        ended = true;
+      }
+    };
+  }
+
+  public printReport() {
+    console.log('\n🚀 PERFORMANCE REPORT 🚀\n');
+    console.log('═'.repeat(90));
+
+    const sorted = Object.entries(this.metrics)
+      .sort(([, a], [, b]) => b.totalTime - a.totalTime);
+
+    if (!sorted.length) {
+      console.log('No performance data collected.');
+      return;
+    }
+
+    let totalTime: number = 0;
+
+    if (this.globalMetric) {
+      totalTime = this.metrics[this.globalMetric]?.totalTime;
+    } else {
+      totalTime = sorted.reduce((sum, [, m]) => sum + m.totalTime, 0);
+    }
+
+    console.log(`⏱️  TOTAL TIME: ${totalTime.toFixed(2)}ms\n`);
+
+    sorted.forEach(([name, m]) => {
+      const pct = totalTime > 0 ? (m.totalTime / totalTime * 100) : 0;
+      console.log(`  ${name.padEnd(40)} │ ${m.totalTime.toFixed(2).padStart(8)}ms │ ${m.avgTime.toFixed(2).padStart(7)}ms avg │ ${pct.toFixed(1).padStart(5)}% │ ${m.count.toString().padStart(4)} calls`);
+    });
+
+    console.log('═'.repeat(90));
+    console.log('🎯 End of Performance Report\n');
+  }
+}
+
+export const perfTracker = new PerfTracker();

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -194,24 +194,12 @@ export class YamlCompiler {
     } else if (typeof obj === 'string') {
       let code = obj;
 
-      if (obj === '') {
-        return t.nullLiteral();
-      }
-
-      if (code.match(PY_TEMPLATE_SYNTAX)) {
-        if (!nonStringFields.has(propertyPath[propertyPath.length - 1])) {
-          code = `f"${this.escapeDoubleQuotes(obj)}"`;
-        }
-
-        const ast = this.parsePythonAndTranspileToJs(code, errorsReport);
-        return this.extractProgramBodyIfNeeded(ast);
-      }
-
       if (!nonStringFields.has(propertyPath[propertyPath.length - 1])) {
-        return t.templateLiteral([t.templateElement({ raw: code, cooked: code })], []);
+        code = `f"${this.escapeDoubleQuotes(obj)}"`;
       }
 
-      return t.identifier(code);
+      const ast = this.parsePythonAndTranspileToJs(code, errorsReport);
+      return this.extractProgramBodyIfNeeded(ast);
     } else if (typeof obj === 'boolean') {
       return t.booleanLiteral(obj);
     } else if (typeof obj === 'number') {


### PR DESCRIPTION
This PR attempts to improve python parser compilation flow speed by avoiding high-cost parsing/transpiling AST for obvious cases when it's possible to construct the resulting expression by hands.

Here is original measurement  of 100+ yaml data model compilation time:
```
Compiling 110 files...

🚀 PERFORMANCE REPORT 🚀

══════════════════════════════════════════════════════════════════════════════════════════
⏱️  TOTAL TIME: 6877.32ms

  doCompile                                │  6877.32ms │ 6877.32ms avg │ 100.0% │    1 calls
  transpileYaml                            │  6553.95ms │   19.00ms avg │  95.3% │  345 calls
  compileYamlFile                          │  6355.80ms │   19.62ms avg │  92.4% │  324 calls
  PythonParser->transpileToJs()            │  6186.45ms │    0.19ms avg │  90.0% │ 31740 calls
  yaml-transpileAndPrepareJsFile           │  5275.99ms │   16.59ms avg │  76.7% │  318 calls
  parsePythonAndTranspileToJs call 225     │  4031.55ms │    0.15ms avg │  58.6% │ 26349 calls
  compilation-phase-0                      │  2215.13ms │ 2215.13ms avg │  32.2% │    1 calls
  parsePythonAndTranspileToJs call 301     │  2180.16ms │    0.37ms avg │  31.7% │ 5877 calls
  compilation-phase-1                      │  2080.09ms │ 2080.09ms avg │  30.2% │    1 calls
  compilation-phase-3                      │  2064.41ms │ 2064.41ms avg │  30.0% │    1 calls
  asyncModules.reduce (jinja)              │   411.26ms │  137.09ms avg │   6.0% │    3 calls
  astIntoArrowFunction                     │   202.59ms │    0.03ms avg │   2.9% │ 5940 calls
  parsePythonAndTranspileToJs call 201     │    25.23ms │    0.17ms avg │   0.4% │  147 calls
  parsePythonAndTranspileToJs call 214     │     3.57ms │    0.20ms avg │   0.1% │   18 calls
  transpilation-stage-0                    │     0.84ms │    0.84ms avg │   0.0% │    1 calls
  transpilation-stage-1                    │     0.29ms │    0.29ms avg │   0.0% │    1 calls
  transpilation-stage-3                    │     0.27ms │    0.27ms avg │   0.0% │    1 calls
══════════════════════════════════════════════════════════════════════════════════════════
```

And here is the same measurement with the updated flow:
```
Compiling 110 files...

🚀 PERFORMANCE REPORT 🚀

══════════════════════════════════════════════════════════════════════════════════════════
⏱️  TOTAL TIME: 6543.44ms

  doCompile                                │  6543.44ms │ 6543.44ms avg │ 100.0% │    1 calls
  transpileYaml                            │  6221.67ms │   18.03ms avg │  95.1% │  345 calls
  compileYamlFile                          │  6030.43ms │   18.61ms avg │  92.2% │  324 calls
  PythonParser->transpileToJs()            │  5923.99ms │    0.20ms avg │  90.5% │ 30336 calls
  yaml-transpileAndPrepareJsFile           │  5018.65ms │   15.78ms avg │  76.7% │  318 calls
  compilation-phase-0                      │  2160.93ms │ 2160.93ms avg │  33.0% │    1 calls
  compilation-phase-1                      │  1947.60ms │ 1947.60ms avg │  29.8% │    1 calls
  compilation-phase-3                      │  1926.70ms │ 1926.70ms avg │  29.4% │    1 calls
  parsePythonAndTranspileToJs call 301     │  1923.06ms │    0.43ms avg │  29.4% │ 4473 calls
  asyncModules.reduce (jinja)              │   398.69ms │  132.90ms avg │   6.1% │    3 calls
  astIntoArrowFunction                     │   180.96ms │    0.04ms avg │   2.8% │ 4665 calls
  parsePythonAndTranspileToJs call 201     │    24.40ms │    0.17ms avg │   0.4% │  147 calls
  parsePythonAndTranspileToJs call 214     │     3.00ms │    0.17ms avg │   0.0% │   18 calls
  transpilation-stage-0                    │     1.84ms │    1.84ms avg │   0.0% │    1 calls
  transpilation-stage-1                    │     0.28ms │    0.28ms avg │   0.0% │    1 calls
  transpilation-stage-3                    │     0.25ms │    0.25ms avg │   0.0% │    1 calls
══════════════════════════════════════════════════════════════════════════════════════════
🎯 End of Performance Report
```

Not as much as wanted, but 10% - is still smth...

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
