### PR TITLE
perf(api-gateway): Return granularity hierarchies only related to query time dimensions

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1623,10 +1623,11 @@ class ApiGateway {
       normalizedQueries.map(
         async (normalizedQuery, index) => {
           const loadRequestSQLStarted = new Date();
-          const sqlQuery = await (await this.getCompilerApi(context))
+          const sqlQueryRaw = await (await this.getCompilerApi(context))
             .getSql(
               this.coerceForSqlQuery(normalizedQuery, context)
             );
+          const sqlQuery = this.sanitizeSqlQuery(sqlQueryRaw);
 
           this.log({
             type: 'Load Request SQL',
@@ -1640,6 +1641,26 @@ class ApiGateway {
       )
     );
     return sqlQueries;
+  }
+
+  private sanitizeSqlQuery(sqlQuery: any): any {
+    if (sqlQuery.canUseTransformedQuery) {
+      // Keep only granularityHierarchies related to the query time dimensions
+      const tdArr = sqlQuery.canUseTransformedQuery.timeDimensions.map(([m, _g]) => m);
+      if (tdArr.length > 0) {
+        sqlQuery.canUseTransformedQuery.granularityHierarchies =
+          Object.fromEntries(
+            Object.entries(sqlQuery.canUseTransformedQuery.granularityHierarchies)
+              .filter(
+                ([key]) => tdArr.some((prefix: string) => key.startsWith(prefix))
+              )
+          );
+      } else {
+        sqlQuery.canUseTransformedQuery.granularityHierarchies = {};
+      }
+    }
+
+    return sqlQuery;
   }
 
   private sanitizeQueryForLogging(query: NormalizedQuery): NormalizedQuery {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
