### PR TITLE
fix(cubesql): Do not panic when executing `MEASURE` function

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -2179,7 +2179,14 @@ pub fn create_measure_udaf() -> AggregateUDF {
         }
     });
 
-    let accumulator: AccumulatorFunctionImplementation = Arc::new(|_| todo!("Not implemented"));
+    let accumulator: AccumulatorFunctionImplementation = Arc::new(|_| {
+        Err(DataFusionError::Execution(
+            "This query is required to be pushed down due to use of MEASURE() function \
+            but planner wasn't able to. Please check that you're using MEASURE() function \
+            on a measure column, and that no filters prevent the pushdown"
+                .to_string(),
+        ))
+    });
 
     let state_type = Arc::new(vec![DataType::Float64]);
     let state_type: StateTypeFunction = Arc::new(move |_, _| Ok(state_type.clone()));

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -18574,4 +18574,20 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_measure_func_returns_error() -> Result<(), CubeError> {
+        let query_result = execute_query(
+            // Easiest way to test `MEASURE` execution is to call it
+            // on a system table
+            "SELECT MEASURE(relname) FROM pg_class".to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let error = query_result.expect_err("Query should return an error");
+        assert!(error.to_string().contains("required to be pushed down"));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR changes the behavior of `MEASURE` function to return a helpful error instead of panicking when it is being executed due to unsupported plan. Related test is included.
