### PR TITLE
refactor(cubestore): reduce InfoSchemaTableDef memory usage with single-pass builders

### DIFF
--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/info_schema_columns.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/info_schema_columns.rs
@@ -3,7 +3,7 @@ use crate::metastore::Column;
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::array::{ArrayRef, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field};
 use std::sync::Arc;
 
@@ -17,7 +17,7 @@ impl InfoSchemaTableDef for ColumnsInfoSchemaTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<(Column, TablePath)>>, CubeError> {
+    ) -> Result<Vec<(Column, TablePath)>, CubeError> {
         let rows = ctx.meta_store.get_tables_with_path(false).await?;
         let mut res = Vec::new();
 
@@ -28,7 +28,7 @@ impl InfoSchemaTableDef for ColumnsInfoSchemaTableDef {
             }
         }
 
-        Ok(Arc::new(res))
+        Ok(res)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -40,34 +40,25 @@ impl InfoSchemaTableDef for ColumnsInfoSchemaTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<(Column, TablePath)>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<(Column, TablePath)>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut schema_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut table_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut column_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut type_builder = StringBuilder::with_capacity(num_rows, num_rows * 16);
+
+        for (column, table_path) in rows.into_iter() {
+            schema_builder.append_value(table_path.schema.get_row().get_name());
+            table_builder.append_value(table_path.table.get_row().get_table_name());
+            column_builder.append_value(column.get_name());
+            type_builder.append_value(column.get_column_type().to_string());
+        }
+
         vec![
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|(_, row)| row.schema.get_row().get_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|(_, row)| row.table.get_row().get_table_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables.iter().map(|(column, _)| column.get_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|(column, _)| column.get_column_type().to_string()),
-                ))
-            }),
+            Arc::new(schema_builder.finish()),
+            Arc::new(table_builder.finish()),
+            Arc::new(column_builder.finish()),
+            Arc::new(type_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/info_schema_schemata.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/info_schema_schemata.rs
@@ -2,7 +2,7 @@ use crate::metastore::{IdRow, MetaStoreTable, Schema};
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::array::{ArrayRef, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field};
 use std::sync::Arc;
 
@@ -16,20 +16,23 @@ impl InfoSchemaTableDef for SchemataInfoSchemaTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.schemas_table().all_rows().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.schemas_table().all_rows().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
         vec![Field::new("schema_name", DataType::Utf8, false)]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
-        vec![Box::new(|tables| {
-            Arc::new(StringArray::from_iter_values(
-                tables.iter().map(|row| row.get_row().get_name()),
-            ))
-        })]
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut name_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+
+        for row in rows.into_iter() {
+            name_builder.append_value(row.get_row().get_name());
+        }
+
+        vec![Arc::new(name_builder.finish())]
     }
 }
 

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/info_schema_tables.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/info_schema_tables.rs
@@ -3,7 +3,7 @@ use crate::queryplanner::info_schema::timestamp_nanos_or_panic;
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray, TimestampNanosecondArray};
+use datafusion::arrow::array::{ArrayRef, StringBuilder, TimestampNanosecondBuilder};
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
 
