### PR TITLE
docs: add user preferences section to manage users page

### DIFF
--- a/docs-mintlify/admin/users-and-permissions/manage-users.mdx
+++ b/docs-mintlify/admin/users-and-permissions/manage-users.mdx
@@ -102,6 +102,21 @@ You cannot delete your own account. Deleting a user is irreversible.
 
 </Warning>
 
+## User preferences
+
+Each user can customize their Cube Cloud experience through the
+**Preferences** page, accessible from the user menu. These settings are
+saved to the user's account and apply across all devices.
+
+| Preference | Description | Default |
+| --- | --- | --- |
+| Theme | Choose between System, Light, or Dark visual theme | System |
+| Sidebar drawer | Show only icons and expand the sidebar on hover | Off |
+| Pointer cursors | Use pointer cursors on interactive elements | On |
+| Code editor | Switch to the new CodeMirror-based code editor for data models | Off |
+| New message scrolling | Automatically scroll to new messages in chat | On |
+| Alternating row colors | Highlight alternating rows in data tables | Off |
+
 ## Provisioning users via SCIM
 
 If your organization uses an identity provider such as [Okta][ref-okta] or


### PR DESCRIPTION
## Summary

- Adds a new "User preferences" section to the manage users documentation page
- Documents all available user preferences: theme, sidebar drawer, pointer cursors, code editor, new message scrolling, and the new alternating row colors preference

Resolves CUB-2215.

## Test plan

- [ ] Verify the documentation renders correctly on the docs site