### PR TITLE
feat(cubesql): Support setting time zone with `SET TIMEZONE`

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "arrow",
  "chrono",
@@ -878,7 +878,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.16.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=16f051486de78a23a0ff252155dd59fc2d35497d#16f051486de78a23a0ff252155dd59fc2d35497d"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=1423a0c16ebba665bdbfdd0e2b8d36f417baa514#1423a0c16ebba665bdbfdd0e2b8d36f417baa514"
 dependencies = [
  "log",
 ]

--- a/packages/cubejs-backend-native/src/sql4sql.rs
+++ b/packages/cubejs-backend-native/src/sql4sql.rs
@@ -131,6 +131,7 @@ async fn get_sql(
                     .generate_sql(
                         session.server.transport.clone(),
                         Arc::new(session.state.get_load_request_meta("sql")),
+                        Arc::clone(&session.state),
                     )
                     .await?;
 

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "arrow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=e7d183cb3686377810f240dd851e943b4c926f0f#e7d183cb3686377810f240dd851e943b4c926f0f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=3171c65655464732abc6182377d2750342a6a0c6#3171c65655464732abc6182377d2750342a6a0c6"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.16.0"
-source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=16f051486de78a23a0ff252155dd59fc2d35497d#16f051486de78a23a0ff252155dd59fc2d35497d"
+source = "git+https://github.com/cube-js/sqlparser-rs.git?rev=1423a0c16ebba665bdbfdd0e2b8d36f417baa514#1423a0c16ebba665bdbfdd0e2b8d36f417baa514"
 dependencies = [
  "log",
 ]

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,14 +10,14 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "e7d183cb3686377810f240dd851e943b4c926f0f", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "3171c65655464732abc6182377d2750342a6a0c6", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }
 thiserror = "2"
 cubeclient = { path = "../cubeclient" }
 pg-srv = { path = "../pg-srv" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "16f051486de78a23a0ff252155dd59fc2d35497d" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "1423a0c16ebba665bdbfdd0e2b8d36f417baa514" }
 base64 = "0.13.0"
 tokio = { version = "^1.35", features = ["full", "rt", "tracing"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -14,7 +14,7 @@ use crate::{
         },
     },
     config::ConfigObj,
-    sql::AuthContextRef,
+    sql::{AuthContextRef, SessionState},
     transport::{
         AliasedColumn, DataSource, LoadRequestMeta, MetaContext, SpanId, SqlGenerator,
         SqlTemplates, TransportLoadRequestQuery, TransportService,
@@ -642,6 +642,7 @@ impl CubeScanWrapperNode {
         &self,
         transport: Arc<dyn TransportService>,
         load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
     ) -> result::Result<CubeScanWrappedSqlNode, CubeError> {
         let schema = self.schema();
         let wrapped_plan = self.wrapped_plan.clone();
@@ -649,6 +650,7 @@ impl CubeScanWrapperNode {
             &self.meta,
             transport,
             load_request_meta,
+            state,
             self.clone().set_max_limit_for_node(wrapped_plan),
             true,
             Vec::new(),
@@ -920,6 +922,7 @@ impl CubeScanWrapperNode {
         meta: &MetaContext,
         transport: Arc<dyn TransportService>,
         load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
         node: Arc<LogicalPlan>,
         can_rename_columns: bool,
         values: Vec<Option<String>>,
@@ -964,6 +967,7 @@ impl CubeScanWrapperNode {
                             meta,
                             transport,
                             load_request_meta,
+                            state,
                             node,
                             can_rename_columns,
                             values,
@@ -997,6 +1001,7 @@ impl CubeScanWrapperNode {
         meta: &'ctx MetaContext,
         transport: Arc<dyn TransportService>,
         load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
         node: Arc<LogicalPlan>,
         can_rename_columns: bool,
         values: Vec<Option<String>>,
@@ -1007,6 +1012,7 @@ impl CubeScanWrapperNode {
             meta,
             transport,
             load_request_meta,
+            state,
             node,
             can_rename_columns,
             values,
@@ -1141,6 +1147,7 @@ impl WrappedSelectNode {
         meta: &MetaContext,
         transport: Arc<dyn TransportService>,
         load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
         sql: &mut SqlQuery,
         data_source: Option<&str>,
     ) -> result::Result<HashMap<String, String>, CubeError> {
@@ -1156,6 +1163,7 @@ impl WrappedSelectNode {
                 meta,
                 transport.clone(),
                 load_request_meta.clone(),
+                state.clone(),
                 subquery.clone(),
                 true,
                 sql.values.clone(),
@@ -3100,6 +3108,7 @@ impl WrappedSelectNode {
         meta: &MetaContext,
         transport: Arc<dyn TransportService>,
         load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
         node: &Arc<dyn UserDefinedLogicalNode + Send + Sync>,
         can_rename_columns: bool,
         values: Vec<Option<String>>,
@@ -3198,6 +3207,7 @@ impl WrappedSelectNode {
                 meta,
                 transport.clone(),
                 load_request_meta.clone(),
+                state.clone(),
                 &mut sql,
                 Some(data_source),
             )
@@ -3257,6 +3267,7 @@ impl WrappedSelectNode {
                     meta,
                     transport.clone(),
                     load_request_meta.clone(),
+                    state.clone(),
                     lp.clone(),
                     true,
                     sql.values.clone(),
@@ -3402,8 +3413,14 @@ impl WrappedSelectNode {
                     .all(|member| meta.find_dimension_with_name(member).is_some())
             });
 
+        let timezone = state
+            .query_timezone
+            .read()
+            .map_err(|_| CubeError::internal("Failed to acquire timezone read lock".to_string()))?
+            .clone();
+
         let load_request = V1LoadRequestQuery {
-            timezone: None,
+            timezone,
             measures: Some(
                 aggregate
                     .iter()
@@ -3553,6 +3570,7 @@ impl WrappedSelectNode {
         meta: &MetaContext,
         transport: Arc<dyn TransportService>,
         load_request_meta: Arc<LoadRequestMeta>,
+        state: Arc<SessionState>,
         node: &Arc<dyn UserDefinedLogicalNode + Send + Sync>,
         can_rename_columns: bool,
         values: Vec<Option<String>>,
@@ -3564,6 +3582,7 @@ impl WrappedSelectNode {
                     meta,
                     transport,
                     load_request_meta,
+                    state,
                     node,
                     can_rename_columns,
                     values,
@@ -3581,6 +3600,7 @@ impl WrappedSelectNode {
             meta,
             transport.clone(),
             load_request_meta.clone(),
+            state.clone(),
             self.from.clone(),
             true,
             values.clone(),
@@ -3593,6 +3613,7 @@ impl WrappedSelectNode {
                 meta,
                 transport.clone(),
                 load_request_meta.clone(),
+                state,
                 &mut sql,
                 data_source.as_deref(),
             )

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -5080,6 +5080,50 @@ ORDER BY
     }
 
     #[tokio::test]
+    async fn test_set_timezone() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "pg_set_time_zone_custom",
+            execute_queries_with_flags(
+                vec![
+                    "SET TIMEZONE TO 'Europe/Rome'".to_string(),
+                    "SHOW TIMEZONE".to_string()
+                ],
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+            .0
+        );
+
+        insta::assert_snapshot!(
+            "pg_set_time_zone_default",
+            execute_queries_with_flags(
+                vec![
+                    "SET TIMEZONE = DEFAULT".to_string(),
+                    "SHOW TIMEZONE".to_string()
+                ],
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+            .0
+        );
+
+        insta::assert_snapshot!(
+            "pg_set_time_zone_local",
+            execute_queries_with_flags(
+                vec![
+                    "SET TIME ZONE LOCAL".to_string(),
+                    "SHOW TIMEZONE".to_string()
+                ],
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+            .0
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_explain() -> Result<(), CubeError> {
         // SELECT with no tables (inline eval)
         insta::assert_snapshot!(
@@ -18250,5 +18294,87 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
                 ..Default::default()
             }
         )
+    }
+
+    #[tokio::test]
+    async fn test_set_time_zone() -> Result<(), CubeError> {
+        if !Rewriter::sql_push_down_enabled() {
+            return Ok(());
+        }
+        init_testing_logger();
+
+        let context = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+
+        context.execute_query("SET TIME ZONE 'Europe/Rome'").await?;
+
+        // Test that time zone has been successfully applied
+        let query = r#"
+            SELECT order_date
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        "#;
+        let expected_cube_scan = V1LoadRequestQuery {
+            measures: Some(vec![]),
+            dimensions: Some(vec!["KibanaSampleDataEcommerce.order_date".to_string()]),
+            segments: Some(vec![]),
+            order: Some(vec![]),
+            timezone: Some("Europe/Rome".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            context
+                .convert_sql_to_cube_query(&query)
+                .await
+                .unwrap()
+                .as_logical_plan()
+                .find_cube_scan()
+                .request,
+            expected_cube_scan
+        );
+
+        // Test that time zone is applied with SQL push down as well
+        let query = r#"
+            SELECT order_date
+            FROM KibanaSampleDataEcommerce
+            WHERE LOWER(customer_gender) = 'test'
+            GROUP BY 1
+        "#;
+        let sql = context
+            .convert_sql_to_cube_query(&query)
+            .await
+            .unwrap()
+            .as_logical_plan()
+            .find_cube_scan_wrapped_sql()
+            .wrapped_sql
+            .sql;
+        assert!(sql.contains("\"Europe/Rome\""));
+
+        // Test that time zone correctly resets to default
+        context.execute_query("SET TIMEZONE TO DEFAULT").await?;
+
+        let query = r#"
+            SELECT order_date
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        "#;
+        let expected_cube_scan = V1LoadRequestQuery {
+            measures: Some(vec![]),
+            dimensions: Some(vec!["KibanaSampleDataEcommerce.order_date".to_string()]),
+            segments: Some(vec![]),
+            order: Some(vec![]),
+            ..Default::default()
+        };
+        assert_eq!(
+            context
+                .convert_sql_to_cube_query(&query)
+                .await
+                .unwrap()
+                .as_logical_plan()
+                .find_cube_scan()
+                .request,
+            expected_cube_scan
+        );
+
+        Ok(())
     }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_time_zone_custom.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_time_zone_custom.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_queries_with_flags(vec![\"SET TIMEZONE TO 'Europe/Rome'\".to_string(),\n\"SHOW TIMEZONE\".to_string()], DatabaseProtocol::PostgreSQL).await? .0"
+---
++-------------+
+| setting     |
++-------------+
+| Europe/Rome |
++-------------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_time_zone_default.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_time_zone_default.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_queries_with_flags(vec![\"SET TIMEZONE = DEFAULT\".to_string(),\n\"SHOW TIMEZONE\".to_string()], DatabaseProtocol::PostgreSQL).await? .0"
+---
++---------+
+| setting |
++---------+
+| GMT     |
++---------+

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_time_zone_local.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_time_zone_local.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_queries_with_flags(vec![\"SET TIME ZONE LOCAL\".to_string(),\n\"SHOW TIMEZONE\".to_string()], DatabaseProtocol::PostgreSQL).await? .0"
+---
++---------+
+| setting |
++---------+
+| GMT     |
++---------+


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#4142

**Description of Changes Made**

This PR adds support for setting session time zone with `SET TIMEZONE` (or `SET TIME ZONE` PostgreSQL-specific syntax by bumping cube-js/sqlparser-rs@1423a0c and cube-js/arrow-datafusion@3171c65). Related tests are included.
