### PR TITLE
Pass CUBEJS_DB_QUERY_TIMEOUT to Firebolt driver

### DIFF
--- a/packages/cubejs-firebolt-driver/src/FireboltDriver.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltDriver.ts
@@ -30,6 +30,7 @@ export type FireboltDriverConfiguration = {
   readOnly?: boolean;
   apiEndpoint?: string;
   connection: ConnectionOptions;
+  requestTimeout: number;
 };
 
 const FireboltTypeToGeneric: Record<string, string> = {
@@ -91,6 +92,7 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
 
     this.config = {
       readOnly: true,
+      requestTimeout: getEnv('dbQueryTimeout') * 1000,
       apiEndpoint:
         getEnv('fireboltApiEndpoint', { dataSource }) || 'api.app.firebolt.io',
       ...config,
@@ -225,7 +227,7 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
       const connection = await this.getConnection();
 
       const statement = await connection.execute(query, {
-        settings: { output_format: OutputFormat.JSON },
+        settings: { output_format: OutputFormat.JSON, statement_timeout: this.config.requestTimeout },
         parameters,
         response: { hydrateRow: this.hydrateRow }
       });
@@ -275,7 +277,7 @@ export class FireboltDriver extends BaseDriver implements DriverInterface {
       const connection = await this.getConnection();
 
       const statement = await connection.execute(query, {
-        settings: { output_format: OutputFormat.JSON },
+        settings: { output_format: OutputFormat.JSON, statement_timeout: this.config.requestTimeout },
         parameters,
         response: { hydrateRow: this.hydrateRow }
       });

--- a/packages/cubejs-firebolt-driver/test/FireboltDriver.test.ts
+++ b/packages/cubejs-firebolt-driver/test/FireboltDriver.test.ts
@@ -1,6 +1,7 @@
 import { DriverTests } from '@cubejs-backend/testing-shared';
 
 import { FireboltDriver } from '../src';
+import { getEnv } from '@cubejs-backend/shared';
 
 describe('FireboltDriver', () => {
   let tests: DriverTests;
@@ -22,4 +23,22 @@ describe('FireboltDriver', () => {
   test('stream', async () => {
     await tests.testStream();
   });
+
+  test('query should fail on timeout', async () => {
+    const slowQuery = 'SELECT checksum(*) FROM GENERATE_SERIES(1, 1000000000000)';
+    // Set query timeout to 2 seconds
+    process.env.CUBEJS_DB_QUERY_TIMEOUT = '2';
+    const driver = new FireboltDriver({});
+
+    let timedOut = false;
+    try {
+      await driver.query(slowQuery);
+    } catch (e) {
+      if (String(e).toLowerCase().includes('timeout expired (2000 ms)')) {
+        timedOut = true;
+      }
+    }
+
+    expect(timedOut).toBe(true);
+  }, 10000);
 });


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

Pass `CUBEJS_DB_QUERY_TIMEOUT` variable through as https://docs.firebolt.io/reference/system-settings#statement-timeout to Firebolt so that query cancellation works correctly.

Example `curl`:

```
curl --location 'https://XXXXX.api.eu-west-1.app.firebolt.io/?database=XXXXX\&output_format=JSON_Compact&engine=test_engine&statement_timeout=1000' \
--header 'Authorization: Bearer XXXXXXX' \
--data 'SELECT checksum(*) FROM GENERATE_SERIES(1, 1000000000000);'
{
  "errors": [
    {
      "description": "Query was canceled with reason 'Query timeout expired (1000 ms)'"
    }
  ],
  "query": {
    "query_id": "def8ff9a-3f85-4c89-ac41-030cb56bfa19",
    "query_label": null,
    "request_id": "7159c249-edc3-42f0-a518-4b5d13bc05f3"
  },
  "statistics": {
    "elapsed": 0.0
  }
}
```

