### PR TITLE
fix(api-gateway): Sanitize query before logging

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1298,7 +1298,7 @@ class ApiGateway {
     this.log({
       type: 'Query Rewrite completed',
       queryRewriteId,
-      normalizedQueries,
+      normalizedQueries: normalizedQueries.map(q => this.sanitizeQueryForLogging(q)),
       duration: Date.now() - startTime,
       query
     }, context);
@@ -1631,7 +1631,7 @@ class ApiGateway {
           this.log({
             type: 'Load Request SQL',
             duration: this.duration(loadRequestSQLStarted),
-            query: normalizedQueries[index],
+            query: this.sanitizeQueryForLogging(normalizedQueries[index]),
             sqlQuery
           }, context);
 
@@ -1640,6 +1640,12 @@ class ApiGateway {
       )
     );
     return sqlQueries;
+  }
+
+  private sanitizeQueryForLogging(query: NormalizedQuery): NormalizedQuery {
+    const res: NormalizedQuery = { ...query };
+    delete res.cacheMode;
+    return res;
   }
 
   /**
@@ -2170,7 +2176,7 @@ class ApiGateway {
 
   public async contextByReq(req: Request, securityContext, requestId: string): Promise<ExtendedRequestContext> {
     req.securityContext = securityContext;
-    
+
     const extensions = typeof this.extendContext === 'function' ? await this.extendContext(req) : {};
 
     return {
@@ -2205,7 +2211,7 @@ class ApiGateway {
     if (e instanceof CubejsHandlerError) {
       this.log({
         type: e.type,
-        query,
+        query: this.sanitizeQueryForLogging(query),
         error: e.message,
         duration: this.duration(requestStarted)
       }, context);
@@ -2213,7 +2219,7 @@ class ApiGateway {
     } else if (e.error === 'Continue wait') {
       this.log({
         type: 'Continue wait',
-        query,
+        query: this.sanitizeQueryForLogging(query),
         error: e.message,
         duration: this.duration(requestStarted),
       }, context);
@@ -2221,7 +2227,7 @@ class ApiGateway {
     } else if (e.error) {
       this.log({
         type: 'Orchestrator error',
-        query,
+        query: this.sanitizeQueryForLogging(query),
         error: e.error,
         duration: this.duration(requestStarted),
       }, context);
@@ -2229,7 +2235,7 @@ class ApiGateway {
     } else if (e.type === 'UserError') {
       this.log({
         type: e.type,
-        query,
+        query: this.sanitizeQueryForLogging(query),
         error: e.message,
         duration: this.duration(requestStarted)
       }, context);


### PR DESCRIPTION
This removes internal service cacheMode property from the query before logging it.

**Check List**
- [x] Tests have been run in packages where changes have been made, if available
- [x] Linter has been run for changed code
