### PR TITLE
fix(api-gateway): Accept `cache` parameter in WebSocket requests, fix…

### DIFF
--- a/packages/cubejs-api-gateway/src/ws/message-schema.ts
+++ b/packages/cubejs-api-gateway/src/ws/message-schema.ts
@@ -14,6 +14,7 @@ export const unsubscribeMessageSchema = z.object({
 const queryParams = z.object({
   query: z.unknown(),
   queryType: z.string().optional(),
+  cache: z.string().optional(),
 }).strict();
 
 const queryOnlyParams = z.object({

--- a/packages/cubejs-api-gateway/src/ws/subscription-server.ts
+++ b/packages/cubejs-api-gateway/src/ws/subscription-server.ts
@@ -15,11 +15,11 @@ import type { ApiGateway } from '../gateway';
 import type { LocalSubscriptionStore } from './local-subscription-store';
 
 const methodParams: Record<string, string[]> = Object.freeze({
-  load: ['query', 'queryType'],
+  load: ['query', 'queryType', 'cache'],
   sql: ['query'],
   'dry-run': ['query'],
   meta: [],
-  subscribe: ['query', 'queryType'],
+  subscribe: ['query', 'queryType', 'cache'],
   unsubscribe: [],
 });
 
@@ -181,6 +181,11 @@ export class SubscriptionServer {
         for (const k of methodParams[message.method]) {
           collectedParams[k] = message.params[k];
         }
+      }
+
+      if (collectedParams.cache !== undefined) {
+        collectedParams.cacheMode = collectedParams.cache;
+        delete collectedParams.cache;
       }
 
       const method = message.method.replace(/[^a-z]+(.)/g, (_m, chr) => chr.toUpperCase());

--- a/packages/cubejs-api-gateway/test/ws/subscription-server.test.ts
+++ b/packages/cubejs-api-gateway/test/ws/subscription-server.test.ts
@@ -248,6 +248,51 @@ describe('SubscriptionServer', () => {
       );
     });
 
+    it('should forward cache param as cacheMode for load', async () => {
+      const { mockApiGateway, mockSubscriptionStore, mockSendMessage, mockContextAcceptor } = createMocks();
+      const server = new SubscriptionServer(mockApiGateway, mockSendMessage, mockSubscriptionStore, mockContextAcceptor);
+
+      const message = {
+        method: 'load',
+        messageId: '123',
+        params: { query: { measures: ['Orders.count'] }, cache: 'no-cache' }
+      };
+      await server.processMessage('conn-1', JSON.stringify(message));
+
+      expect(mockApiGateway.load).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { measures: ['Orders.count'] },
+          cacheMode: 'no-cache',
+          connectionId: 'conn-1',
+          apiType: 'ws',
+        })
+      );
+      // cache should be remapped, not passed through as-is
+      expect(mockApiGateway.load).not.toHaveBeenCalledWith(
+        expect.objectContaining({ cache: 'no-cache' })
+      );
+    });
+
+    it('should forward cache param as cacheMode for subscribe', async () => {
+      const { mockApiGateway, mockSubscriptionStore, mockSendMessage, mockContextAcceptor } = createMocks();
+      const server = new SubscriptionServer(mockApiGateway, mockSendMessage, mockSubscriptionStore, mockContextAcceptor);
+
+      const message = {
+        method: 'subscribe',
+        messageId: '123',
+        params: { query: { measures: ['Orders.count'] }, cache: 'no-cache' }
+      };
+      await server.processMessage('conn-1', JSON.stringify(message));
+
+      expect(mockApiGateway.subscribe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { measures: ['Orders.count'] },
+          cacheMode: 'no-cache',
+          connectionId: 'conn-1',
+        })
+      );
+    });
+
     it('should call subscribe method correctly', async () => {
       const { mockApiGateway, mockSubscriptionStore, mockSendMessage, mockContextAcceptor } = createMocks();
       const server = new SubscriptionServer(mockApiGateway, mockSendMessage, mockSubscriptionStore, mockContextAcceptor);


### PR DESCRIPTION
… #10451

WS `load` and `subscribe` messages now accept the `cache` param and remap it to `cacheMode` before calling the gateway method, matching the existing REST API behavior.