### PR TITLE
perf: Transfer ResultWrapper rawData as Buffer(JSON), ~10x faster

### DIFF
--- a/packages/cubejs-backend-native/js/ResultWrapper.ts
+++ b/packages/cubejs-backend-native/js/ResultWrapper.ts
@@ -126,6 +126,7 @@ export class ResultWrapper extends BaseWrapper implements DataResult {
       }
       this.cached = true;
     }
+
     return this.cache;
   }
 
@@ -139,7 +140,14 @@ export class ResultWrapper extends BaseWrapper implements DataResult {
       return [this.nativeReference];
     }
 
-    return [this.jsResult];
+    // Serialize to a Buffer so the Rust side can decode via
+    // serde_json::from_slice instead of walking a JsArray through the
+    // Neon bridge with JsValueDeserializer. On 5 MB of AoO rows
+    // (~21k rows × 8 fields) the JsArray walk costs ~80 ms locally;
+    // Buffer + serde_json is ~7× faster (M3 MAX) and tracks V8's JSON.parse
+    // (~11 ms on the same payload). On a real server it should be 3-6× slower,
+    // so avoiding the JsArray walk matters even more there.
+    return [Buffer.from(JSON.stringify(this.jsResult))];
   }
 
   public setTransformData(td: any) {

--- a/packages/cubejs-backend-native/src/orchestrator.rs
+++ b/packages/cubejs-backend-native/src/orchestrator.rs
@@ -90,6 +90,18 @@ impl ResultWrapper {
         let query_result =
             if let Ok(js_box) = raw_data_js.downcast::<JsBox<Arc<QueryResult>>, _>(cx) {
                 Arc::clone(&js_box)
+            } else if let Ok(js_buffer) = raw_data_js.downcast::<JsBuffer, _>(cx) {
+                let bytes = js_buffer.as_slice(cx);
+                let js_raw_data: JsRawData = serde_json::from_slice(bytes).map_err(|e| {
+                    CubeError::internal(format!(
+                        "Can't parse raw data JSON from JS ResultWrapper: {}",
+                        e
+                    ))
+                })?;
+
+                QueryResult::from_js_raw_data(js_raw_data)
+                    .map(Arc::new)
+                    .map_cube_err("Can't build results data from JS rawData")?
             } else if let Ok(js_array) = raw_data_js.downcast::<JsArray, _>(cx) {
                 let deserializer = JsValueDeserializer::new(cx, js_array.upcast());
                 let js_raw_data: JsRawData = match Deserialize::deserialize(deserializer) {
@@ -222,6 +234,13 @@ fn extract_query_result(
 ) -> Result<Arc<QueryResult>, anyhow::Error> {
     if let Ok(js_box) = data_arg.downcast::<JsBox<Arc<QueryResult>>, _>(cx) {
         Ok(Arc::clone(&js_box))
+    } else if let Ok(js_buffer) = data_arg.downcast::<JsBuffer, _>(cx) {
+        let bytes = js_buffer.as_slice(cx);
+        let js_raw_data: JsRawData = serde_json::from_slice(bytes)?;
+
+        QueryResult::from_js_raw_data(js_raw_data)
+            .map(Arc::new)
+            .map_err(anyhow::Error::from)
     } else if let Ok(js_array) = data_arg.downcast::<JsArray, _>(cx) {
         let deserializer = JsValueDeserializer::new(cx, js_array.upcast());
         let js_raw_data: JsRawData = Deserialize::deserialize(deserializer)?;


### PR DESCRIPTION
Serialize JS result rows once on the JS side and pass them across the Neon bridge as a Buffer, so Rust can consume them via serde_json::from_slice instead of walking a JsArray through JsValueDeserializer.