### PR TITLE
fix(cubesql): Always repartition joins when right side has multiple partitions

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "arrow",
  "chrono",
@@ -839,7 +839,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "async-trait",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -907,7 +907,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "arrow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "async-trait",
  "chrono",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e3eb4cf60bab0136b3925fe4795f82f67dad7e49#e3eb4cf60bab0136b3925fe4795f82f67dad7e49"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=8e60e17fb5872d50e00ee65bf2200e1ebe5122ea#8e60e17fb5872d50e00ee65bf2200e1ebe5122ea"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "e3eb4cf60bab0136b3925fe4795f82f67dad7e49", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "8e60e17fb5872d50e00ee65bf2200e1ebe5122ea", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@8e60e17, fixing an issue with joins providing extra empty rows when `target_partition` in DataFusion config is set to `1` and right input of the join happens to have multiple partitions (e.g. `Union`).
