### PR TITLE
fix(mssql-driver): Use parameter placeholders for Tesseract

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -269,6 +269,7 @@ export class MssqlQuery extends BaseQuery {
     templates.types.timestamp = 'DATETIME2';
     delete templates.types.interval;
     templates.types.binary = 'VARBINARY';
+    templates.params.param = '@_{{ param_index + 1 }}';
     return templates;
   }
 }


### PR DESCRIPTION
Add params.param template override in MssqlQuery.sqlTemplates() to generate @_1, @_2, ... style named parameters instead of the default ? placeholders.

refs https://github.com/cube-js/cube/issues/9567