@@ -17,8 +17,10 @@ impl InfoSchemaTableDef for TablesInfoSchemaTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<TablePath>>, CubeError> {
-        ctx.meta_store.get_tables_with_path(false).await
+    ) -> Result<Vec<TablePath>, CubeError> {
+        Ok(Arc::unwrap_or_clone(
+            ctx.meta_store.get_tables_with_path(false).await?,
+        ))
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -38,42 +40,31 @@ impl InfoSchemaTableDef for TablesInfoSchemaTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut schema_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut name_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut range_end_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut seal_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+
+        for row in rows.into_iter() {
+            schema_builder.append_value(row.schema.get_row().get_name());
+            let table = row.table.get_row();
+            name_builder.append_value(table.get_table_name());
+            range_end_builder.append_option(
+                table
+                    .build_range_end()
+                    .as_ref()
+                    .map(timestamp_nanos_or_panic),
+            );
+            seal_builder.append_option(table.seal_at().as_ref().map(timestamp_nanos_or_panic));
+        }
+
         vec![
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables.iter().map(|row| row.schema.get_row().get_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|row| row.table.get_row().get_table_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(TimestampNanosecondArray::from_iter(tables.iter().map(
-                    |row| {
-                        row.table
-                            .get_row()
-                            .build_range_end()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|tables| {
-                Arc::new(TimestampNanosecondArray::from_iter(tables.iter().map(
-                    |row| {
-                        row.table
-                            .get_row()
-                            .seal_at()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
+            Arc::new(schema_builder.finish()),
+            Arc::new(name_builder.finish()),
+            Arc::new(range_end_builder.finish()),
+            Arc::new(seal_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/rocksdb_properties.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/rocksdb_properties.rs
@@ -2,7 +2,7 @@ use crate::metastore::RocksPropertyRow;
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::array::{ArrayRef, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field};
 use std::sync::Arc;
 
@@ -32,12 +32,12 @@ impl InfoSchemaTableDef for RocksDBPropertiesTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(if self.for_cachestore {
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(if self.for_cachestore {
             ctx.cache_store.rocksdb_properties().await?
         } else {
             ctx.meta_store.rocksdb_properties().await?
-        }))
+        })
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -47,18 +47,22 @@ impl InfoSchemaTableDef for RocksDBPropertiesTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut key_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut value_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+
+        for row in rows.into_iter() {
+            key_builder.append_value(&row.key);
+            match row.value.as_ref() {
+                Some(v) => value_builder.append_value(v),
+                None => value_builder.append_null(),
+            }
+        }
+
         vec![
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter_values(
-                    items.iter().map(|row| row.key.clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items.iter().map(|row| row.value.as_ref()),
-                ))
-            }),
+            Arc::new(key_builder.finish()),
+            Arc::new(value_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_cache.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_cache.rs
@@ -4,7 +4,7 @@ use crate::queryplanner::info_schema::timestamp_nanos_or_panic;
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray, TimestampNanosecondArray};
+use datafusion::arrow::array::{ArrayRef, StringBuilder, TimestampNanosecondBuilder};
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
 
@@ -18,8 +18,8 @@ impl InfoSchemaTableDef for SystemCacheTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.cache_store.cache_all(limit).await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.cache_store.cache_all(limit).await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -35,33 +35,26 @@ impl InfoSchemaTableDef for SystemCacheTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut key_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut prefix_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut expire_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut value_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+
+        for row in rows.into_iter() {
+            let item = row.get_row();
+            key_builder.append_value(item.get_key());
+            prefix_builder.append_option(item.get_prefix().as_deref());
+            expire_builder.append_option(item.get_expire().as_ref().map(timestamp_nanos_or_panic));
+            value_builder.append_value(item.get_value());
+        }
+
         vec![
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items.iter().map(|row| Some(row.get_row().get_key())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items.iter().map(|row| row.get_row().get_prefix().clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(TimestampNanosecondArray::from_iter(items.iter().map(
-                    |row| {
-                        row.get_row()
-                            .get_expire()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items.iter().map(|row| Some(row.get_row().get_value())),
-                ))
-            }),
+            Arc::new(key_builder.finish()),
+            Arc::new(prefix_builder.finish()),
+            Arc::new(expire_builder.finish()),
+            Arc::new(value_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_chunks.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_chunks.rs
@@ -5,7 +5,7 @@ use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, StringArray, TimestampNanosecondArray, UInt64Array,
+    ArrayRef, BooleanBuilder, StringBuilder, TimestampNanosecondBuilder, UInt64Builder,
 };
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
@@ -20,8 +20,8 @@ impl InfoSchemaTableDef for SystemChunksTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.chunks_table().all_rows().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.chunks_table().all_rows().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -55,106 +55,68 @@ impl InfoSchemaTableDef for SystemChunksTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut file_name_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut partition_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut replay_handle_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut row_count_builder = UInt64Builder::with_capacity(num_rows);
+        let mut uploaded_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut active_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut in_memory_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut created_at_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut oldest_insert_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut deactivated_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut file_size_builder = UInt64Builder::with_capacity(num_rows);
+        let mut min_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut max_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+
+        for row in rows.into_iter() {
+            let id = row.get_id();
+            let chunk = row.get_row();
+            id_builder.append_value(id);
+            file_name_builder.append_value(chunk_file_name(id, chunk.suffix()));
+            partition_id_builder.append_value(chunk.get_partition_id());
+            replay_handle_id_builder.append_option(*chunk.replay_handle_id());
+            row_count_builder.append_value(chunk.get_row_count());
+            uploaded_builder.append_value(chunk.uploaded());
+            active_builder.append_value(chunk.active());
+            in_memory_builder.append_value(chunk.in_memory());
+            created_at_builder
+                .append_option(chunk.created_at().as_ref().map(timestamp_nanos_or_panic));
+            oldest_insert_builder.append_option(
+                chunk
+                    .oldest_insert_at()
+                    .as_ref()
+                    .map(timestamp_nanos_or_panic),
+            );
+            deactivated_builder.append_option(
+                chunk
+                    .deactivated_at()
+                    .as_ref()
+                    .map(timestamp_nanos_or_panic),
+            );
+            file_size_builder.append_option(chunk.file_size());
+            min_builder.append_option(chunk.min().as_ref().map(|v| format!("{:?}", v)));
+            max_builder.append_option(chunk.max().as_ref().map(|v| format!("{:?}", v)));
+        }
+
         vec![
-            Box::new(|chunks| {
-                Arc::new(UInt64Array::from_iter_values(
-                    chunks.iter().map(|row| row.get_id()),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(StringArray::from_iter_values(chunks.iter().map(|row| {
-                    chunk_file_name(row.get_id(), row.get_row().suffix())
-                })))
-            }),
-            Box::new(|chunks| {
-                Arc::new(UInt64Array::from_iter_values(
-                    chunks.iter().map(|row| row.get_row().get_partition_id()),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(UInt64Array::from_iter(
-                    chunks
-                        .iter()
-                        .map(|row| row.get_row().replay_handle_id().clone()),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(UInt64Array::from_iter_values(
-                    chunks.iter().map(|row| row.get_row().get_row_count()),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(BooleanArray::from_iter(
-                    chunks.iter().map(|row| Some(row.get_row().uploaded())),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(BooleanArray::from_iter(
-                    chunks.iter().map(|row| Some(row.get_row().active())),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(BooleanArray::from_iter(
-                    chunks.iter().map(|row| Some(row.get_row().in_memory())),
-                ))
-            }),
-            Box::new(|chunks| {
-                Arc::new(TimestampNanosecondArray::from_iter(chunks.iter().map(
-                    |row| {
-                        row.get_row()
-                            .created_at()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|chunks| {
-                Arc::new(TimestampNanosecondArray::from_iter(chunks.iter().map(
-                    |row| {
-                        row.get_row()
-                            .oldest_insert_at()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|chunks| {
-                Arc::new(TimestampNanosecondArray::from_iter(chunks.iter().map(
-                    |row| {
-                        row.get_row()
-                            .deactivated_at()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|chunks| {
-                Arc::new(UInt64Array::from(
-                    chunks
-                        .iter()
-                        .map(|row| row.get_row().file_size())
-                        .collect::<Vec<_>>(),
-                ))
-            }),
-            Box::new(|chunks| {
-                let min_array = chunks
-                    .iter()
-                    .map(|row| row.get_row().min().as_ref().map(|x| format!("{:?}", x)))
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    min_array.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|chunks| {
-                let max_array = chunks
-                    .iter()
-                    .map(|row| row.get_row().max().as_ref().map(|x| format!("{:?}", x)))
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    max_array.iter().map(|v| v.as_deref()),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(file_name_builder.finish()),
+            Arc::new(partition_id_builder.finish()),
+            Arc::new(replay_handle_id_builder.finish()),
+            Arc::new(row_count_builder.finish()),
+            Arc::new(uploaded_builder.finish()),
+            Arc::new(active_builder.finish()),
+            Arc::new(in_memory_builder.finish()),
+            Arc::new(created_at_builder.finish()),
+            Arc::new(oldest_insert_builder.finish()),
+            Arc::new(deactivated_builder.finish()),
+            Arc::new(file_size_builder.finish()),
+            Arc::new(min_builder.finish()),
+            Arc::new(max_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_indexes.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_indexes.rs
@@ -2,7 +2,7 @@ use crate::metastore::{IdRow, Index, MetaStoreTable};
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray, UInt64Array};
+use datafusion::arrow::array::{ArrayRef, StringBuilder, UInt64Builder};
 use datafusion::arrow::datatypes::{DataType, Field};
 use std::sync::Arc;
 
@@ -16,8 +16,8 @@ impl InfoSchemaTableDef for SystemIndexesTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.index_table().all_rows().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.index_table().all_rows().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -33,54 +33,38 @@ impl InfoSchemaTableDef for SystemIndexesTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut table_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut name_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut columns_builder = StringBuilder::with_capacity(num_rows, num_rows * 128);
+        let mut sort_key_builder = UInt64Builder::with_capacity(num_rows);
+        let mut partition_split_builder = UInt64Builder::with_capacity(num_rows);
+        let mut multi_index_builder = UInt64Builder::with_capacity(num_rows);
+        let mut type_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+
+        for row in rows.into_iter() {
+            id_builder.append_value(row.get_id());
+            let index = row.get_row();
+            table_id_builder.append_value(index.table_id());
+            name_builder.append_value(index.get_name());
+            columns_builder.append_value(format!("{:?}", index.get_columns()));
+            sort_key_builder.append_value(index.sort_key_size());
+            partition_split_builder.append_option(*index.partition_split_key_size());
+            multi_index_builder.append_option(index.multi_index_id());
+            type_builder.append_value(format!("{:?}", index.get_type()));
+        }
+
         vec![
-            Box::new(|indexes| {
-                Arc::new(UInt64Array::from_iter_values(
-                    indexes.iter().map(|row| row.get_id()),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(UInt64Array::from_iter_values(
-                    indexes.iter().map(|row| row.get_row().table_id()),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(StringArray::from_iter_values(
-                    indexes.iter().map(|row| row.get_row().get_name()),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(StringArray::from_iter_values(
-                    indexes
-                        .iter()
-                        .map(|row| format!("{:?}", row.get_row().get_columns())),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(UInt64Array::from_iter_values(
-                    indexes.iter().map(|row| row.get_row().sort_key_size()),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(UInt64Array::from_iter(
-                    indexes
-                        .iter()
-                        .map(|row| row.get_row().partition_split_key_size().clone()),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(UInt64Array::from_iter(
-                    indexes.iter().map(|row| row.get_row().multi_index_id()),
-                ))
-            }),
-            Box::new(|indexes| {
-                Arc::new(StringArray::from_iter_values(
-                    indexes
-                        .iter()
-                        .map(|row| format!("{:?}", row.get_row().get_type())),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(table_id_builder.finish()),
+            Arc::new(name_builder.finish()),
+            Arc::new(columns_builder.finish()),
+            Arc::new(sort_key_builder.finish()),
+            Arc::new(partition_split_builder.finish()),
+            Arc::new(multi_index_builder.finish()),
+            Arc::new(type_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_jobs.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_jobs.rs
@@ -4,7 +4,9 @@ use crate::queryplanner::info_schema::timestamp_nanos_or_panic;
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray, TimestampNanosecondArray, UInt64Array};
+use datafusion::arrow::array::{
+    ArrayRef, StringBuilder, TimestampNanosecondBuilder, UInt64Builder,
+};
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
 
@@ -18,8 +20,8 @@ impl InfoSchemaTableDef for SystemJobsTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.all_jobs().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.all_jobs().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -36,36 +38,29 @@ impl InfoSchemaTableDef for SystemJobsTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut row_ref_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut job_type_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut status_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut heartbeat_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+
+        for row in rows.into_iter() {
+            id_builder.append_value(row.get_id());
+            let job = row.get_row();
+            row_ref_builder.append_value(format!("{:?}", job.row_reference()));
+            job_type_builder.append_value(format!("{:?}", job.job_type()));
+            status_builder.append_value(format!("{:?}", job.status()));
+            heartbeat_builder.append_value(timestamp_nanos_or_panic(job.last_heart_beat()));
+        }
+
         vec![
-            Box::new(|jobs| {
-                Arc::new(UInt64Array::from_iter_values(
-                    jobs.iter().map(|row| row.get_id()),
-                ))
-            }),
-            Box::new(|jobs| {
-                Arc::new(StringArray::from_iter_values(
-                    jobs.iter()
-                        .map(|row| format!("{:?}", row.get_row().row_reference())),
-                ))
-            }),
-            Box::new(|jobs| {
-                Arc::new(StringArray::from_iter_values(
-                    jobs.iter()
-                        .map(|row| format!("{:?}", row.get_row().job_type())),
-                ))
-            }),
-            Box::new(|jobs| {
-                Arc::new(StringArray::from_iter_values(
-                    jobs.iter()
-                        .map(|row| format!("{:?}", row.get_row().status())),
-                ))
-            }),
-            Box::new(|jobs| {
-                Arc::new(TimestampNanosecondArray::from_iter_values(jobs.iter().map(
-                    |row| timestamp_nanos_or_panic(row.get_row().last_heart_beat()),
-                )))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(row_ref_builder.finish()),
+            Arc::new(job_type_builder.finish()),
+            Arc::new(status_builder.finish()),
+            Arc::new(heartbeat_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_partitions.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_partitions.rs
@@ -3,7 +3,7 @@ use crate::metastore::{IdRow, MetaStoreTable, Partition};
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, BooleanArray, StringArray, UInt64Array};
+use datafusion::arrow::array::{ArrayRef, BooleanBuilder, StringBuilder, UInt64Builder};
 use datafusion::arrow::datatypes::{DataType, Field};
 use std::sync::Arc;
 
@@ -17,8 +17,8 @@ impl InfoSchemaTableDef for SystemPartitionsTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.partition_table().all_rows().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.partition_table().all_rows().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -39,107 +39,54 @@ impl InfoSchemaTableDef for SystemPartitionsTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut file_name_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut index_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut parent_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut multi_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut min_val_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut max_val_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut min_row_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut max_row_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut active_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut warmed_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut row_count_builder = UInt64Builder::with_capacity(num_rows);
+        let mut file_size_builder = UInt64Builder::with_capacity(num_rows);
+
+        for row in rows.into_iter() {
+            let id = row.get_id();
+            let part = row.get_row();
+            id_builder.append_value(id);
+            file_name_builder.append_value(partition_file_name(id, part.suffix()));
+            index_id_builder.append_value(part.get_index_id());
+            parent_id_builder.append_option(*part.parent_partition_id());
+            multi_id_builder.append_option(part.multi_partition_id());
+            min_val_builder.append_option(part.get_min_val().as_ref().map(|v| format!("{:?}", v)));
+            max_val_builder.append_option(part.get_max_val().as_ref().map(|v| format!("{:?}", v)));
+            min_row_builder.append_option(part.get_min().as_ref().map(|v| format!("{:?}", v)));
+            max_row_builder.append_option(part.get_max().as_ref().map(|v| format!("{:?}", v)));
+            active_builder.append_value(part.is_active());
+            warmed_builder.append_value(part.is_warmed_up());
+            row_count_builder.append_value(part.main_table_row_count());
+            file_size_builder.append_option(part.file_size());
+        }
+
         vec![
-            Box::new(|partitions| {
-                Arc::new(UInt64Array::from_iter_values(
-                    partitions.iter().map(|row| row.get_id()),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(StringArray::from_iter_values(partitions.iter().map(
-                    |row| partition_file_name(row.get_id(), row.get_row().suffix()),
-                )))
-            }),
-            Box::new(|partitions| {
-                Arc::new(UInt64Array::from_iter_values(
-                    partitions.iter().map(|row| row.get_row().get_index_id()),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(UInt64Array::from_iter(
-                    partitions
-                        .iter()
-                        .map(|row| row.get_row().parent_partition_id().clone()),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(UInt64Array::from_iter(
-                    partitions
-                        .iter()
-                        .map(|row| row.get_row().multi_partition_id().clone()),
-                ))
-            }),
-            Box::new(|partitions| {
-                let min_array = partitions
-                    .iter()
-                    .map(|row| {
-                        row.get_row()
-                            .get_min_val()
-                            .as_ref()
-                            .map(|x| format!("{:?}", x))
-                    })
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    min_array.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|partitions| {
-                let max_array = partitions
-                    .iter()
-                    .map(|row| {
-                        row.get_row()
-                            .get_max_val()
-                            .as_ref()
-                            .map(|x| format!("{:?}", x))
-                    })
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    max_array.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|partitions| {
-                let min_array = partitions
-                    .iter()
-                    .map(|row| row.get_row().get_min().as_ref().map(|x| format!("{:?}", x)))
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    min_array.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|partitions| {
-                let max_array = partitions
-                    .iter()
-                    .map(|row| row.get_row().get_max().as_ref().map(|x| format!("{:?}", x)))
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    max_array.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(BooleanArray::from_iter(
-                    partitions.iter().map(|row| Some(row.get_row().is_active())),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(BooleanArray::from_iter(
-                    partitions
-                        .iter()
-                        .map(|row| Some(row.get_row().is_warmed_up())),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(UInt64Array::from_iter_values(
-                    partitions
-                        .iter()
-                        .map(|row| row.get_row().main_table_row_count()),
-                ))
-            }),
-            Box::new(|partitions| {
-                Arc::new(UInt64Array::from_iter(
-                    partitions.iter().map(|row| row.get_row().file_size()),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(file_name_builder.finish()),
+            Arc::new(index_id_builder.finish()),
+            Arc::new(parent_id_builder.finish()),
+            Arc::new(multi_id_builder.finish()),
+            Arc::new(min_val_builder.finish()),
+            Arc::new(max_val_builder.finish()),
+            Arc::new(min_row_builder.finish()),
+            Arc::new(max_row_builder.finish()),
+            Arc::new(active_builder.finish()),
+            Arc::new(warmed_builder.finish()),
+            Arc::new(row_count_builder.finish()),
+            Arc::new(file_size_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_queue.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_queue.rs
@@ -4,7 +4,7 @@ use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, Int64Array, StringArray, TimestampNanosecondArray,
+    ArrayRef, BooleanBuilder, Int64Builder, StringBuilder, TimestampNanosecondBuilder,
 };
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
@@ -19,8 +19,8 @@ impl InfoSchemaTableDef for SystemQueueTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.cache_store.queue_all(limit).await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.cache_store.queue_all(limit).await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -52,96 +52,52 @@ impl InfoSchemaTableDef for SystemQueueTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut prefix_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut created_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut status_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut priority_builder = Int64Builder::with_capacity(num_rows);
+        let mut heartbeat_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut orphaned_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut value_builder = StringBuilder::with_capacity(num_rows, num_rows * 128);
+        let mut extra_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut process_id_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut exclusive_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut external_id_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+
+        for row in rows.into_iter() {
+            let item = row.item.get_row();
+            id_builder.append_value(item.get_key());
+            prefix_builder.append_option(item.get_prefix().as_deref());
+            created_builder.append_value(timestamp_nanos_or_panic(item.get_created()));
+            status_builder.append_value(format!("{:?}", item.get_status()));
+            priority_builder.append_value(*item.get_priority());
+            heartbeat_builder
+                .append_option(item.get_heartbeat().as_ref().map(timestamp_nanos_or_panic));
+            orphaned_builder
+                .append_option(item.get_orphaned().as_ref().map(timestamp_nanos_or_panic));
+            value_builder.append_option(row.payload.as_deref());
+            extra_builder.append_option(item.get_extra().as_deref());
+            process_id_builder.append_option(item.get_process_id().as_deref());
+            exclusive_builder.append_value(item.get_exclusive());
+            external_id_builder.append_option(item.get_external_id().as_deref());
+        }
+
         vec![
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items.iter().map(|row| Some(row.item.get_row().get_key())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| row.item.get_row().get_prefix().clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(TimestampNanosecondArray::from_iter_values(
-                    items
-                        .iter()
-                        .map(|row| timestamp_nanos_or_panic(row.item.get_row().get_created())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter_values(
-                    items
-                        .iter()
-                        .map(|row| format!("{:?}", row.item.get_row().get_status())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(Int64Array::from_iter_values(
-                    items
-                        .iter()
-                        .map(|row| row.item.get_row().get_priority().clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(TimestampNanosecondArray::from_iter(items.iter().map(
-                    |row| {
-                        row.item
-                            .get_row()
-                            .get_heartbeat()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|items| {
-                Arc::new(TimestampNanosecondArray::from_iter(items.iter().map(
-                    |row| {
-                        row.item
-                            .get_row()
-                            .get_orphaned()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items.iter().map(|row| row.payload.as_ref()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| row.item.get_row().get_extra().clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| row.item.get_row().get_process_id().clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(BooleanArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| Some(row.item.get_row().get_exclusive())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| row.item.get_row().get_external_id().clone()),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(prefix_builder.finish()),
+            Arc::new(created_builder.finish()),
+            Arc::new(status_builder.finish()),
+            Arc::new(priority_builder.finish()),
+            Arc::new(heartbeat_builder.finish()),
+            Arc::new(orphaned_builder.finish()),
+            Arc::new(value_builder.finish()),
+            Arc::new(extra_builder.finish()),
+            Arc::new(process_id_builder.finish()),
+            Arc::new(exclusive_builder.finish()),
+            Arc::new(external_id_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_queue_results.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_queue_results.rs
@@ -5,7 +5,7 @@ use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, StringArray, TimestampNanosecondArray, UInt64Array,
+    ArrayRef, BooleanBuilder, StringBuilder, TimestampNanosecondBuilder, UInt64Builder,
 };
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
@@ -20,8 +20,8 @@ impl InfoSchemaTableDef for SystemQueueResultsTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.cache_store.queue_results_all(limit).await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.cache_store.queue_results_all(limit).await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -39,44 +39,32 @@ impl InfoSchemaTableDef for SystemQueueResultsTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut path_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut expire_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut deleted_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut value_builder = StringBuilder::with_capacity(num_rows, num_rows * 128);
+        let mut external_id_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+
+        for row in rows.into_iter() {
+            id_builder.append_value(row.get_id());
+            let result = row.get_row();
+            path_builder.append_value(result.get_path());
+            expire_builder.append_value(timestamp_nanos_or_panic(result.get_expire()));
+            deleted_builder.append_value(result.is_deleted());
+            value_builder.append_value(result.get_value());
+            external_id_builder.append_option(result.get_external_id().as_deref());
+        }
+
         vec![
-            Box::new(|items| {
-                Arc::new(UInt64Array::from_iter(
-                    items.iter().map(|row| Some(row.get_id())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| Some(row.get_row().get_path().clone())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(TimestampNanosecondArray::from_iter_values(
-                    items
-                        .iter()
-                        .map(|row| timestamp_nanos_or_panic(row.get_row().get_expire())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(BooleanArray::from_iter(
-                    items.iter().map(|row| Some(row.get_row().is_deleted())),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter_values(
-                    items.iter().map(|row| row.get_row().get_value().clone()),
-                ))
-            }),
-            Box::new(|items| {
-                Arc::new(StringArray::from_iter(
-                    items
-                        .iter()
-                        .map(|row| row.get_row().get_external_id().clone()),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(path_builder.finish()),
+            Arc::new(expire_builder.finish()),
+            Arc::new(deleted_builder.finish()),
+            Arc::new(value_builder.finish()),
+            Arc::new(external_id_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_replay_handles.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_replay_handles.rs
@@ -5,7 +5,7 @@ use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, StringArray, TimestampNanosecondArray, UInt64Array,
+    ArrayRef, BooleanBuilder, StringBuilder, TimestampNanosecondBuilder, UInt64Builder,
 };
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
@@ -20,8 +20,8 @@ impl InfoSchemaTableDef for SystemReplayHandlesTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.all_replay_handles().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.all_replay_handles().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -38,37 +38,29 @@ impl InfoSchemaTableDef for SystemReplayHandlesTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut table_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut failed_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut seq_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut created_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+
+        for row in rows.into_iter() {
+            id_builder.append_value(row.get_id());
+            let handle = row.get_row();
+            table_id_builder.append_value(handle.table_id());
+            failed_builder.append_value(handle.has_failed_to_persist_chunks());
+            seq_builder.append_value(format!("{:?}", handle.seq_pointers_by_location()));
+            created_builder.append_value(timestamp_nanos_or_panic(handle.created_at()));
+        }
+
         vec![
-            Box::new(|handles| {
-                Arc::new(UInt64Array::from_iter_values(
-                    handles.iter().map(|row| row.get_id()),
-                ))
-            }),
-            Box::new(|handles| {
-                Arc::new(UInt64Array::from_iter_values(
-                    handles.iter().map(|row| row.get_row().table_id()),
-                ))
-            }),
-            Box::new(|handles| {
-                Arc::new(BooleanArray::from_iter(
-                    handles
-                        .iter()
-                        .map(|row| Some(row.get_row().has_failed_to_persist_chunks())),
-                ))
-            }),
-            Box::new(|jobs| {
-                Arc::new(StringArray::from_iter_values(jobs.iter().map(|row| {
-                    format!("{:?}", row.get_row().seq_pointers_by_location())
-                })))
-            }),
-            Box::new(|handles| {
-                Arc::new(TimestampNanosecondArray::from_iter_values(
-                    handles
-                        .iter()
-                        .map(|row| timestamp_nanos_or_panic(row.get_row().created_at())),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(table_id_builder.finish()),
+            Arc::new(failed_builder.finish()),
+            Arc::new(seq_builder.finish()),
+            Arc::new(created_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_snapshots.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_snapshots.rs
@@ -2,7 +2,9 @@ use crate::metastore::snapshot_info::SnapshotInfo;
 use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, BooleanArray, StringArray, TimestampNanosecondArray};
+use datafusion::arrow::array::{
+    ArrayRef, BooleanBuilder, StringBuilder, TimestampNanosecondBuilder,
+};
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
 
@@ -16,8 +18,8 @@ impl InfoSchemaTableDef for SystemSnapshotsTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        Ok(Arc::new(ctx.meta_store.get_snapshots_list().await?))
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(ctx.meta_store.get_snapshots_list().await?)
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -32,23 +34,22 @@ impl InfoSchemaTableDef for SystemSnapshotsTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut created_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut current_builder = BooleanBuilder::with_capacity(num_rows);
+
+        for row in rows.into_iter() {
+            id_builder.append_value(format!("{}", row.id));
+            created_builder.append_value((row.id * 1000000) as i64);
+            current_builder.append_value(row.current);
+        }
+
         vec![
-            Box::new(|snapshots| {
-                Arc::new(StringArray::from_iter_values(
-                    snapshots.iter().map(|row| format!("{}", row.id)),
-                ))
-            }),
-            Box::new(|snapshots| {
-                Arc::new(TimestampNanosecondArray::from_iter_values(
-                    snapshots.iter().map(|row| (row.id * 1000000) as i64),
-                ))
-            }),
-            Box::new(|snapshots| {
-                Arc::new(BooleanArray::from_iter(
-                    snapshots.iter().map(|row| Some(row.current)),
-                ))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(created_builder.finish()),
+            Arc::new(current_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/info_schema/system_tables.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/info_schema/system_tables.rs
@@ -4,7 +4,7 @@ use crate::queryplanner::{InfoSchemaTableDef, InfoSchemaTableDefContext};
 use crate::CubeError;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, StringArray, TimestampNanosecondArray, UInt64Array,
+    ArrayRef, BooleanBuilder, StringBuilder, TimestampNanosecondBuilder, UInt64Builder,
 };
 use datafusion::arrow::datatypes::{DataType, Field, TimeUnit};
 use std::sync::Arc;
@@ -19,8 +19,10 @@ impl InfoSchemaTableDef for SystemTablesTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         _limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError> {
-        ctx.meta_store.get_tables_with_path(true).await
+    ) -> Result<Vec<Self::T>, CubeError> {
+        Ok(Arc::unwrap_or_clone(
+            ctx.meta_store.get_tables_with_path(true).await?,
+        ))
     }
 
     fn schema(&self) -> Vec<Field> {
@@ -59,157 +61,83 @@ impl InfoSchemaTableDef for SystemTablesTableDef {
         ]
     }
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>> {
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef> {
+        let num_rows = rows.len();
+        let mut id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut schema_id_builder = UInt64Builder::with_capacity(num_rows);
+        let mut schema_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut name_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut columns_builder = StringBuilder::with_capacity(num_rows, num_rows * 128);
+        let mut locations_builder = StringBuilder::with_capacity(num_rows, num_rows * 128);
+        let mut format_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut has_data_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut is_ready_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut unique_key_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut agg_columns_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut seq_column_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+        let mut split_threshold_builder = UInt64Builder::with_capacity(num_rows);
+        let mut created_at_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut range_end_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut seal_at_builder = TimestampNanosecondBuilder::with_capacity(num_rows);
+        let mut sealed_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut select_builder = StringBuilder::with_capacity(num_rows, num_rows * 128);
+        let mut extension_builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
+
+        for row in rows.into_iter() {
+            id_builder.append_value(row.table.get_id());
+            let table = row.table.get_row();
+            schema_id_builder.append_value(table.get_schema_id());
+            schema_builder.append_value(row.schema.get_row().get_name());
+            name_builder.append_value(table.get_table_name());
+            columns_builder.append_value(format!("{:?}", table.get_columns()));
+            locations_builder.append_value(format!("{:?}", table.locations()));
+            format_builder.append_value(format!("{:?}", table.import_format()));
+            has_data_builder.append_value(*table.has_data());
+            is_ready_builder.append_value(table.is_ready());
+            unique_key_builder.append_option(
+                table
+                    .unique_key_columns()
+                    .as_ref()
+                    .map(|v| format!("{:?}", v)),
+            );
+            agg_columns_builder.append_value(format!("{:?}", table.aggregate_columns()));
+            seq_column_builder
+                .append_option(table.seq_column().as_ref().map(|v| format!("{:?}", v)));
+            split_threshold_builder.append_option(*table.partition_split_threshold());
+            created_at_builder
+                .append_option(table.created_at().as_ref().map(timestamp_nanos_or_panic));
+            range_end_builder.append_option(
+                table
+                    .build_range_end()
+                    .as_ref()
+                    .map(timestamp_nanos_or_panic),
+            );
+            seal_at_builder.append_option(table.seal_at().as_ref().map(timestamp_nanos_or_panic));
+            sealed_builder.append_value(table.sealed());
+            select_builder.append_option(table.select_statement().as_ref().map(|s| s.as_str()));
+            extension_builder.append_option(table.extension().as_ref().map(|e| e.as_str()));
+        }
+
         vec![
-            Box::new(|tables| {
-                Arc::new(UInt64Array::from_iter_values(
-                    tables.iter().map(|row| row.table.get_id()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(UInt64Array::from_iter_values(
-                    tables.iter().map(|row| row.table.get_row().get_schema_id()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables.iter().map(|row| row.schema.get_row().get_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|row| row.table.get_row().get_table_name()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|row| format!("{:?}", row.table.get_row().get_columns())),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|row| format!("{:?}", row.table.get_row().locations())),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(
-                    tables
-                        .iter()
-                        .map(|row| format!("{:?}", row.table.get_row().import_format())),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(BooleanArray::from_iter(
-                    tables
-                        .iter()
-                        .map(|row| Some(*row.table.get_row().has_data())),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(BooleanArray::from_iter(
-                    tables
-                        .iter()
-                        .map(|row| Some(row.table.get_row().is_ready())),
-                ))
-            }),
-            Box::new(|tables| {
-                let unique_key_columns = tables
-                    .iter()
-                    .map(|row| {
-                        row.table
-                            .get_row()
-                            .unique_key_columns()
-                            .as_ref()
-                            .map(|v| format!("{:?}", v))
-                    })
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    unique_key_columns.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter_values(tables.iter().map(|row| {
-                    format!("{:?}", row.table.get_row().aggregate_columns())
-                })))
-            }),
-            Box::new(|tables| {
-                let seq_columns = tables
-                    .iter()
-                    .map(|row| {
-                        row.table
-                            .get_row()
-                            .seq_column()
-                            .as_ref()
-                            .map(|v| format!("{:?}", v))
-                    })
-                    .collect::<Vec<_>>();
-                Arc::new(StringArray::from_iter(
-                    seq_columns.iter().map(|v| v.as_deref()),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(UInt64Array::from_iter(tables.iter().map(|row| {
-                    row.table.get_row().partition_split_threshold().clone()
-                })))
-            }),
-            Box::new(|tables| {
-                Arc::new(TimestampNanosecondArray::from_iter(tables.iter().map(
-                    |row| {
-                        row.table
-                            .get_row()
-                            .created_at()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|tables| {
-                Arc::new(TimestampNanosecondArray::from_iter(tables.iter().map(
-                    |row| {
-                        row.table
-                            .get_row()
-                            .build_range_end()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|tables| {
-                Arc::new(TimestampNanosecondArray::from_iter(tables.iter().map(
-                    |row| {
-                        row.table
-                            .get_row()
-                            .seal_at()
-                            .as_ref()
-                            .map(timestamp_nanos_or_panic)
-                    },
-                )))
-            }),
-            Box::new(|tables| {
-                Arc::new(BooleanArray::from_iter(
-                    tables.iter().map(|row| Some(row.table.get_row().sealed())),
-                ))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter(tables.iter().map(|row| {
-                    row.table
-                        .get_row()
-                        .select_statement()
-                        .as_ref()
-                        .map(|t| t.as_str())
-                })))
-            }),
-            Box::new(|tables| {
-                Arc::new(StringArray::from_iter(tables.iter().map(|row| {
-                    row.table.get_row().extension().as_ref().map(|t| t.as_str())
-                })))
-            }),
+            Arc::new(id_builder.finish()),
+            Arc::new(schema_id_builder.finish()),
+            Arc::new(schema_builder.finish()),
+            Arc::new(name_builder.finish()),
+            Arc::new(columns_builder.finish()),
+            Arc::new(locations_builder.finish()),
+            Arc::new(format_builder.finish()),
+            Arc::new(has_data_builder.finish()),
+            Arc::new(is_ready_builder.finish()),
+            Arc::new(unique_key_builder.finish()),
+            Arc::new(agg_columns_builder.finish()),
+            Arc::new(seq_column_builder.finish()),
+            Arc::new(split_threshold_builder.finish()),
+            Arc::new(created_at_builder.finish()),
+            Arc::new(range_end_builder.finish()),
+            Arc::new(seal_at_builder.finish()),
+            Arc::new(sealed_builder.finish()),
+            Arc::new(select_builder.finish()),
+            Arc::new(extension_builder.finish()),
         ]
     }
 }

--- a/rust/cubestore/cubestore/src/queryplanner/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/mod.rs
@@ -677,9 +677,9 @@ pub trait InfoSchemaTableDef {
         &self,
         ctx: InfoSchemaTableDefContext,
         limit: Option<usize>,
-    ) -> Result<Arc<Vec<Self::T>>, CubeError>;
+    ) -> Result<Vec<Self::T>, CubeError>;
 
-    fn columns(&self) -> Vec<Box<dyn Fn(Arc<Vec<Self::T>>) -> ArrayRef>>;
+    fn columns(&self, rows: Vec<Self::T>) -> Vec<ArrayRef>;
 
     fn schema(&self) -> Vec<Field>;
 }
@@ -711,11 +711,7 @@ macro_rules! base_info_schema_table_def {
             ) -> Result<datafusion::arrow::record_batch::RecordBatch, crate::CubeError> {
                 let rows = self.rows(ctx, limit).await?;
                 let schema = self.schema_ref();
-                let columns = self.columns();
-                let columns = columns
-                    .into_iter()
-                    .map(|c| c(rows.clone()))
-                    .collect::<Vec<_>>();
+                let columns = self.columns(rows);
                 Ok(datafusion::arrow::record_batch::RecordBatch::try_new(
                     schema, columns,
                 )?)


### PR DESCRIPTION
Replace closure-per-column pattern with into_iter() + Arrow builders.

Each row's heap data is freed incrementally during iteration instead of all source data alive until RecordBatch creation. Removes Arc wrapping, Box<dyn Fn> allocations, and reduces N passes to 1.

  | Total cache | Per-row value (avg) | N      | OLD peak Δ   | NEW peak Δ       | Savings                  | OLD allocs | NEW allocs | OLD time | NEW time |                                               
  | ----------- | ------------------- | -----: | -----------: | ---------------: | -----------------------: | ---------: | ---------: | -------: | -------: |
  | ~11 MB      | ~1 KB               | 10 000 |    16.76 MB  |    **10.79 MB**  |     **−5.97 MB (−36 %)** |     26 736 |         46 |   4.1 ms |   2.0 ms |                                               
  | ~55 MB      | ~5 KB               | 10 000 |    57.77 MB  |    **40.17 MB**  |     **−17.6 MB (−30 %)** |     26 736 |         48 |  10.3 ms |   9.5 ms |                                               
  | ~127 MB     | ~13 KB              | 10 000 |   150.78 MB  |    **79.28 MB**  |     **−71.5 MB (−47 %)** |     26 737 |         49 |  18.0 ms |  15.0 ms |                                               
  | ~257 MB     | ~26 KB              | 10 000 |   438.81 MB  |   **157.40 MB**  |      **−281 MB (−64 %)** |     26 737 |         50 |  53.1 ms |  34.1 ms |                                               
  | ~1.5 GB     | **512 KB (fixed)**  |  3 000 † | 2 048.70 MB | **1 024.34 MB**  |    **−1 024 MB (−50 %)** |      8 065 |         54 |    804 ms |   671 ms |                                             
  | ~1.5 GB     | **1 MB (fixed)**    |  1 500 † | 2 049.10 MB | **1 024.17 MB**  |    **−1 025 MB (−50 %)** |      4 062 |         53 |   85.6 ms |  61.1 ms |    