### PR TITLE
fix(backend-shared): Exclude non-credential env vars from separate pr…

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -144,12 +144,29 @@ type DataSourceOpts = { dataSource: string, preAggregations?: boolean };
  * Checks if at least one PRE_AGGREGATIONS env var is set for a given data source.
  */
 export function hasPreAggregationsEnvVars(dataSource: string = 'default'): boolean {
-  const prefix = dataSource === 'default'
-    ? 'CUBEJS_PRE_AGGREGATIONS_'
-    : `CUBEJS_DS_${dataSource.toUpperCase()}_PRE_AGGREGATIONS_`;
+  if (dataSource === 'default') {
+    /**
+     * Non-credential env vars that share the CUBEJS_PRE_AGGREGATIONS_ prefix
+     * but should NOT trigger separate pre-aggregation credentials.
+     */
+    const PRE_AGGREGATIONS_NON_CREDENTIAL_KEYS = new Set([
+      'CUBEJS_PRE_AGGREGATIONS_SCHEMA',
+      'CUBEJS_PRE_AGGREGATIONS_BUILDER',
+      'CUBEJS_PRE_AGGREGATIONS_BACKOFF_MAX_TIME',
+      'CUBEJS_PRE_AGGREGATIONS_ALLOW_NON_STRICT_DATE_RANGE_MATCH',
+    ]);
+
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('CUBEJS_PRE_AGGREGATIONS_') && !PRE_AGGREGATIONS_NON_CREDENTIAL_KEYS.has(key)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith(prefix) && key !== `${prefix}SCHEMA`) {
+    if (key.startsWith(`CUBEJS_DS_${dataSource.toUpperCase()}_PRE_AGGREGATIONS_`)) {
       return true;
     }
   }

--- a/packages/cubejs-backend-shared/test/db_env_pre_aggregations.test.ts
+++ b/packages/cubejs-backend-shared/test/db_env_pre_aggregations.test.ts
@@ -148,6 +148,9 @@ describe('hasPreAggregationsEnvVars', () => {
   afterEach(() => {
     delete process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST;
     delete process.env.CUBEJS_PRE_AGGREGATIONS_SCHEMA;
+    delete process.env.CUBEJS_PRE_AGGREGATIONS_BUILDER;
+    delete process.env.CUBEJS_PRE_AGGREGATIONS_BACKOFF_MAX_TIME;
+    delete process.env.CUBEJS_PRE_AGGREGATIONS_ALLOW_NON_STRICT_DATE_RANGE_MATCH;
     delete process.env.CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_HOST;
     delete process.env.CUBEJS_DATASOURCES;
   });
@@ -169,6 +172,25 @@ describe('hasPreAggregationsEnvVars', () => {
   test('ignores CUBEJS_PRE_AGGREGATIONS_SCHEMA', () => {
     process.env.CUBEJS_PRE_AGGREGATIONS_SCHEMA = 'my_preaggs';
     expect(hasPreAggregationsEnvVars('default')).toBe(false);
+  });
+
+  test('ignores CUBEJS_PRE_AGGREGATIONS_BUILDER', () => {
+    process.env.CUBEJS_PRE_AGGREGATIONS_BUILDER = 'true';
+    expect(hasPreAggregationsEnvVars('default')).toBe(false);
+  });
+
+  test('returns false when only non-credential PRE_AGGREGATIONS vars are set', () => {
+    process.env.CUBEJS_PRE_AGGREGATIONS_SCHEMA = 'my_preaggs';
+    process.env.CUBEJS_PRE_AGGREGATIONS_BUILDER = 'true';
+    process.env.CUBEJS_PRE_AGGREGATIONS_BACKOFF_MAX_TIME = '600';
+    process.env.CUBEJS_PRE_AGGREGATIONS_ALLOW_NON_STRICT_DATE_RANGE_MATCH = 'true';
+    expect(hasPreAggregationsEnvVars('default')).toBe(false);
+  });
+
+  test('returns true when credential var is set alongside non-credential vars', () => {
+    process.env.CUBEJS_PRE_AGGREGATIONS_BUILDER = 'true';
+    process.env.CUBEJS_PRE_AGGREGATIONS_DB_HOST = 'some-host';
+    expect(hasPreAggregationsEnvVars('default')).toBe(true);
   });
 
   test('returns false for non-matching datasource', () => {


### PR DESCRIPTION
…e-agg credentials trigger

CUBEJS_PRE_AGGREGATIONS_BUILDER, CUBEJS_PRE_AGGREGATIONS_BACKOFF_MAX_TIME, and CUBEJS_PRE_AGGREGATIONS_ALLOW_NON_STRICT_DATE_RANGE_MATCH are config vars that should not cause hasPreAggregationsEnvVars to return true.
