### PR TITLE
fix(postgres-driver): handle connection termination errors gracefully

### DIFF
--- a/packages/cubejs-questdb-driver/src/QuestDriver.ts
+++ b/packages/cubejs-questdb-driver/src/QuestDriver.ts
@@ -99,7 +99,7 @@ export class QuestDriver<Config extends QuestDriverConfiguration = QuestDriverCo
       ...config
     });
     this.pool.on('error', (err) => {
-      console.log(`Unexpected error on idle client: ${err.stack || err}`);
+      this.databasePoolError(err);
     });
     this.config = <Partial<Config>>{
       ...this.getInitialConfiguration(),
@@ -143,6 +143,13 @@ export class QuestDriver<Config extends QuestDriverConfiguration = QuestDriverCo
 
   private async queryResponse(query: string, values: unknown[]) {
     const conn = await this.pool.connect();
+
+    // Attach error handler to the client to prevent unhandled error events
+    // from crashing the process when connections are terminated unexpectedly.
+    // See: https://github.com/brianc/node-postgres/issues/2112
+    conn.on('error', (err) => {
+      this.databasePoolError(err);
+    });
 
     try {
       const res = await conn.query({


### PR DESCRIPTION
Add error handlers to pool clients to prevent unhandled error events from crashing the process when PostgreSQL connections are terminated unexpectedly (e.g., when max connections are reached).

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Issue Reference this PR resolves**

Fixes #10142

**Conversation with Claude**

[claude.txt](https://github.com/user-attachments/files/24295250/claude.txt)
