### PR TITLE
fix(schema-compiler): Resolve time dimension column names correctly in pre-aggregation index definitions

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -359,7 +359,8 @@ export class PreAggregations {
                 preAggregation,
                 preAggregation.indexes?.[index],
                 indexName,
-                tableName
+                tableName,
+                references.timeDimensions
               )
             };
           }
@@ -372,7 +373,7 @@ export class PreAggregations {
             return {
               indexName,
               type: preAggregation.indexes?.[index].type,
-              columns: queryForSqlEvaluation.evaluateIndexColumns(cube, preAggregation.indexes?.[index])
+              columns: queryForSqlEvaluation.evaluateIndexColumns(cube, preAggregation.indexes?.[index], references.timeDimensions)
             };
           }
         ),


### PR DESCRIPTION
## Fix: Time dimension column names in pre-aggregation index definitions

### Problem

When a time dimension (e.g. `publishedAt`) is referenced in a pre-aggregation aggregate index's `columns`, `evaluateIndexColumns()` generates the wrong column name. The actual pre-aggregation table column is `events__published_at_day` (single underscore before granularity), but `evaluateIndexColumns()` produces:

- `events__published_at` (no granularity suffix) when using `publishedAt`

CubeStore rejects the index with `Column not found` because neither matches the actual table column.

### Root cause

`BaseTimeDimension.unescapedAliasName()` builds the table column as `aliasName(dimension) + "_" + granularity` (single underscore concatenation), but `evaluateIndexColumns()` had no awareness of time dimension granularities.

### Fix

Updated `evaluateIndexColumns()` in `BaseQuery.js`:

The pre-aggregation's `timeDimensions` references (containing both dimension path and granularity) are now passed into `evaluateIndexColumns()`. When a column matches a time dimension, `_${granularity}` is appended.

### How to reproduce

Define a rollup pre-aggregation with an aggregate index that includes a time dimension:

```yaml
pre_aggregations:
  - name: master
    type: rollup
    measures: [revenue, requests]
    dimensions: [accountId]
    time_dimension: publishedAt
    granularity: day
    partition_granularity: day
    indexes:
      - name: myIndex
        columns:
          - publishedAt
          - accountId
        type: aggregate