### PR TITLE
fix(schema-compiler): Fix incorrect cache that affects query joins

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -2745,9 +2745,15 @@ export class BaseQuery {
   }
 
   collectJoinHintsFromMembers(members) {
+    // Extract cube names from members to make cache key member-cubes-specific
+    const memberCubes = members
+      .map(m => m.cube?.()?.name)
+      .filter(Boolean)
+      .sort();
+
     return [
       ...members.map(m => m.joinHint).filter(h => h?.length > 0),
-      ...this.collectFrom(members, this.collectJoinHintsFor.bind(this), 'collectJoinHintsFromMembers'),
+      ...this.collectFrom(members, this.collectJoinHintsFor.bind(this), ['collectJoinHintsFromMembers', ...memberCubes]),
     ];
   }
 


### PR DESCRIPTION
An attempt to fix https://github.com/cube-js/cube/issues/9941: Unnecessary JOIN added when using FILTER_PARAMS in a segment

Fixes https://github.com/cube-js/cube/issues/9941

**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
