### PR TITLE
feat(cubesql): Universally prefix all errors

### DIFF
--- a/packages/cubejs-backend-native/src/channel.rs
+++ b/packages/cubejs-backend-native/src/channel.rs
@@ -156,7 +156,7 @@ where
                 Ok(json) => Ok(json),
                 Err(err) => Err(CubeError::internal(err.to_string())),
             },
-            Err(err) => Err(CubeError::internal(err.to_string())),
+            Err(err) => Err(err),
         };
 
         if tx.send(to_channel).is_err() {

--- a/packages/cubejs-backend-native/src/gateway/http_error.rs
+++ b/packages/cubejs-backend-native/src/gateway/http_error.rs
@@ -42,14 +42,22 @@ impl HttpError {
     pub fn from_user_with_status_code(error: CubeError, code: HttpErrorCode) -> Self {
         Self {
             code: match error.cause {
-                CubeErrorCauseType::User(_) => code,
-                CubeErrorCauseType::Internal(_) => {
-                    HttpErrorCode::StatusCode(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
-                }
+                CubeErrorCauseType::User(_)
+                | CubeErrorCauseType::SqlParser(_)
+                | CubeErrorCauseType::Unsupported(_)
+                | CubeErrorCauseType::Planning(_)
+                | CubeErrorCauseType::PostProcessing(_)
+                | CubeErrorCauseType::DatabaseExecution(_) => code,
+                _ => HttpErrorCode::StatusCode(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
             },
             message: match error.cause {
-                CubeErrorCauseType::User(_) => error.message,
-                CubeErrorCauseType::Internal(_) => "Internal Server Error".to_string(),
+                CubeErrorCauseType::User(_)
+                | CubeErrorCauseType::SqlParser(_)
+                | CubeErrorCauseType::Unsupported(_)
+                | CubeErrorCauseType::Planning(_)
+                | CubeErrorCauseType::PostProcessing(_)
+                | CubeErrorCauseType::DatabaseExecution(_) => error.message,
+                _ => "Internal Server Error".to_string(),
             },
         }
     }

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -305,12 +305,7 @@ async fn handle_sql_query(
 
         let execute = || async move {
             // todo: can we use compiler_cache?
-            let meta_context = transport_service
-                .meta(native_auth_ctx)
-                .await
-                .map_err(|err| {
-                    CubeError::internal(format!("Failed to get meta context: {}", err))
-                })?;
+            let meta_context = transport_service.meta(native_auth_ctx).await?;
 
             let stmt =
                 parse_sql_to_statement(sql_query, session.state.protocol.clone(), &mut None)?;

--- a/packages/cubejs-backend-native/src/orchestrator.rs
+++ b/packages/cubejs-backend-native/src/orchestrator.rs
@@ -170,7 +170,7 @@ impl ValueObject for ResultWrapper {
         let value = match data {
             TransformedData::Compact { members, dataset } => {
                 let Some(row) = dataset.get(index) else {
-                    return Err(CubeError::user(format!(
+                    return Err(CubeError::internal(format!(
                         "Unexpected response from Cube, can't get {} row",
                         index
                     )));
@@ -190,7 +190,7 @@ impl ValueObject for ResultWrapper {
                 };
 
                 let Some(column) = columns.get(member_index) else {
-                    return Err(CubeError::user(format!(
+                    return Err(CubeError::internal(format!(
                         "Unexpected response from Cube, missing column for '{}'",
                         field_name
                     )));
@@ -207,7 +207,7 @@ impl ValueObject for ResultWrapper {
             }
             TransformedData::Vanilla(dataset) => {
                 let Some(row) = dataset.get(index) else {
-                    return Err(CubeError::user(format!(
+                    return Err(CubeError::internal(format!(
                         "Unexpected response from Cube, can't get {} row",
                         index
                     )));

--- a/packages/cubejs-backend-native/src/python/runtime.rs
+++ b/packages/cubejs-backend-native/src/python/runtime.rs
@@ -160,7 +160,7 @@ impl PyRuntime {
 
         let task_result = match panic::catch_unwind(task_block) {
             Ok(Ok(r)) => Ok(r),
-            Ok(Err(err)) => Err(CubeError::user(format_python_error(err))),
+            Ok(Err(err)) => Err(CubeError::internal(format_python_error(err))),
             Err(panic_payload) => Err(CubeError::panic_with_message(
                 panic_payload,
                 "Unexpected panic while calling python function",

--- a/packages/cubejs-backend-native/src/rest4sql.rs
+++ b/packages/cubejs-backend-native/src/rest4sql.rs
@@ -96,10 +96,7 @@ async fn handle_rest4sql_query(
 ) -> Result<Rest4SqlResponse, CubeError> {
     with_session(&services, native_auth_ctx.clone(), |session| async move {
         let transport = session.server.transport.clone();
-        let meta_context = transport
-            .meta(native_auth_ctx)
-            .await
-            .map_err(|err| CubeError::internal(format!("Failed to get meta context: {err}")))?;
+        let meta_context = transport.meta(native_auth_ctx).await?;
         let query_plan =
             convert_sql_to_cube_query(sql_query, meta_context.clone(), session.clone()).await?;
         let logical_plan = query_plan.try_as_logical_plan()?;

--- a/packages/cubejs-backend-native/src/sql4sql.rs
+++ b/packages/cubejs-backend-native/src/sql4sql.rs
@@ -177,10 +177,7 @@ async fn handle_sql4sql_query(
 
         let transport = session.server.transport.clone();
         // todo: can we use compiler_cache?
-        let meta_context = transport
-            .meta(native_auth_ctx)
-            .await
-            .map_err(|err| CubeError::internal(format!("Failed to get meta context: {err}")))?;
+        let meta_context = transport.meta(native_auth_ctx).await?;
         let query_plan =
             convert_sql_to_cube_query(sql_query, meta_context.clone(), session.clone()).await?;
         let logical_plan = query_plan.try_as_logical_plan()?;

--- a/packages/cubejs-backend-native/src/stream.rs
+++ b/packages/cubejs-backend-native/src/stream.rs
@@ -131,7 +131,7 @@ impl JsWriteStream {
             sender
                 .send(Some(Ok(chunk)))
                 .await
-                .map_err(|e| CubeError::user(format!("Can't send to channel: {}", e)))
+                .map_err(|e| CubeError::internal(format!("Can't send to channel: {}", e)))
         }
     }
 
@@ -147,7 +147,7 @@ impl JsWriteStream {
             sender
                 .send(None)
                 .await
-                .map_err(|e| CubeError::user(format!("Can't send to channel: {}", e)))
+                .map_err(|e| CubeError::internal(format!("Can't send to channel: {}", e)))
         }
     }
 
@@ -205,11 +205,11 @@ impl ValueObject for JsValueObject<'_> {
             .handle
             .get::<JsObject, _, _>(&mut self.cx, index as u32)
             .map_err(|e| {
-                CubeError::user(format!("Can't get object at array index {}: {}", index, e))
+                CubeError::internal(format!("Can't get object at array index {}: {}", index, e))
             })?
             .get::<JsValue, _, _>(&mut self.cx, field_name)
             .map_err(|e| {
-                CubeError::user(format!("Can't get '{}' field value: {}", field_name, e))
+                CubeError::internal(format!("Can't get '{}' field value: {}", field_name, e))
             })?;
         if let Ok(s) = value.downcast::<JsString, _>(&mut self.cx) {
             Ok(FieldValue::String(Cow::Owned(s.value(&mut self.cx))))
@@ -222,18 +222,18 @@ impl ValueObject for JsValueObject<'_> {
         {
             Ok(FieldValue::Null)
         } else if let Ok(b) = value.downcast::<JsArray, _>(&mut self.cx) {
-            Err(CubeError::user(format!(
+            Err(CubeError::internal(format!(
                 "Expected primitive value but found JsArray({:?})",
                 b
             )))
         } else if let Ok(b) = value.downcast::<JsDate, _>(&mut self.cx) {
             // TODO: Support it?
-            Err(CubeError::user(format!(
+            Err(CubeError::internal(format!(
                 "Expected primitive value but found JsDate({:?})",
                 b
             )))
         } else {
-            Err(CubeError::user(format!(
+            Err(CubeError::internal(format!(
                 "Expected primitive value but found: {:?}",
                 value
             )))

--- a/packages/cubejs-backend-native/src/transport.rs
+++ b/packages/cubejs-backend-native/src/transport.rs
@@ -157,7 +157,7 @@ impl TransportService for NodeBridgeTransport {
                 Box::new(move |cx, v| {
                     let obj = v
                         .downcast::<JsObject, _>(cx)
-                        .map_err(|e| CubeError::user(e.to_string()))?;
+                        .map_err(|e| CubeError::internal(e.to_string()))?;
 
                     let member_to_data_source_obj = obj
                         .get::<JsObject, _, _>(cx, "memberToDataSource")
@@ -204,10 +204,10 @@ impl TransportService for NodeBridgeTransport {
         trace!("[transport] Meta <- {:?} <hidden>", response.compiler_id);
 
         let compiler_id = Uuid::parse_str(response.compiler_id.as_ref().ok_or_else(|| {
-            CubeError::user(format!("No compiler_id in response: {:?}", response))
+            CubeError::internal(format!("No compiler_id in response: {:?}", response))
         })?)
         .map_err(|e| {
-            CubeError::user(format!(
+            CubeError::internal(format!(
                 "Can't parse compiler id: {:?} error: {}",
                 response.compiler_id, e
             ))
@@ -247,10 +247,10 @@ impl TransportService for NodeBridgeTransport {
         .await?;
 
         let compiler_id = Uuid::parse_str(response.compiler_id.as_ref().ok_or_else(|| {
-            CubeError::user(format!("No compiler_id in response: {:?}", response))
+            CubeError::internal(format!("No compiler_id in response: {:?}", response))
         })?)
         .map_err(|e| {
-            CubeError::user(format!(
+            CubeError::internal(format!(
                 "Can't parse compiler id: {:?} error: {}",
                 response.compiler_id, e
             ))
@@ -310,29 +310,29 @@ impl TransportService for NodeBridgeTransport {
 
         let sql = response
             .get("sql")
-            .ok_or_else(|| CubeError::user(format!("No sql in response: {}", response)))?
+            .ok_or_else(|| CubeError::internal(format!("No sql in response: {}", response)))?
             .get("sql")
-            .ok_or_else(|| CubeError::user(format!("No sql in response: {}", response)))?;
+            .ok_or_else(|| CubeError::internal(format!("No sql in response: {}", response)))?;
         Ok(SqlResponse {
             sql: SqlQuery {
                 sql: sql
                     .get(0)
                     .ok_or_else(|| {
-                        CubeError::user(format!("No sql array in response: {}", response))
+                        CubeError::internal(format!("No sql array in response: {}", response))
                     })?
                     .as_str()
                     .ok_or_else(|| {
-                        CubeError::user(format!("SQL not a string in response: {}", response))
+                        CubeError::internal(format!("SQL not a string in response: {}", response))
                     })?
                     .to_string(),
                 values: sql
                     .get(1)
                     .ok_or_else(|| {
-                        CubeError::user(format!("No sql array in response: {}", response))
+                        CubeError::internal(format!("No sql array in response: {}", response))
                     })?
                     .as_array()
                     .ok_or_else(|| {
-                        CubeError::user(format!("No sql array in response: {}", response))
+                        CubeError::internal(format!("No sql array in response: {}", response))
                     })?
                     .iter()
                     .map(|v| -> Result<_, CubeError> { Ok(v.as_str().map(|s| s.to_string())) })
@@ -464,7 +464,7 @@ impl TransportService for NodeBridgeTransport {
             if let Err(e) = &result {
                 if e.message.to_lowercase().contains("continue wait") {
                     if throw_continue_wait {
-                        return Err(CubeError::internal("Continue wait".to_string()));
+                        return Err(CubeError::continue_wait());
                     }
                     continue;
                 }
@@ -491,9 +491,7 @@ impl TransportService for NodeBridgeTransport {
                                             "[transport] load - throwing continue wait, requestId: {}",
                                             request_id
                                         );
-                                        return Err(CubeError::internal(
-                                            "Continue wait".to_string(),
-                                        ));
+                                        return Err(CubeError::continue_wait());
                                     }
 
                                     debug!(
@@ -522,7 +520,7 @@ impl TransportService for NodeBridgeTransport {
                         match serde_json::from_value::<TransportLoadResponseColumnar>(response) {
                             Ok(v) => v,
                             Err(err) => {
-                                return Err(CubeError::user(err.to_string()));
+                                return Err(CubeError::internal(err.to_string()));
                             }
                         };
 
@@ -530,8 +528,7 @@ impl TransportService for NodeBridgeTransport {
                         response,
                         schema.clone(),
                         member_fields,
-                    )
-                    .map_err(|err| CubeError::user(err.to_string()));
+                    );
                 }
                 ValueFromJs::ResultWrapper(result_wrappers) => {
                     break result_wrappers
@@ -625,7 +622,7 @@ impl TransportService for NodeBridgeTransport {
             if let Err(e) = &res {
                 if e.message.to_lowercase().contains("continue wait") {
                     if throw_continue_wait {
-                        return Err(CubeError::internal("Continue wait".to_string()));
+                        return Err(CubeError::continue_wait());
                     }
                     continue;
                 }
@@ -663,7 +660,7 @@ impl TransportService for NodeBridgeTransport {
             Box::new(move |cx, v| {
                 let obj = v
                     .downcast::<JsBoolean, _>(cx)
-                    .map_err(|e| CubeError::user(e.to_string()))?;
+                    .map_err(|e| CubeError::internal(e.to_string()))?;
                 Ok(obj.value(cx))
             }),
         )
@@ -749,6 +746,6 @@ pub trait MapCubeErrExt<T> {
 
 impl<T, E: Display> MapCubeErrExt<T> for Result<T, E> {
     fn map_cube_err(self, message: &str) -> Result<T, CubeError> {
-        self.map_err(|e| CubeError::user(format!("{}: {}", message, e)))
+        self.map_err(|e| CubeError::internal(format!("{}: {}", message, e)))
     }
 }

--- a/packages/cubejs-backend-native/test/__snapshots__/jinja.test.ts.snap
+++ b/packages/cubejs-backend-native/test/__snapshots__/jinja.test.ts.snap
@@ -252,7 +252,7 @@ dump:
 `;
 
 exports[`Jinja (new api) render template_error_python.jinja: template_error_python.jinja 1`] = `
-[Error: could not render block: Call error: Python error: Exception: Random Exception
+[Error: could not render block: Call error: Internal Error: Python error: Exception: Random Exception
 Traceback (most recent call last):
   File "jinja-instance.py", line 120, in throw_exception
 

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -270,7 +270,7 @@ describe('SQLInterface', () => {
 
         throw new Error('Error was not passed from transport to the client');
       } catch (e: any) {
-        expect(e.code).toEqual('XX000');
+        expect(e.code).toEqual('58000');
         expect(e.message).toContain(
           'This error should be passed back to PostgreSQL client'
         );

--- a/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
@@ -233,8 +233,8 @@ Object {
 exports[`SQL API Cube SQL over HTTP sql4sql regular query with missing column 1`] = `
 Object {
   "body": Object {
-    "error": "Error: SQLCompilationError: Internal: Initial planning error: Error during planning: Invalid identifier '#foobar' for schema fields:[Orders.count, Orders.orderCount, Orders.approxOrderCount, Orders.netCollectionCompleted, Orders.arpu, Orders.refundRate, Orders.refundOrdersCount, Orders.overallOrders, Orders.totalAmount, Orders.avgAmount, Orders.minAmount, Orders.maxAmount, Orders.toRemove, Orders.numberTotal, Orders.amountRank, Orders.amountReducedByStatus, Orders.statusPercentageOfTotal, Orders.amountRankView, Orders.amountRankDateMax, Orders.amountRankDate, Orders.countAndTotalAmount, Orders.createdAtMax, Orders.createdAtMaxProxy, Orders.id, Orders.status, Orders.createdAt, Orders.updatedAt, Orders.__user, Orders.__cubeJoinField], metadata:{}",
-    "stack": "Error: SQLCompilationError: Internal: Initial planning error: Error during planning: Invalid identifier '#foobar' for schema fields:[Orders.count, Orders.orderCount, Orders.approxOrderCount, Orders.netCollectionCompleted, Orders.arpu, Orders.refundRate, Orders.refundOrdersCount, Orders.overallOrders, Orders.totalAmount, Orders.avgAmount, Orders.minAmount, Orders.maxAmount, Orders.toRemove, Orders.numberTotal, Orders.amountRank, Orders.amountReducedByStatus, Orders.statusPercentageOfTotal, Orders.amountRankView, Orders.amountRankDateMax, Orders.amountRankDate, Orders.countAndTotalAmount, Orders.createdAtMax, Orders.createdAtMaxProxy, Orders.id, Orders.status, Orders.createdAt, Orders.updatedAt, Orders.__user, Orders.__cubeJoinField], metadata:{}",
+    "error": "Error: Planning Error: Initial planning error: Error during planning: Invalid identifier '#foobar' for schema fields:[Orders.count, Orders.orderCount, Orders.approxOrderCount, Orders.netCollectionCompleted, Orders.arpu, Orders.refundRate, Orders.refundOrdersCount, Orders.overallOrders, Orders.totalAmount, Orders.avgAmount, Orders.minAmount, Orders.maxAmount, Orders.toRemove, Orders.numberTotal, Orders.amountRank, Orders.amountReducedByStatus, Orders.statusPercentageOfTotal, Orders.amountRankView, Orders.amountRankDateMax, Orders.amountRankDate, Orders.countAndTotalAmount, Orders.createdAtMax, Orders.createdAtMaxProxy, Orders.id, Orders.status, Orders.createdAt, Orders.updatedAt, Orders.__user, Orders.__cubeJoinField], metadata:{}",
+    "stack": "Error: Planning Error: Initial planning error: Error during planning: Invalid identifier '#foobar' for schema fields:[Orders.count, Orders.orderCount, Orders.approxOrderCount, Orders.netCollectionCompleted, Orders.arpu, Orders.refundRate, Orders.refundOrdersCount, Orders.overallOrders, Orders.totalAmount, Orders.avgAmount, Orders.minAmount, Orders.maxAmount, Orders.toRemove, Orders.numberTotal, Orders.amountRank, Orders.amountReducedByStatus, Orders.statusPercentageOfTotal, Orders.amountRankView, Orders.amountRankDateMax, Orders.amountRankDate, Orders.countAndTotalAmount, Orders.createdAtMax, Orders.createdAtMaxProxy, Orders.id, Orders.status, Orders.createdAt, Orders.updatedAt, Orders.__user, Orders.__cubeJoinField], metadata:{}",
   },
   "headers": Headers {
     Symbol(map): Object {
@@ -245,7 +245,7 @@ Object {
         "keep-alive",
       ],
       "content-length": Array [
-        "1589",
+        "1559",
       ],
       "content-type": Array [
         "application/json; charset=utf-8",
@@ -320,8 +320,8 @@ Object {
 exports[`SQL API Cube SQL over HTTP sql4sql set variable 1`] = `
 Object {
   "body": Object {
-    "error": "Error: This query doesnt have a plan, because it already has values for response",
-    "stack": "Error: This query doesnt have a plan, because it already has values for response",
+    "error": "Error: Internal Error: This query doesnt have a plan, because it already has values for response",
+    "stack": "Error: Internal Error: This query doesnt have a plan, because it already has values for response",
   },
   "headers": Headers {
     Symbol(map): Object {
@@ -332,7 +332,7 @@ Object {
         "keep-alive",
       ],
       "content-length": Array [
-        "241",
+        "273",
       ],
       "content-type": Array [
         "application/json; charset=utf-8",

--- a/rust/cubesql/cubesql/e2e/tests/postgres.rs
+++ b/rust/cubesql/cubesql/e2e/tests/postgres.rs
@@ -1034,7 +1034,7 @@ impl PostgresIntegrationTestSuite {
 
         assert_eq!(
             err.to_string(),
-            "db error: ERROR: Unexpected panic. Reason: value can not be represented in a timestamp with nanosecond precision."
+            "db error: ERROR: Internal Error: Unexpected panic. Reason: value can not be represented in a timestamp with nanosecond precision."
         );
 
         Ok(())

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -7,7 +7,7 @@ use crate::{
     config::ConfigObj,
     sql::AuthContextRef,
     transport::{CubeStreamReceiver, LoadRequestMeta, SpanId, TransportService},
-    CubeError,
+    CubeError, CubeErrorCauseType,
 };
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDate};
@@ -370,7 +370,7 @@ impl ValueObject for JsonValueObject {
         field_name: &str,
     ) -> std::result::Result<FieldValue<'_>, CubeError> {
         let Some(as_object) = self.rows[index].as_object() else {
-            return Err(CubeError::user(format!(
+            return Err(CubeError::internal(format!(
                 "Unexpected response from Cube, row is not an object: {:?}",
                 self.rows[index]
             )));
@@ -417,7 +417,7 @@ impl ColumnarValueObject for JsonColumnarValueObject {
         };
 
         let Some(column) = self.columns.get(idx) else {
-            return Err(CubeError::user(format!(
+            return Err(CubeError::internal(format!(
                 "Unexpected response from Cube, missing column for '{}'",
                 field_name
             )));
@@ -465,7 +465,7 @@ macro_rules! build_column_custom_builder {
                         $($builder_block)*
                         #[allow(unreachable_patterns)]
                         (v, _) => {
-                            return Err(CubeError::user(format!(
+                            return Err(CubeError::internal(format!(
                                 "Unable to map value {:?} to {:?}",
                                 v,
                                 $data_type
@@ -479,7 +479,7 @@ macro_rules! build_column_custom_builder {
                     match (value, &mut $builder) {
                         $($scalar_block)*
                         (v, _) => {
-                            return Err(CubeError::user(format!(
+                            return Err(CubeError::internal(format!(
                                 "Unable to map value {:?} to {:?}",
                                 v,
                                 $data_type
@@ -826,9 +826,13 @@ async fn load_data(
                 } else {
                     err.message
                 };
-                if !err.message.eq_ignore_ascii_case("continue wait") {
-                    err.message = format!("Database Execution Error: {}", err.message);
+
+                if err.message.eq_ignore_ascii_case("continue wait") {
+                    err.cause = CubeErrorCauseType::ContinueWait;
+                } else {
+                    err.cause = CubeErrorCauseType::DatabaseExecution(err.cause.meta().cloned());
                 }
+
                 ArrowError::ExternalError(Box::new(err))
             })?;
 
@@ -1251,7 +1255,7 @@ macro_rules! transform_response_body {
                     Arc::new(array)
                 }
                 t => {
-                    return Err(CubeError::user(format!(
+                    return Err(CubeError::internal(format!(
                         "Type {} is not supported in response transformation from Cube",
                         t,
                     )))
@@ -1438,7 +1442,6 @@ mod tests {
 
                 let result: V1LoadResponse = serde_json::from_str(response).unwrap();
                 convert_transport_response(result, schema.clone(), member_fields)
-                    .map_err(|err| CubeError::user(err.to_string()))
             }
 
             async fn load_stream(

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -764,7 +764,7 @@ impl CubeScanWrapperNode {
                     ))
                 })?
                 .get_sql_templates();
-            sql.finalize_query(sql_templates).map_err(|e| CubeError::internal(e.to_string()))?;
+            sql.finalize_query(sql_templates)?;
             Ok((sql, request, member_fields))
         })?;
         Ok(CubeScanWrappedSqlNode::new(
@@ -1292,7 +1292,7 @@ impl WrappedSelectNode {
                 }
 
                 if *distinct {
-                    return Err(CubeError::internal(
+                    return Err(CubeError::unsupported(
                         "Patch measure with DISTINCT flag is not supported".to_string(),
                     ));
                 }
@@ -3333,7 +3333,7 @@ impl WrappedSelectNode {
                     LogicalPlan::Extension(Extension { node }) => {
                         if let Some(join_cube_scan) = node.as_any().downcast_ref::<CubeScanNode>() {
                             if join_cube_scan.request.ungrouped == Some(true) {
-                                return Err(CubeError::internal(format!(
+                                return Err(CubeError::unsupported(format!(
                                     "Unsupported ungrouped CubeScan as join subquery: {join_cube_scan:?}"
                                 )));
                             }
@@ -3341,20 +3341,20 @@ impl WrappedSelectNode {
                             node.as_any().downcast_ref::<WrappedSelectNode>()
                         {
                             if wrapped_select.push_to_cube {
-                                return Err(CubeError::internal(format!(
+                                return Err(CubeError::unsupported(format!(
                                     "Unsupported push_to_cube WrappedSelect as join subquery: {wrapped_select:?}"
                                 )));
                             }
                         } else {
                             // TODO support more grouped cases here
-                            return Err(CubeError::internal(format!(
+                            return Err(CubeError::unsupported(format!(
                                 "Unsupported unknown extension as join subquery: {node:?}"
                             )));
                         }
                     }
                     _ => {
                         // TODO support more grouped cases here
-                        return Err(CubeError::internal(format!(
+                        return Err(CubeError::unsupported(format!(
                             "Unsupported logical plan node as join subquery: {lp:?}"
                         )));
                     }
@@ -3365,7 +3365,7 @@ impl WrappedSelectNode {
                         // Do nothing
                     }
                     _ => {
-                        return Err(CubeError::internal(format!(
+                        return Err(CubeError::unsupported(format!(
                             "Unsupported join type for join subquery: {join_type:?}"
                         )));
                     }
@@ -3498,7 +3498,7 @@ impl WrappedSelectNode {
                 JoinType::Left => generator.get_sql_templates().left_join()?,
                 JoinType::Inner => generator.get_sql_templates().inner_join()?,
                 _ => {
-                    return Err(CubeError::internal(format!(
+                    return Err(CubeError::unsupported(format!(
                         "Unsupported join type for join subquery: {join_type:?}"
                     )))
                 }
@@ -3848,7 +3848,7 @@ impl WrappedSelectNode {
         } = columns;
 
         if !patch_measures.is_empty() {
-            return Err(CubeError::internal(format!(
+            return Err(CubeError::unsupported(format!(
                 "Unexpected patch measures for non-push-to-Cube wrapped select: {patch_measures:?}",
             )));
         }

--- a/rust/cubesql/cubesql/src/compile/error.rs
+++ b/rust/cubesql/cubesql/src/compile/error.rs
@@ -1,30 +1,72 @@
 use std::{backtrace::Backtrace, collections::HashMap, fmt::Formatter};
 
+use crate::{CubeError, CubeErrorCauseType};
+
 /// TODO: Migrate back to thiserror crate, when Rust will stabilize feature(error_generic_member_access)
 #[derive(Debug)]
 pub enum CompilationError {
+    // Internal Error is an uncategorized error caused by internal failures
     Internal(String, Backtrace, Option<HashMap<String, String>>),
+    // User Error is an uncategorized error caused by user input or action
     User(String, Option<HashMap<String, String>>),
+    // REST API Error is an error thrown by REST API when running in standalone mode
+    RestApi(String, Option<HashMap<String, String>>),
+    // SQL Parser Error is an error thrown when SQL cannot be parsed
+    SqlParser(String, Option<HashMap<String, String>>),
+    // Unsupported Error is an error thrown when a feature/option is not supported
     Unsupported(String, Option<HashMap<String, String>>),
+    // Planning Error is an error thrown when the query plan is invalid
+    Planning(String, Option<HashMap<String, String>>),
+    // Post-Processing Error is an error thrown during execution of the query
+    PostProcessing(String, Option<HashMap<String, String>>),
+    // Rewrite Error is an error thrown during logical plan e-graph rewriting
+    Rewrite(String, Option<HashMap<String, String>>),
+    // Database Execution Error is an error thrown during execution of the query in the database
+    DatabaseExecution(String, Option<HashMap<String, String>>),
+    // Fatal Error is an error used internally with the PostgreSQL protocol
+    // to indicate that the connection should be closed immediately
+    // after sending the error response to the client
     Fatal(String, Option<HashMap<String, String>>),
+    // Continue wait is an error used internally to indicate that the query is still
+    // being processed and the client should send the request again
+    ContinueWait,
 }
 
 impl std::fmt::Display for CompilationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             CompilationError::Internal(message, _, _) => {
-                f.write_fmt(format_args!("SQLCompilationError: Internal: {}", message))
+                f.write_fmt(format_args!("Internal Error: {}", message))
             }
             CompilationError::User(message, _) => {
-                f.write_fmt(format_args!("SQLCompilationError: User: {}", message))
+                f.write_fmt(format_args!("User Error: {}", message))
             }
-            CompilationError::Unsupported(message, _) => f.write_fmt(format_args!(
-                "SQLCompilationError: Unsupported: {}",
+            CompilationError::RestApi(message, _) => {
+                f.write_fmt(format_args!("REST API Error: {}", message))
+            }
+            CompilationError::SqlParser(message, _) => {
+                f.write_fmt(format_args!("SQL Parser Error: {}", message))
+            }
+            CompilationError::Unsupported(message, _) => {
+                f.write_fmt(format_args!("Unsupported Error: {}", message))
+            }
+            CompilationError::Planning(message, _) => {
+                f.write_fmt(format_args!("Planning Error: {}", message))
+            }
+            CompilationError::PostProcessing(message, _) => {
+                f.write_fmt(format_args!("Post-Processing Error: {}", message))
+            }
+            CompilationError::Rewrite(message, _) => f.write_fmt(format_args!(
+                "Rewrite Error: {}. Please check logs for additional information",
                 message
             )),
-            CompilationError::Fatal(message, _) => {
-                f.write_fmt(format_args!("SQLCompilationError: Fatal: {}", message))
+            CompilationError::DatabaseExecution(message, _) => {
+                f.write_fmt(format_args!("Database Execution Error: {}", message))
             }
+            CompilationError::Fatal(message, _) => {
+                f.write_fmt(format_args!("Fatal Error: {}", message))
+            }
+            CompilationError::ContinueWait => f.write_str("Continue wait"),
         }
     }
 }
@@ -40,14 +82,39 @@ impl PartialEq for CompilationError {
                 CompilationError::User(right, _) => left == right,
                 _ => false,
             },
+            CompilationError::RestApi(left, _) => match other {
+                CompilationError::RestApi(right, _) => left == right,
+                _ => false,
+            },
+            CompilationError::SqlParser(left, _) => match other {
+                CompilationError::SqlParser(right, _) => left == right,
+                _ => false,
+            },
             CompilationError::Unsupported(left, _) => match other {
                 CompilationError::Unsupported(right, _) => left == right,
+                _ => false,
+            },
+            CompilationError::Planning(left, _) => match other {
+                CompilationError::Planning(right, _) => left == right,
+                _ => false,
+            },
+            CompilationError::PostProcessing(left, _) => match other {
+                CompilationError::PostProcessing(right, _) => left == right,
+                _ => false,
+            },
+            CompilationError::Rewrite(left, _) => match other {
+                CompilationError::Rewrite(right, _) => left == right,
+                _ => false,
+            },
+            CompilationError::DatabaseExecution(left, _) => match other {
+                CompilationError::DatabaseExecution(right, _) => left == right,
                 _ => false,
             },
             CompilationError::Fatal(left, _) => match other {
                 CompilationError::Fatal(right, _) => left == right,
                 _ => false,
             },
+            CompilationError::ContinueWait => matches!(other, CompilationError::ContinueWait),
         }
     }
 
@@ -61,8 +128,15 @@ impl CompilationError {
         match self {
             CompilationError::Internal(_, bt, _) => Some(bt),
             CompilationError::User(_, _) => None,
+            CompilationError::RestApi(_, _) => None,
+            CompilationError::SqlParser(_, _) => None,
             CompilationError::Unsupported(_, _) => None,
+            CompilationError::Planning(_, _) => None,
+            CompilationError::PostProcessing(_, _) => None,
+            CompilationError::Rewrite(_, _) => None,
+            CompilationError::DatabaseExecution(_, _) => None,
             CompilationError::Fatal(_, _) => None,
+            CompilationError::ContinueWait => None,
         }
     }
 
@@ -70,8 +144,15 @@ impl CompilationError {
         match self {
             CompilationError::Internal(_, bt, _) => Some(bt),
             CompilationError::User(_, _) => None,
+            CompilationError::RestApi(_, _) => None,
+            CompilationError::SqlParser(_, _) => None,
             CompilationError::Unsupported(_, _) => None,
+            CompilationError::Planning(_, _) => None,
+            CompilationError::PostProcessing(_, _) => None,
+            CompilationError::Rewrite(_, _) => None,
+            CompilationError::DatabaseExecution(_, _) => None,
             CompilationError::Fatal(_, _) => None,
+            CompilationError::ContinueWait => None,
         }
     }
 }
@@ -89,12 +170,40 @@ impl CompilationError {
         Self::User(message, None)
     }
 
+    pub fn rest_api(message: String) -> Self {
+        Self::RestApi(message, None)
+    }
+
+    pub fn sql_parser(message: String) -> Self {
+        Self::SqlParser(message, None)
+    }
+
     pub fn unsupported(message: String) -> Self {
         Self::Unsupported(message, None)
     }
 
+    pub fn planning(message: String) -> Self {
+        Self::Planning(message, None)
+    }
+
+    pub fn post_processing(message: String) -> Self {
+        Self::PostProcessing(message, None)
+    }
+
+    pub fn rewrite(message: String) -> Self {
+        Self::Rewrite(message, None)
+    }
+
+    pub fn database_execution(message: String) -> Self {
+        Self::DatabaseExecution(message, None)
+    }
+
     pub fn fatal(message: String) -> Self {
         Self::Fatal(message, None)
+    }
+
+    pub fn continue_wait() -> Self {
+        Self::ContinueWait
     }
 }
 
@@ -103,8 +212,15 @@ impl CompilationError {
         match self {
             CompilationError::Internal(msg, _, _)
             | CompilationError::User(msg, _)
-            | CompilationError::Unsupported(msg, _) => msg.clone(),
-            CompilationError::Fatal(msg, _) => msg.clone(),
+            | CompilationError::RestApi(msg, _)
+            | CompilationError::SqlParser(msg, _)
+            | CompilationError::Unsupported(msg, _)
+            | CompilationError::Planning(msg, _)
+            | CompilationError::PostProcessing(msg, _)
+            | CompilationError::Rewrite(msg, _)
+            | CompilationError::DatabaseExecution(msg, _)
+            | CompilationError::Fatal(msg, _) => msg.clone(),
+            CompilationError::ContinueWait => "Continue wait".to_string(),
         }
     }
 
@@ -112,8 +228,19 @@ impl CompilationError {
         match self {
             CompilationError::Internal(_, bts, meta) => CompilationError::Internal(msg, bts, meta),
             CompilationError::User(_, meta) => CompilationError::User(msg, meta),
+            CompilationError::RestApi(_, meta) => CompilationError::RestApi(msg, meta),
+            CompilationError::SqlParser(_, meta) => CompilationError::SqlParser(msg, meta),
             CompilationError::Unsupported(_, meta) => CompilationError::Unsupported(msg, meta),
+            CompilationError::Planning(_, meta) => CompilationError::Planning(msg, meta),
+            CompilationError::PostProcessing(_, meta) => {
+                CompilationError::PostProcessing(msg, meta)
+            }
+            CompilationError::Rewrite(_, meta) => CompilationError::Rewrite(msg, meta),
+            CompilationError::DatabaseExecution(_, meta) => {
+                CompilationError::DatabaseExecution(msg, meta)
+            }
             CompilationError::Fatal(_, meta) => CompilationError::Fatal(msg, meta),
+            CompilationError::ContinueWait => CompilationError::ContinueWait,
         }
     }
 }
@@ -123,8 +250,17 @@ impl CompilationError {
         match self {
             CompilationError::Internal(msg, bts, _) => CompilationError::Internal(msg, bts, meta),
             CompilationError::User(msg, _) => CompilationError::User(msg, meta),
+            CompilationError::RestApi(msg, _) => CompilationError::RestApi(msg, meta),
+            CompilationError::SqlParser(msg, _) => CompilationError::SqlParser(msg, meta),
             CompilationError::Unsupported(msg, _) => CompilationError::Unsupported(msg, meta),
+            CompilationError::Planning(msg, _) => CompilationError::Planning(msg, meta),
+            CompilationError::PostProcessing(msg, _) => CompilationError::PostProcessing(msg, meta),
+            CompilationError::Rewrite(msg, _) => CompilationError::Rewrite(msg, meta),
+            CompilationError::DatabaseExecution(msg, _) => {
+                CompilationError::DatabaseExecution(msg, meta)
+            }
             CompilationError::Fatal(msg, _) => CompilationError::Fatal(msg, meta),
+            CompilationError::ContinueWait => CompilationError::ContinueWait,
         }
     }
 }
@@ -140,5 +276,30 @@ impl From<regex::Error> for CompilationError {
 impl From<serde_json::Error> for CompilationError {
     fn from(v: serde_json::Error) -> Self {
         CompilationError::internal(format!("{:?}", v))
+    }
+}
+
+impl From<CubeError> for CompilationError {
+    fn from(v: CubeError) -> Self {
+        match v.cause {
+            CubeErrorCauseType::User(meta) => CompilationError::User(v.message, meta),
+            CubeErrorCauseType::Internal(meta) => CompilationError::Internal(
+                v.message,
+                v.backtrace.unwrap_or_else(|| Backtrace::capture()),
+                meta,
+            ),
+            CubeErrorCauseType::RestApi(meta) => CompilationError::RestApi(v.message, meta),
+            CubeErrorCauseType::SqlParser(meta) => CompilationError::SqlParser(v.message, meta),
+            CubeErrorCauseType::Unsupported(meta) => CompilationError::Unsupported(v.message, meta),
+            CubeErrorCauseType::Planning(meta) => CompilationError::Planning(v.message, meta),
+            CubeErrorCauseType::PostProcessing(meta) => {
+                CompilationError::PostProcessing(v.message, meta)
+            }
+            CubeErrorCauseType::Rewrite(meta) => CompilationError::Rewrite(v.message, meta),
+            CubeErrorCauseType::DatabaseExecution(meta) => {
+                CompilationError::DatabaseExecution(v.message, meta)
+            }
+            CubeErrorCauseType::ContinueWait => CompilationError::ContinueWait,
+        }
     }
 }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -1752,9 +1752,11 @@ GROUP BY
             get_test_session(DatabaseProtocol::PostgreSQL, meta).await,
         ).await;
 
+        let err = create_query.err().unwrap();
+        assert!(matches!(err, CompilationError::Rewrite(..)));
         assert_eq!(
-            create_query.err().unwrap().message(),
-            "Error during rewrite: Dimension 'customer_gender' was used with the aggregate function 'MEASURE()'. Please use a measure instead. Please check logs for additional information.",
+            err.message(),
+            "Dimension 'customer_gender' was used with the aggregate function 'MEASURE()'. Please use a measure instead",
         );
     }
 

--- a/rust/cubesql/cubesql/src/compile/parser.rs
+++ b/rust/cubesql/cubesql/src/compile/parser.rs
@@ -195,7 +195,7 @@ pub fn parse_sql_to_statements(
     };
 
     parse_result.map_err(|err| {
-        CompilationError::user(format!("Unable to parse: {:?}", err)).with_meta(Some(
+        CompilationError::sql_parser(format!("Unable to parse: {:?}", err)).with_meta(Some(
             HashMap::from([("query".to_string(), original_query.to_string())]),
         ))
     })

--- a/rust/cubesql/cubesql/src/compile/plan.rs
+++ b/rust/cubesql/cubesql/src/compile/plan.rs
@@ -103,7 +103,7 @@ impl QueryPlan {
                 DataFrame::new(ctx.state.clone(), plan)
                     .create_physical_plan()
                     .await
-                    .map_err(|e| CubeError::user(e.to_string()))
+                    .map_err(|e| CubeError::from(e))
             }
             QueryPlan::MetaOk(_, _) | QueryPlan::MetaTabular(_, _) => {
                 panic!("This query doesnt have a plan, because it already has values for response")

--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -1,7 +1,4 @@
-use std::{
-    backtrace::Backtrace, collections::HashMap, future::Future, pin::Pin, sync::Arc,
-    time::SystemTime,
-};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::SystemTime};
 
 use crate::{
     compile::{
@@ -31,7 +28,7 @@ use crate::{
         SessionManager, SessionState,
     },
     transport::{LoadRequestMeta, MetaContext, SpanId, TransportService},
-    CubeErrorCauseType,
+    CubeError, CubeErrorCauseType,
 };
 use datafusion::{
     error::DataFusionError,
@@ -116,8 +113,7 @@ pub trait QueryEngine {
                             "planningId": query_planning_id.to_string(),
                         }),
                     )
-                    .await
-                    .map_err(|e| CompilationError::internal(e.to_string()))?;
+                    .await?;
             }
         }
 
@@ -137,7 +133,7 @@ pub trait QueryEngine {
                     ),
                 ]));
 
-                CompilationError::internal(message).with_meta(meta)
+                CompilationError::planning(message).with_meta(meta)
             })?;
 
         let mut optimized_plan = plan;
@@ -179,7 +175,7 @@ pub trait QueryEngine {
                 &mut query_params,
                 &mut LogicalPlanToLanguageContext::default(),
             )
-            .map_err(|e| CompilationError::internal(e.to_string()))?;
+            .map_err(|e| CompilationError::rewrite(e.to_string()))?;
 
         let rewriting_start = SystemTime::now();
         if let Some(span_id) = span_id.as_ref() {
@@ -194,8 +190,7 @@ pub trait QueryEngine {
                             "planningId": query_planning_id.to_string(),
                         }),
                     )
-                    .await
-                    .map_err(|e| CompilationError::internal(e.to_string()))?;
+                    .await?;
             }
         }
 
@@ -209,34 +204,15 @@ pub trait QueryEngine {
                 qtrace,
             )
             .await
-            .map_err(|e| match e.cause {
-                CubeErrorCauseType::Internal(_) => CompilationError::Internal(
-                    format!(
-                        "Error during rewrite: {}. Please check logs for additional information.",
-                        e.message
+            .map_err(|mut e| {
+                e.cause = CubeErrorCauseType::Rewrite(e.cause.meta().cloned());
+                CompilationError::from(e).with_meta(Some(HashMap::from([
+                    ("query".to_string(), stmt.to_string()),
+                    (
+                        "sanitizedQuery".to_string(),
+                        self.sanitize_statement(&stmt).to_string(),
                     ),
-                    e.to_backtrace().unwrap_or_else(|| Backtrace::capture()),
-                    Some(HashMap::from([
-                        ("query".to_string(), stmt.to_string()),
-                        (
-                            "sanitizedQuery".to_string(),
-                            self.sanitize_statement(&stmt).to_string(),
-                        ),
-                    ])),
-                ),
-                CubeErrorCauseType::User(_) => CompilationError::User(
-                    format!(
-                        "Error during rewrite: {}. Please check logs for additional information.",
-                        e.message
-                    ),
-                    Some(HashMap::from([
-                        ("query".to_string(), stmt.to_string()),
-                        (
-                            "sanitizedQuery".to_string(),
-                            self.sanitize_statement(&stmt).to_string(),
-                        ),
-                    ])),
-                ),
+                ])))
             })?;
 
         // Replace Analysis as at least time has changed but it might be also context may affect rewriting in some other ways
@@ -256,34 +232,15 @@ pub trait QueryEngine {
                 span_id.clone(),
             )
             .await
-            .map_err(|e| match e.cause {
-                CubeErrorCauseType::Internal(_) => CompilationError::Internal(
-                    format!(
-                        "Error during rewrite: {}. Please check logs for additional information.",
-                        e.message
+            .map_err(|mut e| {
+                e.cause = CubeErrorCauseType::Rewrite(e.cause.meta().cloned());
+                CompilationError::from(e).with_meta(Some(HashMap::from([
+                    ("query".to_string(), stmt.to_string()),
+                    (
+                        "sanitizedQuery".to_string(),
+                        self.sanitize_statement(&stmt).to_string(),
                     ),
-                    e.to_backtrace().unwrap_or_else(|| Backtrace::capture()),
-                    Some(HashMap::from([
-                        ("query".to_string(), stmt.to_string()),
-                        (
-                            "sanitizedQuery".to_string(),
-                            self.sanitize_statement(&stmt).to_string(),
-                        ),
-                    ])),
-                ),
-                CubeErrorCauseType::User(_) => CompilationError::User(
-                    format!(
-                        "Error during rewrite: {}. Please check logs for additional information.",
-                        e.message
-                    ),
-                    Some(HashMap::from([
-                        ("query".to_string(), stmt.to_string()),
-                        (
-                            "sanitizedQuery".to_string(),
-                            self.sanitize_statement(&stmt).to_string(),
-                        ),
-                    ])),
-                ),
+                ])))
             });
 
         if let Err(_) = &result {
@@ -305,8 +262,7 @@ pub trait QueryEngine {
                             "duration": rewriting_start.elapsed().unwrap().as_millis() as u64,
                         }),
                     )
-                    .await
-                    .map_err(|e| CompilationError::internal(e.to_string()))?;
+                    .await?;
             }
         }
 
@@ -340,8 +296,7 @@ pub trait QueryEngine {
                             "duration": planning_start.elapsed().unwrap().as_millis() as u64,
                         }),
                     )
-                    .await
-                    .map_err(|e| CompilationError::internal(e.to_string()))?;
+                    .await?;
             }
         }
 
@@ -381,8 +336,7 @@ pub trait QueryEngine {
                                     load_request_meta.clone(),
                                     state.clone(),
                                 )
-                                .await
-                                .map_err(|e| CompilationError::internal(e.to_string()))?,
+                                .await?,
                         ),
                     }));
                 }
@@ -400,7 +354,7 @@ pub trait QueryEngine {
                 );
             }
             from_plan(&plan, plan.expressions().as_slice(), children.as_slice())
-                .map_err(|e| CompilationError::internal(e.to_string()))
+                .map_err(|e| CompilationError::from(CubeError::from(e)))
         })
     }
 }
@@ -617,7 +571,7 @@ impl QueryEngine for SqlQueryEngine {
                 state.protocol.clone(),
             )
             .await
-            .map_err(|e| CompilationError::internal(e.to_string()))
+            .map_err(|e| CompilationError::from(e))
     }
 }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/analysis.rs
@@ -297,7 +297,7 @@ impl LogicalPlanAnalysis {
     ) -> Option<OriginalExpr> {
         let id_to_original_expr = |id| {
             egraph[id].data.original_expr.clone().ok_or_else(|| {
-                CubeError::internal(format!(
+                CubeError::rewrite(format!(
                     "Original expr wasn't prepared for {:?}",
                     egraph[id]
                 ))
@@ -306,7 +306,7 @@ impl LogicalPlanAnalysis {
         let id_to_expr = |id| {
             id_to_original_expr(id).and_then(|e| match e {
                 OriginalExpr::Expr(expr) => Ok(expr),
-                OriginalExpr::List(_) => Err(CubeError::internal(format!(
+                OriginalExpr::List(_) => Err(CubeError::rewrite(format!(
                     "Original expr list can't be used in expr eval {:?}",
                     egraph[id]
                 ))),
@@ -995,7 +995,7 @@ impl LogicalPlanAnalysis {
                         None
                     }
                 })
-                .ok_or_else(|| CubeError::internal("Not a constant".to_string()))
+                .ok_or_else(|| CubeError::rewrite("Not a constant".to_string()))
         };
         match enode {
             LogicalPlanLanguage::LiteralExpr(_) => {

--- a/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/converter.rs
@@ -873,7 +873,7 @@ macro_rules! match_data_node {
         match $node_by_id.index($id_expr.clone()) {
             LogicalPlanLanguage::$field_variant($field_variant(data)) => data.clone(),
             x => {
-                return Err(CubeError::internal(format!(
+                return Err(CubeError::rewrite(format!(
                     "Expected {} but found {:?}",
                     std::stringify!($field_variant),
                     x
@@ -1142,7 +1142,7 @@ pub fn node_to_expr(
             let args = match_expr_list_node!(node_by_id, to_expr, params[1], ScalarUDFExprArgs);
             let fun = cube_context
                 .get_function_meta(&fun_name)
-                .ok_or(CubeError::user(format!(
+                .ok_or(CubeError::rewrite(format!(
                     "Scalar UDF '{}' is not found",
                     fun_name
                 )))?;
@@ -1197,7 +1197,7 @@ pub fn node_to_expr(
             let distinct = match_data_node!(node_by_id, params[2], AggregateUDFExprDistinct);
             let fun = cube_context
                 .get_aggregate_meta(&fun_name)
-                .ok_or(CubeError::user(format!(
+                .ok_or(CubeError::rewrite(format!(
                     "Aggregate UDF '{}' is not found",
                     fun_name
                 )))?;
@@ -1212,7 +1212,7 @@ pub fn node_to_expr(
             let args = match_expr_list_node!(node_by_id, to_expr, params[1], TableUDFExprArgs);
             let fun = cube_context
                 .get_table_function_meta(&fun_name)
-                .ok_or(CubeError::user(format!(
+                .ok_or(CubeError::rewrite(format!(
                     "Table UDF '{}' is not found",
                     fun_name
                 )))?;
@@ -1235,7 +1235,7 @@ pub fn node_to_expr(
             Expr::GetIndexedField { expr, key }
         }
         LogicalPlanLanguage::QueryParam(_) => {
-            return Err(CubeError::user(
+            return Err(CubeError::rewrite(
                 "QueryParam can't be evaluated as an Expr node".to_string(),
             ));
         }
@@ -1397,14 +1397,14 @@ impl LanguageToLogicalPlanConverter {
                     if left_on.iter().any(|c| c.name == "__cubeJoinField")
                         || right_on.iter().any(|c| c.name == "__cubeJoinField")
                     {
-                        return Err(CubeError::internal(
+                        return Err(CubeError::rewrite(
                             "Can not join Cubes. This is most likely due to one of the following reasons:\n\
                             • one of the cubes contains a group by\n\
                             • one of the cubes contains a measure\n\
                             • the cube on the right contains a filter, sorting or limits\n".to_string(),
                         ));
                     } else {
-                        return Err(CubeError::internal(
+                        return Err(CubeError::rewrite(
                             "Use __cubeJoinField to join Cubes".to_string(),
                         ));
                     }
@@ -1446,7 +1446,7 @@ impl LanguageToLogicalPlanConverter {
                 if Self::have_ungrouped_cube_scan_inside(&left)
                     || Self::have_ungrouped_cube_scan_inside(&right)
                 {
-                    return Err(CubeError::internal(
+                    return Err(CubeError::rewrite(
                         "Can not join Cubes. This is most likely due to one of the following reasons:\n\
                         • one of the cubes contains a group by\n\
                         • one of the cubes contains a measure\n\
@@ -1519,7 +1519,7 @@ impl LanguageToLogicalPlanConverter {
                 let provider = self
                     .cube_context
                     .get_table_provider(table_reference)
-                    .ok_or(CubeError::user(format!(
+                    .ok_or(CubeError::rewrite(format!(
                         "Table '{}' is not found",
                         source_table_name
                     )))?;
@@ -1611,10 +1611,7 @@ impl LanguageToLogicalPlanConverter {
                             query_measures.push(measure.to_string());
                             let data_type =
                                 self.cube_context.meta.find_df_data_type(&measure).ok_or(
-                                    CubeError::internal(format!(
-                                        "Can't find measure '{}'",
-                                        measure
-                                    )),
+                                    CubeError::rewrite(format!("Can't find measure '{}'", measure)),
                                 )?;
                             fields.push((
                                 DFField::new(
@@ -1667,7 +1664,7 @@ impl LanguageToLogicalPlanConverter {
                             let expr = self.to_expr(params[1])?;
                             let data_type =
                                 self.cube_context.meta.find_df_data_type(&dimension).ok_or(
-                                    CubeError::internal(format!(
+                                    CubeError::rewrite(format!(
                                         "Can't find dimension '{}'",
                                         dimension
                                     )),
@@ -1740,11 +1737,11 @@ impl LanguageToLogicalPlanConverter {
                         }
                         LogicalPlanLanguage::MemberError(params) => {
                             let error = match_data_node!(node_by_id, params[0], MemberErrorError);
-                            return Err(CubeError::user(error.to_string()));
+                            return Err(CubeError::rewrite(error.to_string()));
                         }
                         LogicalPlanLanguage::AllMembers(_) => {
                             if !wrapped {
-                                return Err(CubeError::internal(
+                                return Err(CubeError::rewrite(
                                     "Can't detect Cube query and it may be not supported yet"
                                         .to_string(),
                                 ));
@@ -1755,7 +1752,10 @@ impl LanguageToLogicalPlanConverter {
                                         .meta
                                         .find_cube_with_name(cube)
                                         .ok_or_else(|| {
-                                            CubeError::user(format!("Can't find cube '{}'", cube))
+                                            CubeError::rewrite(format!(
+                                                "Can't find cube '{}'",
+                                                cube
+                                            ))
                                         })?;
                                     for column in cube.get_columns() {
                                         if self
@@ -1859,13 +1859,13 @@ impl LanguageToLogicalPlanConverter {
                                             and: None,
                                         });
                                         if !segments.is_empty() {
-                                            return Err(CubeError::internal(
+                                            return Err(CubeError::rewrite(
                                                 "Can't use OR operator with segments".to_string(),
                                             ));
                                         }
 
                                         if change_user.is_some() {
-                                            return Err(CubeError::internal(
+                                            return Err(CubeError::rewrite(
                                                 "Can't use OR operator with __user column"
                                                     .to_string(),
                                             ));
@@ -1929,7 +1929,7 @@ impl LanguageToLogicalPlanConverter {
                     }
 
                     if change_user_result.len() > 1 {
-                        return Err(CubeError::internal(
+                        return Err(CubeError::rewrite(
                             "Unable to use multiple __user in one Cube query".to_string(),
                         ));
                     }
@@ -1963,7 +1963,7 @@ impl LanguageToLogicalPlanConverter {
                 }
 
                 if !wrapped && fields.len() == 0 {
-                    return Err(CubeError::internal(
+                    return Err(CubeError::rewrite(
                         "Can't detect Cube query and it may be not supported yet".to_string(),
                     ));
                 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -295,7 +295,7 @@ impl Rewriter {
                                 .graph
                                 .lookup(LogicalPlanLanguage::QueryParam([class.id]))
                                 .ok_or_else(|| {
-                                    CubeError::internal(format!(
+                                    CubeError::rewrite(format!(
                                         "Can't find param query node with id {}",
                                         class.id
                                     ))
@@ -366,7 +366,7 @@ impl Rewriter {
                     CubePlanTopDownState::new(),
                 );
                 let Some((best_cost, best)) = extractor.find_best(root) else {
-                    return Err(CubeError::internal("Unable to find best plan".to_string()));
+                    return Err(CubeError::rewrite("Unable to find best plan".to_string()));
                 };
                 log::debug!("Best cost: {:#?}", best_cost);
 
@@ -430,7 +430,7 @@ impl Rewriter {
             write_debug_states(&runner, stage)?;
         }
         if let Some(stop_reason) = stop_reason {
-            return Err(CubeError::user(format!(
+            return Err(CubeError::rewrite(format!(
                 "Can't find rewrite due to {}",
                 stop_reason
             )));

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/flatten/column.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/flatten/column.rs
@@ -84,7 +84,7 @@ impl FlattenRules {
                                 flat_list,
                             )
                             .map_err(|e| {
-                                CubeError::internal(format!(
+                                CubeError::rewrite(format!(
                                     "FlattenColumnPushdown: Can't add expression to egraph: {:?}: {}",
                                     expr, e
                                 ))

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/members.rs
@@ -1361,7 +1361,7 @@ impl MemberRules {
                     .data
                     .original_expr
                     .as_ref()
-                    .ok_or(CubeError::internal(format!(
+                    .ok_or(CubeError::rewrite(format!(
                         "Original expr wasn't prepared for {:?}",
                         original_expr_id
                     )));

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/old_split.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/old_split.rs
@@ -4834,7 +4834,7 @@ impl OldSplitRules {
                     .data
                     .original_expr
                     .as_ref()
-                    .ok_or(CubeError::internal(format!(
+                    .ok_or(CubeError::rewrite(format!(
                         "Original expr wasn't prepared for {:?}",
                         original_expr_id
                     )));
@@ -4889,7 +4889,7 @@ impl OldSplitRules {
                     .data
                     .original_expr
                     .as_ref()
-                    .ok_or(CubeError::internal(format!(
+                    .ok_or(CubeError::rewrite(format!(
                         "Original expr wasn't prepared for {:?}",
                         original_expr_id
                     )));
@@ -6188,7 +6188,7 @@ impl OldSplitRules {
                     .data
                     .original_expr
                     .as_ref()
-                    .ok_or(CubeError::internal(format!(
+                    .ok_or(CubeError::rewrite(format!(
                         "Original expr wasn't prepared for {:?}",
                         original_expr_id
                     )));
@@ -6327,7 +6327,7 @@ impl OldSplitRules {
                 .data
                 .original_expr
                 .as_ref()
-                .ok_or(CubeError::internal(format!(
+                .ok_or(CubeError::rewrite(format!(
                     "Original expr wasn't prepared for {:?}",
                     expr_id
                 )));
@@ -6339,7 +6339,7 @@ impl OldSplitRules {
                         .data
                         .original_expr
                         .as_ref()
-                        .ok_or(CubeError::internal(format!(
+                        .ok_or(CubeError::rewrite(format!(
                             "Original expr wasn't prepared for {:?}",
                             inner_expr_id
                         )));
@@ -6434,7 +6434,7 @@ impl OldSplitRules {
                 .data
                 .original_expr
                 .as_ref()
-                .ok_or(CubeError::internal(format!(
+                .ok_or(CubeError::rewrite(format!(
                     "Original expr wasn't prepared for {:?}",
                     expr_id
                 )));
@@ -6446,7 +6446,7 @@ impl OldSplitRules {
                         .data
                         .original_expr
                         .as_ref()
-                        .ok_or(CubeError::internal(format!(
+                        .ok_or(CubeError::rewrite(format!(
                             "Original expr wasn't prepared for {:?}",
                             inner_expr_id
                         )));

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/split/cast.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/split/cast.rs
@@ -101,7 +101,7 @@ impl SplitRules {
                 .data
                 .original_expr
                 .as_ref()
-                .ok_or(CubeError::internal(format!(
+                .ok_or(CubeError::rewrite(format!(
                     "Original expr wasn't prepared for {:?}",
                     expr_id
                 )));

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/utils.rs
@@ -563,7 +563,7 @@ impl DecomposedDayTime {
         match (self.days as i64, self.millis as i64) {
             (0, millis) => templates.interval_single_expr(millis, Self::MILLIS_LABEL),
             (days, 0) => templates.interval_single_expr(days, Self::DAY_LABEL),
-            (days, millis) => Err(CubeError::internal(format!(
+            (days, millis) => Err(CubeError::rewrite(format!(
                 "Expected simple interval, found composite: (days: {days};  millis: {millis})"
             ))),
         }
@@ -713,7 +713,7 @@ impl DecomposedMonthDayNano {
             (0, 0, millis) => templates.interval_single_expr(millis, Self::MILLIS),
             (0, days, 0) => templates.interval_single_expr(days, Self::DAY),
             (mons, 0, 0) => templates.interval_single_expr(mons, Self::MONTH),
-            (mons, days, millis) => Err(CubeError::internal(format!(
+            (mons, days, millis) => Err(CubeError::rewrite(format!(
                 "Expected simple interval, found composite (months: {mons};  days: {days};  millis: {millis})"
             ))),
         }

--- a/rust/cubesql/cubesql/src/compile/router.rs
+++ b/rust/cubesql/cubesql/src/compile/router.rs
@@ -313,7 +313,7 @@ impl QueryRouter {
         let flags = StatusFlags::SERVER_STATE_CHANGED;
         let username = role_name.as_ref().map(|role_name| role_name.value.clone());
         let Some(to_user) = username.clone().or_else(|| self.state.original_user()) else {
-            return Err(CompilationError::user(
+            return Err(CompilationError::internal(
                 "Cannot reset role when original role has not been set".to_string(),
             ));
         };
@@ -471,7 +471,7 @@ impl QueryRouter {
     async fn change_user(&self, username: String) -> Result<(), CompilationError> {
         self.reauthenticate_if_needed().await?;
 
-        let auth_context = self.state.auth_context().ok_or(CompilationError::user(
+        let auth_context = self.state.auth_context().ok_or(CompilationError::internal(
             "No auth context set but tried to set current user".to_string(),
         ))?;
 
@@ -637,8 +637,7 @@ impl QueryRouter {
         let temp_tables = self.state.temp_tables();
         tokio::task::spawn_blocking(move || temp_tables.remove(&table_name_lower))
             .await
-            .map_err(|err| CompilationError::internal(err.to_string()))?
-            .map_err(|err| CompilationError::internal(err.to_string()))?;
+            .map_err(|err| CompilationError::internal(err.to_string()))??;
         let flags = StatusFlags::empty();
         Ok(QueryPlan::MetaOk(flags, CommandCompletion::DropTable))
     }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_role_bad_user.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_set_role_bad_user.snap
@@ -1,5 +1,5 @@
 ---
 source: cubesql/src/compile/mod.rs
-expression: "execute_queries_with_flags(vec![\"SET ROLE bad_user\".to_string(),],\nDatabaseProtocol::PostgreSQL).await.err().unwrap().to_string()"
+expression: "execute_queries_with_flags(vec![\"SET ROLE bad_user\".to_string()],\nDatabaseProtocol::PostgreSQL).await.err().unwrap().to_string()"
 ---
-Error during planning: SQLCompilationError: User: user 'not specified' is not allowed to switch to 'bad_user'
+Planning Error: user 'not specified' is not allowed to switch to 'bad_user'

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__set_bad_user.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__set_bad_user.snap
@@ -2,4 +2,4 @@
 source: cubesql/src/compile/mod.rs
 expression: "execute_queries_with_flags(vec![\"SET user = 'bad_user'\".to_string()],\nDatabaseProtocol::PostgreSQL).await.err().unwrap().to_string()"
 ---
-Error during planning: SQLCompilationError: User: user 'not specified' is not allowed to switch to 'bad_user'
+Planning Error: user 'not specified' is not allowed to switch to 'bad_user'

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         CubeStreamReceiver, LoadRequestMeta, MetaContext, SpanId, SqlGenerator, SqlResponse,
         SqlTemplates, TransportLoadRequestQuery, TransportLoadResponse, TransportService,
     },
-    CubeError,
+    CubeError, CubeErrorCauseType,
 };
 use async_trait::async_trait;
 use cubeclient::models::V1CubeMetaType;
@@ -1171,10 +1171,11 @@ impl TestContext {
         let mut output_flags = StatusFlags::empty();
 
         for query in queries {
-            let query = self
-                .convert_sql_to_cube_query(&query)
-                .await
-                .map_err(|e| CubeError::internal(format!("Error during planning: {}", e)))?;
+            let query = self.convert_sql_to_cube_query(&query).await.map_err(|e| {
+                let mut error = CubeError::from(e);
+                error.cause = CubeErrorCauseType::Planning(error.cause.meta().cloned());
+                error
+            })?;
             match query {
                 QueryPlan::DataFusionSelect(plan, ctx) => {
                     let df = DFDataFrame::new(ctx.state, &plan);

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_join.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_join.rs
@@ -6,6 +6,7 @@ use pretty_assertions::assert_eq;
 use serde_json::json;
 
 use crate::compile::test::TestContext;
+use crate::compile::CompilationError;
 use crate::compile::{
     rewrite::rewriter::Rewriter,
     test::{
@@ -536,10 +537,12 @@ async fn test_join_cubes_on_wrong_field_error() {
     )
     .await;
 
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
     assert_eq!(
-        query.unwrap_err().message(),
-        "Error during rewrite: Use __cubeJoinField to join Cubes. Please check logs for additional information.".to_string()
-    )
+        error.message(),
+        "Use __cubeJoinField to join Cubes".to_string()
+    );
 }
 
 #[tokio::test]
@@ -560,13 +563,15 @@ async fn test_join_cubes_filter_from_wrong_side_error() {
     )
         .await;
 
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
     assert_eq!(
-        query.unwrap_err().message(),
-        "Error during rewrite: Can not join Cubes. This is most likely due to one of the following reasons:\n\
+        error.message(),
+        "Can not join Cubes. This is most likely due to one of the following reasons:\n\
             • one of the cubes contains a group by\n\
             • one of the cubes contains a measure\n\
-            • the cube on the right contains a filter, sorting or limits\n\
-            . Please check logs for additional information.".to_string()
+            • the cube on the right contains a filter, sorting or limits\n"
+            .to_string()
     )
 }
 
@@ -587,13 +592,15 @@ async fn test_join_cubes_with_aggr_error() {
     )
         .await;
 
+    let error = query.unwrap_err();
+    assert!(matches!(error, CompilationError::Rewrite(..)));
     assert_eq!(
-        query.unwrap_err().message(),
-        "Error during rewrite: Can not join Cubes. This is most likely due to one of the following reasons:\n\
+        error.message(),
+        "Can not join Cubes. This is most likely due to one of the following reasons:\n\
             • one of the cubes contains a group by\n\
             • one of the cubes contains a measure\n\
-            • the cube on the right contains a filter, sorting or limits\n\
-            . Please check logs for additional information.".to_string()
+            • the cube on the right contains a filter, sorting or limits\n"
+            .to_string()
     )
 }
 

--- a/rust/cubesql/cubesql/src/error.rs
+++ b/rust/cubesql/cubesql/src/error.rs
@@ -21,8 +21,27 @@ pub struct CubeError {
 
 #[derive(Debug, Clone)]
 pub enum CubeErrorCauseType {
+    // User Error is an uncategorized error caused by user input or action
     User(Option<HashMap<String, String>>),
+    // Internal Error is an uncategorized error caused by internal failures
     Internal(Option<HashMap<String, String>>),
+    // REST API Error is an error thrown by REST API when running in standalone mode
+    RestApi(Option<HashMap<String, String>>),
+    // SQL Parser Error is an error thrown when SQL cannot be parsed
+    SqlParser(Option<HashMap<String, String>>),
+    // Unsupported Error is an error thrown when a feature/option is not supported
+    Unsupported(Option<HashMap<String, String>>),
+    // Planning Error is an error thrown when the query plan is invalid
+    Planning(Option<HashMap<String, String>>),
+    // Post-Processing Error is an error thrown during execution of the query
+    PostProcessing(Option<HashMap<String, String>>),
+    // Rewrite Error is an error thrown during logical plan e-graph rewriting
+    Rewrite(Option<HashMap<String, String>>),
+    // Database Execution Error is an error thrown during execution of the query in the database
+    DatabaseExecution(Option<HashMap<String, String>>),
+    // Continue wait is an error used internally to indicate that the query is still
+    // being processed and the client should send the request again
+    ContinueWait,
 }
 
 impl CubeError {
@@ -47,6 +66,70 @@ impl CubeError {
             message,
             cause: CubeErrorCauseType::Internal(None),
             backtrace,
+        }
+    }
+
+    pub fn rest_api(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::RestApi(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn sql_parser(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::SqlParser(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn unsupported(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::Unsupported(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn planning(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::Planning(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn post_processing(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::PostProcessing(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn rewrite(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::Rewrite(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn database_execution(message: String) -> Self {
+        Self {
+            message,
+            cause: CubeErrorCauseType::DatabaseExecution(None),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn continue_wait() -> Self {
+        Self {
+            message: "Continue wait".to_string(),
+            cause: CubeErrorCauseType::ContinueWait,
+            backtrace: None,
         }
     }
 
@@ -75,11 +158,55 @@ impl CubeError {
     }
 }
 
+impl CubeErrorCauseType {
+    pub fn meta(&self) -> Option<&HashMap<String, String>> {
+        match self {
+            CubeErrorCauseType::User(meta)
+            | CubeErrorCauseType::Internal(meta)
+            | CubeErrorCauseType::RestApi(meta)
+            | CubeErrorCauseType::SqlParser(meta)
+            | CubeErrorCauseType::Unsupported(meta)
+            | CubeErrorCauseType::Planning(meta)
+            | CubeErrorCauseType::PostProcessing(meta)
+            | CubeErrorCauseType::Rewrite(meta)
+            | CubeErrorCauseType::DatabaseExecution(meta) => meta.as_ref(),
+            CubeErrorCauseType::ContinueWait => None,
+        }
+    }
+}
+
 impl fmt::Display for CubeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.cause {
-            CubeErrorCauseType::User(_) => f.write_fmt(format_args!("{}", self.message)),
-            CubeErrorCauseType::Internal(_) => f.write_fmt(format_args!("{}", self.message)),
+            CubeErrorCauseType::User(_) => {
+                f.write_fmt(format_args!("User Error: {}", self.message))
+            }
+            CubeErrorCauseType::Internal(_) => {
+                f.write_fmt(format_args!("Internal Error: {}", self.message))
+            }
+            CubeErrorCauseType::RestApi(_) => {
+                f.write_fmt(format_args!("REST API Error: {}", self.message))
+            }
+            CubeErrorCauseType::SqlParser(_) => {
+                f.write_fmt(format_args!("SQL Parser Error: {}", self.message))
+            }
+            CubeErrorCauseType::Unsupported(_) => {
+                f.write_fmt(format_args!("Unsupported Error: {}", self.message))
+            }
+            CubeErrorCauseType::Planning(_) => {
+                f.write_fmt(format_args!("Planning Error: {}", self.message))
+            }
+            CubeErrorCauseType::PostProcessing(_) => {
+                f.write_fmt(format_args!("Post-Processing Error: {}", self.message))
+            }
+            CubeErrorCauseType::Rewrite(_) => f.write_fmt(format_args!(
+                "Rewrite Error: {}. Please check logs for additional information",
+                self.message
+            )),
+            CubeErrorCauseType::DatabaseExecution(_) => {
+                f.write_fmt(format_args!("Database Execution Error: {}", self.message))
+            }
+            CubeErrorCauseType::ContinueWait => write!(f, "Continue wait"),
         }
     }
 }
@@ -95,7 +222,7 @@ impl From<cubeclient::apis::Error<LoadV1Error>> for CubeError {
             },
             _ => v.to_string(),
         };
-        return CubeError::internal(message);
+        return CubeError::rest_api(message);
     }
 }
 
@@ -110,21 +237,50 @@ impl From<cubeclient::apis::Error<MetaV1Error>> for CubeError {
             },
             _ => v.to_string(),
         };
-        return CubeError::internal(message);
+        return CubeError::rest_api(message);
     }
 }
 
 impl From<crate::compile::CompilationError> for CubeError {
     fn from(v: crate::compile::CompilationError) -> Self {
-        let cause = match &v {
-            crate::compile::CompilationError::User(_, meta)
-            | crate::compile::CompilationError::Unsupported(_, meta)
-            | crate::compile::CompilationError::Internal(_, _, meta)
-            | crate::compile::CompilationError::Fatal(_, meta) => {
-                CubeErrorCauseType::Internal(meta.clone())
+        let (message, cause) = match &v {
+            crate::compile::CompilationError::Internal(message, _, meta)
+            | crate::compile::CompilationError::Fatal(message, meta) => {
+                (message.clone(), CubeErrorCauseType::Internal(meta.clone()))
             }
+            crate::compile::CompilationError::User(message, meta) => {
+                (message.clone(), CubeErrorCauseType::User(meta.clone()))
+            }
+            crate::compile::CompilationError::RestApi(message, meta) => {
+                (message.clone(), CubeErrorCauseType::RestApi(meta.clone()))
+            }
+            crate::compile::CompilationError::SqlParser(message, meta) => {
+                (message.clone(), CubeErrorCauseType::SqlParser(meta.clone()))
+            }
+            crate::compile::CompilationError::Unsupported(message, meta) => (
+                message.clone(),
+                CubeErrorCauseType::Unsupported(meta.clone()),
+            ),
+            crate::compile::CompilationError::Planning(message, meta) => {
+                (message.clone(), CubeErrorCauseType::Planning(meta.clone()))
+            }
+            crate::compile::CompilationError::PostProcessing(message, meta) => (
+                message.clone(),
+                CubeErrorCauseType::PostProcessing(meta.clone()),
+            ),
+            crate::compile::CompilationError::Rewrite(message, meta) => {
+                (message.clone(), CubeErrorCauseType::Rewrite(meta.clone()))
+            }
+            crate::compile::CompilationError::DatabaseExecution(message, meta) => (
+                message.clone(),
+                CubeErrorCauseType::DatabaseExecution(meta.clone()),
+            ),
+            crate::compile::CompilationError::ContinueWait => (
+                "Continue wait".to_string(),
+                CubeErrorCauseType::ContinueWait,
+            ),
         };
-        let mut err = CubeError::internal_with_bt(v.to_string(), v.to_backtrace());
+        let mut err = CubeError::internal_with_bt(message, v.to_backtrace());
         err.cause = cause;
 
         err
@@ -139,13 +295,16 @@ impl From<std::io::Error> for CubeError {
 
 impl From<ParserError> for CubeError {
     fn from(v: ParserError) -> Self {
-        CubeError::internal(format!("{:?}", v))
+        match v {
+            ParserError::ParserError(message) => CubeError::sql_parser(message),
+            ParserError::TokenizerError(message) => CubeError::sql_parser(message),
+        }
     }
 }
 
 impl From<rust_decimal::Error> for CubeError {
     fn from(v: rust_decimal::Error) -> Self {
-        CubeError::internal(format!("{:?}", v))
+        CubeError::internal(format!("Decimal Error: {}", v))
     }
 }
 
@@ -190,6 +349,12 @@ impl From<tokio::sync::broadcast::error::RecvError> for CubeError {
 impl From<datafusion::error::DataFusionError> for CubeError {
     fn from(v: datafusion::error::DataFusionError) -> Self {
         match v {
+            datafusion::error::DataFusionError::ArrowError(e) => CubeError::from(e),
+            datafusion::error::DataFusionError::SQL(e) => CubeError::from(e),
+            datafusion::error::DataFusionError::NotImplemented(e) => CubeError::unsupported(e),
+            datafusion::error::DataFusionError::Internal(e) => CubeError::internal(e),
+            datafusion::error::DataFusionError::Plan(e) => CubeError::planning(e),
+            datafusion::error::DataFusionError::Execution(e) => CubeError::post_processing(e),
             datafusion::error::DataFusionError::External(e) => match e.downcast::<CubeError>() {
                 Ok(e) => *e,
                 Err(e) => match e.downcast::<arrow::error::ArrowError>() {
@@ -197,7 +362,6 @@ impl From<datafusion::error::DataFusionError> for CubeError {
                     Err(e) => CubeError::internal(e.to_string()),
                 },
             },
-            datafusion::error::DataFusionError::ArrowError(e) => CubeError::from(e),
             _ => CubeError::internal(v.to_string()),
         }
     }
@@ -206,6 +370,7 @@ impl From<datafusion::error::DataFusionError> for CubeError {
 impl From<arrow::error::ArrowError> for CubeError {
     fn from(v: arrow::error::ArrowError) -> Self {
         match v {
+            arrow::error::ArrowError::NotYetImplemented(e) => CubeError::unsupported(e),
             arrow::error::ArrowError::ExternalError(e) => match e.downcast::<CubeError>() {
                 Ok(e) => *e,
                 Err(e) => match e.downcast::<datafusion::error::DataFusionError>() {
@@ -213,6 +378,12 @@ impl From<arrow::error::ArrowError> for CubeError {
                     Err(e) => CubeError::internal(e.to_string()),
                 },
             },
+            v @ arrow::error::ArrowError::CastError(_)
+            | v @ arrow::error::ArrowError::ParseError(_)
+            | v @ arrow::error::ArrowError::ComputeError(_)
+            | v @ arrow::error::ArrowError::DivideByZero => {
+                CubeError::post_processing(v.to_string())
+            }
             _ => CubeError::internal(v.to_string()),
         }
     }

--- a/rust/cubesql/cubesql/src/sql/dataframe.rs
+++ b/rust/cubesql/cubesql/src/sql/dataframe.rs
@@ -332,7 +332,7 @@ pub fn arrow_to_column_type(arrow_type: DataType) -> Result<ColumnType, CubeErro
         | DataType::UInt16
         | DataType::UInt64 => Ok(ColumnType::Int64),
         DataType::Null => Ok(ColumnType::String),
-        x => Err(CubeError::internal(format!("unsupported type {:?}", x))),
+        x => Err(CubeError::unsupported(format!("unsupported type {:?}", x))),
     }
 }
 

--- a/rust/cubesql/cubesql/src/sql/postgres/error.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/error.rs
@@ -6,7 +6,7 @@ use pg_srv::{
     ProtocolError,
 };
 
-use crate::{compile::CompilationError, transport::SpanId, CubeError};
+use crate::{compile::CompilationError, transport::SpanId, CubeError, CubeErrorCauseType};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConnectionError {
@@ -36,33 +36,10 @@ impl ConnectionError {
     /// Converts Error to protocol::ErrorResponse which is usefully for writing response to the client
     pub fn to_error_response(self) -> protocol::ErrorResponse {
         match self {
-            ConnectionError::Cube(e, _) => Self::cube_to_error_response(&e),
-            ConnectionError::DataFusion(e, _) => Self::df_to_error_response(&e),
-            ConnectionError::Arrow(e, _) => Self::arrow_to_error_response(&e),
-            ConnectionError::CompilationError(e, _) => {
-                fn to_error_response(e: CompilationError) -> protocol::ErrorResponse {
-                    match e {
-                        CompilationError::Internal(_, _, _) => protocol::ErrorResponse::error(
-                            protocol::ErrorCode::InternalError,
-                            e.to_string(),
-                        ),
-                        CompilationError::User(_, _) => protocol::ErrorResponse::error(
-                            protocol::ErrorCode::InvalidSqlStatement,
-                            e.to_string(),
-                        ),
-                        CompilationError::Unsupported(_, _) => protocol::ErrorResponse::error(
-                            protocol::ErrorCode::FeatureNotSupported,
-                            e.to_string(),
-                        ),
-                        CompilationError::Fatal(_, _) => protocol::ErrorResponse::fatal(
-                            protocol::ErrorCode::InternalError,
-                            e.to_string(),
-                        ),
-                    }
-                }
-
-                to_error_response(e)
-            }
+            ConnectionError::Cube(e, _) => Self::cube_to_error_response(e),
+            ConnectionError::DataFusion(e, _) => Self::df_to_error_response(e),
+            ConnectionError::Arrow(e, _) => Self::arrow_to_error_response(e),
+            ConnectionError::CompilationError(e, _) => Self::compilation_to_error_response(e),
             ConnectionError::Protocol(e, _) => e.to_error_response(),
         }
     }
@@ -89,51 +66,64 @@ impl ConnectionError {
         }
     }
 
-    fn cube_to_error_response(e: &CubeError) -> protocol::ErrorResponse {
-        let message = e.to_string();
-        // Remove `Error: ` prefix that can come from JS
-        let message = if let Some(message) = message.strip_prefix("Error: ") {
-            message.to_string()
-        } else {
-            message
-        };
-        protocol::ErrorResponse::error(protocol::ErrorCode::InternalError, message)
+    fn cube_to_error_response(e: CubeError) -> protocol::ErrorResponse {
+        match e.cause {
+            CubeErrorCauseType::User(_) => protocol::ErrorResponse::error(
+                protocol::ErrorCode::InvalidSqlStatement,
+                e.to_string(),
+            ),
+            CubeErrorCauseType::Internal(_) => {
+                protocol::ErrorResponse::error(protocol::ErrorCode::InternalError, e.to_string())
+            }
+            CubeErrorCauseType::RestApi(_) => {
+                protocol::ErrorResponse::error(protocol::ErrorCode::SystemError, e.to_string())
+            }
+            CubeErrorCauseType::SqlParser(_) => {
+                protocol::ErrorResponse::error(protocol::ErrorCode::SyntaxError, e.to_string())
+            }
+            CubeErrorCauseType::Unsupported(_) => protocol::ErrorResponse::error(
+                protocol::ErrorCode::FeatureNotSupported,
+                e.to_string(),
+            ),
+            CubeErrorCauseType::Planning(_) => protocol::ErrorResponse::error(
+                protocol::ErrorCode::SyntaxErrorOrAccessRuleViolation,
+                e.to_string(),
+            ),
+            CubeErrorCauseType::PostProcessing(_) => {
+                protocol::ErrorResponse::error(protocol::ErrorCode::DataException, e.to_string())
+            }
+            CubeErrorCauseType::Rewrite(_) => {
+                protocol::ErrorResponse::error(protocol::ErrorCode::InternalError, e.to_string())
+            }
+            CubeErrorCauseType::DatabaseExecution(_) => {
+                protocol::ErrorResponse::error(protocol::ErrorCode::SystemError, e.to_string())
+            }
+            CubeErrorCauseType::ContinueWait => {
+                // Should never happen
+                protocol::ErrorResponse::error(
+                    protocol::ErrorCode::SqlStatementNotYetComplete,
+                    e.to_string(),
+                )
+            }
+        }
     }
 
-    fn df_to_error_response(e: &DataFusionError) -> protocol::ErrorResponse {
-        match e {
-            DataFusionError::ArrowError(arrow_err) => {
-                return Self::arrow_to_error_response(arrow_err);
-            }
-            DataFusionError::External(err) => {
-                if let Some(cube_err) = err.downcast_ref::<CubeError>() {
-                    return Self::cube_to_error_response(cube_err);
-                }
-            }
-            _ => {}
-        }
-        protocol::ErrorResponse::error(
-            protocol::ErrorCode::InternalError,
-            format!("Post-processing Error: {}", e),
-        )
+    fn df_to_error_response(e: DataFusionError) -> protocol::ErrorResponse {
+        Self::cube_to_error_response(CubeError::from(e))
     }
 
-    fn arrow_to_error_response(e: &ArrowError) -> protocol::ErrorResponse {
-        match e {
-            ArrowError::ExternalError(err) => {
-                if let Some(df_err) = err.downcast_ref::<DataFusionError>() {
-                    return Self::df_to_error_response(df_err);
-                }
-                if let Some(cube_err) = err.downcast_ref::<CubeError>() {
-                    return Self::cube_to_error_response(cube_err);
-                }
-            }
-            _ => {}
+    fn arrow_to_error_response(e: ArrowError) -> protocol::ErrorResponse {
+        Self::cube_to_error_response(CubeError::from(e))
+    }
+
+    fn compilation_to_error_response(e: CompilationError) -> protocol::ErrorResponse {
+        if let CompilationError::Fatal(message, _) = e {
+            return protocol::ErrorResponse::fatal(
+                protocol::ErrorCode::InternalError,
+                format!("Fatal Error: {}", message),
+            );
         }
-        protocol::ErrorResponse::error(
-            protocol::ErrorCode::InternalError,
-            format!("Post-processing Error: {}", e),
-        )
+        Self::cube_to_error_response(CubeError::from(e))
     }
 }
 

--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -448,21 +448,35 @@ impl AsyncPostgresShim {
     ) -> Result<(), ConnectionError> {
         let (message, props) = match &err {
             ConnectionError::CompilationError(e, _) => match e {
-                CompilationError::Unsupported(msg, meta)
-                | CompilationError::User(msg, meta)
-                | CompilationError::Internal(msg, _, meta) => (msg.clone(), meta.clone()),
+                CompilationError::Unsupported(_, meta)
+                | CompilationError::User(_, meta)
+                | CompilationError::Internal(_, _, meta)
+                | CompilationError::RestApi(_, meta)
+                | CompilationError::SqlParser(_, meta)
+                | CompilationError::Planning(_, meta)
+                | CompilationError::PostProcessing(_, meta)
+                | CompilationError::Rewrite(_, meta)
+                | CompilationError::DatabaseExecution(_, meta) => (e.to_string(), meta.clone()),
                 CompilationError::Fatal(_, _) => return Err(err),
+                // Should never execute
+                CompilationError::ContinueWait => ("Continue wait".to_string(), None),
             },
             ConnectionError::Protocol(ProtocolError::IO { source, .. }, _) => match source.kind() {
                 // Propagate unrecoverable errors to top level - run_on
                 ErrorKind::UnexpectedEof | ErrorKind::BrokenPipe => return Err(err),
                 _ => (
-                    format!("Error during processing PostgreSQL message: {}", err),
+                    format!(
+                        "Internal Error: Error during processing PostgreSQL message: {}",
+                        err
+                    ),
                     None,
                 ),
             },
             _ => (
-                format!("Error during processing PostgreSQL message: {}", err),
+                format!(
+                    "Internal Error: Error during processing PostgreSQL message: {}",
+                    err
+                ),
                 None,
             ),
         };

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -292,7 +292,7 @@ impl TransportService for HttpTransport {
         _throw_continue_wait: bool,
     ) -> Result<Vec<RecordBatch>, CubeError> {
         if meta.change_user().is_some() {
-            return Err(CubeError::internal(
+            return Err(CubeError::user(
                 "Changing security context (__user) is not supported in the standalone mode"
                     .to_string(),
             ));
@@ -544,14 +544,13 @@ impl SqlTemplates {
     }
 
     pub fn quote_identifier(&self, column_name: &str) -> Result<String, CubeError> {
-        let quote = self
-            .templates
-            .get("quotes/identifiers")
-            .ok_or_else(|| CubeError::user("quotes/identifiers template not found".to_string()))?;
+        let quote = self.templates.get("quotes/identifiers").ok_or_else(|| {
+            CubeError::internal("quotes/identifiers template not found".to_string())
+        })?;
         let escape = self
             .templates
             .get("quotes/escape")
-            .ok_or_else(|| CubeError::user("quotes/escape template not found".to_string()))?;
+            .ok_or_else(|| CubeError::internal("quotes/escape template not found".to_string()))?;
         Ok(format!(
             "{}{}{}",
             quote,
@@ -791,7 +790,7 @@ impl SqlTemplates {
         } else if self.contains_template(INTERVAL_SINGLE_TEMPLATE) {
             self.interval_single_expr(num, date_part)
         } else {
-            Err(CubeError::internal(
+            Err(CubeError::unsupported(
                 "Interval template generation is not supported".to_string(),
             ))
         }
@@ -905,7 +904,7 @@ impl SqlTemplates {
             LikeType::Like => "like",
             LikeType::ILike => "ilike",
             _ => {
-                return Err(CubeError::internal(format!(
+                return Err(CubeError::unsupported(format!(
                     "Error rendering template: like type {} is not supported",
                     like_type
                 )))
@@ -979,7 +978,7 @@ impl SqlTemplates {
             DataType::Duration(_) | DataType::Interval(_) => "interval",
             DataType::Binary | DataType::FixedSizeBinary(_) | DataType::LargeBinary => "binary",
             dt => {
-                return Err(CubeError::internal(format!(
+                return Err(CubeError::unsupported(format!(
                     "Can't generate SQL for type {:?}: not supported",
                     dt
                 )))

--- a/rust/cubesql/pg-srv/src/protocol.rs
+++ b/rust/cubesql/pg-srv/src/protocol.rs
@@ -971,6 +971,8 @@ pub enum FrontendMessage {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum ErrorCode {
+    // Class 03 — SQL Statement Not Yet Complete
+    SqlStatementNotYetComplete,
     // 0A — Feature Not Supported
     FeatureNotSupported,
     // 8 -  Connection Exception
@@ -988,6 +990,7 @@ pub enum ErrorCode {
     // 34
     InvalidCursorName,
     // Class 42 — Syntax Error or Access Rule Violation
+    SyntaxErrorOrAccessRuleViolation,
     DuplicateCursor,
     SyntaxError,
     // Class 53 — Insufficient Resources
@@ -998,6 +1001,8 @@ pub enum ErrorCode {
     // Class 57 - Operator Intervention
     QueryCanceled,
     AdminShutdown,
+    // Class 58 — System Error (errors external to PostgreSQL itself)
+    SystemError,
     // XX - Internal Error
     InternalError,
 }
@@ -1005,6 +1010,7 @@ pub enum ErrorCode {
 impl Display for ErrorCode {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let string = match self {
+            Self::SqlStatementNotYetComplete => "03000",
             Self::FeatureNotSupported => "0A000",
             Self::ProtocolViolation => "08P01",
             Self::InvalidAuthorizationSpecification => "28000",
@@ -1014,6 +1020,7 @@ impl Display for ErrorCode {
             Self::NoActiveSqlTransaction => "25P01",
             Self::InvalidSqlStatement => "26000",
             Self::InvalidCursorName => "34000",
+            Self::SyntaxErrorOrAccessRuleViolation => "42000",
             Self::DuplicateCursor => "42P03",
             Self::SyntaxError => "42601",
             Self::TooManyConnections => "53300",
@@ -1021,6 +1028,7 @@ impl Display for ErrorCode {
             Self::ObjectNotInPrerequisiteState => "55000",
             Self::QueryCanceled => "57014",
             Self::AdminShutdown => "57P01",
+            Self::SystemError => "58000",
             Self::InternalError => "XX000",
         };
         write!(f, "{}", string)


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR makes an effort to universally prefix all errors with preset messages, and unwrap error onions wherever possible.
