### PR TITLE
fix(cubestore): Queue - filter expired queue_results

### DIFF
--- a/rust/cubestore/cubestore/src/cachestore/queue_result.rs
+++ b/rust/cubestore/cubestore/src/cachestore/queue_result.rs
@@ -73,16 +73,18 @@ impl<'a> QueueResultRocksTable<'a> {
     }
 
     pub fn get_row_by_key(&self, key: QueueKey) -> Result<Option<IdRow<QueueResult>>, CubeError> {
-        match key {
+        let row = match key {
             QueueKey::ByPath(path) => {
                 let index_key = QueueResultIndexKey::ByPath(path);
-                self.get_single_opt_row_by_index_reverse(&index_key, &QueueResultRocksIndex::ByPath)
+                self.get_single_opt_row_by_index_reverse(
+                    &index_key,
+                    &QueueResultRocksIndex::ByPath,
+                )?
             }
-            QueueKey::ById(id) => match self.get_row(id)? {
-                Some(row) if row.get_row().get_expire() < &Utc::now() => Ok(None),
-                other => Ok(other),
-            },
-        }
+            QueueKey::ById(id) => self.get_row(id)?,
+        };
+
+        Ok(row.filter(|r| r.get_row().get_expire() >= &Utc::now()))
     }
 
     pub fn get_row_by_external_id(

--- a/rust/cubestore/cubestore/src/metastore/rocks_table.rs
+++ b/rust/cubestore/cubestore/src/metastore/rocks_table.rs
@@ -813,17 +813,16 @@ pub trait RocksTable: BaseRocksTable + Debug + Send + Sync {
             )));
         }
 
-        let id = if let Some(id) = if reverse {
+        let to_fetch = if reverse {
             row_ids.last()
         } else {
             row_ids.first()
-        } {
-            id.clone()
-        } else {
+        };
+        let Some(id) = to_fetch else {
             return Ok(None);
         };
 
-        if let Some(row) = self.get_row(id)? {
+        if let Some(row) = self.get_row(*id)? {
             Ok(Some(row))
         } else {
             let index = self.get_index_by_id(BaseRocksSecondaryIndex::get_id(secondary_index));


### PR DESCRIPTION
Adding expire guard covering both lookup paths as defense-in-depth to protect issues after server restart when GC tasks were lost or issues with queue scheduler .