### PR TITLE
fix(shared): add retry with backoff to asyncRetry and retryFetch utility

### DIFF
--- a/packages/cubejs-backend-shared/src/promises.ts
+++ b/packages/cubejs-backend-shared/src/promises.ts
@@ -446,10 +446,17 @@ export const asyncMemoizeBackground = <Ret, Arguments>(
 
 export type RetryOptions = {
   times: number,
+  delay?: number,
+  backoffFactor?: number,
+  shouldRetry?: (err: unknown) => boolean,
+  onRetry?: (err: unknown, attempt: number) => void,
 };
 
 /**
- * High order function that do retry when async function throw an exception
+ * High order function that do retry when async function throw an exception.
+ *
+ * Supports optional delay between retries, exponential backoff, and
+ * a predicate to decide which errors are retryable.
  */
 export const asyncRetry = async <Ret>(
   fn: () => Promise<Ret>,
@@ -466,8 +473,76 @@ export const asyncRetry = async <Ret>(
       return await fn();
     } catch (e) {
       latestException = e;
+
+      const isLastAttempt = i === options.times - 1;
+      if (isLastAttempt) {
+        break;
+      }
+
+      if (options.shouldRetry && !options.shouldRetry(e)) {
+        break;
+      }
+
+      if (options.onRetry) {
+        options.onRetry(e, i + 1);
+      }
+
+      if (options.delay && options.delay > 0) {
+        const backoff = options.backoffFactor ?? 1;
+        const waitMs = options.delay * (backoff ** i);
+        await new Promise((resolve) => { setTimeout(resolve, waitMs); });
+      }
     }
   }
 
   throw latestException;
+};
+
+export type RetryFetchOptions = {
+  times?: number,
+  delay?: number,
+  backoffFactor?: number,
+  onRetry?: (err: unknown, attempt: number) => void,
+};
+
+const isTransientFetchError = (err: unknown): boolean => {
+  if (err instanceof TypeError) {
+    const msg = (err as TypeError).message || '';
+    return msg === 'fetch failed' ||
+      msg.includes('network') ||
+      msg.includes('ECONNREFUSED') ||
+      msg.includes('ECONNRESET') ||
+      msg.includes('ETIMEDOUT') ||
+      msg.includes('UND_ERR_SOCKET') ||
+      msg.includes('UND_ERR_CONNECT_TIMEOUT');
+  }
+  return false;
+};
+
+/**
+ * Wraps a fetch-like function with retry logic for transient network errors.
+ * Designed for use with HTTP clients (e.g. Qdrant, external APIs) that may
+ * experience intermittent connectivity issues.
+ */
+export const retryFetch = (
+  fetchFn: typeof globalThis.fetch,
+  options: RetryFetchOptions = {},
+): typeof globalThis.fetch => {
+  const {
+    times = 3,
+    delay = 500,
+    backoffFactor = 2,
+    onRetry,
+  } = options;
+
+  return (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => asyncRetry(
+    () => fetchFn(input, init),
+    {
+      times,
+      delay,
+      backoffFactor,
+      shouldRetry: isTransientFetchError,
+      onRetry,
+    }
+  );
 };

--- a/packages/cubejs-backend-shared/test/promises.test.ts
+++ b/packages/cubejs-backend-shared/test/promises.test.ts
@@ -9,6 +9,7 @@ import {
   asyncRetry,
   asyncDebounceFn,
   asyncMemoizeBackground,
+  retryFetch,
 } from '../src';
 
 test('createCancelablePromise', async () => {
@@ -483,6 +484,206 @@ describe('asyncDebounce', () => {
 
     await doOnce('arg1', 'arg2');
     expect(called).toEqual(2);
+  });
+});
+
+describe('asyncRetry with delay and backoff', () => {
+  test('retries with delay between attempts', async () => {
+    let called = 0;
+    const start = Date.now();
+
+    const result = await asyncRetry(
+      async () => {
+        called++;
+        if (called < 3) {
+          throw new Error('transient');
+        }
+        return 42;
+      },
+      {
+        times: 5,
+        delay: 50,
+      }
+    );
+
+    const elapsed = Date.now() - start;
+    expect(result).toEqual(42);
+    expect(called).toEqual(3);
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+  });
+
+  test('retries with exponential backoff', async () => {
+    let called = 0;
+    const start = Date.now();
+
+    const result = await asyncRetry(
+      async () => {
+        called++;
+        if (called < 3) {
+          throw new Error('transient');
+        }
+        return 99;
+      },
+      {
+        times: 5,
+        delay: 50,
+        backoffFactor: 2,
+      }
+    );
+
+    const elapsed = Date.now() - start;
+    expect(result).toEqual(99);
+    expect(called).toEqual(3);
+    expect(elapsed).toBeGreaterThanOrEqual(140);
+  });
+
+  test('stops retrying when shouldRetry returns false', async () => {
+    let called = 0;
+
+    try {
+      await asyncRetry(
+        async () => {
+          called++;
+          throw new Error(called === 1 ? 'retryable' : 'fatal');
+        },
+        {
+          times: 5,
+          shouldRetry: (err) => (err as Error).message === 'retryable',
+        }
+      );
+      throw new Error('should have thrown');
+    } catch (e: any) {
+      expect(e.message).toEqual('fatal');
+      expect(called).toEqual(2);
+    }
+  });
+
+  test('calls onRetry callback on each retry', async () => {
+    const retryLog: Array<{ err: string, attempt: number }> = [];
+
+    await asyncRetry(
+      async () => {
+        if (retryLog.length < 2) {
+          throw new Error(`fail-${retryLog.length}`);
+        }
+        return 'ok';
+      },
+      {
+        times: 5,
+        onRetry: (err, attempt) => {
+          retryLog.push({ err: (err as Error).message, attempt });
+        },
+      }
+    );
+
+    expect(retryLog).toEqual([
+      { err: 'fail-0', attempt: 1 },
+      { err: 'fail-1', attempt: 2 },
+    ]);
+  });
+});
+
+describe('retryFetch', () => {
+  test('returns response on success without retrying', async () => {
+    const mockResponse = { ok: true, status: 200 } as Response;
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch);
+    const result = await fetchWithRetry('http://example.com/test');
+
+    expect(result).toBe(mockResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on TypeError: fetch failed', async () => {
+    const mockResponse = { ok: true, status: 200 } as Response;
+    const mockFetch = jest.fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValue(mockResponse);
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch, {
+      times: 3,
+      delay: 10,
+    });
+    const result = await fetchWithRetry('http://qdrant:6333/collections');
+
+    expect(result).toBe(mockResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('does not retry on non-transient errors', async () => {
+    const mockFetch = jest.fn()
+      .mockRejectedValue(new Error('invalid argument'));
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch, {
+      times: 3,
+      delay: 10,
+    });
+
+    await expect(fetchWithRetry('http://qdrant:6333/collections'))
+      .rejects.toThrow('invalid argument');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws after exhausting all retries', async () => {
+    const mockFetch = jest.fn()
+      .mockRejectedValue(new TypeError('fetch failed'));
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch, {
+      times: 3,
+      delay: 10,
+    });
+
+    await expect(fetchWithRetry('http://qdrant:6333/collections'))
+      .rejects.toThrow('fetch failed');
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('retries on ECONNREFUSED', async () => {
+    const mockResponse = { ok: true, status: 200 } as Response;
+    const mockFetch = jest.fn()
+      .mockRejectedValueOnce(new TypeError('ECONNREFUSED'))
+      .mockResolvedValue(mockResponse);
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch, {
+      times: 3,
+      delay: 10,
+    });
+    const result = await fetchWithRetry('http://qdrant:6333/collections');
+
+    expect(result).toBe(mockResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('passes input and init through to underlying fetch', async () => {
+    const mockResponse = { ok: true, status: 200 } as Response;
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch);
+    const init = { method: 'POST', body: '{}' };
+    await fetchWithRetry('http://qdrant:6333/collections', init);
+
+    expect(mockFetch).toHaveBeenCalledWith('http://qdrant:6333/collections', init);
+  });
+
+  test('calls onRetry callback', async () => {
+    const mockResponse = { ok: true, status: 200 } as Response;
+    const retries: number[] = [];
+    const mockFetch = jest.fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValue(mockResponse);
+
+    const fetchWithRetry = retryFetch(mockFetch as typeof globalThis.fetch, {
+      times: 3,
+      delay: 10,
+      onRetry: (_err, attempt) => { retries.push(attempt); },
+    });
+    await fetchWithRetry('http://qdrant:6333/collections');
+
+    expect(retries).toEqual([1]);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes [AI-ENGINEER-G](https://cubedevinc.sentry.io/issues/7432388543/) — `TypeError: fetch failed` in Qdrant vector store calls (204 occurrences)

**Description of Changes Made**

The `ai-engineer` service experiences intermittent `TypeError: fetch failed` errors when connecting to the Qdrant vector store within Kubernetes. The error occurs in `QdrantVectorStore.ensureCollection` when calling `client.getCollections()`, which uses the native `fetch` API under the hood. These are transient network errors that would succeed on retry.

### Changes

**`packages/cubejs-backend-shared/src/promises.ts`**

1. **Enhanced `asyncRetry`** with new optional parameters:
   - `delay` — base delay in ms between retries (default: no delay, preserving backward compatibility)
   - `backoffFactor` — multiplier for exponential backoff (default: 1 = constant delay)
   - `shouldRetry` — predicate to filter which errors are retryable (default: retry all)
   - `onRetry` — callback invoked on each retry for logging/observability

2. **Added `retryFetch` utility** — a wrapper that creates a retry-enabled `fetch` function:
   - Defaults: 3 attempts, 500ms base delay, 2x exponential backoff
   - Only retries transient network errors (`TypeError: fetch failed`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`)
   - Non-transient errors (e.g. bad arguments, auth failures) are not retried
   - Returns a function with the same signature as `globalThis.fetch`

**`packages/cubejs-backend-shared/test/promises.test.ts`**

- Added tests for `asyncRetry` with delay, backoff, `shouldRetry`, and `onRetry`
- Added tests for `retryFetch`: success without retry, retry on transient errors, no retry on non-transient errors, exhausted retries, argument passthrough, `onRetry` callback

### Usage in ai-engineer (enterprise repo)

The ai-engineer service can use `retryFetch` to wrap the Qdrant client's fetch:

```typescript
import { retryFetch } from '@cubejs-backend/shared';

const fetchWithRetry = retryFetch(fetch, {
  times: 3,
  delay: 500,
  backoffFactor: 2,
  onRetry: (err, attempt) => {
    logger.warn(`Qdrant fetch retry attempt ${attempt}`, { error: err });
  },
});

const client = new QdrantClient({
  url: qdrantUrl,
  // Pass the retry-enabled fetch to the client
});
```

Or alternatively wrap individual operations:

```typescript
import { asyncRetry } from '@cubejs-backend/shared';

const collections = await asyncRetry(
  () => client.getCollections(),
  { times: 3, delay: 500, backoffFactor: 2 }
);
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904e5423-7950-4f9b-b900-416d9b71b07a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904e5423-7950-4f9b-b900-416d9b71b07a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

