### PR TITLE
fix(databricks-jdbc-driver): map ISODOW to DAYOFWEEK_ISO in extract template

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -178,7 +178,7 @@ export class DatabricksQuery extends BaseQuery {
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
     templates.functions.TRUNC = 'CASE WHEN ({{ args[0] }}) >= 0 THEN FLOOR({{ args_concat }}) ELSE CEIL({{ args_concat }}) END';
     templates.expressions.timestamp_literal = 'from_utc_timestamp(\'{{ value }}\', \'UTC\')';
-    templates.expressions.extract = '{% if date_part|lower == "epoch" %}unix_timestamp({{ expr }}){% else %}EXTRACT({{ date_part }} FROM {{ expr }}){% endif %}';
+    templates.expressions.extract = '{% if date_part|lower == "epoch" %}unix_timestamp({{ expr }}){% elif date_part|lower == "isodow" %}EXTRACT(DAYOFWEEK_ISO FROM {{ expr }}){% else %}EXTRACT({{ date_part }} FROM {{ expr }}){% endif %}';
     templates.expressions.interval_single_date_part = 'INTERVAL \'{{ num }}\' {{ date_part }}';
     templates.quotes.identifiers = '`';
     templates.quotes.escape = '``';


### PR DESCRIPTION
## Summary
- CubeSQL's Rust SQL parser emits PostgreSQL-standard date part names
  (e.g. `isodow`) which get passed through to dialect-specific extract templates
- Spark SQL does not recognize `ISODOW` in `EXTRACT()` — the documented
  equivalent is `DAYOFWEEK_ISO` (returns Monday=1 through Sunday=7)
- Adds an `isodow` → `DAYOFWEEK_ISO` mapping in the Databricks extract
  template, following the same pattern BigqueryQuery uses for `DOW`/`DOY`

## Ref
- Spark SQL extract docs: https://docs.databricks.com/en/sql/language-manual/functions/extract.html
- CubeSQL date part mapping: `rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs:130`

## Test plan
- [ ] Queries using `extract(ISODOW FROM ...)` via Cube SQL API produce
      correct results against Databricks
- [ ] Existing extract expressions (epoch, dow, doy, etc.) unaffected