### PR TITLE
fix(backend-native): Use JSON format logging for production environment

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -47,7 +47,8 @@ export class SQLServer {
   ) {
     setupLogger(
       ({ event }) => apiGateway.log(event),
-      process.env.CUBEJS_LOG_LEVEL === 'trace' ? 'trace' : 'warn'
+      process.env.CUBEJS_LOG_LEVEL === 'trace' ? 'trace' : 'warn',
+      process.env.NODE_ENV === 'production'
     );
 
     // Actually, proxy is enabled in gateway

--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -1937,14 +1937,16 @@ dependencies = [
 
 [[package]]
 name = "log_nonblock"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996472e113c3ffe82a220863dfdd137a74b63995b413c1ea81b5a0d494d829d2"
+checksum = "0f4f0da5d6bbed520811b50d73904b3a8d2ad3be42aaa3cbca0ca7ad59735660"
 dependencies = [
  "colored 3.0.0",
  "crossbeam-channel",
  "libc",
  "log",
+ "serde",
+ "serde_json",
  "time",
 ]
 

--- a/packages/cubejs-backend-native/Cargo.toml
+++ b/packages/cubejs-backend-native/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0.127"
 simple_logger = "1.7.0"
 tokio = { version = "1", features = ["full", "rt"] }
 uuid = { version = "1", features = ["v4"] }
-log_nonblock = { version = "0.1.6", optional = true }
+log_nonblock = { version = "0.1.7", features = ["json"], optional = true }
 
 [dependencies.neon]
 version = "=1"

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -353,9 +353,9 @@ function wrapNativeFunctionWithStream(
 
 type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
 
-export const setupLogger = (logger: (extra: any) => unknown, logLevel: LogLevel): void => {
+export const setupLogger = (logger: (extra: any) => unknown, logLevel: LogLevel, prodLogger: boolean = false): void => {
   const native = loadNative();
-  native.setupLogger({ logger: wrapNativeFunctionWithChannelCallback(logger), logLevel });
+  native.setupLogger({ logger: wrapNativeFunctionWithChannelCallback(logger), logLevel, prodLogger });
 };
 
 /// Reset local to default implementation, which uses STDOUT

--- a/packages/cubejs-backend-native/test/cross.test.ts
+++ b/packages/cubejs-backend-native/test/cross.test.ts
@@ -1,6 +1,6 @@
 import { loadNative, setupLogger } from '../js';
 
-setupLogger(({ event }) => console.log(event), 'trace');
+setupLogger(({ event }) => console.log(event), 'trace', false);
 
 describe('Cross language representation (CLR)', () => {
   it('all types', async () => {

--- a/packages/cubejs-backend-native/test/python.ts
+++ b/packages/cubejs-backend-native/test/python.ts
@@ -7,6 +7,7 @@ import * as native from '../js';
   native.setupLogger(
     ({ event }) => console.log(event),
     'trace',
+    false
   );
 
   const content = await fs.readFile(path.join(process.cwd(), 'test', 'config.py'), 'utf8');

--- a/packages/cubejs-backend-native/test/python_async_bench.ts
+++ b/packages/cubejs-backend-native/test/python_async_bench.ts
@@ -7,6 +7,7 @@ import * as native from '../js';
   native.setupLogger(
     ({ event }) => console.log(event),
     'trace',
+    false,
   );
 
   const content = await fs.readFile(path.join(process.cwd(), 'test', 'config.py'), 'utf8');

--- a/packages/cubejs-backend-native/test/server.js
+++ b/packages/cubejs-backend-native/test/server.js
@@ -116,6 +116,7 @@ const meta_fixture = require('./meta');
   native.setupLogger(
     ({ event }) => console.log(event),
     'trace',
+    false,
   );
 
   const server = await native.registerInterface({


### PR DESCRIPTION
Previusly, Rust logger output simple strings in stdout in production env, while Node.js logger output JSON. Let's align it to usage of JSON.
