### PR TITLE
feat(doris-driver): Add Apache Doris database driver

### DIFF
--- a/packages/cubejs-doris-driver/index.js
+++ b/packages/cubejs-doris-driver/index.js
@@ -1,0 +1,15 @@
+const fromExports = require('./dist/src');
+const { DorisDriver } = require('./dist/src/DorisDriver');
+
+/**
+ * After 5 years working with TypeScript, now I know
+ * that commonjs and nodejs require is not compatibility with using export default
+ */
+const toExport = DorisDriver;
+
+// eslint-disable-next-line no-restricted-syntax
+for (const [key, module] of Object.entries(fromExports)) {
+  toExport[key] = module;
+}
+
+module.exports = toExport;

--- a/packages/cubejs-doris-driver/jest.config.js
+++ b/packages/cubejs-doris-driver/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.base.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...base,
+  rootDir: '.',
+};

--- a/packages/cubejs-doris-driver/package.json
+++ b/packages/cubejs-doris-driver/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@cubejs-backend/doris-driver",
+  "description": "Cube.js Apache Doris database driver",
+  "author": "Cube Dev, Inc.",
+  "version": "1.6.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cube-js/cube.git",
+    "directory": "packages/cubejs-doris-driver"
+  },
+  "engines": {
+    "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
+  },
+  "files": [
+    "dist/src",
+    "index.js"
+  ],
+  "main": "index.js",
+  "typings": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist && npm run tsc",
+    "tsc": "tsc",
+    "watch": "tsc -w",
+    "integration": "npm run integration:doris",
+    "integration:doris": "jest --verbose dist/test",
+    "lint": "eslint src/* test/* --ext .ts,.js",
+    "lint:fix": "eslint --fix src/* test/* --ext .ts,.js"
+  },
+  "dependencies": {
+    "@cubejs-backend/base-driver": "1.6.1",
+    "@cubejs-backend/shared": "1.6.1",
+    "generic-pool": "^3.9.0",
+    "mysql": "^2.18.1"
+  },
+  "devDependencies": {
+    "@cubejs-backend/linter": "1.6.1",
+    "@cubejs-backend/testing-shared": "1.6.1",
+    "@types/jest": "^29",
+    "@types/mysql": "^2.15.21",
+    "jest": "^29",
+    "stream-to-array": "^2.3.0",
+    "testcontainers": "^10.28.0",
+    "typescript": "~5.2.2"
+  },
+  "eslintConfig": {
+    "extends": "../cubejs-linter"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cubejs-doris-driver/src/DorisDriver.ts
+++ b/packages/cubejs-doris-driver/src/DorisDriver.ts
@@ -1,0 +1,540 @@
+/**
+ * @copyright Cube Dev, Inc.
+ * @license Apache-2.0
+ * @fileoverview The `DorisDriver` and related types declaration.
+ */
+
+import {
+  getEnv,
+  assertDataSource,
+} from '@cubejs-backend/shared';
+import mysql, { Connection, ConnectionConfig, FieldInfo, QueryOptions } from 'mysql';
+import genericPool from 'generic-pool';
+import { promisify } from 'util';
+import {
+  BaseDriver,
+  GenericDataBaseType,
+  DriverInterface,
+  StreamOptions,
+  DownloadQueryResultsOptions,
+  TableStructure,
+  DownloadTableData,
+  IndexesSQL,
+  DownloadTableMemoryData,
+  DriverCapabilities,
+  TableColumn,
+} from '@cubejs-backend/base-driver';
+
+/**
+ * Doris type mappings: Generic types -> Doris SQL types
+ */
+const GenericTypeToDoris: Record<GenericDataBaseType, string> = {
+  string: 'varchar(255)',
+  text: 'varchar(255)',
+  decimal: 'decimal(38,10)',
+};
+
+/**
+ * MySQL Native types -> SQL type
+ * @link https://github.com/mysqljs/mysql/blob/master/lib/protocol/constants/types.js#L9
+ */
+const MySqlNativeToMySqlType: Record<number, string> = {
+  [mysql.Types.DECIMAL]: 'decimal',
+  [mysql.Types.NEWDECIMAL]: 'decimal',
+  [mysql.Types.TINY]: 'tinyint',
+  [mysql.Types.SHORT]: 'smallint',
+  [mysql.Types.LONG]: 'int',
+  [mysql.Types.INT24]: 'mediumint',
+  [mysql.Types.LONGLONG]: 'bigint',
+  [mysql.Types.NEWDATE]: 'datetime',
+  [mysql.Types.TIMESTAMP2]: 'timestamp',
+  [mysql.Types.DATETIME2]: 'datetime',
+  [mysql.Types.TIME2]: 'time',
+  [mysql.Types.TINY_BLOB]: 'tinytext',
+  [mysql.Types.MEDIUM_BLOB]: 'mediumtext',
+  [mysql.Types.LONG_BLOB]: 'longtext',
+  [mysql.Types.BLOB]: 'text',
+  [mysql.Types.VAR_STRING]: 'varchar',
+  [mysql.Types.STRING]: 'varchar',
+};
+
+/**
+ * Doris SQL types -> Generic types
+ * Includes both MySQL-compatible types and Doris-specific types
+ */
+const DorisToGenericType: Record<string, GenericDataBaseType> = {
+  // Doris-specific types
+  largeint: 'bigint',
+  datev2: 'date',
+  datetimev2: 'timestamp',
+  string: 'text',
+  // MySQL-compatible types
+  mediumtext: 'text',
+  longtext: 'text',
+  text: 'text',
+  tinytext: 'text',
+  mediumint: 'int',
+  smallint: 'int',
+  bigint: 'int',
+  tinyint: 'int',
+  'mediumint unsigned': 'int',
+  'smallint unsigned': 'int',
+  'bigint unsigned': 'int',
+  'tinyint unsigned': 'int',
+  int: 'int',
+  'int unsigned': 'int',
+  boolean: 'boolean',
+  bool: 'boolean',
+  char: 'text',
+  varchar: 'text',
+  date: 'date',
+  datetime: 'timestamp',
+  timestamp: 'timestamp',
+};
+
+export interface DorisDriverConfiguration extends ConnectionConfig {
+  readOnly?: boolean;
+  loadPreAggregationWithoutMetaLock?: boolean;
+  storeTimezone?: string;
+  pool?: any;
+}
+
+interface DorisConnection extends Connection {
+  execute: (options: string | QueryOptions, values?: any) => Promise<any>;
+}
+
+/**
+ * Apache Doris driver class.
+ * Doris is MySQL protocol compatible, so we use the mysql npm package.
+ */
+export class DorisDriver extends BaseDriver implements DriverInterface {
+  /**
+   * Returns default concurrency value.
+   */
+  public static getDefaultConcurrency(): number {
+    return 2;
+  }
+
+  protected readonly config: DorisDriverConfiguration;
+
+  protected readonly pool: genericPool.Pool<DorisConnection>;
+
+  /**
+   * Class constructor.
+   */
+  public constructor(
+    config: DorisDriverConfiguration & {
+      /**
+       * Data source name.
+       */
+      dataSource?: string;
+
+      /**
+       * Max pool size value for the [cube]<-->[db] pool.
+       */
+      maxPoolSize?: number;
+
+      /**
+       * Time to wait for a response from a connection after validation
+       * request before determining it as not valid. Default - 10000 ms.
+       */
+      testConnectionTimeout?: number;
+    } = {}
+  ) {
+    super({
+      testConnectionTimeout: config.testConnectionTimeout,
+    });
+
+    const dataSource = config.dataSource || assertDataSource('default');
+
+    const { pool, ...restConfig } = config;
+    this.config = {
+      host: getEnv('dbHost', { dataSource }),
+      database: getEnv('dbName', { dataSource }),
+      // Doris FE uses port 9030 for MySQL protocol
+      port: getEnv('dbPort', { dataSource }) || 9030,
+      user: getEnv('dbUser', { dataSource }),
+      password: getEnv('dbPass', { dataSource }),
+      socketPath: getEnv('dbSocketPath', { dataSource }),
+      timezone: 'Z',
+      ssl: this.getSslOptions(dataSource),
+      dateStrings: true,
+      readOnly: true,
+      ...restConfig,
+    };
+
+    this.pool = genericPool.createPool(
+      {
+        create: async () => {
+          const conn: any = mysql.createConnection(this.config);
+          const connect = promisify(conn.connect.bind(conn));
+
+          if (conn.on) {
+            conn.on('error', () => {
+              conn.destroy();
+            });
+          }
+          conn.execute = promisify(conn.query.bind(conn));
+
+          await connect();
+
+          return conn;
+        },
+        validate: async (connection) => {
+          try {
+            await connection.execute('SELECT 1');
+          } catch (e) {
+            this.databasePoolError(e);
+            return false;
+          }
+          return true;
+        },
+        destroy: (connection) => promisify(connection.end.bind(connection))(),
+      },
+      {
+        min: 0,
+        max: config.maxPoolSize || getEnv('dbMaxPoolSize', { dataSource }) || 8,
+        evictionRunIntervalMillis: 10000,
+        softIdleTimeoutMillis: 30000,
+        idleTimeoutMillis: 30000,
+        testOnBorrow: true,
+        acquireTimeoutMillis: 60000,
+        ...pool,
+      }
+    );
+  }
+
+  /**
+   * Query for primary keys in the database.
+   * Doris uses Unique Key model for primary keys.
+   */
+  protected primaryKeysQuery(conditionString?: string): string | null {
+    return `SELECT
+      TABLE_SCHEMA as ${this.quoteIdentifier('table_schema')},
+      TABLE_NAME as ${this.quoteIdentifier('table_name')},
+      COLUMN_NAME as ${this.quoteIdentifier('column_name')}
+  FROM
+      information_schema.KEY_COLUMN_USAGE
+  WHERE
+      CONSTRAINT_NAME = 'PRIMARY'
+      AND TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
+      ${conditionString ? ` AND (${conditionString})` : ''}
+  ORDER BY
+      TABLE_SCHEMA,
+      TABLE_NAME,
+      ORDINAL_POSITION;`;
+  }
+
+  /**
+   * Query for foreign keys.
+   * Apache Doris does not support foreign keys, so return null.
+   */
+  protected foreignKeysQuery(_conditionString?: string): string | null {
+    return null;
+  }
+
+  public readOnly() {
+    return !!this.config.readOnly;
+  }
+
+  protected withConnection(fn: (conn: DorisConnection) => Promise<any>) {
+    const self = this;
+    const connectionPromise = this.pool.acquire();
+
+    let cancelled = false;
+    const cancelObj: any = {};
+
+    const promise: any = connectionPromise.then(async (conn) => {
+      const [{ connectionId }] = await conn.execute(
+        'select connection_id() as connectionId'
+      );
+      cancelObj.cancel = async () => {
+        cancelled = true;
+        await self.withConnection(async (processConnection) => {
+          await processConnection.execute(`KILL ${connectionId}`);
+        });
+      };
+      return fn(conn)
+        .then((res) => this.pool.release(conn).then(() => {
+          if (cancelled) {
+            throw new Error('Query cancelled');
+          }
+          return res;
+        }))
+        .catch((err) => this.pool.release(conn).then(() => {
+          if (cancelled) {
+            throw new Error('Query cancelled');
+          }
+          throw err;
+        }));
+    });
+    promise.cancel = () => cancelObj.cancel();
+    return promise;
+  }
+
+  public async testConnection() {
+    // eslint-disable-next-line no-underscore-dangle
+    const conn: DorisConnection = await (<any> this.pool)._factory.create();
+
+    try {
+      return await conn.execute('SELECT 1');
+    } finally {
+      // eslint-disable-next-line no-underscore-dangle
+      await (<any> this.pool)._factory.destroy(conn);
+    }
+  }
+
+  /**
+   * Creates a table with the given columns.
+   * Validates table name length (Doris has 64 character limit).
+   */
+  public async createTable(
+    quotedTableName: string,
+    columns: TableColumn[]
+  ): Promise<void> {
+    if (quotedTableName.length > 64) {
+      throw new Error(
+        'Doris cannot work with table names longer than 64 characters. ' +
+          `Consider using the 'sqlAlias' attribute in your cube definition for ${quotedTableName}.`
+      );
+    }
+    return super.createTable(quotedTableName, columns);
+  }
+
+  public async query(query: string, values: unknown[]) {
+    return this.withConnection(async (conn) => {
+      await this.setTimeZone(conn);
+
+      return conn.execute(query, values);
+    });
+  }
+
+  protected setTimeZone(conn: DorisConnection) {
+    return conn.execute(
+      `SET time_zone = '${this.config.storeTimezone || '+00:00'}'`,
+      []
+    );
+  }
+
+  public async release() {
+    await this.pool.drain();
+    await this.pool.clear();
+  }
+
+  public informationSchemaQuery() {
+    return `${super.informationSchemaQuery()} AND columns.table_schema = '${this.config.database}'`;
+  }
+
+  public quoteIdentifier(identifier: string) {
+    return `\`${identifier}\``;
+  }
+
+  public fromGenericType(columnType: GenericDataBaseType) {
+    return GenericTypeToDoris[columnType] || super.fromGenericType(columnType);
+  }
+
+  public loadPreAggregationIntoTable(
+    preAggregationTableName: string,
+    loadSql: any,
+    params: any,
+    tx: any
+  ) {
+    if (this.config.loadPreAggregationWithoutMetaLock) {
+      return this.cancelCombinator(async (saveCancelFn: any) => {
+        await saveCancelFn(this.query(`${loadSql} LIMIT 0`, params));
+        await saveCancelFn(
+          this.query(
+            loadSql.replace(/^CREATE TABLE (\S+) AS/i, 'INSERT INTO $1'),
+            params
+          )
+        );
+      });
+    }
+
+    return super.loadPreAggregationIntoTable(
+      preAggregationTableName,
+      loadSql,
+      params,
+      tx
+    );
+  }
+
+  public async stream(
+    query: string,
+    values: unknown[],
+    { highWaterMark }: StreamOptions
+  ) {
+    // eslint-disable-next-line no-underscore-dangle
+    const conn: DorisConnection = await (<any> this.pool)._factory.create();
+
+    try {
+      await this.setTimeZone(conn);
+
+      const [rowStream, fields] = await new Promise<[any, mysql.FieldInfo[]]>(
+        (resolve, reject) => {
+          const stream = conn.query(query, values).stream({ highWaterMark });
+
+          stream.on('fields', (f) => {
+            resolve([stream, f]);
+          });
+          stream.on('error', (e) => {
+            reject(e);
+          });
+        }
+      );
+
+      return {
+        rowStream,
+        types: this.mapFieldsToGenericTypes(fields),
+        release: async () => {
+          // eslint-disable-next-line no-underscore-dangle
+          await (<any> this.pool)._factory.destroy(conn);
+        },
+      };
+    } catch (e) {
+      // eslint-disable-next-line no-underscore-dangle
+      await (<any> this.pool)._factory.destroy(conn);
+
+      throw e;
+    }
+  }
+
+  protected mapFieldsToGenericTypes(fields: mysql.FieldInfo[]) {
+    return fields.map((field) => {
+      // @ts-ignore
+      let dbType = mysql.Types[field.type];
+
+      if (field.type in MySqlNativeToMySqlType) {
+        // @ts-ignore
+        dbType = MySqlNativeToMySqlType[field.type];
+      }
+
+      return {
+        name: field.name,
+        type: this.toGenericType(dbType),
+      };
+    });
+  }
+
+  public async downloadQueryResults(
+    query: string,
+    values: unknown[],
+    options: DownloadQueryResultsOptions
+  ) {
+    if ((options || {}).streamImport) {
+      return this.stream(query, values, options);
+    }
+
+    return this.withConnection(async (conn) => {
+      await this.setTimeZone(conn);
+
+      return new Promise((resolve, reject) => {
+        conn.query(query, values, (err, rows, fields) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve({
+              rows,
+              types: this.mapFieldsToGenericTypes(<FieldInfo[]>fields),
+            });
+          }
+        });
+      });
+    });
+  }
+
+  public toColumnValue(value: any, genericType: GenericDataBaseType) {
+    if (genericType === 'timestamp' && typeof value === 'string') {
+      return value && value.replace('Z', '');
+    }
+    if (genericType === 'boolean' && typeof value === 'string') {
+      if (value.toLowerCase() === 'true') {
+        return true;
+      }
+      if (value.toLowerCase() === 'false') {
+        return false;
+      }
+    }
+    return super.toColumnValue(value, genericType);
+  }
+
+  protected isDownloadTableDataRow(
+    tableData: DownloadTableData
+  ): tableData is DownloadTableMemoryData {
+    return (<DownloadTableMemoryData>tableData).rows !== undefined;
+  }
+
+  public async uploadTableWithIndexes(
+    table: string,
+    columns: TableStructure,
+    tableData: DownloadTableData,
+    indexesSql: IndexesSQL
+  ) {
+    if (!this.isDownloadTableDataRow(tableData)) {
+      throw new Error(`${this.constructor} driver supports only rows upload`);
+    }
+
+    await this.createTable(table, columns);
+
+    try {
+      const batchSize = 1000;
+      for (let j = 0; j < Math.ceil(tableData.rows.length / batchSize); j++) {
+        const currentBatchSize = Math.min(
+          tableData.rows.length - j * batchSize,
+          batchSize
+        );
+        const indexArray = Array.from(
+          { length: currentBatchSize },
+          (v, i) => i
+        );
+        const valueParamPlaceholders = indexArray
+          .map(
+            (i) => `(${columns
+              .map((c, paramIndex) => this.param(paramIndex + i * columns.length))
+              .join(', ')})`
+          )
+          .join(', ');
+        const params = indexArray
+          .map((i) => columns.map((c) => this.toColumnValue(tableData.rows[i + j * batchSize][c.name], c.type)))
+          .reduce((a, b) => a.concat(b), []);
+
+        await this.query(
+          `INSERT INTO ${table}
+        (${columns.map((c) => this.quoteIdentifier(c.name)).join(', ')})
+        VALUES ${valueParamPlaceholders}`,
+          params
+        );
+      }
+
+      for (let i = 0; i < indexesSql.length; i++) {
+        const [query, p] = indexesSql[i].sql;
+        await this.query(query, p);
+      }
+    } catch (e) {
+      await this.dropTable(table);
+      throw e;
+    }
+  }
+
+  public override async tableColumnTypes(table: string): Promise<TableStructure> {
+    return this.tableColumnTypesWithPrecision(table);
+  }
+
+  protected override toGenericType(
+    columnType: string,
+    precision?: number | null,
+    scale?: number | null
+  ): GenericDataBaseType {
+    return (
+      DorisToGenericType[columnType.toLowerCase()] ||
+      DorisToGenericType[columnType.toLowerCase().split('(')[0]] ||
+      super.toGenericType(columnType, precision, scale)
+    );
+  }
+
+  public capabilities(): DriverCapabilities {
+    return {
+      incrementalSchemaLoading: true,
+    };
+  }
+}

