### PR TITLE
fix(client-core): Fix TypeScript module resolution via `exports.types`

### DIFF
--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -13,6 +13,7 @@
   "typings": "dist/src/index.d.ts",
   "author": "Cube Dev, Inc.",
   "exports": {
+    "types": "./dist/src/index.d.ts",
     "import": "./dist/src/index.js",
     "require": "./dist/cubejs-client-core.cjs.js"
   },


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

https://github.com/cube-js/cube/issues/10015

**Description of Changes Made**

This should fix TypeScript module resolution for apps using `"moduleResolution": "Node16"` or `"moduleResolution": "NodeNext"`.
