### PR TITLE
docs: remove example pricing table from AI tokens page

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -38,13 +38,7 @@ is subject to change as the product evolves.
 
 Self-serve customers on paid plans receive **per-seat token grants** equal to
 **half of the seat price**. Each user is awarded an individual monthly token
-allocation based on their role:
-
-| Example | Seat price | Monthly token grant |
-| --- | --- | --- |
-| Developer at $100/month | $100 | $50 |
-| Explorer at $60/month | $60 | $30 |
-| Viewer at $20/month | $20 | $10 |
+allocation based on their role.
 
 Per-seat grants:
 


### PR DESCRIPTION
The example table was being misread as actual pricing. The rule (grants equal half the seat price) is stated in prose, which is sufficient.

Made-with: Cursor

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
