### PR TITLE
feat(cubesql): Support `STRING_AGG` SQL push down

### DIFF
--- a/packages/cubejs-dremio-driver/driver/DremioQuery.js
+++ b/packages/cubejs-dremio-driver/driver/DremioQuery.js
@@ -163,6 +163,7 @@ class DremioQuery extends BaseQuery {
     // really need the date locale formatting here...
     templates.functions.DATE = 'TO_DATE({{ args_concat }},\'YYYY-MM-DD\', 1)';
     templates.functions.DATEDIFF = 'DATE_DIFF(DATE, DATE_TRUNC(\'{{ date_part }}\', {{ args[1] }}), DATE_TRUNC(\'{{ date_part }}\', {{ args[2] }}))';
+    templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.expressions.interval_single_date_part = 'CAST({{ num }} as INTERVAL {{ date_part }})';
     templates.quotes.identifiers = '"';
     return templates;

--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -63,6 +63,7 @@ export class DuckDBQuery extends BaseQuery {
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
+    templates.functions.STRING_AGG = 'STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}, COALESCE({{ args[1] }}, \'\'))';
     return templates;
   }
 

--- a/packages/cubejs-pinot-driver/src/PinotQuery.ts
+++ b/packages/cubejs-pinot-driver/src/PinotQuery.ts
@@ -141,6 +141,7 @@ export class PinotQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
+    templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.statements.select = 'SELECT {{ select_concat | map(attribute=\'aliased\') | join(\', \') }} \n' +
       'FROM (\n  {{ from }}\n) AS {{ from_alias }} \n' +
       '{% if group_by %} GROUP BY {{ group_by }}{% endif %}' +

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4256,6 +4256,7 @@ export class BaseQuery {
         COVAR_POP: 'COVAR_POP({{ args_concat }})',
         COVAR_SAMP: 'COVAR_SAMP({{ args_concat }})',
         GROUP_ANY: 'max({{ expr }})',
+        STRING_AGG: 'STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})',
         COALESCE: 'COALESCE({{ args_concat }})',
         CONCAT: 'CONCAT({{ args_concat }})',
         FLOOR: 'FLOOR({{ args_concat }})',

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -263,6 +263,7 @@ export class ClickHouseQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
+    templates.functions.STRING_AGG = 'arrayStringConcat(group{% if distinct %}Uniq{% endif %}Array({{ args[0] }}), {{ args[1] }})';
     // TODO: Introduce additional filter in jinja? or parseDateTimeBestEffort?
     // https://github.com/ClickHouse/ClickHouse/issues/19351
     templates.expressions.timestamp_literal = 'parseDateTimeBestEffort(\'{{ value }}\')';

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -246,6 +246,8 @@ export class MssqlQuery extends BaseQuery {
     const templates = super.sqlTemplates();
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
+    // NOTE: MSSQL does not support DISTINCT clause. No workaround is available
+    delete templates.functions.STRING_AGG;
     // PERCENTILE_CONT works but requires PARTITION BY
     delete templates.functions.PERCENTILECONT;
     delete templates.expressions.ilike;

--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -181,6 +181,7 @@ export class MysqlQuery extends BaseQuery {
 
   public sqlTemplates() {
     const templates = super.sqlTemplates();
+    templates.functions.STRING_AGG = 'GROUP_CONCAT({% if distinct %}DISTINCT {% endif %}{{ args[0] }} SEPARATOR {{ args[1] }})';
     // PERCENTILE_CONT works but requires PARTITION BY
     delete templates.functions.PERCENTILECONT;
     templates.quotes.identifiers = '`';

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -139,6 +139,7 @@ export class PrestodbQuery extends BaseQuery {
     templates.functions.DATEDIFF = 'DATE_DIFF(\'{{ date_part }}\', {{ args[1] }}, {{ args[2] }})';
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
     templates.functions.TRUNC = 'TRUNCATE({{ args_concat }})';
+    templates.functions.STRING_AGG = 'ARRAY_JOIN(ARRAY_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}), COALESCE({{ args[1] }}, \'\'))';
     delete templates.functions.PERCENTILECONT;
     templates.statements.select = '{% if ctes %} WITH \n' +
           '{{ ctes | join(\',\n\') }}\n' +

--- a/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.ts
@@ -85,6 +85,7 @@ export class RedshiftQuery extends PostgresQuery {
     const templates = super.sqlTemplates();
     templates.functions.DLOG10 = 'LOG(10, {{ args_concat }})';
     templates.functions.DATEDIFF = 'DATEDIFF({{ date_part }}, {{ args[1] }}, {{ args[2] }})';
+    templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.statements.time_series_select = 'SELECT dates.f::timestamp date_from, dates.t::timestamp date_to \n' +
     'FROM (\n' +
     '{% for time_item in seria  %}' +

--- a/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
@@ -112,6 +112,7 @@ export class SnowflakeQuery extends BaseQuery {
     templates.functions.DLOG10 = 'LOG(10, {{ args_concat }})';
     templates.functions.CHARACTERLENGTH = 'LENGTH({{ args[0] }})';
     templates.functions.BTRIM = 'TRIM({{ args_concat }})';
+    templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
     templates.expressions.interval = 'INTERVAL \'{{ interval }}\'';
     templates.expressions.timestamp_literal = '\'{{ value }}\'::timestamp_tz';

--- a/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/mod.rs
@@ -1491,6 +1491,14 @@ fn udaf_expr_var_arg(
     )
 }
 
+fn udaf_fun_expr_args(left: impl Display, right: impl Display) -> String {
+    format!("(AggregateUDFExprArgs {} {})", left, right)
+}
+
+fn udaf_fun_expr_args_empty_tail() -> String {
+    "AggregateUDFExprArgs".to_string()
+}
+
 fn limit(skip: impl Display, fetch: impl Display, input: impl Display) -> String {
     format!("(Limit {} {} {})", skip, fetch, input)
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/mod.rs
@@ -24,6 +24,7 @@ mod projection;
 mod scalar_function;
 mod sort_expr;
 mod subquery;
+mod udaf_function;
 mod udf_function;
 mod window;
 mod window_function;
@@ -76,6 +77,7 @@ impl RewriteRules for WrapperRules {
         self.window_function_rules(&mut rules);
         self.scalar_function_rules(&mut rules);
         self.udf_function_rules(&mut rules);
+        self.udaf_function_rules(&mut rules);
         self.extract_rules(&mut rules);
         self.alias_rules(&mut rules);
         self.case_rules(&mut rules);

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/udaf_function.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/udaf_function.rs
@@ -1,0 +1,111 @@
+use crate::{
+    compile::rewrite::{
+        rewrite,
+        rewriter::{CubeEGraph, CubeRewrite},
+        rules::wrapper::WrapperRules,
+        transforming_rewrite, udaf_expr_var_arg, udaf_fun_expr_args, udaf_fun_expr_args_empty_tail,
+        wrapper_pullup_replacer, wrapper_pushdown_replacer, wrapper_replacer_context,
+        AggregateUDFExprFun,
+    },
+    var, var_iter,
+};
+use egg::Subst;
+
+impl WrapperRules {
+    pub fn udaf_function_rules(&self, rules: &mut Vec<CubeRewrite>) {
+        rules.extend(vec![
+            rewrite(
+                "wrapper-push-down-udaf",
+                wrapper_pushdown_replacer(
+                    udaf_expr_var_arg("?fun", "?args", "?distinct"),
+                    "?context",
+                ),
+                udaf_expr_var_arg(
+                    "?fun",
+                    wrapper_pushdown_replacer("?args", "?context"),
+                    "?distinct",
+                ),
+            ),
+            transforming_rewrite(
+                "wrapper-pull-up-udaf",
+                udaf_expr_var_arg(
+                    "?fun",
+                    wrapper_pullup_replacer(
+                        "?args",
+                        wrapper_replacer_context(
+                            "?alias_to_cube",
+                            "?push_to_cube",
+                            "?in_projection",
+                            "?cube_members",
+                            "?grouped_subqueries",
+                            "?ungrouped_scan",
+                            "?input_data_source",
+                        ),
+                    ),
+                    "?distinct",
+                ),
+                wrapper_pullup_replacer(
+                    udaf_expr_var_arg("?fun", "?args", "?distinct"),
+                    wrapper_replacer_context(
+                        "?alias_to_cube",
+                        "?push_to_cube",
+                        "?in_projection",
+                        "?cube_members",
+                        "?grouped_subqueries",
+                        "?ungrouped_scan",
+                        "?input_data_source",
+                    ),
+                ),
+                self.transform_udaf_expr("?fun", "?input_data_source"),
+            ),
+            rewrite(
+                "wrapper-push-down-udaf-args",
+                wrapper_pushdown_replacer(udaf_fun_expr_args("?left", "?right"), "?context"),
+                udaf_fun_expr_args(
+                    wrapper_pushdown_replacer("?left", "?context"),
+                    wrapper_pushdown_replacer("?right", "?context"),
+                ),
+            ),
+            rewrite(
+                "wrapper-pull-up-udaf-args",
+                udaf_fun_expr_args(
+                    wrapper_pullup_replacer("?left", "?context"),
+                    wrapper_pullup_replacer("?right", "?context"),
+                ),
+                wrapper_pullup_replacer(udaf_fun_expr_args("?left", "?right"), "?context"),
+            ),
+            rewrite(
+                "wrapper-push-down-udaf-empty-tail",
+                wrapper_pushdown_replacer(udaf_fun_expr_args_empty_tail(), "?context"),
+                wrapper_pullup_replacer(udaf_fun_expr_args_empty_tail(), "?context"),
+            ),
+        ]);
+    }
+
+    fn transform_udaf_expr(
+        &self,
+        fun_var: &'static str,
+        input_data_source_var: &'static str,
+    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let fun_var = var!(fun_var);
+        let input_data_source_var = var!(input_data_source_var);
+        let meta = self.meta_context.clone();
+        move |egraph, subst| {
+            let Ok(data_source) = Self::get_data_source(egraph, subst, input_data_source_var)
+            else {
+                return false;
+            };
+
+            for fun in var_iter!(egraph[subst[fun_var]], AggregateUDFExprFun).cloned() {
+                if Self::can_rewrite_template(
+                    &data_source,
+                    &meta,
+                    &format!("functions/{}", fun.to_uppercase()),
+                ) {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -626,6 +626,7 @@ pub fn sql_generator(
                     ),
                     ("functions/AVG".to_string(), "AVG({{ args_concat }})".to_string()),
                     ("functions/APPROXDISTINCT".to_string(), "COUNTDISTINCTAPPROX({{ args_concat }})".to_string()),
+                    ("functions/STRING_AGG".to_string(), "STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})".to_string()),
                     ("functions/DATETRUNC".to_string(), "DATE_TRUNC({{ args_concat }})".to_string()),
                     ("functions/DATEPART".to_string(), "DATE_PART({{ args_concat }})".to_string()),
                     ("functions/FLOOR".to_string(), "FLOOR({{ args_concat }})".to_string()),

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -8,6 +8,7 @@ use datafusion::{
         datatypes::{DataType, SchemaRef},
         record_batch::RecordBatch,
     },
+    logical_expr::AggregateUDF,
     logical_plan::window_frames::{WindowFrame, WindowFrameBound, WindowFrameUnits},
     physical_plan::{aggregates::AggregateFunction, windows::WindowFunction},
 };
@@ -412,6 +413,10 @@ impl SqlTemplates {
         aggregate_function.to_string()
     }
 
+    pub fn udaf_function_name(&self, udaf: &AggregateUDF, _distinct: bool) -> String {
+        udaf.name.to_ascii_uppercase()
+    }
+
     pub fn select(
         &self,
         from: String,
@@ -581,6 +586,20 @@ impl SqlTemplates {
         self.render_template(
             "expressions/within_group",
             context! { fun_sql => sql, within_group_concat => within_group_concat },
+        )
+    }
+
+    pub fn udaf_function(
+        &self,
+        udaf: &AggregateUDF,
+        args: Vec<String>,
+        distinct: bool,
+    ) -> Result<String, CubeError> {
+        let function = self.udaf_function_name(udaf, distinct);
+        let args_concat = args.join(", ");
+        self.render_template(
+            &format!("functions/{}", function),
+            context! { args_concat => args_concat, args => args, distinct => distinct },
         )
     }
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR adds support for aggregate UDF SQL push down, and marks `STRING_AGG` the first UDAF supporting SQL push down, including `DISTINCT` clause. Related test is included.
