### PR TITLE
feat(cubestore-driver): improve WebSocket connection error messages

### DIFF
--- a/packages/cubejs-cubestore-driver/src/errors.ts
+++ b/packages/cubejs-cubestore-driver/src/errors.ts
@@ -1,0 +1,20 @@
+abstract class CubeStoreError extends Error {
+
+}
+
+export class ConnectionError extends CubeStoreError {
+  public readonly cause?: Error;
+
+  public constructor(message: string, cause?: Error) {
+    super(message);
+    this.name = 'ConnectionError';
+    this.cause = cause;
+  }
+}
+
+export class QueryError extends CubeStoreError {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'QueryError';
+  }
+}


### PR DESCRIPTION
Add ConnectionError class to wrap WebSocket errors with CubeStore context, making it easier to diagnose connection failures.