--- a/packages/cubejs-doris-driver/src/index.ts
+++ b/packages/cubejs-doris-driver/src/index.ts
@@ -1,0 +1,5 @@
+import { DorisDriver } from './DorisDriver';
+
+export * from './DorisDriver';
+
+export default DorisDriver;

--- a/packages/cubejs-doris-driver/test/doris.db.runner.ts
+++ b/packages/cubejs-doris-driver/test/doris.db.runner.ts
@@ -1,0 +1,15 @@
+import { StartedTestContainer } from 'testcontainers';
+
+import { DorisDriver } from '../src/DorisDriver';
+
+/**
+ * Creates a DorisDriver instance for testing.
+ * Since Doris is MySQL-compatible, we can use a MySQL container for unit tests.
+ */
+export const createDriver = (c: StartedTestContainer) => new DorisDriver({
+  host: c.getHost(),
+  user: 'root',
+  password: process.env.TEST_DB_PASSWORD || 'Test1test',
+  port: c.getMappedPort(3306),
+  database: 'mysql',
+});

--- a/packages/cubejs-doris-driver/tsconfig.json
+++ b/packages/cubejs-doris-driver/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src",
+    "test"
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+  }
+}

--- a/packages/cubejs-schema-compiler/src/adapter/QueryBuilder.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/QueryBuilder.ts
@@ -41,6 +41,7 @@ const ADAPTERS = {
   elasticsearch: ElasticSearchQuery,
   materialize: PostgresQuery,
   cubestore: CubeStoreQuery,
+  doris: MysqlQuery,
 };
 
 export const queryClass = (dbType: string, dialectClass) => dialectClass || ADAPTERS[dbType];

