### PR TITLE
chore(cubesql): Pass span_id to logical plan creation function

### DIFF
--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -80,6 +80,8 @@ pub trait QueryEngine {
         &self,
         cube_ctx: &CubeContext,
         stmt: &Self::AstStatementType,
+        span_id: Option<Arc<SpanId>>,
+        query_planning_id: Option<Uuid>,
     ) -> Result<(LogicalPlan, Self::PlanMetadataType), DataFusionError>;
 
     fn sanitize_statement(&self, stmt: &Self::AstStatementType) -> Self::AstStatementType;
@@ -122,18 +124,20 @@ pub trait QueryEngine {
         let ctx = self.create_session_ctx(state.clone())?;
         let cube_ctx = self.create_cube_ctx(state.clone(), meta.clone(), ctx.clone())?;
 
-        let (plan, metadata) = self.create_logical_plan(&cube_ctx, &stmt).map_err(|err| {
-            let message = format!("Initial planning error: {}", err,);
-            let meta = Some(HashMap::from([
-                ("query".to_string(), stmt.to_string()),
-                (
-                    "sanitizedQuery".to_string(),
-                    self.sanitize_statement(&stmt).to_string(),
-                ),
-            ]));
+        let (plan, metadata) = self
+            .create_logical_plan(&cube_ctx, &stmt, span_id.clone(), Some(query_planning_id))
+            .map_err(|err| {
+                let message = format!("Initial planning error: {}", err,);
+                let meta = Some(HashMap::from([
+                    ("query".to_string(), stmt.to_string()),
+                    (
+                        "sanitizedQuery".to_string(),
+                        self.sanitize_statement(&stmt).to_string(),
+                    ),
+                ]));
 
-            CompilationError::internal(message).with_meta(meta)
-        })?;
+                CompilationError::internal(message).with_meta(meta)
+            })?;
 
         let mut optimized_plan = plan;
         // ctx.optimize(&plan).map_err(|err| {
@@ -567,6 +571,8 @@ impl QueryEngine for SqlQueryEngine {
         &self,
         cube_ctx: &CubeContext,
         stmt: &Self::AstStatementType,
+        _span_id: Option<Arc<SpanId>>,
+        _query_planning_id: Option<Uuid>,
     ) -> Result<(LogicalPlan, Self::PlanMetadataType), DataFusionError> {
         let df_query_planner = SqlToRel::new_with_options(cube_ctx, true);
         let plan =


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR adds passing `span_id` to `create_logical_plan` function, allowing implementors of `QueryEngine` to log events in `create_logical_plan` implementation.
