### PR TITLE
fix(client-ws-transport): Handle WebSocket close code 1009 (Message T…

### DIFF
--- a/packages/cubejs-client-ws-transport/src/index.ts
+++ b/packages/cubejs-client-ws-transport/src/index.ts
@@ -1,4 +1,6 @@
 import WebSocket from 'isomorphic-ws';
+
+import type { CloseEvent, MessageEvent } from 'ws';
 import type { ITransport, ITransportResponse } from '@cubejs-client/core';
 
 class WebSocketTransportResult {
@@ -132,10 +134,10 @@ class WebSocketTransport implements ITransport<WebSocketTransportResult> {
         ws.sendMessage({ authorization: this.authorization });
       };
 
-      ws.onmessage = (event: any) => {
+      ws.onmessage = (event: MessageEvent) => {
         ws.lastMessageTimestamp = new Date();
 
-        const message: any = JSON.parse(event.data);
+        const message: any = JSON.parse(event.data.toString());
         if (message.handshake) {
           ws.reconcile();
           ws.reconcileTimer = setInterval(() => {
@@ -154,16 +156,37 @@ class WebSocketTransport implements ITransport<WebSocketTransportResult> {
         ws.sendQueue();
       };
 
-      ws.onclose = () => {
+      ws.onclose = (event: CloseEvent) => {
         if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
           ws.close();
         }
+
         if (ws.reconcileTimer) {
           clearInterval(ws.reconcileTimer);
           ws.reconcileTimer = null;
         }
+
         if (this.ws === ws) {
           this.ws = null;
+
+          // Close code 1009: Message Too Big. Server rejects messages exceeding maxPayload
+          // without decoding. Retrying would cause an infinite loop, so we notify subscribers
+          // and clear subscriptions instead.
+          if (event?.code === 1009) {
+            const error = new WebSocketTransportResult({
+              status: 413,
+              message: { error: event?.reason || 'WebSocket message too big' }
+            });
+
+            Object.values(this.messageIdToSubscription).forEach(sub => {
+              sub.callback(error);
+            });
+
+            this.messageIdToSubscription = {};
+
+            return;
+          }
+
           if (Object.keys(this.messageIdToSubscription).length) {
             this.initSocket();
           }


### PR DESCRIPTION
When the server has a low maxPayload limit, and the client sends an oversized message,
the server closes the connection with code 1009 without decoding. Previously,
the client would retry indefinitely, causing an infinite loop.