### PR TITLE
fix(schema-compiler): Fix datetime tz conversion for Athena/Trino

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/AthenaQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/AthenaQuery.ts
@@ -1,0 +1,9 @@
+import { PrestodbQuery } from './PrestodbQuery';
+
+export class AthenaQuery extends PrestodbQuery {
+  // Athena doesn't require odd prestodb manual datetime offset calculations
+  // as it uses mature timestamps models
+  public override convertTz(field) {
+    return this.timezone ? `CAST((${field} AT TIME ZONE '${this.timezone}') AS TIMESTAMP)` : field;
+  }
+}

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -49,7 +49,7 @@ export class PrestodbQuery extends BaseQuery {
     return `from_iso8601_timestamp(${value})`;
   }
 
-  public convertTz(field) {
+  public override convertTz(field) {
     const atTimezone = `${field} AT TIME ZONE '${this.timezone}'`;
     return this.timezone ?
       `CAST(date_add('minute', timezone_minute(${atTimezone}), date_add('hour', timezone_hour(${atTimezone}), ${field})) AS TIMESTAMP)` :

--- a/packages/cubejs-schema-compiler/src/adapter/QueryBuilder.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/QueryBuilder.ts
@@ -15,6 +15,8 @@ import { SqliteQuery } from './SqliteQuery';
 import { AWSElasticSearchQuery } from './AWSElasticSearchQuery';
 import { ElasticSearchQuery } from './ElasticSearchQuery';
 import { CubeStoreQuery } from './CubeStoreQuery';
+import { AthenaQuery } from './AthenaQuery';
+import { TrinoQuery } from './TrinoQuery';
 
 const ADAPTERS = {
   postgres: PostgresQuery,
@@ -26,7 +28,8 @@ const ADAPTERS = {
   bigquery: BigqueryQuery,
   prestodb: PrestodbQuery,
   qubole_prestodb: PrestodbQuery,
-  athena: PrestodbQuery,
+  athena: AthenaQuery,
+  trino: TrinoQuery,
   vertica: VerticaQuery,
   snowflake: SnowflakeQuery,
   clickhouse: ClickHouseQuery,

--- a/packages/cubejs-schema-compiler/src/adapter/TrinoQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/TrinoQuery.ts
@@ -1,0 +1,9 @@
+import { PrestodbQuery } from './PrestodbQuery';
+
+export class TrinoQuery extends PrestodbQuery {
+  // Trino doesn't require odd prestodb manual datetime offset calculations
+  // as it uses mature timestamps models
+  public override convertTz(field) {
+    return this.timezone ? `CAST((${field} AT TIME ZONE '${this.timezone}') AS TIMESTAMP)` : field;
+  }
+}


### PR DESCRIPTION
Athena and Trino don't require old prestodb hacks for time zone conversion.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
