### PR TITLE
feat(api-gateway): CORE-418 readiness probe data model check

### DIFF
--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -463,6 +463,14 @@ monitoring service of choice to use the [`/readyz`][ref-api-readyz] and
 [`/livez`][ref-api-livez] API endpoints so you can check on the Cube
 deployment's health and be alerted to any issues.
 
+For rolling deploys where a broken data model should not be promoted to
+production, set the
+[`CUBEJS_READINESS_CHECK_DATA_MODEL`](/reference/configuration/environment-variables#cubejs_readiness_check_data_model)
+environment variable to `true`. The `/readyz` probe will then compile the
+data model for every tenant on each probe, fail with a `500` response if any
+tenant fails to compile, and let the previous (working) build continue
+serving traffic until the issue is resolved.
+
 ### Appropriate cluster sizing
 
 There's no one-size-fits-all when it comes to sizing a Cube cluster and its

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -467,9 +467,11 @@ For rolling deploys where a broken data model should not be promoted to
 production, set the
 [`CUBEJS_READINESS_CHECK_DATA_MODEL`](/reference/configuration/environment-variables#cubejs_readiness_check_data_model)
 environment variable to `true`. The `/readyz` probe will then compile the
-data model for every tenant on each probe, fail with a `500` response if any
-tenant fails to compile, and let the previous (working) build continue
-serving traffic until the issue is resolved.
+data model for every tenant, fail with a `500` response if any tenant fails
+to compile, and let the previous (working) build continue serving traffic
+until the issue is resolved. Compiled schemas are cached by version, and
+probe responses are coalesced for one second, so steady-state cost is
+minimal even with many tenants.
 
 ### Appropriate cluster sizing
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1431,6 +1431,20 @@ For example, if set to `/`, a nested folder structure like the `Customer Informa
 folder with the `Personal Details` subfolder will be flattened to `Customer
 Information / Personal Details` at the root level.
 
+## `CUBEJS_READINESS_CHECK_DATA_MODEL`
+
+If `true`, the [`/readyz`](/reference/rest-api/reference#readyz) readiness
+probe additionally compiles the data model for every tenant returned by
+[`scheduled_refresh_contexts`](/reference/configuration/config#scheduled_refresh_contexts)
+(or once with an empty security context in single-tenant deployments). The
+probe returns a `500` response if compilation fails for any tenant, allowing
+container orchestrators to keep the previous build serving traffic when a
+new build ships with a broken data model.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false`                | `false`               |
+
 ## `CUBEJS_TELEMETRY`
 
 If `true`, then send telemetry to Cube.

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -2794,12 +2794,21 @@ class ApiGateway {
   // fails fast and the deployment platform refuses to promote a broken
   // build. The previous (working) version keeps serving traffic.
   protected async checkDataModelCompiles(): Promise<'HEALTH' | 'DOWN'> {
-    const backgroundContexts = this.scheduledRefreshContexts
-      ? await this.scheduledRefreshContexts()
-      : [];
+    let backgroundContexts: UserBackgroundContext[];
+    try {
+      backgroundContexts = this.scheduledRefreshContexts
+        ? await this.scheduledRefreshContexts()
+        : [];
+    } catch (e: any) {
+      this.logProbeError(e, 'Internal Server Error on readiness probe (scheduledRefreshContexts)');
+      return 'DOWN';
+    }
 
     if (backgroundContexts.length === 0 && this.scheduledRefreshContexts) {
-      this.log({ type: 'Readiness probe data model check skipped — scheduledRefreshContexts returned no contexts' });
+      this.log({
+        type: 'Readiness probe data model check',
+        warning: 'scheduledRefreshContexts returned no contexts; checking with empty security context',
+      });
     }
 
     const contexts = backgroundContexts.length > 0 ? backgroundContexts : [{ securityContext: {} }];

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -2783,8 +2783,44 @@ class ApiGateway {
       }
     }
 
+    if (health === 'HEALTH' && getEnv('readinessCheckDataModel')) {
+      health = await this.checkDataModelCompiles();
+    }
+
     return this.healthResponse(res, health);
   };
+
+  // Returns 'DOWN' on the first per-tenant compile failure so the probe
+  // fails fast and the deployment platform refuses to promote a broken
+  // build. The previous (working) version keeps serving traffic.
+  protected async checkDataModelCompiles(): Promise<'HEALTH' | 'DOWN'> {
+    const backgroundContexts = this.scheduledRefreshContexts
+      ? await this.scheduledRefreshContexts()
+      : [];
+
+    if (backgroundContexts.length === 0 && this.scheduledRefreshContexts) {
+      this.log({ type: 'Readiness probe data model check skipped — scheduledRefreshContexts returned no contexts' });
+    }
+
+    const contexts = backgroundContexts.length > 0 ? backgroundContexts : [{ securityContext: {} }];
+
+    for (const backgroundContext of contexts) {
+      const requestContext: RequestContext = {
+        securityContext: backgroundContext?.securityContext || backgroundContext?.authInfo || {},
+        requestId: `readiness-${uuidv4()}`,
+      };
+
+      try {
+        const compilerApi = await this.getCompilerApi(requestContext);
+        await compilerApi.metaConfig(requestContext, { requestId: requestContext.requestId });
+      } catch (e: any) {
+        this.logProbeError(e, 'Internal Server Error on readiness probe (data model compilation)');
+        return 'DOWN';
+      }
+    }
+
+    return 'HEALTH';
+  }
 
   protected liveness: RequestHandler = async (req, res) => {
     let health: 'HEALTH' | 'DOWN' = 'HEALTH';

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -1186,6 +1186,120 @@ describe('API Gateway', () => {
       expect(dataSourceStorage.$testConnectionsDone).toEqual(true);
       expect(dataSourceStorage.$testOrchestratorConnectionsDone).toEqual(false);
     });
+
+    describe('readyz with CUBEJS_READINESS_CHECK_DATA_MODEL', () => {
+      const originalEnv = process.env.CUBEJS_READINESS_CHECK_DATA_MODEL;
+      const originalCompilerApiImpl = compilerApi.getMockImplementation();
+
+      afterEach(() => {
+        if (originalEnv === undefined) {
+          delete process.env.CUBEJS_READINESS_CHECK_DATA_MODEL;
+        } else {
+          process.env.CUBEJS_READINESS_CHECK_DATA_MODEL = originalEnv;
+        }
+        if (originalCompilerApiImpl) {
+          compilerApi.mockImplementation(originalCompilerApiImpl);
+        }
+        compilerApi.mockClear();
+      });
+
+      test('disabled by default — /readyz does not invoke compilerApi', async () => {
+        delete process.env.CUBEJS_READINESS_CHECK_DATA_MODEL;
+
+        const metaConfigMock = jest.fn();
+        compilerApi.mockImplementation(async () => ({ metaConfig: metaConfigMock }));
+
+        const { app } = await createApiGateway();
+        const res = await request(app)
+          .get('/readyz')
+          .set('Content-type', 'application/json')
+          .expect(200);
+
+        expect(res.body).toMatchObject({ health: 'HEALTH' });
+        expect(metaConfigMock).not.toHaveBeenCalled();
+      });
+
+      test('enabled, single tenant, healthy compile', async () => {
+        process.env.CUBEJS_READINESS_CHECK_DATA_MODEL = 'true';
+
+        const metaConfigMock = jest.fn().mockResolvedValue([]);
+        compilerApi.mockImplementation(async () => ({ metaConfig: metaConfigMock }));
+
+        const { app } = await createApiGateway();
+        const res = await request(app)
+          .get('/readyz')
+          .set('Content-type', 'application/json')
+          .expect(200);
+
+        expect(res.body).toMatchObject({ health: 'HEALTH' });
+        expect(metaConfigMock).toHaveBeenCalledTimes(1);
+      });
+
+      test('enabled, single tenant, broken compile → DOWN', async () => {
+        process.env.CUBEJS_READINESS_CHECK_DATA_MODEL = 'true';
+
+        compilerApi.mockImplementation(async () => ({
+          metaConfig: async () => { throw new Error('Compile errors: duplicate view'); },
+        }));
+
+        const { app } = await createApiGateway();
+        const res = await request(app)
+          .get('/readyz')
+          .set('Content-type', 'application/json')
+          .expect(500);
+
+        expect(res.body).toMatchObject({ health: 'DOWN' });
+      });
+
+      test('enabled, multi-tenant, all healthy', async () => {
+        process.env.CUBEJS_READINESS_CHECK_DATA_MODEL = 'true';
+
+        const metaConfigMock = jest.fn().mockResolvedValue([]);
+        compilerApi.mockImplementation(async () => ({ metaConfig: metaConfigMock }));
+
+        const { app } = await createApiGateway(new AdapterApiMock(), new DataSourceStorageMock(), {
+          scheduledRefreshContexts: async () => [
+            { securityContext: { tenant: 'a' } },
+            { securityContext: { tenant: 'b' } },
+            { securityContext: { tenant: 'c' } },
+          ],
+        });
+
+        const res = await request(app)
+          .get('/readyz')
+          .set('Content-type', 'application/json')
+          .expect(200);
+
+        expect(res.body).toMatchObject({ health: 'HEALTH' });
+        expect(metaConfigMock).toHaveBeenCalledTimes(3);
+      });
+
+      test('enabled, multi-tenant, one tenant broken → DOWN', async () => {
+        process.env.CUBEJS_READINESS_CHECK_DATA_MODEL = 'true';
+
+        const healthy = { metaConfig: async () => [] };
+        const broken = { metaConfig: async () => { throw new Error('Compile errors: duplicate view'); } };
+        compilerApi
+          .mockImplementationOnce(async () => healthy)
+          .mockImplementationOnce(async () => broken)
+          .mockImplementation(async () => healthy);
+
+        const { app } = await createApiGateway(new AdapterApiMock(), new DataSourceStorageMock(), {
+          scheduledRefreshContexts: async () => [
+            { securityContext: { tenant: 'a' } },
+            { securityContext: { tenant: 'b' } },
+            { securityContext: { tenant: 'c' } },
+          ],
+        });
+
+        const res = await request(app)
+          .get('/readyz')
+          .set('Content-type', 'application/json')
+          .expect(500);
+
+        expect(res.body).toMatchObject({ health: 'DOWN' });
+      });
+    });
   });
 
   describe('/v1/cubesql', () => {

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -1299,6 +1299,21 @@ describe('API Gateway', () => {
 
         expect(res.body).toMatchObject({ health: 'DOWN' });
       });
+
+      test('enabled, scheduledRefreshContexts itself throws → DOWN', async () => {
+        process.env.CUBEJS_READINESS_CHECK_DATA_MODEL = 'true';
+
+        const { app } = await createApiGateway(new AdapterApiMock(), new DataSourceStorageMock(), {
+          scheduledRefreshContexts: async () => { throw new Error('Tenant directory unavailable'); },
+        });
+
+        const res = await request(app)
+          .get('/readyz')
+          .set('Content-type', 'application/json')
+          .expect(500);
+
+        expect(res.body).toMatchObject({ health: 'DOWN' });
+      });
     });
   });
 

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -243,6 +243,9 @@ const variables: Record<string, (...args: any) => any> = {
   rollupOnlyMode: () => get('CUBEJS_ROLLUP_ONLY')
     .default('false')
     .asBoolStrict(),
+  readinessCheckDataModel: () => get('CUBEJS_READINESS_CHECK_DATA_MODEL')
+    .default('false')
+    .asBoolStrict(),
   schemaPath: () => get('CUBEJS_SCHEMA_PATH')
     .default('model')
     .asString(),


### PR DESCRIPTION
## Summary

Linear: [CORE-418](https://linear.app/cube-d3/issue/CORE-418/duplicate-view-definitions-break-deployment-compilation)

A user reported that merging a data model with two definitions of the same view caused Cube to successfully promote the build to production: the API process stayed alive and existing health checks passed, but every request that needed the schema (querying, Playground, SQL Runner, meta) broke with a compile error like:

```
some_view cube: Included member 'some_key' conflicts with existing member of 'some_view'.
```

The existing `/readyz` probe only verifies orchestrator connectivity in standalone mode; in multi-tenant deployments the schema compiles lazily on first request per tenant, so a broken model passes deploy-time checks and silently breaks the deployment.

This PR adds an opt-in readiness check that compiles the data model for every tenant returned by `scheduledRefreshContexts` (or once with an empty security context for single-tenant deployments). When enabled, `/readyz` returns 500 if any tenant fails to compile, so the deployment platform refuses to promote the bad build and the previous (working) version keeps serving traffic.

- New env var: `CUBEJS_READINESS_CHECK_DATA_MODEL` (default `false`).
- `/livez` is intentionally **not** changed — failing it would crash-loop the pod on a bad model.
- Sequential per-tenant compile with early-exit on first failure. `CompilerApi.getCompilers` already caches by `compilerVersion`, so steady-state probe cost is dominated by cache hits. The existing `cachedHandler` (1s TTL) coalesces concurrent probes.

## Files changed

- `packages/cubejs-backend-shared/src/env.ts` — register `readinessCheckDataModel`.
- `packages/cubejs-api-gateway/src/gateway.ts` — extend `readiness` handler with `checkDataModelCompiles()`.
- `packages/cubejs-api-gateway/test/index.test.ts` — 5 new jest tests covering: env disabled, single-tenant healthy, single-tenant broken, multi-tenant healthy, multi-tenant one-broken.
- `docs-mintlify/reference/configuration/environment-variables.mdx` — new env var section.
- `docs-mintlify/cube-core/deployment.mdx` — paragraph in the existing health-checks section pointing to the new env var.

## Test plan

- [x] `yarn build` — TS compiles (no new errors; pre-existing `sql-server.ts` errors unrelated).
- [x] `yarn lint` — 0 errors.
- [x] `cubejs-backend-shared` unit tests — 308 passing.
- [x] `cubejs-api-gateway` unit tests — 185 passing, including 5 new healthcheck tests.
- [x] Local Docker (`cubejs/cube:dev` built from this branch) end-to-end scenarios:
  - env var unset (default), broken model → `/readyz` 200 (existing behavior preserved)
  - env var `false`, broken model → `/readyz` 200
  - env var `true`, healthy single-tenant → `/readyz` 200
  - env var `true`, broken single-tenant → `/readyz` 500, expected error reproduced
  - env var `true`, multi-tenant all healthy → `/readyz` 200, three compilations executed
  - env var `true`, multi-tenant one broken → `/readyz` 500
  - live recovery: broken → fix in place → `/readyz` 500 → 200 within `cachedHandler` TTL, no restart
  - `/livez` returns 200 in every scenario regardless of compile state
