### PR TITLE
Fix crash when parsing f-strings with single-letter content like F

### DIFF
--- a/packages/cubejs-schema-compiler/src/parser/PythonParser.ts
+++ b/packages/cubejs-schema-compiler/src/parser/PythonParser.ts
@@ -148,6 +148,18 @@ export class PythonParser {
           }
           return t.templateElement({ raw: node.getText(), cooked: node.getText() });
         } else if (node instanceof String_templateContext) {
+          // Handle empty f-strings (e.g., f"F" where F is just a literal with no interpolation)
+          // This can happen when YAML values like "F" get wrapped as f"F" by the schema compiler
+          if (children.length === 0) {
+            const text = node.getText();
+            // Extract the content between the f-string prefix and quotes (e.g., f"content" -> content)
+            const match = text.match(/^[fF]["'](.*)["']$/s);
+            const content = match ? match[1] : text;
+            return t.templateLiteral(
+              [t.templateElement({ raw: content, cooked: content }, true)],
+              []
+            );
+          }
           if (children[children.length - 1].type === 'TemplateElement') {
             children[children.length - 1].tail = true;
           } else {

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -321,6 +321,36 @@ describe('Yaml Schema Testing', () => {
 
       await compiler.compile();
     });
+
+    it('single letter F in metadata does not crash - issue#XXXX', async () => {
+      // Single letters "F" and "f" look like Python f-string prefixes when YAML values
+      // get wrapped as f"..." during parsing. This test verifies they are handled correctly.
+      const { compiler } = prepareYamlCompiler(
+        `cubes:
+    - name: Products
+      sql: SELECT * FROM products
+      dimensions:
+        - name: id
+          sql: id
+          type: number
+          primaryKey: true
+        - name: status
+          sql: status
+          type: string
+          meta:
+            enumValues:
+              - A
+              - B
+              - C
+              - D
+              - E
+              - F
+              - G
+      `
+      );
+
+      await compiler.compile();
+    });
   });
 
   it('accepts cube meta', async () => {


### PR DESCRIPTION
## Summary
Fixes a crash in `PythonParser.ts` when parsing YAML values that get interpreted as f-strings with single-letter content.

When the YAML schema compiler processes string values, it wraps them as `f"..."` for interpolation support. However, single letters like `F` become `f"F"` which causes the Python parser to crash with "Cannot read properties of undefined (reading 'type')" because the parser doesn't handle empty children arrays.

### The Bug
In `YamlCompiler.ts`, all YAML string values get wrapped as f-strings:
```typescript
value = \`f"\${value}"\`;
```

When the value is just `F`, it becomes `f"F"` which the `String_templateContext` handler tries to process but `children` array is empty, causing:
```typescript
children[children.length - 1].type  // crashes when children.length === 0
```

### The Fix
Added an early return in `PythonParser.ts` to handle the empty children case:
```typescript
if (children.length === 0) {
  const text = node.getText();
  const match = text.match(/^[fF]["'](.*)["']$/s);
  const content = match ? match[1] : text;
  return t.templateLiteral(
    [t.templateElement({ raw: content, cooked: content }, true)],
    []
  );
}
```

### Reproducer
This YAML schema causes the crash:
```yaml
cubes:
  - name: Products
    sql: SELECT * FROM products
    dimensions:
      - name: status
        sql: status
        type: string
        meta:
          enumValues:
            - A
            - B
            - F  # This single letter causes the crash
```

### Test
Added a test case in `yaml-schema.test.ts` to prevent regression.

## Checklist
- [x] Unit test added
- [x] No breaking changes