### PR TITLE
feat(cubestore): Enable ZSTD compression for Parquet file

### DIFF
--- a/rust/cubestore/cubestore/src/table/parquet.rs
+++ b/rust/cubestore/cubestore/src/table/parquet.rs
@@ -137,7 +137,8 @@ impl ParquetTableStore {
                 table,
                 WriterProperties::builder()
                     .set_max_row_group_size(self.row_group_size)
-                    .set_writer_version(WriterVersion::PARQUET_2_0),
+                    .set_writer_version(WriterVersion::PARQUET_2_0)
+                    .set_compression(datafusion::parquet::basic::Compression::ZSTD),
             )
             .await
             .map_err(CubeError::from)


### PR DESCRIPTION
Problem

  Cube Store writes Parquet files without explicit compression, relying on datafusion's default behavior. This results in
  larger file sizes, which impacts performance when:
  - Transferring pre-aggregation results from remote storage (S3, GCS, etc.)
  - Storing intermediate computation results locally

  Changes Made

  - Add .set_compression(datafusion::parquet::basic::Compression::ZSTD) to Parquet writer properties
  - Single-line change in ParquetTableStore::writer_props() method
  - No breaking changes or API modifications
