### PR TITLE
fix(api-gateway): Remove Transfer-Encoding header on /cubesql error r…

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -453,6 +453,11 @@ class ApiGateway {
 
           await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, req.body.timezone);
         } catch (e: any) {
+          // Quickfix for https://github.com/cube-js/cube/issues/10450,
+          // Right now, it's too complicated to fix the issue correctly, because
+          // native side control stream, without understanding that it's Express.response
+          res.removeHeader('Transfer-Encoding');
+
           this.handleError({
             e,
             query: {


### PR DESCRIPTION
…esponses, fix #10450

The /cubejs-api/v1/cubesql endpoint sets Transfer-Encoding: chunked for streaming responses. When an error occurs before streaming begins, the error handler calls res.json() which adds Content-Length. Having both headers violates RFC 9112 and causes Node.js 22+ fetch() to reject with HPE_UNEXPECTED_CONTENT_LENGTH.
