### PR TITLE
docs: add legacy docs banner pointing to new docs.cube.dev

### DIFF
--- a/docs/app/layout.jsx
+++ b/docs/app/layout.jsx
@@ -1,5 +1,5 @@
 import { Layout, Navbar } from 'nextra-theme-docs'
-import { Head } from 'nextra/components'
+import { Banner, Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import localFont from 'next/font/local'
 import 'nextra-theme-docs/style.css'
@@ -79,6 +79,14 @@ const navbar = (
 
 const footer = <Footer />
 
+const banner = (
+  <Banner storageKey="legacy-docs-2026">
+    <a href="https://docs.cube.dev" target="_blank" rel="noreferrer">
+      You're looking at the old Cube documentation. Visit the new docs →
+    </a>
+  </Banner>
+)
+
 export default async function RootLayout({ children }) {
   return (
     <html
@@ -114,6 +122,7 @@ export default async function RootLayout({ children }) {
           <PurpleBannerWrapper />
           <AnalyticsProvider>
             <Layout
+              banner={banner}
               navbar={navbar}
               pageMap={await getPageMap()}
               docsRepositoryBase="https://github.com/cube-js/cube/tree/master/docs"


### PR DESCRIPTION
Notify visitors of the old Nextra docs site that documentation has moved to the new Mintlify-based docs.cube.dev so they can switch over.

Made-with: Cursor

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
