### PR TITLE
fix(schema-compiler): Free jinja instance after compilation

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -532,11 +532,14 @@ export class DataSchemaCompiler {
         if (!this.omitErrors) {
           this.throwIfAnyErrors();
         }
+
         // Free unneeded resources
         this.compileV8ContextCache = null;
         this.cubeDictionary.free();
         this.cubeOnlySymbols.free();
         this.cubeAndViewSymbols.free();
+        this.yamlCompiler.free();
+
         return res;
       });
     }

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -38,6 +38,10 @@ export class YamlCompiler {
   ) {
   }
 
+  public free() {
+    this.jinjaEngine = null;
+  }
+
   public getJinjaEngine(): JinjaEngine {
     if (this.jinjaEngine) {
       return this.jinjaEngine;


### PR DESCRIPTION
Jinja instance stores all templates, because it resolves dependencies inside `minijinja`. If we have at least one jinja file, then compiler load all templates to jinja instance.