### PR TITLE
fix(cubesql): Merge subqueries with SQL push down

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/aggregate.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/aggregate.rs
@@ -609,7 +609,7 @@ impl WrapperRules {
                             ),
                         ),
                         wrapper_pullup_replacer(
-                            wrapped_select_subqueries_empty_tail(),
+                            "?inner_subqueries",
                             wrapper_replacer_context(
                                 "?alias_to_cube",
                                 "WrapperReplacerContextPushToCube:true",
@@ -735,7 +735,7 @@ impl WrapperRules {
                         ),
                     ),
                     wrapper_pullup_replacer(
-                        wrapped_select_subqueries_empty_tail(),
+                        "?inner_subqueries",
                         wrapper_replacer_context(
                             "?alias_to_cube",
                             "WrapperReplacerContextPushToCube:true",


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR alters the behavior of SQL push down, allowing to merge aggregation nodes with wrapped selects containing subqueries. This helps with SQL push down when subqueries are used in WHERE clause. Related test is included.
