### PR TITLE
feat(cubesql): Coerce strings to any type in functions

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "arrow",
  "chrono",
@@ -840,7 +840,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "arrow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -878,7 +878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=48ff05841a0758bba9d69c4918f724d9515d84a6#48ff05841a0758bba9d69c4918f724d9515d84a6"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=cf034bac8babafdeb56d29a6bf75cbaa7912a8b4#cf034bac8babafdeb56d29a6bf75cbaa7912a8b4"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "48ff05841a0758bba9d69c4918f724d9515d84a6", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "cf034bac8babafdeb56d29a6bf75cbaa7912a8b4", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -18170,4 +18170,14 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
             }
         )
     }
+
+    #[tokio::test]
+    async fn test_coerce_string_to_number() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "coerce_string_to_number",
+            execute_query("SELECT COS('0')".to_string(), DatabaseProtocol::PostgreSQL).await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__coerce_string_to_number.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__coerce_string_to_number.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT COS('0')\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
+---
++----------------+
+| cos(Utf8("0")) |
++----------------+
+| 1              |
++----------------+


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@cf034ba, adding automatic coercion of `Utf8` type to other types in function arguments. This mimics the behavior PostgreSQL uses. Related test is included.
