### PR TITLE
fix(cubesql): Fix columns referencing outer context in subqueries

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "chrono",
@@ -837,7 +837,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "async-trait",
  "chrono",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubenativeutils/Cargo.lock
+++ b/rust/cubenativeutils/Cargo.lock
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "chrono",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "async-trait",
  "chrono",
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -758,7 +758,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "async-trait",
  "chrono",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "e3bb7fe5b16461893234db44950f539c58081bfe", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "0ba29ac12e2b13444bd536e1cbe4f73411383521", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesqlplanner/Cargo.lock
+++ b/rust/cubesqlplanner/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "chrono",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "async-trait",
  "chrono",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3bb7fe5b16461893234db44950f539c58081bfe#e3bb7fe5b16461893234db44950f539c58081bfe"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=0ba29ac12e2b13444bd536e1cbe4f73411383521#0ba29ac12e2b13444bd536e1cbe4f73411383521"
 dependencies = [
  "ahash 0.7.8",
  "arrow",


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes an issue with queries like this:
```
SELECT table_name
FROM information_schema.tables
WHERE table_name IN (
  SELECT table_name
  FROM information_schema.tables
  WHERE tables.table_name = 'tables'
)
```
In this case, the inner `WHERE` clause would pick outer `table_name` column due to a logic error in compound identifier planning.

Related test is included.