### PR TITLE
fix(cubesql): Do not throw error on empty peer based evaluation in window aggregates

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "arrow",
  "chrono",
@@ -878,7 +878,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -922,7 +922,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "async-trait",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "arrow",
  "chrono",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -865,7 +865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "async-trait",
  "chrono",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -900,7 +900,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=66a5026b7cbd77829014d122cd80056b8904c614#66a5026b7cbd77829014d122cd80056b8904c614"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=fc9fa63d78671bf38f31c3319302579f7c3961de#fc9fa63d78671bf38f31c3319302579f7c3961de"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "66a5026b7cbd77829014d122cd80056b8904c614", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "fc9fa63d78671bf38f31c3319302579f7c3961de", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -18697,4 +18697,19 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
             }
         )
     }
+
+    #[tokio::test]
+    async fn test_window_aggr_empty() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "window_aggr_empty",
+            execute_query(
+                "SELECT oid, COUNT(*) OVER() AS c FROM pg_class WHERE oid < 0 GROUP BY 1"
+                    .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__window_aggr_empty.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__window_aggr_empty.snap
@@ -1,0 +1,8 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(\"SELECT oid, COUNT(*) OVER() AS c FROM pg_class WHERE oid < 0 GROUP BY 1\".to_string(),\nDatabaseProtocol::PostgreSQL).await?"
+---
++-----+---+
+| oid | c |
++-----+---+
++-----+---+


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@fc9fa63, fixing an issue with empty peer based evaluation in window aggregates throwing an error. Example: `SELECT col, COUNT(*) OVER() AS cnt FROM tbl WHERE col = 'tmp' GROUP BY 1`. Related test is included.
