### PR TITLE
fix(server-core): Support config dict return from externalDriverFactory

### DIFF
--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -653,20 +653,29 @@ export class CubejsServerCore {
             let driver: BaseDriver | null = null;
 
             try {
-              driver = await this.options.externalDriverFactory(context);
-              if (typeof driver === 'object' && driver != null) {
-                if (driver.setLogger) {
-                  driver.setLogger(this.logger);
-                }
+              const val = await this.options.externalDriverFactory(context);
 
-                await driver.testConnection();
-
-                return driver;
+              if (isDriver(val)) {
+                driver = <BaseDriver>val;
+              } else if (val && (<DriverConfig>val).type && typeof (<DriverConfig>val).type === 'string') {
+                const { type, ...rest } = <DriverConfig>val;
+                driver = CubejsServerCore.createDriver(type, rest);
+              } else if (val && typeof val === 'object') {
+                // Accept driver-like objects for backward compatibility
+                driver = <BaseDriver><unknown>val;
+              } else {
+                throw new Error(
+                  `Unexpected return type, externalDriverFactory must return driver or config, actual: ${getRealType(val)}`
+                );
               }
 
-              throw new Error(
-                `Unexpected return type, externalDriverFactory must return driver, actual: ${getRealType(driver)}`
-              );
+              if (driver.setLogger) {
+                driver.setLogger(this.logger);
+              }
+
+              await driver.testConnection();
+
+              return driver;
             } catch (e) {
               externalPreAggregationsDriverPromise = null;
 

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -178,7 +178,8 @@ export type DialectClassFn = (options: { dataSource: string; dbType: string }) =
 
 // external
 export type ExternalDbTypeFn = (context: RequestContext) => DatabaseType;
-export type ExternalDriverFactoryFn = (context: RequestContext) => Promise<BaseDriver> | BaseDriver;
+export type ExternalDriverFactoryFn = (context: RequestContext) =>
+  Promise<BaseDriver | DriverConfig> | BaseDriver | DriverConfig;
 export type ExternalDialectFactoryFn = (context: RequestContext) => BaseQuery;
 
 export type LoggerFnParams = {


### PR DESCRIPTION
It is my first PR on your repo, so don’t hesitate to help me improve it if I’ve done things wrong.


**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue**

Fixes #10317

**Description**

`external_driver_factory` in Python (`cube.py`) fails because it expects a `BaseDriver` instance but Python can only return config dicts. This works fine for `driver_factory` which has conversion logic in `resolveDriver()`, but `externalDriverFactory` was missing the same treatment.

This PR adds the same config-to-driver conversion pattern used by `driverFactory`:

```typescript
if (isDriver(val)) {
  driver = val;
} else if (val.type && typeof val.type === 'string') {
  const { type, ...rest } = val;
  driver = CubejsServerCore.createDriver(type, rest);
}
```

Now both factories behave consistently and Python users can use `external_driver_factory` with config dicts.