### PR TITLE
feat: Migrate from rust-s3 fork to official AWS SDK for Rust

### DIFF
--- a/rust/cubestore/Cargo.lock
+++ b/rust/cubestore/Cargo.lock
@@ -5483,8 +5483,8 @@ dependencies = [
 
 [[package]]
 name = "rust-s3"
-version = "0.32.3"
-source = "git+https://github.com/cube-js/rust-s3.git?rev=c662b9c66c2929da185c46084fc5f455030ad75f#c662b9c66c2929da185c46084fc5f455030ad75f"
+version = "0.37.1"
+source = "git+https://github.com/durch/rust-s3.git?tag=v0.37.1#db637a9264eec8e1c10d09ef2b0adecf994b490a"
 dependencies = [
  "async-trait",
  "aws-creds",
@@ -5508,6 +5508,46 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "url",
+]
+
+[[package]]
+name = "aws-config"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc2c34dbe583a282e583a81e5abc717e0eaf19dd1e8d369178994c11eae186c"
+dependencies = [
+ "aws-credential-provider-chain",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-types",
+ "tokio",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e72e78b0f8c5b3b0d4c5c3c5e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e"
+dependencies = [
+ "aws-credential-provider-chain",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "futures-util",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/rust/cubestore/cubestore/Cargo.toml
+++ b/rust/cubestore/cubestore/Cargo.toml
@@ -58,12 +58,8 @@ async-stream = "0.3.6"
 indexmap = "2.10.0"
 itertools = "0.14.0"
 bigdecimal = { version = "0.2.0", features = ["serde"] }
-# Right now, it's not possible to use the 0.33 release because it has bugs
-# At the same time, 0.34-rc has a problem with large files uploading because it doesn't control number of parallels put(s)
-# Tracking PR with backports: https://github.com/cube-js/rust-s3/pull/1
-# The fork also includes a fix for AWS_STS_REGIONAL_ENDPOINTS
-# See https://github.com/cube-js/rust-s3/pull/1/commits for more details
-rust-s3 = { git = "https://github.com/cube-js/rust-s3.git", rev = "c662b9c66c2929da185c46084fc5f455030ad75f", default-features = false, features = ["tokio", "tokio-native-tls"] }
+aws-config = "1.1"
+aws-sdk-s3 = "1.27"
 deadqueue = "0.2.4"
 reqwest = { version = "0.12.5", features = ["json", "rustls-tls", "stream", "http2"], default-features = false }
 nanoid = "0.3.0"


### PR DESCRIPTION
- Replace rust-s3 fork dependency with aws-config and aws-sdk-s3
- Refactor S3RemoteFs to use AWS SDK client instead of Bucket wrapper
- Remove manual credential refresh loop - AWS SDK handles automatically
- Update all S3 operations: put_object, get_object, delete_object, list_objects_v2
- Simplify credential chain by leveraging AWS SDK's built-in providers
- No breaking changes to RemoteFs and ExtendedRemoteFs interfaces

Benefits:
- Removes fork maintenance burden
- Better automatic credential handling
- Cleaner, more maintainable code
- Uses officially maintained library

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