--- a/packages/cubejs-server-core/src/core/DriverDependencies.ts
+++ b/packages/cubejs-server-core/src/core/DriverDependencies.ts
@@ -32,6 +32,7 @@ const DriverDependencies: Record<DatabaseType, string> = {
   pinot: '@cubejs-backend/pinot-driver',
   // List for JDBC drivers
   'databricks-jdbc': '@cubejs-backend/databricks-jdbc-driver',
+  doris: '@cubejs-backend/doris-driver',
 };
 
 export default DriverDependencies;

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -130,7 +130,8 @@ export type DatabaseType =
   | 'duckdb'
   | 'ksql'
   | 'vertica'
-  | 'databricks-jdbc';
+  | 'databricks-jdbc'
+  | 'doris';
 
 export type ContextToAppIdFn = (context: RequestContext) => string | Promise<string>;
 export type ContextToRolesFn = (context: RequestContext) => string[] | Promise<string[]>;

--- a/packages/cubejs-testing-shared/src/db-container-runners/doris.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/doris.ts
@@ -1,0 +1,43 @@
+import { GenericContainer, Wait } from 'testcontainers';
+
+import { DbRunnerAbstract, DBRunnerContainerOptions } from './db-runner.abstract';
+
+/**
+ * DorisDBRunner for testing Apache Doris.
+ * Since Doris requires a complex FE/BE setup, we use MySQL container as a stand-in
+ * for unit/integration tests (Doris is MySQL protocol compatible).
+ */
+export class DorisDBRunner extends DbRunnerAbstract {
+  public static startContainer(options: DBRunnerContainerOptions) {
+    const version = process.env.TEST_MYSQL_VERSION || options.version || '8.0';
+
+    const container = new GenericContainer(`mysql:${version}`)
+      .withEnvironment({
+        MYSQL_ROOT_PASSWORD: process.env.TEST_DB_PASSWORD || 'Test1test',
+      })
+      .withHealthCheck({
+        test: ['CMD-SHELL', 'mysqladmin ping -h localhost'],
+        interval: 5 * 1000,
+        timeout: 2 * 1000,
+        retries: 3,
+        startPeriod: 10 * 1000,
+      })
+      .withWaitStrategy(Wait.forHealthCheck())
+      .withExposedPorts(3306);
+
+    if (version.split('.')[0] === '8') {
+      /**
+       * workaround for MySQL 8 and unsupported auth in mysql package
+       * @link https://github.com/mysqljs/mysql/pull/2233
+       */
+      container.withCommand(['--default-authentication-plugin=mysql_native_password']);
+    }
+
+    if (options.volumes) {
+      const binds = options.volumes.map(v => ({ source: v.source, target: v.target, mode: v.bindMode }));
+      container.withBindMounts(binds);
+    }
+
+    return container.start();
+  }
+}

