### PR TITLE
playground: fix 'occured' -> 'occurred' in error boundary message

### DIFF
--- a/packages/cubejs-playground/src/App.tsx
+++ b/packages/cubejs-playground/src/App.tsx
@@ -120,7 +120,7 @@ class App extends Component<PropsWithChildren<RouteComponentProps>, AppState> {
           <StyledLayoutContent>
             {fatalError ? (
               <Alert
-                message="Error occured while rendering"
+                message="Error occurred while rendering"
                 description={fatalError.stack || ''}
                 type="error"
               />


### PR DESCRIPTION
Error boundary message in `packages/cubejs-playground/src/App.tsx` line 123 reads `Error occured while rendering`. This is user-visible in the playground UI. Fixed to `occurred`. String-literal-only change.