### PR TITLE
docs: document configurable default role for SAML/SCIM auto-provisioning

### DIFF
--- a/docs-mintlify/admin/sso/google-workspace.mdx
+++ b/docs-mintlify/admin/sso/google-workspace.mdx
@@ -106,10 +106,45 @@ SAML integration in Google into Cube Cloud.
 
 3. Enable **Auto-provision new users** if you want users to be automatically
    created in Cube on their first login via this SAML provider. New users
-   are assigned the Viewer role by default. Enable this if you are not using
-   SCIM provisioning.
+   are assigned the Viewer role by default — see
+   [Default role for new users](#default-role-for-new-users) to choose a
+   different role. Enable this if you are not using SCIM provisioning.
 
 4. Scroll down and click **Save SAML Settings** to save the changes.
+
+## Default role for new users
+
+By default, users auto-provisioned via SAML receive the **Viewer** role.
+To assign a different role, expand the **Advanced** section of the SAML
+configuration form and pick from **Default role for new users**:
+
+- **Developer**, **Explorer**, or **Viewer** — Cube Cloud's [default
+  roles][ref-roles].
+- Any [custom role][ref-custom-roles] defined in your account, listed
+  below the divider.
+
+The selected role applies **only when a user is first created**. Existing
+users are not modified on subsequent SSO logins. It is applied **in
+addition to** any roles your identity provider sends via the role
+attribute (subject to the `rolesMap`).
+
+<Info>
+
+Admin status is not assignable through this picker — Admin is controlled
+separately. To grant admin permissions, update the user's role manually
+under [Admin → Users][ref-manage-users].
+
+</Info>
+
+<Warning>
+
+If the selected role is later renamed or deleted, new users will fall
+back to the **Viewer** role until you pick a valid role here. The Viewer
+fallback applies whenever the configured default cannot be resolved —
+whether that's because no default is set or the configured role no longer
+exists.
+
+</Warning>
 
 ## Test SAML authentication
 
@@ -118,3 +153,6 @@ To start using SAML authentication, use the
 (typically `<YOUR_CUBE_CLOUD_URL>/sso/saml`) to log in to Cube Cloud.
 
 [google-docs-create-saml-app]: https://support.google.com/a/answer/6087519?hl=en
+[ref-roles]: /admin/users-and-permissions/roles-and-permissions
+[ref-custom-roles]: /admin/users-and-permissions/custom-roles
+[ref-manage-users]: /admin/users-and-permissions/manage-users

--- a/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
@@ -83,9 +83,47 @@ values from the Entra **Single sign-on** page:
 In both options, also configure the following setting:
 
 - **Auto-provision new users** — When enabled, users are automatically