--- a/packages/cubejs-testing-shared/src/db-container-runners/index.ts
+++ b/packages/cubejs-testing-shared/src/db-container-runners/index.ts
@@ -12,3 +12,4 @@ export * from './trino';
 export * from './oracle';
 export * from './kafka';
 export * from './ksql';
+export * from './doris';

--- a/packages/cubejs-testing/birdbox-fixtures/doris/schema/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/doris/schema/Orders.js
@@ -1,0 +1,33 @@
+cube('Orders', {
+  sql: `
+    select 1 as id, 100 as amount, 'new' status
+    UNION ALL
+    select 2 as id, 200 as amount, 'new' status
+    UNION ALL
+    select 3 as id, 300 as amount, 'processed' status
+    UNION ALL
+    select 4 as id, 500 as amount, 'processed' status
+    UNION ALL
+    select 5 as id, 600 as amount, 'shipped' status
+    `,
+  measures: {
+    count: {
+      type: 'count',
+    },
+    totalAmount: {
+      sql: 'amount',
+      type: 'sum',
+    },
+  },
+  dimensions: {
+    id: {
+      sql: 'id',
+      type: 'number',
+      primaryKey: true,
+    },
+    status: {
+      sql: 'status',
+      type: 'string',
+    },
+  },
+});

--- a/packages/cubejs-testing/test/driver-doris.test.ts
+++ b/packages/cubejs-testing/test/driver-doris.test.ts
@@ -1,0 +1,30 @@
+import { mainTestSet, multiQueryTestSet, preAggsTestSet, productionTestSet } from './driverTests/testSets';
+import { executeTestSuite } from './driver-test-suite';
+
+executeTestSuite({
+  type: 'doris',
+  tests: mainTestSet,
+});
+
+executeTestSuite({
+  type: 'doris',
+  tests: multiQueryTestSet,
+});
+
+executeTestSuite({
+  type: 'doris',
+  tests: mainTestSet,
+  config: { CUBEJS_EXTERNAL_DEFAULT: 'true' }
+});
+
+executeTestSuite({
+  type: 'doris',
+  tests: preAggsTestSet,
+  config: { CUBEJS_EXTERNAL_DEFAULT: 'true' }
+});
+
+executeTestSuite({
+  type: 'doris',
+  tests: productionTestSet,
+  config: { CUBEJS_DEV_MODE: 'false' },
+});

