### PR TITLE
feat(cubesql): Push down `CAST(... AS DATE)` to CubeScan filters

### DIFF
--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -2198,6 +2198,32 @@ impl RewriteRules for FilterRules {
                 not_expr(binary_expr("?left", "LIKE", "?right")),
                 binary_expr("?left", "NOT_LIKE", "?right"),
             ),
+            rewrite(
+                "cast-as-date-to-datetrunc-replacer",
+                filter_replacer(
+                    binary_expr(
+                        cast_expr_explicit(column_expr("?column"), DataType::Date32),
+                        "?op",
+                        "?date_expr",
+                    ),
+                    "?alias_to_cube",
+                    "?members",
+                    "?filter_aliases",
+                ),
+                filter_replacer(
+                    binary_expr(
+                        self.fun_expr(
+                            "DateTrunc",
+                            vec![literal_string("day"), column_expr("?column")],
+                        ),
+                        "?op",
+                        "?date_expr",
+                    ),
+                    "?alias_to_cube",
+                    "?members",
+                    "?filter_aliases",
+                ),
+            ),
             transforming_rewrite(
                 "not-like-expr-to-like-negated-expr",
                 not_expr(like_expr(


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR adds a rule to transform `CAST ... AS DATE` filter to `DATE_TRUNC` with `day` granularity, allowing such a filter to be pushed down CubeScan. Related test is included.
