### PR TITLE
docs: document request ID propagation for /v1/cubesql endpoint

### DIFF
--- a/docs/content/product/apis-integrations/core-data-apis/rest-api/index.mdx
+++ b/docs/content/product/apis-integrations/core-data-apis/rest-api/index.mdx
@@ -264,13 +264,19 @@ Cube REST API has basic errors and HTTP Error codes for all requests.
 
 ### Request span annotation
 
-For monitoring tools such as Cube Cloud proper request span annotation should be
-provided in `x-request-id` header of a request. Each request id should consist
-of two parts: `spanId` and `requestSequenceId` which define `x-request-id` as
-whole: `${spanId}-span-${requestSequenceId}`. Values of `x-request-id` header
-should be unique for each separate request. `spanId` should define user
-interaction span such us `Continue wait` retry cycle and it's value shouldn't
-change during one single interaction.
+Both [`/v1/load`][ref-ref-load] and [`/v1/cubesql`][ref-ref-cubesql] endpoints
+support request span annotation for monitoring and tracing.
+
+You can provide a request ID via the `x-request-id` header or the `traceparent`
+header. Each request ID should consist of two parts: `spanId` and
+`requestSequenceId` which define `x-request-id` as whole:
+`${spanId}-span-${requestSequenceId}`. Values of `x-request-id` header should
+be unique for each separate request. `spanId` should define user interaction span
+such as `Continue wait` retry cycle and its value shouldn't change during one
+single interaction.
+
+If neither header is provided, Cube auto-generates a request ID in the
+`${uuid}-span-1` format.
 
 ## Cache control
 

--- a/docs/content/product/apis-integrations/core-data-apis/rest-api/reference.mdx
+++ b/docs/content/product/apis-integrations/core-data-apis/rest-api/reference.mdx
@@ -335,6 +335,11 @@ This endpoint is part of the [SQL API][ref-sql-api].
 | `timezone` | The [time zone][ref-time-zone] for this query in the [TZ Database Name][link-tzdb] format, e.g., `America/Los_Angeles` | ❌ No |
 | `cache` | See [cache control][ref-cache-control]. `stale-if-slow` by default | ❌ No |
 
+This endpoint supports [request span annotation][ref-request-span]. You can
+pass the `x-request-id` or `traceparent` HTTP header to propagate your
+request ID through the entire SQL execution chain for tracing and monitoring.
+If neither header is provided, Cube auto-generates a request ID.
+
 Response: a stream of newline-delimited JSON objects. The first object contains
 the `schema` property with column names and types, and optionally
 `lastRefreshTime` indicating when the data was last refreshed.
@@ -379,6 +384,18 @@ Response:
 ```json
 {"schema":[{"name":"full_name","column_type":"String"},{"name":"wins","column_type":"Int64"},{"name":"avg_position","column_type":"Double"}],"lastRefreshTime":"2025-01-13T12:00:00.000Z"}
 {"data":[["Max VERSTAPPEN","10","3.730769230769231"],["Lando NORRIS","4","4"],["Charles LECLERC","4","4.730769230769231"],["Oscar PIASTRI","3","4.8076923076923075"],["Andrea Kimi ANTONELLI","0","5"]]}
+```
+
+Request with a custom request ID for tracing:
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "x-request-id: my-trace-id-span-1" \
+  -d '{"query": "SELECT 123 AS value"}' \
+  http://localhost:4000/cubejs-api/v1/cubesql
 ```
 
 ## `{base_path}/v1/pre-aggregations/jobs`
@@ -883,3 +900,4 @@ Keep-Alive: timeout=5
 [link-tzdb]: https://en.wikipedia.org/wiki/Tz_database
 [ref-control-plane-api]: /product/apis-integrations/control-plane-api
 [self-metadata-api]: #metadata-api
+[ref-request-span]: /product/apis-integrations/rest-api#request-span-annotation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Documents the feature added in #10633 (`feat(api-gateway): propagate request ID for REST /cubesql endpoint`).

**Description of Changes Made**

The recent commit 1bce74bc1 added request ID propagation from the HTTP request context (via `x-request-id` header, `traceparent` header, or auto-generated UUID) through to the native SQL execution for the `/v1/cubesql` endpoint. This PR adds documentation for this feature.

### Changes

**REST API overview** (`docs/content/product/apis-integrations/core-data-apis/rest-api/index.mdx`):
- Updated the "Request span annotation" section to explicitly list both `/v1/load` and `/v1/cubesql` as endpoints that support request span annotation
- Documented `traceparent` header as an alternative to `x-request-id`
- Added documentation for the auto-generated request ID format (`${uuid}-span-1`) when no header is provided

**REST API reference** (`docs/content/product/apis-integrations/core-data-apis/rest-api/reference.mdx`):
- Added a paragraph to the `/v1/cubesql` endpoint section explaining request span annotation support with `x-request-id` and `traceparent` headers
- Added a curl example demonstrating usage of the `x-request-id` header with the `/v1/cubesql` endpoint
- Added a cross-reference link to the request span annotation section in the overview page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a1fa357-25a4-4bbc-a846-fea381eff4d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a1fa357-25a4-4bbc-a846-fea381eff4d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

