### PR TITLE
fix(snowflake-driver): Fix type mapping for `fixed` type

### DIFF
--- a/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
+++ b/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
@@ -100,6 +100,9 @@ const SnowflakeToGenericType: Record<string, GenericDataBaseType> = {
   // It's a limitation for now, because anyway we don't work with JSON objects in Cube Store.
   object: 'HLL_SNOWFLAKE',
   number: 'decimal',
+  // For some reason, snowflake SDK returns `fixed` type for DWH types like NUMBER(38, 15)
+  // @see https://docs.snowflake.com/en/sql-reference/data-types-numeric for more info on types
+  fixed: 'decimal',
   timestamp_ntz: 'timestamp'
 };
 


### PR DESCRIPTION
For some reason, snowflake SDK returns `fixed` type for DWH types like NUMBER(38, 15)