### PR TITLE
fix(docker): Set UTF-8 locale environment variables to fix Python Uni…

### DIFF
--- a/packages/cubejs-docker/dev.Dockerfile
+++ b/packages/cubejs-docker/dev.Dockerfile
@@ -184,6 +184,8 @@ COPY packages/cubejs-docker/bin/cubejs-dev /usr/local/bin/cubejs
 # By default Node dont search in parent directory from /cube/conf, @todo Reaserch a little bit more
 ENV NODE_PATH /cube/conf/node_modules:/cube/node_modules
 ENV PYTHONUNBUFFERED=1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 RUN ln -s  /cubejs/packages/cubejs-docker /cube
 RUN ln -s  /cubejs/rust/cubestore/bin/cubestore-dev /usr/local/bin/cubestore-dev
 

--- a/packages/cubejs-docker/latest-debian-jdk.Dockerfile
+++ b/packages/cubejs-docker/latest-debian-jdk.Dockerfile
@@ -49,6 +49,8 @@ COPY --chown=cube:cube --from=builder /cube .
 # By default Node dont search in parent directory from /cube/conf, @todo Reaserch a little bit more
 ENV NODE_PATH /cube/conf/node_modules:/cube/node_modules
 ENV PYTHONUNBUFFERED=1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 RUN ln -s /cube/node_modules/.bin/cubejs /usr/local/bin/cubejs
 RUN ln -s /cube/node_modules/.bin/cubestore-dev /usr/local/bin/cubestore-dev
 

--- a/packages/cubejs-docker/latest.Dockerfile
+++ b/packages/cubejs-docker/latest.Dockerfile
@@ -36,6 +36,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
 RUN yarn policies set-version v1.22.22
 
 ENV NODE_ENV=production
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 WORKDIR /cube
 

--- a/packages/cubejs-docker/local.Dockerfile
+++ b/packages/cubejs-docker/local.Dockerfile
@@ -41,6 +41,8 @@ RUN yarn install --prod && yarn cache clean && yarn link:dev
 # By default Node dont search in parent directory from /cube/conf, @todo Reaserch a little bit more
 ENV NODE_PATH /cube/conf/node_modules:/cube/node_modules
 ENV PYTHONUNBUFFERED=1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 RUN ln -s /cube/node_modules/.bin/cubejs /usr/local/bin/cubejs
 RUN ln -s /cube/node_modules/.bin/cubestore-dev /usr/local/bin/cubestore-dev
 

--- a/packages/cubejs-docker/testing-drivers.Dockerfile
+++ b/packages/cubejs-docker/testing-drivers.Dockerfile
@@ -179,6 +179,9 @@ COPY packages/cubejs-docker/bin/cubejs-dev /usr/local/bin/cubejs
 
 # By default Node dont search in parent directory from /cube/conf, @todo Reaserch a little bit more
 ENV NODE_PATH /cube/conf/node_modules:/cube/node_modules
+ENV PYTHONUNBUFFERED=1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 RUN ln -s  /cubejs/packages/cubejs-docker /cube
 RUN ln -s  /cubejs/rust/cubestore/bin/cubestore-dev /usr/local/bin/cubestore-dev
 

--- a/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
+++ b/rust/cubestore/cross/aarch64-unknown-linux-gnu-python.Dockerfile
@@ -30,3 +30,5 @@ RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VER
 ENV PYO3_CROSS_PYTHON_VERSION=${PYTHON_RELEASE} \
     PYO3_CROSS_INCLUDE_DIR=/usr/aarch64-linux-gnu/include \
     PYO3_CROSS_LIB_DIR=/usr/aarch64-linux-gnu/lib
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8

--- a/rust/cubestore/cross/x86_64-unknown-linux-gnu-python.Dockerfile
+++ b/rust/cubestore/cross/x86_64-unknown-linux-gnu-python.Dockerfile
@@ -18,3 +18,5 @@ RUN cd tmp && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${
     && cd .. && rm -rf Python-${PYTHON_VERSION};
 
 ENV PYO3_PYTHON=python${PYTHON_RELEASE}
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
…codeEncodeError

Without LANG and LC_ALL set to C.UTF-8, embedded Python in Docker containers fails with "UnicodeEncodeError: 'ascii' codec can't encode character" when outputting non-ASCII characters. This adds the locale environment variables to all Dockerfiles that run Python code at runtime.