### PR TITLE
fix(backend-native): Respect `isDataQuery` flag in `cubesql` endpoint

### DIFF
--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -446,7 +446,7 @@ async fn handle_sql_query(
                             },
                             "apiType": "sql",
                             "duration": span_id.as_ref().unwrap().duration(),
-                            "isDataQuery": true
+                            "isDataQuery": span_id.as_ref().unwrap().is_data_query().await,
                         }),
                     )
                     .await?;


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes an issue with `/cubesql` endpoint not respecting the `isDataQuery` flag passed by cubesql, always reporting queries as data queries even if those are service queries.