--- a/packages/cubejs-testing/test/driver-test-suite.ts
+++ b/packages/cubejs-testing/test/driver-test-suite.ts
@@ -15,7 +15,8 @@ type SupportedDriverType =
   'bigquery' |
   'athena' |
   'databricks-jdbc' |
-  'vertica';
+  'vertica' |
+  'doris';
 
 type TestSuite = {
   config?: Partial<Env>

--- a/packages/cubejs-testing/test/smoke-doris.test.ts
+++ b/packages/cubejs-testing/test/smoke-doris.test.ts
@@ -1,0 +1,62 @@
+import cubejs, { CubeApi } from '@cubejs-client/core';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { afterAll, beforeAll, expect, jest } from '@jest/globals';
+import { DorisDBRunner } from '@cubejs-backend/testing-shared';
+import { BirdBox, getBirdbox } from '../src';
+import {
+  DEFAULT_API_TOKEN,
+  DEFAULT_CONFIG,
+  JEST_AFTER_ALL_DEFAULT_TIMEOUT,
+  JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+  testQueryMeasure,
+} from './smoke-tests';
+
+describe('doris', () => {
+  jest.setTimeout(60 * 5 * 1000);
+  let birdbox: BirdBox;
+  let client: CubeApi;
+
+  beforeAll(async () => {
+    const db = await DorisDBRunner.startContainer({});
+    birdbox = await getBirdbox(
+      'doris',
+      {
+        CUBEJS_DB_TYPE: 'doris',
+
+        CUBEJS_DB_HOST: db.getHost(),
+        // Use MySQL port since DorisDBRunner uses MySQL container for testing
+        CUBEJS_DB_PORT: `${db.getMappedPort(3306)}`,
+        CUBEJS_DB_NAME: 'mysql',
+        CUBEJS_DB_USER: 'root',
+        CUBEJS_DB_PASS: process.env.TEST_DB_PASSWORD || 'Test1test',
+
+        ...DEFAULT_CONFIG,
+      },
+      {
+        schemaDir: 'doris/schema',
+      }
+    );
+    client = cubejs(async () => DEFAULT_API_TOKEN, {
+      apiUrl: birdbox.configuration.apiUrl,
+    });
+  }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
+
+  afterAll(async () => {
+    await birdbox.stop();
+  }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+  test('query measure', () => testQueryMeasure(client));
+
+  test('query dimensions', async () => {
+    const response = await client.load({
+      measures: [
+        'Orders.totalAmount',
+      ],
+      dimensions: [
+        'Orders.status',
+      ],
+    });
+
+    expect(response.rawData()).toMatchSnapshot('dimensions');
+  });
+});


### PR DESCRIPTION
- Add new @cubejs-backend/doris-driver package
- Doris is MySQL protocol compatible, uses mysql npm package
- Supports Doris-specific types: LARGEINT, DATEV2, DATETIMEV2, STRING
- Features:
  - Connection pooling via generic-pool
  - Stream query support
  - Batch inserts (1000 rows per batch)
  - 64-character table name validation
  - No foreign key support (Doris limitation)
  - Default port 9030 (Doris FE query port)
- Register driver in DriverDependencies and DatabaseType
- Map to MysqlQuery dialect in QueryBuilder
- Add unit tests and integration test infrastructure

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
