### PR TITLE
fix: Return value for custom-time/numeric formatios for /v1/load anno…

### DIFF
--- a/rust/cubeorchestrator/src/transport.rs
+++ b/rust/cubeorchestrator/src/transport.rs
@@ -334,7 +334,10 @@ mod tests {
 
         // Round-trip
         let serialized = serde_json::to_value(&format).unwrap();
-        assert_eq!(serialized, json!({"type": "custom-numeric", "value": ".2f"}));
+        assert_eq!(
+            serialized,
+            json!({"type": "custom-numeric", "value": ".2f"})
+        );
     }
 
     #[test]
@@ -344,7 +347,10 @@ mod tests {
 
         // Round-trip
         let serialized = serde_json::to_value(&format).unwrap();
-        assert_eq!(serialized, json!({"type": "custom-time", "value": "%Y-%m-%d %H:%M:%S"}));
+        assert_eq!(
+            serialized,
+            json!({"type": "custom-time", "value": "%Y-%m-%d %H:%M:%S"})
+        );
     }
 
     #[test]


### PR DESCRIPTION
…tations

After moving to native query orchestrator, we lost it.

Before fix:

<img width="2964" height="1794" alt="image" src="https://github.com/user-attachments/assets/74cda5f6-a2b4-469d-9a32-28f2d0bb2f86" />

After:

<img width="3258" height="1756" alt="image" src="https://github.com/user-attachments/assets/415e2574-083c-458b-84c8-f94aa513f3cc" />
