### PR TITLE
docs: update banner to promote Agentic Analytics Summit

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -9,8 +9,8 @@
   },
   "favicon": "/favicon.svg",
   "banner": {
-    "content": "This is an upcoming version of the Cube documentation. For the current version, visit [cube.dev/docs](https://cube.dev/docs)",
-    "dismissible": false
+    "content": "🟣 Agentic Analytics Summit — April 29, 2026 — Online. Registration is open! [Join now →](https://cube.dev/events/agentic-analytics-summit)",
+    "dismissible": true
   },
   "navigation": {
     "tabs": [


### PR DESCRIPTION
Replace the docs preview notice banner with a promotion for the Agentic Analytics Summit on April 29, 2026.

Made-with: Cursor

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
