### PR TITLE
fix(clickhouse): use parseDateTime64BestEffort to preserve millisecond precision

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -119,7 +119,7 @@ export class ClickHouseQuery extends BaseQuery {
     // value yields a string formatted in ISO8601, so this function returns a expression to parse a string to a DateTime
     // ClickHouse provides toDateTime which expects dates in UTC in format YYYY-MM-DD HH:MM:SS
     // However parseDateTimeBestEffort works with ISO8601
-    return `parseDateTimeBestEffort(${value})`;
+    return `parseDateTime64BestEffort(${value}, 3)`;
   }
 
   public dimensionsJoinCondition(leftAlias, rightAlias) {
@@ -219,7 +219,7 @@ export class ClickHouseQuery extends BaseQuery {
       datesTo.push(to);
     });
 
-    return `SELECT parseDateTimeBestEffort(arrayJoin(['${datesFrom.join('\',\'')}'])) as date_from, parseDateTimeBestEffort(arrayJoin(['${datesTo.join('\',\'')}'])) as date_to`;
+    return `SELECT parseDateTime64BestEffort(arrayJoin(['${datesFrom.join('\',\'')}']), 3) as date_from, parseDateTime64BestEffort(arrayJoin(['${datesTo.join('\',\'')}']), 3) as date_to`;
   }
 
   public concatStringsSql(strings) {
@@ -266,7 +266,7 @@ export class ClickHouseQuery extends BaseQuery {
     templates.functions.STRING_AGG = 'arrayStringConcat(group{% if distinct %}Uniq{% endif %}Array({{ args[0] }}), {{ args[1] }})';
     // TODO: Introduce additional filter in jinja? or parseDateTimeBestEffort?
     // https://github.com/ClickHouse/ClickHouse/issues/19351
-    templates.expressions.timestamp_literal = 'parseDateTimeBestEffort(\'{{ value }}\')';
+    templates.expressions.timestamp_literal = 'parseDateTime64BestEffort(\'{{ value }}\', 3)';
     delete templates.functions.PERCENTILECONT;
     delete templates.expressions.like_escape;
     templates.quotes.identifiers = '`';
@@ -279,7 +279,7 @@ export class ClickHouseQuery extends BaseQuery {
     delete templates.types.binary;
     templates.expressions.is_not_distinct_from = 'isNotDistinctFrom({{ left }}, {{ right }})';
 
-    templates.statements.time_series_select = 'SELECT parseDateTimeBestEffort(dates.f) date_from, parseDateTimeBestEffort(dates.t) date_to \n' +
+    templates.statements.time_series_select = 'SELECT parseDateTime64BestEffort(dates.f, 3) date_from, parseDateTime64BestEffort(dates.t, 3) date_to \n' +
     'FROM (\n' +
     '{% for time_item in seria  %}' +
     '    select \'{{ time_item[0] }}\' f, \'{{ time_item[1] }}\' t \n' +

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -118,7 +118,7 @@ export class ClickHouseQuery extends BaseQuery {
 
     // value yields a string formatted in ISO8601, so this function returns a expression to parse a string to a DateTime
     // ClickHouse provides toDateTime which expects dates in UTC in format YYYY-MM-DD HH:MM:SS
-    // However parseDateTimeBestEffort works with ISO8601
+    // However parseDateTime64BestEffort works with ISO8601 and preserves millisecond precision
     return `parseDateTime64BestEffort(${value}, 3)`;
   }
 
@@ -205,8 +205,8 @@ export class ClickHouseQuery extends BaseQuery {
    ClickHouse uses :
 
      select
-      parseDateTimeBestEffort(arrayJoin(['2017-01-01T00:00:00.000','2017-01-02T00:00:00.000'])) as date_from,
-      parseDateTimeBestEffort(arrayJoin(['2017-01-01T23:59:59.999','2017-01-02T23:59:59.999'])) as date_to
+      parseDateTime64BestEffort(arrayJoin(['2017-01-01T00:00:00.000','2017-01-02T00:00:00.000']), 3) as date_from,
+      parseDateTime64BestEffort(arrayJoin(['2017-01-01T23:59:59.999','2017-01-02T23:59:59.999']), 3) as date_to
       ...
    )
    */
@@ -264,7 +264,7 @@ export class ClickHouseQuery extends BaseQuery {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
     templates.functions.STRING_AGG = 'arrayStringConcat(group{% if distinct %}Uniq{% endif %}Array({{ args[0] }}), {{ args[1] }})';
-    // TODO: Introduce additional filter in jinja? or parseDateTimeBestEffort?
+    // TODO: Introduce additional filter in jinja? or parseDateTime64BestEffort?
     // https://github.com/ClickHouse/ClickHouse/issues/19351
     templates.expressions.timestamp_literal = 'parseDateTime64BestEffort(\'{{ value }}\', 3)';
     delete templates.functions.PERCENTILECONT;

--- a/packages/cubejs-schema-compiler/test/unit/clickhouse-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/clickhouse-query.test.ts
@@ -1,0 +1,35 @@
+import { ClickHouseQuery } from '../../src/adapter/ClickHouseQuery';
+import { prepareJsCompiler } from './PrepareCompiler';
+import { createCubeSchema } from './utils';
+
+describe('ClickHouseQuery', () => {
+  const compilers = prepareJsCompiler(
+    createCubeSchema({ name: 'cards', sqlTable: 'card_tbl' })
+  );
+
+  it('dateTimeCast uses parseDateTime64BestEffort with precision 3', async () => {
+    await compilers.compiler.compile();
+
+    const query = new ClickHouseQuery(compilers, {
+      measures: ['cards.count'],
+      timeDimensions: [],
+      filters: [],
+    });
+
+    const result = query.dateTimeCast("'2017-01-01T00:00:00.000'");
+    expect(result).toBe("parseDateTime64BestEffort('2017-01-01T00:00:00.000', 3)");
+  });
+
+  it('dateTimeCast with timezone uses toDateTime64 with precision 3', async () => {
+    await compilers.compiler.compile();
+
+    const query = new ClickHouseQuery(compilers, {
+      measures: ['cards.count'],
+      timeDimensions: [],
+      filters: [],
+    });
+
+    const result = query.dateTimeCast("'2017-01-01T00:00:00.000'", 'UTC');
+    expect(result).toBe("toDateTime64('2017-01-01T00:00:00.000', 3, 'UTC')");
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #10326

**Description of Changes Made**

Replace all occurrences of `parseDateTimeBestEffort` with `parseDateTime64BestEffort(…, 3)` in `ClickHouseQuery.ts` to preserve millisecond precision in pre-aggregation WHERE clauses and time series queries.

`parseDateTimeBestEffort` returns `DateTime` (second precision), which silently truncates milliseconds from timestamps like `2024-01-01T00:00:00.000`. `parseDateTime64BestEffort` is a drop-in replacement that returns `DateTime64` with configurable sub-second precision. Precision 3 = milliseconds, consistent with the timezone-aware branch that already uses `toDateTime64(..., 3)`.

**Changes:**

1. `dateTimeCast()` — primary fix for the reported issue. WHERE clause timestamp casts now preserve milliseconds.
2. `seriesSql()` — time series date_from/date_to parsing also updated for consistency.
3. `sqlTemplates()` — Tesseract timestamp_literal and time_series_select templates updated.
4. Updated stale comments referencing the old function name.
5. Added unit test for `dateTimeCast()` verifying the output contains `parseDateTime64BestEffort`.

User-defined SQL in FILTER_PARAMS (e.g., in test fixtures) is intentionally left unchanged.