### PR TITLE
fix(bigquery): align DATE() function output to TIMESTAMP for SQL API compatibility

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -347,6 +347,10 @@ export class BigqueryQuery extends BaseQuery {
     // DATEADD is being rewritten to DATE_ADD
     templates.functions.DATE_ADD = 'DATETIME_ADD(DATETIME({{ args[0] }}), INTERVAL {{ interval }} {{ date_part }})';
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
+    // DATE in CubeSQL is a day-truncating UDF that returns TIMESTAMP, so the
+    // rendered SQL must stay TIMESTAMP-typed; inner DATE() handles both string
+    // and timestamp arguments and keeps the truncation
+    templates.functions.DATE = 'TIMESTAMP(DATE({{ args_concat }}))';
     delete templates.functions.TO_CHAR;
     delete templates.functions.PERCENTILECONT;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';

--- a/packages/cubejs-testing-drivers/fixtures/mssql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mssql.json
@@ -196,6 +196,7 @@
     "SQL API: SQL push down push to cube quoted alias",
     "SQL API: Date/time comparison with SQL push down",
     "SQL API: Date/time comparison with date_trunc with SQL push down",
+    "SQL API: Date/time comparison with DATE() function in SQL push down",
 
     "---------------------------------------",
     "Error during rewrite: Can't detect Cube query and it may be not supported yet.",
@@ -247,6 +248,7 @@
     "SQL API: SQL push down push to cube quoted alias",
     "SQL API: Date/time comparison with SQL push down",
     "SQL API: Date/time comparison with date_trunc with SQL push down",
+    "SQL API: Date/time comparison with DATE() function in SQL push down",
 
     "---------------------------------------",
     "Error during rewrite: Can't detect Cube query and it may be not supported yet.",

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -2689,5 +2689,14 @@ from
       `);
       expect(res.rows).toMatchSnapshot();
     });
+
+    executePg('SQL API: Date/time comparison with DATE() function in SQL push down', async (connection) => {
+      const res = await connection.query(`
+        SELECT MEASURE(BigECommerce.totalQuantity) as qty
+        FROM BigECommerce
+        WHERE CAST(BigECommerce.orderDate AS DATE) = DATE('2020-01-01')
+      `);
+      expect(res.rows).toEqual([{ qty: 4 }]);
+    });
   });
 }


### PR DESCRIPTION
Fixes #10643. Tableau over the SQL API generates `CAST(orderDate AS DATE) = DATE('2020-01-01')`, which fails on BigQuery with `No matching signature for operator = for argument types: TIMESTAMP, DATE`.

## Problem

`DATE()` here is CubeSQL's UDF, not a Postgres builtin: it's declared to return a day-truncated TIMESTAMP, and the planner types the comparison accordingly. But the BigQuery push-down template rendered the call literally as `DATE('2020-01-01')`, producing a DATE compared against a TIMESTAMP — which BigQuery rejects, killing the query (and in stream mode, the server — see #10875).

## Fix

Override the BigQuery `functions/DATE` template to `TIMESTAMP(DATE({{ args_concat }}))`. The inner `DATE()` keeps the UDF's day-truncation and accepts both string and timestamp arguments; the outer `TIMESTAMP()` restores the type the planner already assigned. Wire-visible types don't change.

## Testing

Integration test runs the Tableau-shaped comparison through the SQL API with an exact expected value (`qty: 4`). Verified against live BigQuery with Tesseract on and off. MSSQL is skipped (no SQL-API `DATE()` support).
