### PR TITLE
fix(cubestore): add statsd metrics bind address ENV VAR

### DIFF
--- a/docs/content/product/configuration/reference/environment-variables.mdx
+++ b/docs/content/product/configuration/reference/environment-variables.mdx
@@ -1438,6 +1438,15 @@ Define which metrics collector format.
 | --------------------- | ---------------------- | --------------------- |
 | `statsd`, `dogstatsd` | `statsd`               | `statsd`              |
 
+## `CUBESTORE_METRICS_BIND_ADDRESS`
+
+Define the IP address to bind the metrics collector server to. Binding to
+the default loopback interface will prevent sending of metrics to other devices.
+
+| Possible Values    | Default in Development | Default in Production |
+| ------------------ | ---------------------- | --------------------- |
+| A valid IP address | `127.0.0.1`            | `127.0.0.1`         |
+
 ## `CUBESTORE_METRICS_ADDRESS`
 
 Required IP address to send metrics.

--- a/rust/cubestore/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/cubestore/src/bin/cubestored.rs
@@ -38,7 +38,12 @@ fn main() {
     let metrics_port = std::env::var("CUBESTORE_METRICS_PORT").unwrap_or("8125".to_string());
     let metrics_server_address = format!("{}:{}", metrics_addr, metrics_port);
 
-    init_metrics(format!("{}:0", metrics_bind_address), metrics_server_address, metrics_format, vec![]);
+    init_metrics(
+        format!("{}:0", metrics_bind_address),
+        metrics_server_address,
+        metrics_format,
+        vec![],
+    );
     let telemetry_env = std::env::var("CUBESTORE_TELEMETRY")
         .or(std::env::var("CUBEJS_TELEMETRY"))
         .unwrap_or("true".to_string());

--- a/rust/cubestore/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/cubestore/src/bin/cubestored.rs
@@ -36,12 +36,7 @@ fn main() {
     let metrics_port = std::env::var("CUBESTORE_METRICS_PORT").unwrap_or("8125".to_string());
     let metrics_server_address = format!("{}:{}", metrics_addr, metrics_port);
 
-    init_metrics(
-        "127.0.0.1:0",
-        metrics_server_address,
-        metrics_format,
-        vec![],
-    );
+    init_metrics("0.0.0.0:0", metrics_server_address, metrics_format, vec![]);
     let telemetry_env = std::env::var("CUBESTORE_TELEMETRY")
         .or(std::env::var("CUBEJS_TELEMETRY"))
         .unwrap_or("true".to_string());

--- a/rust/cubestore/cubestore/src/bin/cubestored.rs
+++ b/rust/cubestore/cubestore/src/bin/cubestored.rs
@@ -31,12 +31,14 @@ fn main() {
         ),
         Err(_) => metrics::Compatibility::StatsD,
     };
+    let metrics_bind_address =
+        std::env::var("CUBESTORE_METRICS_BIND_ADDRESS").unwrap_or("127.0.0.1".to_string());
     let metrics_addr =
         std::env::var("CUBESTORE_METRICS_ADDRESS").unwrap_or("127.0.0.1".to_string());
     let metrics_port = std::env::var("CUBESTORE_METRICS_PORT").unwrap_or("8125".to_string());
     let metrics_server_address = format!("{}:{}", metrics_addr, metrics_port);
 
-    init_metrics("0.0.0.0:0", metrics_server_address, metrics_format, vec![]);
+    init_metrics(format!("{}:0", metrics_bind_address), metrics_server_address, metrics_format, vec![]);
     let telemetry_env = std::env::var("CUBESTORE_TELEMETRY")
         .or(std::env::var("CUBEJS_TELEMETRY"))
         .unwrap_or("true".to_string());


### PR DESCRIPTION
… to non-localhost

**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
Closes https://github.com/cube-js/cube/issues/9920