### PR TITLE
chore(server-core): Split default compiler API options to separate function

### DIFF
--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -30,7 +30,7 @@ import type { SubscriptionServer, WebSocketSendMessageFn } from '@cubejs-backend
 
 import { RefreshScheduler, ScheduledRefreshOptions } from './RefreshScheduler';
 import { OrchestratorApi, OrchestratorApiOptions } from './OrchestratorApi';
-import { CompilerApi } from './CompilerApi';
+import { CompilerApi, type CompilerApiOptions } from './CompilerApi';
 import { DevServer } from './DevServer';
 import { agentCollect } from './agentCollect';
 import { OrchestratorStorage } from './OrchestratorStorage';
@@ -700,31 +700,35 @@ export class CubejsServerCore {
     return new CompilerApi(
       repository,
       options.dbType || this.options.dbType,
-      {
-        schemaVersion: options.schemaVersion || this.options.schemaVersion,
-        contextToRoles: this.options.contextToRoles,
-        contextToGroups: this.options.contextToGroups,
-        devServer: this.options.devServer,
-        logger: this.logger,
-        externalDbType: options.externalDbType,
-        preAggregationsSchema: options.preAggregationsSchema,
-        allowUngroupedWithoutPrimaryKey:
-            this.options.allowUngroupedWithoutPrimaryKey ||
-            getEnv('allowUngroupedWithoutPrimaryKey'),
-        convertTzForRawTimeDimension: getEnv('convertTzForRawTimeDimension'),
-        compileContext: options.context,
-        dialectClass: options.dialectClass,
-        externalDialectClass: options.externalDialectClass,
-        allowJsDuplicatePropsInSchema: options.allowJsDuplicatePropsInSchema,
-        sqlCache: this.options.sqlCache,
-        standalone: this.standalone,
-        allowNodeRequire: options.allowNodeRequire,
-        fastReload: options.fastReload || getEnv('fastReload'),
-        compilerCacheSize: this.options.compilerCacheSize || 250,
-        maxCompilerCacheKeepAlive: this.options.maxCompilerCacheKeepAlive,
-        updateCompilerCacheKeepAlive: this.options.updateCompilerCacheKeepAlive
-      },
+      this.createCompilerApiOptions(options),
     );
+  }
+
+  protected createCompilerApiOptions(options: Record<string, any> = {}): CompilerApiOptions {
+    return {
+      schemaVersion: options.schemaVersion || this.options.schemaVersion,
+      contextToRoles: this.options.contextToRoles,
+      contextToGroups: this.options.contextToGroups,
+      devServer: this.options.devServer,
+      logger: this.logger,
+      externalDbType: options.externalDbType,
+      preAggregationsSchema: options.preAggregationsSchema,
+      allowUngroupedWithoutPrimaryKey:
+          this.options.allowUngroupedWithoutPrimaryKey ||
+          getEnv('allowUngroupedWithoutPrimaryKey'),
+      convertTzForRawTimeDimension: getEnv('convertTzForRawTimeDimension'),
+      compileContext: options.context,
+      dialectClass: options.dialectClass,
+      externalDialectClass: options.externalDialectClass,
+      allowJsDuplicatePropsInSchema: options.allowJsDuplicatePropsInSchema,
+      sqlCache: this.options.sqlCache,
+      standalone: this.standalone,
+      allowNodeRequire: options.allowNodeRequire,
+      fastReload: options.fastReload || getEnv('fastReload'),
+      compilerCacheSize: this.options.compilerCacheSize || 250,
+      maxCompilerCacheKeepAlive: this.options.maxCompilerCacheKeepAlive,
+      updateCompilerCacheKeepAlive: this.options.updateCompilerCacheKeepAlive,
+    };
   }
 
   protected createOrchestratorApi(


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR splits default compiler API options into a separate function to allow easier overriding when extending `CubejsServerCore`.
