### PR TITLE
Docs: extends warning

### DIFF
--- a/docs/pages/product/data-modeling/reference/cube.mdx
+++ b/docs/pages/product/data-modeling/reference/cube.mdx
@@ -217,7 +217,7 @@ cube(`extended_order_facts`, {
 
 <WarningBox>
 
-Extends does not apply to the `refresh_key` parameter - cubes which extend another and do not declare a `refresh_key` will use the [default for their given engine][ref-cube-refresh-key].
+Extends using non-named cubes will not copy all fields across. For example the `refresh_key` value will not be copied and the default refresh key for the given database will be used (see `refresh_key` below for more details)
 
 </WarningBox>
 


### PR DESCRIPTION
Add a warning to extends keyword to note which keys it doesn't extend

**Check List**
- [x] Tests have been run in packages where changes made if available (n/a)
- [x] Linter has been run for changed code (n/a)
- [x] Tests for the changes have been added if not covered yet (n/a)
- [x] Docs have been added / updated if required (docs only)

**Description of Changes Made (if issue reference is not provided)**

The `extends` keyword does not apply `refresh_key` to the cube that's extended, if the base cube is abstract, instead that cube will use the default refresh. There's no indication of this being a bug but the docs don't clarify it. Checking the code it's unclear if this is deliberate but it feels like this would be a clear bug otherwise so assuming it's intended. This clarifies the behaviour to avoid unnecessary cache refreshes.
