### PR TITLE
revert(duckdb-driver): Revert version bump from 1.3.1 to 1.4.0

### DIFF
--- a/packages/cubejs-duckdb-driver/package.json
+++ b/packages/cubejs-duckdb-driver/package.json
@@ -30,7 +30,7 @@
     "@cubejs-backend/base-driver": "1.3.75",
     "@cubejs-backend/schema-compiler": "1.3.75",
     "@cubejs-backend/shared": "1.3.75",
-    "duckdb": "^1.4.0"
+    "duckdb": "^1.3.1"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13353,10 +13353,10 @@ draft-js@^0.10.0, draft-js@~0.10.0:
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
-duckdb@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/duckdb/-/duckdb-1.4.0.tgz#38e440f06d7e669aecd71398f605f850cf894129"
-  integrity sha512-v6tjnmFY2cYJn/7ojNKHzFyuxauEX6QeRYODxlHE218xGQrD0H6Tz5btZzNZHdfObl07P7WlExjGWDLWrg1UyA==
+duckdb@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/duckdb/-/duckdb-1.3.1.tgz#984427fba39e0d321a4dc592bbf9b06cdd39992f"
+  integrity sha512-wSCxu6zSkHkGHtLrI5MmHYUOpbi08s2eIY/QCg2f1YsSyohjA3MRnUMdDb88oqgLa7/h+/wHuIe1RXRu4k04Sw==
   dependencies:
     "@mapbox/node-pre-gyp" "^2.0.0"
     node-addon-api "^7.0.0"


### PR DESCRIPTION
This reverts commit f9b6f0da20934786ab68f72e8805d21a156c7388.

Unfortunately, the 1.4.0 version has a change that might break the existing installations. It's related to the region support in aws s3 urls. So if s3 urls doesn't have a region in it, you can hit an error. 

Some info might be found in https://github.com/duckdb/duckdb/pull/18258, https://github.com/duckdb/duckdb-httpfs/pull/83

We'll include this update in the upcoming minor release of the cube (1.4) where such breaking changes are expected.

