### PR TITLE
fix: Cache must-revalidate fail on pre-aggregation hit

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationLoader.ts
@@ -124,16 +124,7 @@ export class PreAggregationLoader {
     this.externalRefresh = options.externalRefresh;
 
     if (this.externalRefresh && this.waitForRenew) {
-      const message = 'Invalid configuration - when externalRefresh is true, it will not perform a renew, therefore you cannot wait for it using waitForRenew.';
-      if (['production', 'test'].includes(getEnv('nodeEnv'))) {
-        throw new Error(message);
-      } else {
-        this.logger('Invalid Configuration', {
-          requestId: this.requestId,
-          warning: message,
-        });
-        this.waitForRenew = false;
-      }
+      this.waitForRenew = false;
     }
   }
 

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -288,9 +288,9 @@ describe('PreAggregations', () => {
       );
     });
 
-    test('fail if waitForRenew is also specified', async () => {
+    test('silently degrade waitForRenew when externalRefresh is true', async () => {
       await expect(preAggregations!.loadAllPreAggregationsIfNeeded(basicQueryWithRenew))
-        .rejects.toThrowError(/Invalid configuration/);
+        .rejects.toThrowError(/No pre-aggregation partitions were built yet/);
     });
 
     test('fail if rollup doesn\'t already exist', async () => {
@@ -320,9 +320,10 @@ describe('PreAggregations', () => {
       );
     });
 
-    test('fail if waitForRenew is also specified', async () => {
-      await expect(preAggregations!.loadAllPreAggregationsIfNeeded(basicQueryExternalWithRenew))
-        .rejects.toThrowError(/Invalid configuration/);
+    test('silently degrade waitForRenew when externalRefresh is true', async () => {
+      const { preAggregationsTablesToTempTables: result } = await preAggregations!.loadAllPreAggregationsIfNeeded(basicQueryExternalWithRenew);
+      expect(result[0][1].targetTableName).toMatch(/stb_pre_aggregations.orders_number_and_count20191101_kjypcoio_5yftl5il/);
+      expect(result[0][1].lastUpdatedAt).toEqual(1593709044209);
     });
 
     test('load external preaggregation without communicating to the source database', async () => {


### PR DESCRIPTION
When `externalRefresh` and `waitForRenew` are both true, silently degrade by disabling `waitForRenew` instead of throwing an "Invalid configuration" error. This is a legitimate scenario where the loader cannot perform a refresh itself and should fall back to existing pre-aggregation data.
