### PR TITLE
perf(cubesql): Avoid cloning row payload in convert_transport_response

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDate};
-use cubeclient::models::{V1LoadRequestQuery, V1LoadResponse};
+use cubeclient::models::{V1LoadRequestQuery, V1LoadResponse, V1LoadResult};
 pub use datafusion::{
     arrow::{
         array::{
@@ -1194,9 +1194,15 @@ pub fn convert_transport_response(
     response
         .results
         .into_iter()
-        .map(|r| {
-            let mut response = JsonValueObject::new(r.data.clone());
-            let updated_schema = if let Some(last_refresh_time) = r.last_refresh_time.clone() {
+        .map(|result| {
+            let V1LoadResult {
+                data,
+                last_refresh_time,
+                ..
+            } = result;
+
+            let mut response = JsonValueObject::new(data);
+            let updated_schema = if let Some(last_refresh_time) = last_refresh_time {
                 let mut metadata = schema.metadata().clone();
                 metadata.insert("lastRefreshTime".to_string(), last_refresh_time);
                 Arc::new(Schema::new_with_metadata(


### PR DESCRIPTION
Destructure V1LoadResult to move `data` and `last_refresh_time` out of the owned value instead of cloning. Eliminates a full copy of the row Vec on every Cube load result, reducing peak memory and allocator churn.