### PR TITLE
feat(api-gateway): Always include usedPreAggregations in Load Request Success logs

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1798,7 +1798,6 @@ class ApiGateway {
           context.signedWithPlaygroundAuthSecret
           ? {
             refreshKeyValues: response.refreshKeyValues,
-            usedPreAggregations: response.usedPreAggregations,
             transformedQuery: sqlQuery.canUseTransformedQuery,
             requestId: context.requestId,
           }
@@ -1811,6 +1810,7 @@ class ApiGateway {
       external: response.external,
       slowQuery: Boolean(response.slowQuery),
       total: normalizedQuery.total ? response.total : null,
+      usedPreAggregations: response.usedPreAggregations,
     };
 
     resultWrapper.setTransformData(transformDataParams);


### PR DESCRIPTION
**Check List**
- [X] Tests have been run in packages where changes have been made if available
- [X] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**
Closes https://github.com/cube-js/cube/issues/10309

**Description of Changes Made (if issue reference is not provided)**

Moving the `usedPreAggregations` entry of the response object in the api gateway to always be present, instead of being filtered on "devMode" and playground request only.

This allows the `Load Request Success` log to properly include `queriesWithPreAggregations`. This will help with using cubejs logs when self hosting to see which requests goes through a pre-aggregation or not.