-  created in Cube on their first login via this SAML provider and assigned
-  the Viewer role by default. Enable this if you want to provision users
-  only when they first access Cube and you are not using SCIM provisioning.
+  created in Cube on their first login via this SAML provider. Enable this
+  if you want to provision users only when they first access Cube and you
+  are not using SCIM provisioning. New users receive the Viewer role by
+  default; see [Default role for new users](#default-role-for-new-users)
+  to choose a different role.
+
+## Default role for new users
+
+Auto-provisioned users — both via SAML and via [SCIM][ref-scim] — receive
+the **Viewer** role by default. To assign a different role, expand the
+**Advanced** section of the SAML configuration form and pick from
+**Default role for new users**:
+
+- **Developer**, **Explorer**, or **Viewer** — Cube's [default
+  roles][ref-roles].
+- Any [custom role][ref-custom-roles] defined in your account, listed
+  below the divider.
+
+The selected role applies **only when a user is first created** during
+provisioning. Existing users are not modified on subsequent SSO logins or
+SCIM updates. It is applied **in addition to** any roles your identity
+provider sends via the [role attribute](#configure-attribute-mappings)
+(subject to the `rolesMap`).
+
+<Info>
+
+Admin status is not assignable through this picker — Admin is controlled
+separately. To grant admin permissions, update the user's role manually
+under [Admin → Users][ref-manage-users].
+
+</Info>
+
+<Warning>
+
+If the selected role is later renamed or deleted, new users will fall
+back to the **Viewer** role until you pick a valid role here. The Viewer
+fallback applies whenever the configured default cannot be resolved —
+whether that's because no default is set or the configured role no longer
+exists.
+
+</Warning>
 
 ## Configure attribute mappings
 
@@ -122,3 +160,7 @@ users or groups in Entra before testing.
    Entra for authentication and then back to Cube.
 
 [ext-ms-entra-id]: https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id
+[ref-scim]: /admin/sso/microsoft-entra-id/scim
+[ref-roles]: /admin/users-and-permissions/roles-and-permissions
+[ref-custom-roles]: /admin/users-and-permissions/custom-roles
+[ref-manage-users]: /admin/users-and-permissions/manage-users

--- a/docs-mintlify/admin/sso/microsoft-entra-id/scim.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/scim.mdx
@@ -73,9 +73,14 @@ Cube:
 
 <Info>
 
-Users provisioned via SCIM will receive the Explorer role.
-To grant admin permissions, update the user's role manually in
-Cube under **Team & Security**.
+Users provisioned via SCIM receive the **Viewer** role by default. To
+choose a different default role (including [custom roles][ref-custom-roles]),
+see [Default role for new users][ref-saml-default-role] on the SAML setup
+page — the setting is shared between SAML and SCIM.
+
+Admin permissions cannot be assigned through this setting. To grant admin
+permissions, update the user's role manually in Cube under **Admin →
+Users**.
 
 </Info>
 
@@ -120,4 +125,6 @@ The next time the Entra application syncs, the attribute values will be
 provisioned as [user attributes][ref-user-attributes] in Cube.
 
 [ref-saml]: /admin/sso/microsoft-entra-id/saml
+[ref-saml-default-role]: /admin/sso/microsoft-entra-id/saml#default-role-for-new-users
+[ref-custom-roles]: /admin/users-and-permissions/custom-roles
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes

--- a/docs-mintlify/admin/sso/okta/saml.mdx
+++ b/docs-mintlify/admin/sso/okta/saml.mdx
@@ -85,9 +85,46 @@ identity provider details:
   Sign-On URL** value from Okta.
 - **Certificate** — Paste the **X.509 Certificate** from Okta.
 - **Auto-provision new users** — When enabled, users are automatically
-  created in Cube on their first login via this SAML provider and assigned
-  the Viewer role by default. Enable this if you want to provision users
-  only when they first access Cube and you are not using SCIM provisioning.
+  created in Cube on their first login via this SAML provider. Enable this
+  if you want to provision users only when they first access Cube and you
+  are not using SCIM provisioning. New users receive the Viewer role by
+  default; see [Default role for new users](#default-role-for-new-users)
+  to choose a different role.
+
+## Default role for new users
+
+Auto-provisioned users — both via SAML and via [SCIM][ref-scim] — receive
+the **Viewer** role by default. To assign a different role, expand the
+**Advanced** section of the SAML configuration form and pick from
+**Default role for new users**:
+
+- **Developer**, **Explorer**, or **Viewer** — Cube's [default
+  roles][ref-roles].
+- Any [custom role][ref-custom-roles] defined in your account, listed
+  below the divider.
+
+The selected role applies **only when a user is first created** during
+provisioning. Existing users are not modified on subsequent SSO logins or
+SCIM updates. It is applied **in addition to** any roles your identity
+provider sends via the role attribute (subject to the `rolesMap`).
+
+<Info>
+
+Admin status is not assignable through this picker — Admin is controlled
+separately. To grant admin permissions, update the user's role manually
+under [Admin → Users][ref-manage-users].
+
+</Info>
+
+<Warning>
+
+If the selected role is later renamed or deleted, new users will fall
+back to the **Viewer** role until you pick a valid role here. The Viewer
+fallback applies whenever the configured default cannot be resolved —
+whether that's because no default is set or the configured role no longer
+exists.
+
+</Warning>
 
 ## Test SAML authentication
 
@@ -100,3 +137,7 @@ identity provider details:
 
 [okta-docs-create-saml-app]:
   https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm
+[ref-scim]: /admin/sso/okta/scim
+[ref-roles]: /admin/users-and-permissions/roles-and-permissions
+[ref-custom-roles]: /admin/users-and-permissions/custom-roles
+[ref-manage-users]: /admin/users-and-permissions/manage-users

--- a/docs-mintlify/admin/sso/okta/scim.mdx
+++ b/docs-mintlify/admin/sso/okta/scim.mdx
@@ -119,4 +119,18 @@ groups to push:
    search by name or rule.
 3. Select the groups you want to push to Cube Cloud and click **Save**.
 
+## Default role for SCIM-provisioned users
+
+Users created through SCIM receive the same default role configured for
+SAML auto-provisioning — there is no separate SCIM control. By default
+this is the **Viewer** role; to choose a different default role (including
+[custom roles][ref-custom-roles]), see
+[Default role for new users][ref-saml-default-role] on the SAML setup page.
+
+The default role only applies to users created by SCIM (`POST
+/api/scim/v2/Users`). Existing users are not modified by subsequent SCIM
+profile or group updates.
+
 [ref-saml]: /admin/sso/okta/saml
+[ref-saml-default-role]: /admin/sso/okta/saml#default-role-for-new-users
+[ref-custom-roles]: /admin/users-and-permissions/custom-roles

--- a/docs-mintlify/admin/users-and-permissions/manage-users.mdx
+++ b/docs-mintlify/admin/users-and-permissions/manage-users.mdx
@@ -124,6 +124,12 @@ If your organization uses an identity provider such as [Okta][ref-okta] or
 deprovisioning through SCIM. See the [SSO & Identity Providers][ref-sso]
 documentation for setup instructions.
 
+Users created via SCIM — and users auto-provisioned on first SAML
+login — receive the **Viewer** role by default. To assign a different
+default role (including [custom roles][ref-custom-roles]), configure
+**Default role for new users** in the **Advanced** section of your SAML
+configuration. The setting is shared between SAML and SCIM.
+
 
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
 [ref-custom-roles]: /admin/users-and-permissions/custom-roles


### PR DESCRIPTION
Document the new "Default role for new users" picker (Settings → Authentication → SAML → Advanced) across the SSO guides:

- Add a "Default role for new users" section to the Okta, Microsoft Entra ID, and Google Workspace SAML pages explaining the picker, the Developer/Explorer/Viewer + custom role options, scope (only applied to first-time provisioning), and the Viewer fallback when the configured role cannot be resolved.
- Update the Okta and Microsoft Entra ID SCIM pages to note that the default role is shared with the SAML config (no separate SCIM control); replace the inaccurate "Explorer role" callout on the Entra SCIM page with the correct Viewer-default behavior.
- Cross-link the SCIM section of manage-users.mdx to the new default-role setting.

Made-with: Cursor

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
