### PR TITLE
fix(cubesql): Fix planning with `CASE` and `LIKE`

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "arrow",
  "chrono",
@@ -878,7 +878,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "arrow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=bc52a4fe856c1e2f4e98761d4854e86a8a497bea#bc52a4fe856c1e2f4e98761d4854e86a8a497bea"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "bc52a4fe856c1e2f4e98761d4854e86a8a497bea", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "e7d183cb3686377810f240dd851e943b4c926f0f", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@e7d183c, fixing an issue with naming similar expressions. There are two variations of `LIKE` expressions: `Expr::Like` which also supports an escape character, and simplier form of `Expr::BinaryExpr` with `Like` operator. While two are logically equivalent and can easily swapped, provided that there's no escape character, they had different physical names which led to invalid logical plan generation if an expression of one type has been replaced with a different one.
Related test is included.
