### PR TITLE
fix(tesseract): tautological FK-aggregate join for filtered PK counts

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
@@ -1,6 +1,7 @@
 use super::super::{LogicalNodeProcessor, ProcessableNode, PushDownBuilderContext};
 use crate::logical_plan::{AggregateMultipliedSubquery, AggregateMultipliedSubquerySource};
 use crate::physical_plan::ReferencesBuilder;
+use crate::physical_plan::VisitorContext;
 use crate::physical_plan::{
     Expr, From, JoinBuilder, JoinCondition, MemberExpression, QualifiedColumnName, Select,
     SelectBuilder,
@@ -59,6 +60,24 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
 
         match &aggregate_multiplied_subquery.source {
             AggregateMultipliedSubquerySource::Cube(cube) => {
+                // Bind a dedicated VisitorContext to the join's right-hand side
+                // so that primary-key dimensions render against `pk_cube_alias`
+                // (the source cube join). Without it, the outer factory's
+                // render_references — populated later for the SELECT — map
+                // these dimensions to the inner `keys` subquery alias, and
+                // both sides of the ON clause collapse to `keys.<pk> = keys.<pk>`.
+                // Clone the parent factory rather than rebuilding from context so
+                // that any state already added above (currently none, but this
+                // makes the lineage explicit for future maintenance) is preserved.
+                let mut join_context_factory = context_factory.clone();
+                join_context_factory
+                    .add_cube_name_reference(cube.cube().name().clone(), pk_cube_alias.clone());
+                let join_visitor_context = Rc::new(VisitorContext::new(
+                    query_tools.clone(),
+                    &join_context_factory,
+                    None,
+                ));
+
                 let conditions = primary_keys_dimensions
                     .iter()
                     .map(|dim| -> Result<_, CubeError> {
@@ -67,7 +86,10 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
                             Some(keys_query_alias.clone()),
                             alias_in_keys_query,
                         ));
-                        let pk_cube_expr = Expr::Member(MemberExpression::new(dim.clone()));
+                        let pk_cube_expr = Expr::new_member_with_context(
+                            dim.clone(),
+                            join_visitor_context.clone(),
+                        );
                         Ok(vec![(keys_query_ref, pk_cube_expr)])
                     })
                     .collect::<Result<Vec<_>, _>>()?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_fact.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_fact.yaml
@@ -50,6 +50,11 @@ cubes:
             sql: lifetime_value
             filters:
               - sql: "{regions.name} = 'East'"
+          - name: active_count
+            type: count
+            sql: "{id}"
+            filters:
+              - sql: "{name} LIKE 'A%'"
 
     - name: orders
       sql: "SELECT * FROM orders"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_fact.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_fact.rs
@@ -488,6 +488,71 @@ async fn test_multiplied_aggregate_hub_sum_measure() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_multiplied_aggregate_filtered_count_on_pk() {
+    let ctx = create_context();
+
+    // customers.active_count (type: count, sql: "{CUBE}.id", filters: [...])
+    // grouped by orders.status.
+    // customers→orders is one_to_many, so customers is multiplied → AggregateMultipliedSubquery
+    // The measure references only customers → source = Cube branch.
+    // Regression: the Cube branch used to render the right side of the FK-aggregate
+    // rejoin via Expr::Member, which the outer factory's render_references mapped
+    // back to the inner `keys` subquery alias — yielding a tautological
+    // `ON keys.<pk> = keys.<pk>` that cross-joined the source table and over-counted.
+    let query = indoc! {"
+        measures:
+          - customers.active_count
+        dimensions:
+          - orders.status
+        order:
+          - id: orders.status
+    "};
+
+    let sql = ctx.build_sql(query).unwrap();
+
+    // The buggy output contained `keys.customers__id = keys.customers__id`. Flatten
+    // the SQL so the assertion survives any future line-wrapping in the planner's
+    // formatter, then walk every ON predicate and assert no tautological equality
+    // survives. The snapshot below is the airtight guard; this is a targeted
+    // structural sanity check pinned to the bug shape.
+    let flat = sql.replace('\n', " ");
+    let flat_upper = flat.to_ascii_uppercase();
+    let mut cursor = 0;
+    while let Some(rel) = flat_upper[cursor..].find(" ON ") {
+        let on_end = cursor + rel + 4;
+        let after = &flat[on_end..];
+        let after_upper = &flat_upper[on_end..];
+        let bound = [
+            " GROUP BY ",
+            " ORDER BY ",
+            " LEFT JOIN ",
+            " INNER JOIN ",
+            " RIGHT JOIN ",
+            " UNION ",
+        ]
+        .iter()
+        .filter_map(|kw| after_upper.find(kw))
+        .min()
+        .unwrap_or(after.len());
+        for chunk in after[..bound].split(" AND ") {
+            if let Some((lhs, rhs)) = chunk.split_once('=') {
+                let lhs = lhs.trim().trim_matches('(').trim();
+                let rhs = rhs.trim().trim_matches(')').trim();
+                assert!(
+                    lhs != rhs,
+                    "tautological join condition `{lhs} = {rhs}` in:\n{sql}"
+                );
+            }
+        }
+        cursor = on_end;
+    }
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multiplied_aggregate_with_measure_subquery() {
     let ctx = create_context();
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__multi_fact__multiplied_aggregate_filtered_count_on_pk.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__multi_fact__multiplied_aggregate_filtered_count_on_pk.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/src/tests/integration/multi_fact.rs
+expression: result
+---
+orders__status | customers__active_count
+---------------+------------------------
+completed      | 1                      
+pending        | 1                      
+NULL           | 0


### PR DESCRIPTION
## Summary

Filtered count measures of shape `type: count` + `sql: "{primary_key}"` + `filters: [...]`, when reached through a 1→N (one-to-many) join with `CUBESQL_SQL_PUSH_DOWN=true`, generated SQL with a tautological FK-aggregate rejoin: `LEFT JOIN <source_cube> AS <pk_alias> ON keys.pk = keys.pk`. Both sides referenced the inner `keys` subquery, so the join cross-produced and the count over-included any row whose filter predicates were satisfied anywhere in the source table — silently incorrect and orders of magnitude slower.

The legacy JS path (`BaseQuery.js::aggregateSubQuery`) generates the correct `keys.pk = source.pk` join. **The bug is exclusive to the Tesseract Rust planner.**

Discovered as a production over-count in a downstream Cube deployment: a measure pattern matching ~70 instances across the model returned silently inflated counts whenever queried through a fanout-prone view. Reproduced into the upstream test suite and fixed here.

## Changes

- `rust/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs` — bind a dedicated `VisitorContext` to the right-hand side of the FK-aggregate `ON` clause in the `Cube` source arm.
- `rust/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_fact.yaml` — add `customers.active_count` (filtered count on PK) to the existing 1→N schema.
- `rust/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_fact.rs` — new `test_multiplied_aggregate_filtered_count_on_pk` regression test with a structural tautology assertion over every `ON` predicate, plus the suite-standard `assert_snapshot!(result)` on postgres execution row data when `integration-postgres` is on.

## Implementation Details

The `Cube` source arm of `AggregateMultipliedSubquery::process` used `Expr::Member(dim)` for the join's right-hand side, deferring resolution to SQL-emission time. By then, the outer factory's `render_references` had been populated by the schema-resolution pass — and because the `keys` subquery (the join's root) projects the PK dimension, `ReferencesBuilder::find_reference_column_for_member_in_join` resolved it to `(keys, <alias>)`. That mapping intercepted both sides of the `ON` clause via `RenderReferencesSqlNode`, producing the tautology.

**Fix:** snapshot a `VisitorContext` *before* the schema-resolution pollution, register `pk_cube.name() → pk_cube_alias` in `cube_name_references`, and bind it to the RHS via `Expr::new_member_with_context`. The dim then renders via `AutoPrefixSqlNode` against `pk_cube_alias` — preserves full SQL semantics for custom-SQL or composite PKs, not just simple `sql: id` cases.

## Risk / Compatibility

The change is scoped to the `Cube` arm of `AggregateMultipliedSubquerySource`. The `MeasureSubquery` arm is unchanged — it already used `Expr::Reference` with `pk_cube_alias` and was unaffected. No other call sites are at risk: `add_subquery_join` (`builder.rs:141`) uses the same `Expr::new_member` pattern but joins against a Cube-rooted `From` where `ReferencesBuilder` returns `None` for cube sources, so it doesn't trigger the render-reference pollution that caused the bug.

## Testing

- `cargo test --lib` in `rust/cubesqlplanner/`: 823 tests pass locally, 0 failures, 14 ignored (Docker-dependent).
- Pre-fix manifestation: `LEFT JOIN customers AS "..." ON (("keys"."customers__id" = "keys"."customers__id"))` — tautology, both sides reference `keys`.
- Post-fix: `LEFT JOIN customers AS "customers_key_customers" ON (("keys"."customers__id" = "customers_key_customers".id))` — RHS correctly resolves to the source-cube alias.
- Regression coverage: (a) the test's structural tautology scanner walks every `ON` predicate and fails on any `lhs == rhs` equality (environment-independent, robust to planner formatting); (b) `assert_snapshot!(result)` on postgres execution row data when `integration-postgres` is enabled validates end-to-end correctness against a real database. SQL strings themselves are not snapshotted — that follows the existing convention in the suite (226 result-data snapshots vs 0 SQL-string snapshots), since SQL formatting is unstable across template-rendering passes while row data is stable.

## Linear Ticket

N/A — upstream OSS contribution.
