### PR TITLE
feat(cubejs-api-gateway): Adds `dataSource` to the /v1/sql API response

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1393,8 +1393,8 @@ class ApiGateway {
       });
 
       await res(queryType === QueryTypeEnum.REGULAR_QUERY ?
-        { sql: toQuery(sqlQueries[0]) } :
-        sqlQueries.map((sqlQuery) => ({ sql: toQuery(sqlQuery) })));
+        { sql: toQuery(sqlQueries[0]), dataSource: sqlQueries[0].dataSource } :
+        sqlQueries.map((sqlQuery) => ({ sql: toQuery(sqlQuery), dataSource: sqlQuery.dataSource })));
     } catch (e: any) {
       this.handleError({
         e, context, query, res, requestStarted

--- a/packages/cubejs-api-gateway/test/mocks.ts
+++ b/packages/cubejs-api-gateway/test/mocks.ts
@@ -67,7 +67,8 @@ export const compilerApi = jest.fn().mockImplementation(async () => ({
         foo__bar: 'Foo.bar',
         foo__time: 'Foo.time',
       },
-      order: [{ id: 'id', desc: true, }]
+      order: [{ id: 'id', desc: true, }],
+      dataSource: 'default'
     };
   },
 


### PR DESCRIPTION
**Check List**
- [X] Tests have been run in packages where changes have been made if available
- [X] Linter has been run for changed code
- [X] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

We use Cube as a canonical store of metadata. With [multiple data sources](https://cube.dev/docs/product/configuration/multiple-data-sources) we're able to generate SQL queries for a data source other than the implicit `default`, but need to know which data source the query can be executed on.