### PR TITLE
chore(cubesql): Make `create_logical_plan` async

### DIFF
--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -76,7 +76,7 @@ pub trait QueryEngine {
         state: Arc<SessionState>,
     ) -> Result<DFSessionContext, CompilationError>;
 
-    fn create_logical_plan(
+    async fn create_logical_plan(
         &self,
         cube_ctx: &CubeContext,
         stmt: &Self::AstStatementType,
@@ -126,6 +126,7 @@ pub trait QueryEngine {
 
         let (plan, metadata) = self
             .create_logical_plan(&cube_ctx, &stmt, span_id.clone(), Some(query_planning_id))
+            .await
             .map_err(|err| {
                 let message = format!("Initial planning error: {}", err,);
                 let meta = Some(HashMap::from([
@@ -567,7 +568,7 @@ impl QueryEngine for SqlQueryEngine {
         Ok(ctx)
     }
 
-    fn create_logical_plan(
+    async fn create_logical_plan(
         &self,
         cube_ctx: &CubeContext,
         stmt: &Self::AstStatementType,


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR makes `create_logical_plan` function of `QueryEngine` trait async.
