### PR TITLE
perf(cubeorchestrator): Improve performance of get_vanilla_row (−66.8%, 3x)

### DIFF
--- a/rust/cubeorchestrator/benches/transform.rs
+++ b/rust/cubeorchestrator/benches/transform.rs
@@ -10,21 +10,26 @@ use cubeorchestrator::transport::{
 };
 use indexmap::IndexMap;
 
-const DIMENSIONS: &[(&str, &str)] = &[
-    ("Sales.country", "sales__country"),
-    ("Sales.city", "sales__city"),
-    ("Sales.region", "sales__region"),
-    ("Sales.product", "sales__product"),
-    ("Sales.category", "sales__category"),
-    ("Sales.segment", "sales__segment"),
-];
+const ROW_COUNTS: &[usize] = &[1_000, 10_000, 50_000, 100_000];
+const COLUMN_COUNTS: &[usize] = &[8, 16, 32, 64];
 
-const MEASURES: &[(&str, &str)] = &[
-    ("Sales.revenue", "sales__revenue"),
-    ("Sales.profit", "sales__profit"),
-    ("Sales.discount", "sales__discount"),
-    ("Sales.count", "sales__count"),
-];
+/// Split a target column count into ~60% dimensions and ~40% measures.
+fn split_dim_measure(col_count: usize) -> (usize, usize) {
+    let dim_count = (col_count * 6) / 10;
+    let measure_count = col_count - dim_count;
+    (dim_count, measure_count)
+}
+
+fn make_member_aliases(prefix: &str, count: usize) -> Vec<(String, String)> {
+    (0..count)
+        .map(|i| {
+            (
+                format!("Sales.{}{}", prefix, i),
+                format!("sales__{}{}", prefix, i),
+            )
+        })
+        .collect()
+}
 
 fn config_item(member_type: &str) -> ConfigItem {
     ConfigItem {
@@ -42,31 +47,35 @@ fn config_item(member_type: &str) -> ConfigItem {
     }
 }
 
-fn build_request(res_type: Option<ResultType>) -> TransformDataRequest {
+fn build_request(
+    res_type: Option<ResultType>,
+    dimensions: &[(String, String)],
+    measures: &[(String, String)],
+) -> TransformDataRequest {
     let mut alias_to_member_name_map = HashMap::new();
     let mut annotation = HashMap::new();
 
-    for (member, alias) in DIMENSIONS {
-        alias_to_member_name_map.insert((*alias).to_string(), (*member).to_string());
-        annotation.insert((*member).to_string(), config_item("string"));
+    for (member, alias) in dimensions {
+        alias_to_member_name_map.insert(alias.clone(), member.clone());
+        annotation.insert(member.clone(), config_item("string"));
     }
-    for (member, alias) in MEASURES {
-        alias_to_member_name_map.insert((*alias).to_string(), (*member).to_string());
-        annotation.insert((*member).to_string(), config_item("number"));
+    for (member, alias) in measures {
+        alias_to_member_name_map.insert(alias.clone(), member.clone());
+        annotation.insert(member.clone(), config_item("number"));
     }
 
-    let dimensions = DIMENSIONS
+    let dimensions_query = dimensions
         .iter()
-        .map(|(m, _)| MemberOrMemberExpression::Member((*m).to_string()))
+        .map(|(m, _)| MemberOrMemberExpression::Member(m.clone()))
         .collect();
-    let measures = MEASURES
+    let measures_query = measures
         .iter()
-        .map(|(m, _)| MemberOrMemberExpression::Member((*m).to_string()))
+        .map(|(m, _)| MemberOrMemberExpression::Member(m.clone()))
         .collect();
 
     let query = NormalizedQuery {
-        measures: Some(measures),
-        dimensions: Some(dimensions),
+        measures: Some(measures_query),
+        dimensions: Some(dimensions_query),
         time_dimensions: None,
         segments: None,
         limit: None,
@@ -92,22 +101,25 @@ fn build_request(res_type: Option<ResultType>) -> TransformDataRequest {
     }
 }
 
-fn build_dataset(row_count: usize) -> JsRawData {
-    let dim_count = DIMENSIONS.len();
-    let total_cols = dim_count + MEASURES.len();
+fn build_dataset(
+    row_count: usize,
+    dimensions: &[(String, String)],
+    measures: &[(String, String)],
+) -> JsRawData {
+    let total_cols = dimensions.len() + measures.len();
     let mut rows = Vec::with_capacity(row_count);
 
     for i in 0..row_count {
         let mut row = IndexMap::with_capacity(total_cols);
-        for (j, (_, alias)) in DIMENSIONS.iter().enumerate() {
+        for (j, (_, alias)) in dimensions.iter().enumerate() {
             row.insert(
-                (*alias).to_string(),
+                alias.clone(),
                 DBResponsePrimitive::String(format!("dim_{}_{}", j, i % 1000)),
             );
         }
-        for (j, (_, alias)) in MEASURES.iter().enumerate() {
+        for (j, (_, alias)) in measures.iter().enumerate() {
             row.insert(
-                (*alias).to_string(),
+                alias.clone(),
                 DBResponsePrimitive::Number(((i * (j + 1)) as f64) * 0.5),
             );
         }
@@ -120,25 +132,35 @@ fn build_dataset(row_count: usize) -> JsRawData {
 fn bench_transform(c: &mut Criterion) {
     let mut group = c.benchmark_group("TransformedData::transform");
 
-    for &row_count in &[1_000usize, 10_000, 50_000, 100_000] {
-        let raw =
-            QueryResult::from_js_raw_data(build_dataset(row_count)).expect("from_js_raw_data");
+    for &col_count in COLUMN_COUNTS {
+        let (dim_count, measure_count) = split_dim_measure(col_count);
+        let dimensions = make_member_aliases("dim", dim_count);
+        let measures = make_member_aliases("measure", measure_count);
 
-        group.throughput(Throughput::Elements(row_count as u64));
+        for &row_count in ROW_COUNTS {
+            let raw =
+                QueryResult::from_js_raw_data(build_dataset(row_count, &dimensions, &measures))
+                    .expect("from_js_raw_data");
 
-        for (label, res_type) in [
-            ("compact", Some(ResultType::Compact)),
-            ("columnar", Some(ResultType::Columnar)),
-            ("vanilla", None),
-        ] {
-            let request = build_request(res_type);
-            group.bench_with_input(BenchmarkId::new(label, row_count), &row_count, |b, _| {
-                b.iter(|| {
-                    let result = TransformedData::transform(black_box(&request), black_box(&raw))
-                        .expect("transform");
-                    black_box(result);
+            // Throughput in cells/sec so numbers are comparable across widths.
+            group.throughput(Throughput::Elements((row_count * col_count) as u64));
+
+            for (label, res_type) in [
+                ("compact", Some(ResultType::Compact)),
+                ("columnar", Some(ResultType::Columnar)),
+                ("vanilla", None),
+            ] {
+                let request = build_request(res_type, &dimensions, &measures);
+                let id_param = format!("c{:02}_r{}", col_count, row_count);
+                group.bench_with_input(BenchmarkId::new(label, id_param), &(), |b, _| {
+                    b.iter(|| {
+                        let result =
+                            TransformedData::transform(black_box(&request), black_box(&raw))
+                                .expect("transform");
+                        black_box(result);
+                    });
                 });
-            });
+            }
         }
     }
 

--- a/rust/cubeorchestrator/benches/transform.rs
+++ b/rust/cubeorchestrator/benches/transform.rs
@@ -13,6 +13,12 @@ use indexmap::IndexMap;
 const ROW_COUNTS: &[usize] = &[1_000, 10_000, 50_000, 100_000];
 const COLUMN_COUNTS: &[usize] = &[8, 16, 32, 64];
 
+/// Total columns and row count used by `bench_transform_time_scenarios`.
+/// Held fixed so the cells/sec figures are directly comparable to the
+/// 16-col / 100k-row entries from `bench_transform`.
+const SCENARIO_COL_COUNT: usize = 16;
+const SCENARIO_ROW_COUNT: usize = 100_000;
+
 /// Split a target column count into ~60% dimensions and ~40% measures.
 fn split_dim_measure(col_count: usize) -> (usize, usize) {
     let dim_count = (col_count * 6) / 10;
@@ -47,10 +53,60 @@ fn config_item(member_type: &str) -> ConfigItem {
     }
 }
 
+#[derive(Clone)]
+struct TimeColumn {
+    member: String,
+    alias: String,
+}
+
+#[derive(Clone, Copy)]
+enum TimeScenario {
+    NoTimeDim,
+    OneTimeDim,
+    CustomGranularityTimeDimension,
+    TwoTimeDims,
+}
+
+impl TimeScenario {
+    fn label(self) -> &'static str {
+        match self {
+            TimeScenario::NoTimeDim => "no_time_dim",
+            TimeScenario::OneTimeDim => "one_time_dim_day",
+            TimeScenario::CustomGranularityTimeDimension => "one_time_dim_custom_granularity",
+            TimeScenario::TwoTimeDims => "two_time_dims",
+        }
+    }
+
+    fn time_columns(self) -> Vec<TimeColumn> {
+        match self {
+            TimeScenario::NoTimeDim => vec![],
+            TimeScenario::OneTimeDim => vec![TimeColumn {
+                member: "Cube.orderDate.day".to_string(),
+                alias: "cube__order_date_day".to_string(),
+            }],
+            TimeScenario::CustomGranularityTimeDimension => vec![TimeColumn {
+                member: "Cube.orderDate.fiscalQuarter".to_string(),
+                alias: "cube__order_date_fiscal_quarter".to_string(),
+            }],
+            TimeScenario::TwoTimeDims => vec![
+                TimeColumn {
+                    member: "Cube.orderDate.day".to_string(),
+                    alias: "cube__order_date_day".to_string(),
+                },
+                TimeColumn {
+                    member: "Cube.shipDate.month".to_string(),
+                    alias: "cube__ship_date_month".to_string(),
+                },
+            ],
+        }
+    }
+}
+
 fn build_request(
     res_type: Option<ResultType>,
     dimensions: &[(String, String)],
     measures: &[(String, String)],
+    time_dims: &[TimeColumn],
 ) -> TransformDataRequest {
     let mut alias_to_member_name_map = HashMap::new();
     let mut annotation = HashMap::new();
@@ -63,10 +119,19 @@ fn build_request(
         alias_to_member_name_map.insert(alias.clone(), member.clone());
         annotation.insert(member.clone(), config_item("number"));
     }
+    for td in time_dims {
+        alias_to_member_name_map.insert(td.alias.clone(), td.member.clone());
+        annotation.insert(td.member.clone(), config_item("time"));
+    }
 
     let dimensions_query = dimensions
         .iter()
         .map(|(m, _)| MemberOrMemberExpression::Member(m.clone()))
+        .chain(
+            time_dims
+                .iter()
+                .map(|td| MemberOrMemberExpression::Member(td.member.clone())),
+        )
         .collect();
     let measures_query = measures
         .iter()
@@ -105,8 +170,9 @@ fn build_dataset(
     row_count: usize,
     dimensions: &[(String, String)],
     measures: &[(String, String)],
+    time_dims: &[TimeColumn],
 ) -> JsRawData {
-    let total_cols = dimensions.len() + measures.len();
+    let total_cols = dimensions.len() + measures.len() + time_dims.len();
     let mut rows = Vec::with_capacity(row_count);
 
     for i in 0..row_count {
@@ -121,6 +187,18 @@ fn build_dataset(
             row.insert(
                 alias.clone(),
                 DBResponsePrimitive::Number(((i * (j + 1)) as f64) * 0.5),
+            );
+        }
+        for (j, td) in time_dims.iter().enumerate() {
+            // Format mirrors typical CubeStore output: ISO-8601 with millisecond
+            // fractional and no timezone. None of `transform_value`'s six chrono
+            // parsers fully match this shape, so the function falls through to
+            // `s.clone()` — measuring the production worst case.
+            let month = ((i + j) % 12) + 1;
+            let day = ((i / 12) % 28) + 1;
+            row.insert(
+                td.alias.clone(),
+                DBResponsePrimitive::String(format!("2024-{:02}-{:02}T00:00:00.000", month, day)),
             );
         }
         rows.push(row);
@@ -138,9 +216,13 @@ fn bench_transform(c: &mut Criterion) {
         let measures = make_member_aliases("measure", measure_count);
 
         for &row_count in ROW_COUNTS {
-            let raw =
-                QueryResult::from_js_raw_data(build_dataset(row_count, &dimensions, &measures))
-                    .expect("from_js_raw_data");
+            let raw = QueryResult::from_js_raw_data(build_dataset(
+                row_count,
+                &dimensions,
+                &measures,
+                &[],
+            ))
+            .expect("from_js_raw_data");
 
             // Throughput in cells/sec so numbers are comparable across widths.
             group.throughput(Throughput::Elements((row_count * col_count) as u64));
@@ -150,7 +232,7 @@ fn bench_transform(c: &mut Criterion) {
                 ("columnar", Some(ResultType::Columnar)),
                 ("vanilla", None),
             ] {
-                let request = build_request(res_type, &dimensions, &measures);
+                let request = build_request(res_type, &dimensions, &measures, &[]);
                 let id_param = format!("c{:02}_r{}", col_count, row_count);
                 group.bench_with_input(BenchmarkId::new(label, id_param), &(), |b, _| {
                     b.iter(|| {
@@ -167,5 +249,61 @@ fn bench_transform(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_transform);
+fn bench_transform_time_scenarios(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TransformedData::transform/scenarios");
+
+    let scenarios = [
+        TimeScenario::NoTimeDim,
+        TimeScenario::OneTimeDim,
+        TimeScenario::CustomGranularityTimeDimension,
+        TimeScenario::TwoTimeDims,
+    ];
+
+    for scenario in scenarios {
+        let time_dims = scenario.time_columns();
+        let regular_count = SCENARIO_COL_COUNT - time_dims.len();
+        let (dim_count, measure_count) = split_dim_measure(regular_count);
+        let dimensions = make_member_aliases("dim", dim_count);
+        let measures = make_member_aliases("measure", measure_count);
+
+        let raw = QueryResult::from_js_raw_data(build_dataset(
+            SCENARIO_ROW_COUNT,
+            &dimensions,
+            &measures,
+            &time_dims,
+        ))
+        .expect("from_js_raw_data");
+
+        // Throughput in cells/sec; total cells = row_count * total_cols, where
+        // total_cols == SCENARIO_COL_COUNT regardless of scenario.
+        group.throughput(Throughput::Elements(
+            (SCENARIO_ROW_COUNT * SCENARIO_COL_COUNT) as u64,
+        ));
+
+        for (label, res_type) in [
+            ("compact", Some(ResultType::Compact)),
+            ("columnar", Some(ResultType::Columnar)),
+            ("vanilla", None),
+        ] {
+            let request = build_request(res_type, &dimensions, &measures, &time_dims);
+            let id_param = format!(
+                "{}/c{:02}_r{}",
+                scenario.label(),
+                SCENARIO_COL_COUNT,
+                SCENARIO_ROW_COUNT
+            );
+            group.bench_with_input(BenchmarkId::new(label, id_param), &(), |b, _| {
+                b.iter(|| {
+                    let result = TransformedData::transform(black_box(&request), black_box(&raw))
+                        .expect("transform");
+                    black_box(result);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_transform, bench_transform_time_scenarios);
 criterion_main!(benches);

--- a/rust/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cubeorchestrator/src/query_result_transform.rs
@@ -393,73 +393,112 @@ pub fn get_compact_row(
     Ok(row)
 }
 
+/// Per-column information that is constant across all rows for a given request.
+/// Built once and walked per row to avoid redoing hash lookups, annotation checks,
+/// and member-name parsing for every cell.
+pub struct VanillaColumnPlan<'a> {
+    column_index: usize,
+    member_name: &'a str,
+    member_type: &'a str,
+    granularity_track: Option<VanillaGranularityTrack<'a>>,
+}
+
+pub struct VanillaGranularityTrack<'a> {
+    /// Slice of `member_name` containing only the `{cube}.{dim}` prefix.
+    base_member: &'a str,
+    level: u8,
+}
+
+pub fn build_vanilla_column_plan<'a>(
+    columns_pos: &'a IndexMap<String, usize>,
+    alias_to_member_name_map: &'a HashMap<String, String>,
+    annotation: &'a HashMap<String, ConfigItem>,
+    query: &NormalizedQuery,
+) -> Result<Vec<VanillaColumnPlan<'a>>> {
+    let mut plans = Vec::with_capacity(columns_pos.len());
+    for (alias, &index) in columns_pos {
+        let member_name = match alias_to_member_name_map.get(alias) {
+            Some(m) => m.as_str(),
+            None => bail!("Missing member name for alias: {}", alias),
+        };
+        ensure_member_in_annotation(member_name, annotation)?;
+        let annotation_for_member = annotation.get(member_name).unwrap();
+        let member_type = annotation_for_member.member_type.as_deref().unwrap_or("");
+
+        // Handle deprecated time dimensions without granularity.
+        // Try to collect minimal granularity value for time dimensions without granularity
+        // as there might be more than one granularity column for the same dimension.
+        let granularity_track = compute_vanilla_granularity_track(member_name, query);
+
+        plans.push(VanillaColumnPlan {
+            column_index: index,
+            member_name,
+            member_type,
+            granularity_track,
+        });
+    }
+    Ok(plans)
+}
+
+// FIXME: For now custom granularities are not supported, only common ones.
+// There is no granularity type/class implementation in rust yet.
+fn compute_vanilla_granularity_track<'a>(
+    member_name: &'a str,
+    query: &NormalizedQuery,
+) -> Option<VanillaGranularityTrack<'a>> {
+    // Require exactly two `.` separators — i.e. the `{cube}.{dim}.{granularity}` form.
+    let mut indices = member_name.match_indices(MEMBER_SEPARATOR);
+    indices.next()?;
+
+    let second = indices.next()?.0;
+    if indices.next().is_some() {
+        return None;
+    }
+
+    let base_member = &member_name[..second];
+    let granularity = &member_name[second + MEMBER_SEPARATOR.len()..];
+
+    // Check that a member without granularity is absent in the query
+    let already_requested = query.dimensions.as_ref().is_some_and(|dims| {
+        dims.iter()
+            .any(|dim| matches!(dim, MemberOrMemberExpression::Member(s) if s == base_member))
+    });
+    if already_requested {
+        return None;
+    }
+
+    let level = GRANULARITY_LEVELS
+        .get(granularity)
+        .cloned()
+        .unwrap_or(DEFAULT_LEVEL_FOR_UNKNOWN);
+    Some(VanillaGranularityTrack { base_member, level })
+}
+
 /// Convert DB response object to the vanilla output format.
 pub fn get_vanilla_row(
-    alias_to_member_name_map: &HashMap<String, String>,
-    annotation: &HashMap<String, ConfigItem>,
+    plan: &[VanillaColumnPlan<'_>],
     query_type: &QueryType,
     query: &NormalizedQuery,
     db_row: &[DBResponseValue],
-    columns_pos: &IndexMap<String, usize>,
 ) -> Result<IndexMap<String, DBResponsePrimitive>> {
-    let mut row = IndexMap::new();
+    // +1 to cover the optional tail entry (compareDateRange / blending key).
+    let mut row = IndexMap::with_capacity(plan.len() + 1);
 
     // FIXME: For now custom granularities are not supported, only common ones.
     // There is no granularity type/class implementation in rust yet.
-    let mut minimal_granularities: HashMap<String, (u8, DBResponsePrimitive)> = HashMap::new();
+    let mut minimal_granularities: HashMap<&str, (u8, DBResponsePrimitive)> = HashMap::new();
 
-    for (alias, &index) in columns_pos {
-        if let Some(value) = db_row.get(index) {
-            let member_name = match alias_to_member_name_map.get(alias) {
-                Some(m) => m,
-                None => {
-                    bail!("Missing member name for alias: {}", alias);
-                }
-            };
+    for column in plan {
+        if let Some(value) = db_row.get(column.column_index) {
+            let transformed_value = transform_value(value.clone(), column.member_type);
+            row.insert(column.member_name.to_string(), transformed_value.clone());
 
-            ensure_member_in_annotation(member_name, annotation)?;
-            let annotation_for_member = annotation.get(member_name).unwrap();
-
-            let transformed_value = transform_value(
-                value.clone(),
-                annotation_for_member
-                    .member_type
-                    .as_ref()
-                    .unwrap_or(&"".to_string()),
-            );
-
-            row.insert(member_name.clone(), transformed_value.clone());
-
-            // Handle deprecated time dimensions without granularity
-            // Try to collect minimal granularity value for time dimensions without granularity
-            // as there might be more than one granularity column for the same dimension
-            let path: Vec<&str> = member_name.split(MEMBER_SEPARATOR).collect();
-            if path.len() == 3 {
-                let granularity = path[2];
-                let member_name_without_granularity =
-                    format!("{}{}{}", path[0], MEMBER_SEPARATOR, path[1]);
-
-                // Check that a member without granularity is absent in the query
-                if query.dimensions.as_ref().map_or(true, |dims| {
-                    !dims.iter().any(|dim| {
-                        *dim == MemberOrMemberExpression::Member(
-                            member_name_without_granularity.clone(),
-                        )
-                    })
-                }) {
-                    let level = GRANULARITY_LEVELS
-                        .get(granularity)
-                        .cloned()
-                        .unwrap_or(DEFAULT_LEVEL_FOR_UNKNOWN);
-
-                    match minimal_granularities.get(&member_name_without_granularity) {
-                        Some((existing_level, _)) if *existing_level < level => {}
-                        _ => {
-                            minimal_granularities.insert(
-                                member_name_without_granularity,
-                                (level, transformed_value),
-                            );
-                        }
+            if let Some(track) = &column.granularity_track {
+                match minimal_granularities.get(track.base_member) {
+                    Some((existing_level, _)) if *existing_level < track.level => {}
+                    _ => {
+                        minimal_granularities
+                            .insert(track.base_member, (track.level, transformed_value));
                     }
                 }
             }
@@ -467,8 +506,8 @@ pub fn get_vanilla_row(
     }
 
     // Handle deprecated time dimensions without granularity
-    for (member, (_, value)) in minimal_granularities {
-        row.insert(member, value);
+    for (base_member, (_, value)) in minimal_granularities {
+        row.insert(base_member.to_string(), value);
     }
 
     match query_type {
@@ -660,19 +699,16 @@ impl TransformedData {
                 Ok(TransformedData::Columnar { members, columns })
             }
             _ => {
+                let plan = build_vanilla_column_plan(
+                    &cube_store_result.columns_pos,
+                    alias_to_member_name_map,
+                    annotation,
+                    query,
+                )?;
                 let dataset: Vec<_> = cube_store_result
                     .rows
                     .iter()
-                    .map(|row| {
-                        get_vanilla_row(
-                            alias_to_member_name_map,
-                            annotation,
-                            query_type,
-                            query,
-                            row,
-                            &cube_store_result.columns_pos,
-                        )
-                    })
+                    .map(|row| get_vanilla_row(&plan, query_type, query, row))
                     .collect::<Result<Vec<_>>>()?;
                 Ok(TransformedData::Vanilla(dataset))
             }
@@ -2874,14 +2910,13 @@ mod tests {
         let query = test_data.request.query.clone();
         let query_type = &test_data.request.query_type.clone().unwrap_or_default();
 
-        let res = get_vanilla_row(
-            &alias_to_member_name_map,
-            &annotation,
-            &query_type,
-            &query,
-            &raw_data.rows[0],
+        let plan = build_vanilla_column_plan(
             &raw_data.columns_pos,
+            alias_to_member_name_map,
+            annotation,
+            &query,
         )?;
+        let res = get_vanilla_row(&plan, query_type, &query, &raw_data.rows[0])?;
         let expected = IndexMap::from([
             (
                 "ECommerceRecordsUs2021.city".to_string(),
@@ -2910,17 +2945,14 @@ mod tests {
         let alias_to_member_name_map = &test_data.request.alias_to_member_name_map;
         let annotation = &test_data.request.annotation;
         let query = test_data.request.query.clone();
-        let query_type = &test_data.request.query_type.clone().unwrap_or_default();
 
-        match get_vanilla_row(
-            &alias_to_member_name_map,
-            &annotation,
-            &query_type,
-            &query,
-            &raw_data.rows[0],
+        match build_vanilla_column_plan(
             &raw_data.columns_pos,
+            alias_to_member_name_map,
+            annotation,
+            &query,
         ) {
-            Ok(_) => Err(TestError("get_vanilla_row() should fail ".to_string()).into()),
+            Ok(_) => Err(TestError("build_vanilla_column_plan() should fail ".to_string()).into()),
             Err(err) => {
                 assert!(err.to_string().contains("Missing member name for alias"));
                 Ok(())
@@ -2942,17 +2974,14 @@ mod tests {
         let alias_to_member_name_map = &test_data.request.alias_to_member_name_map;
         let annotation = &test_data.request.annotation;
         let query = test_data.request.query.clone();
-        let query_type = &test_data.request.query_type.clone().unwrap_or_default();
 
-        match get_vanilla_row(
-            &alias_to_member_name_map,
-            &annotation,
-            &query_type,
-            &query,
-            &raw_data.rows[0],
+        match build_vanilla_column_plan(
             &raw_data.columns_pos,
+            alias_to_member_name_map,
+            annotation,
+            &query,
         ) {
-            Ok(_) => Err(TestError("get_vanilla_row() should fail ".to_string()).into()),
+            Ok(_) => Err(TestError("build_vanilla_column_plan() should fail ".to_string()).into()),
             Err(err) => {
                 assert!(err.to_string().contains("You requested hidden member"));
                 Ok(())
@@ -3069,5 +3098,90 @@ mod tests {
         let columns = transpose_to_columns(&members, dataset);
         assert_eq!(columns.len(), 3);
         assert_eq!(columns[2], vec![DBResponsePrimitive::Null]);
+    }
+
+    fn make_query_with_dims(dimensions: Option<Vec<MemberOrMemberExpression>>) -> NormalizedQuery {
+        NormalizedQuery {
+            measures: None,
+            dimensions,
+            time_dimensions: None,
+            segments: None,
+            limit: None,
+            offset: None,
+            total: None,
+            total_query: None,
+            timezone: None,
+            renew_query: None,
+            ungrouped: None,
+            response_format: None,
+            filters: None,
+            row_limit: None,
+            order: None,
+            query_type: None,
+        }
+    }
+
+    #[test]
+    fn test_compute_vanilla_granularity_track_none() {
+        let q = make_query_with_dims(None);
+        assert!(compute_vanilla_granularity_track("nodots", &q).is_none());
+
+        let q = make_query_with_dims(None);
+        assert!(compute_vanilla_granularity_track("Cube.dim", &q).is_none());
+
+        let q = make_query_with_dims(None);
+        assert!(compute_vanilla_granularity_track("Cube.dim.day.extra", &q).is_none());
+    }
+
+    #[test]
+    fn test_compute_vanilla_granularity_track_known_granularity() {
+        let q = make_query_with_dims(None);
+        let track = compute_vanilla_granularity_track("Cube.orderDate.day", &q)
+            .expect("should produce a track");
+        assert_eq!(track.base_member, "Cube.orderDate");
+        assert_eq!(track.level, 4);
+    }
+
+    #[test]
+    fn test_compute_vanilla_granularity_track_levels_for_all_known_granularities() {
+        let q = make_query_with_dims(None);
+        let cases: &[(&str, u8)] = &[
+            ("Cube.t.second", 1),
+            ("Cube.t.minute", 2),
+            ("Cube.t.hour", 3),
+            ("Cube.t.day", 4),
+            ("Cube.t.week", 5),
+            ("Cube.t.month", 6),
+            ("Cube.t.quarter", 7),
+            ("Cube.t.year", 8),
+        ];
+        for (member, expected_level) in cases {
+            let track = compute_vanilla_granularity_track(member, &q)
+                .unwrap_or_else(|| panic!("expected Some for {}", member));
+            assert_eq!(
+                track.level, *expected_level,
+                "level mismatch for {}",
+                member
+            );
+            assert_eq!(track.base_member, "Cube.t");
+        }
+    }
+
+    #[test]
+    fn test_compute_vanilla_granularity_track_skips_when_base_in_dimensions() {
+        let q = make_query_with_dims(Some(vec![MemberOrMemberExpression::Member(
+            "Cube.orderDate".to_string(),
+        )]));
+        assert!(compute_vanilla_granularity_track("Cube.orderDate.day", &q).is_none());
+    }
+
+    #[test]
+    fn test_compute_vanilla_granularity_track_proceeds_when_other_dims_present() {
+        let q = make_query_with_dims(Some(vec![MemberOrMemberExpression::Member(
+            "Cube.other".to_string(),
+        )]));
+        let track = compute_vanilla_granularity_track("Cube.orderDate.day", &q)
+            .expect("should produce a track");
+        assert_eq!(track.base_member, "Cube.orderDate");
     }
 }

--- a/rust/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cubeorchestrator/src/query_result_transform.rs
@@ -409,9 +409,6 @@ pub(crate) struct VanillaGranularityTrack<'a> {
     level: u8,
 }
 
-/// Plan for the entire vanilla transform: per-column entries plus a flag
-/// telling `get_vanilla_row` whether any column requires the
-/// minimal-granularity bookkeeping path.
 pub struct VanillaPlan<'a> {
     columns: Vec<VanillaColumnPlan<'a>>,
     has_granularity_tracking: bool,
@@ -425,6 +422,7 @@ pub fn build_vanilla_plan<'a>(
 ) -> Result<VanillaPlan<'a>> {
     let mut columns = Vec::with_capacity(columns_pos.len());
     let mut has_granularity_tracking = false;
+
     for (alias, &index) in columns_pos {
         let member_name = match alias_to_member_name_map.get(alias) {
             Some(m) => m.as_str(),
@@ -449,6 +447,7 @@ pub fn build_vanilla_plan<'a>(
             granularity_track,
         });
     }
+
     Ok(VanillaPlan {
         columns,
         has_granularity_tracking,

--- a/rust/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cubeorchestrator/src/query_result_transform.rs
@@ -409,13 +409,22 @@ pub(crate) struct VanillaGranularityTrack<'a> {
     level: u8,
 }
 
-pub fn build_vanilla_column_plan<'a>(
+/// Plan for the entire vanilla transform: per-column entries plus a flag
+/// telling `get_vanilla_row` whether any column requires the
+/// minimal-granularity bookkeeping path.
+pub struct VanillaPlan<'a> {
+    columns: Vec<VanillaColumnPlan<'a>>,
+    has_granularity_tracking: bool,
+}
+
+pub fn build_vanilla_plan<'a>(
     columns_pos: &'a IndexMap<String, usize>,
     alias_to_member_name_map: &'a HashMap<String, String>,
     annotation: &'a HashMap<String, ConfigItem>,
     query: &NormalizedQuery,
-) -> Result<Vec<VanillaColumnPlan<'a>>> {
-    let mut plans = Vec::with_capacity(columns_pos.len());
+) -> Result<VanillaPlan<'a>> {
+    let mut columns = Vec::with_capacity(columns_pos.len());
+    let mut has_granularity_tracking = false;
     for (alias, &index) in columns_pos {
         let member_name = match alias_to_member_name_map.get(alias) {
             Some(m) => m.as_str(),
@@ -429,15 +438,21 @@ pub fn build_vanilla_column_plan<'a>(
         // Try to collect minimal granularity value for time dimensions without granularity
         // as there might be more than one granularity column for the same dimension.
         let granularity_track = compute_vanilla_granularity_track(member_name, query);
+        if granularity_track.is_some() {
+            has_granularity_tracking = true;
+        }
 
-        plans.push(VanillaColumnPlan {
+        columns.push(VanillaColumnPlan {
             column_index: index,
             member_name,
             member_type,
             granularity_track,
         });
     }
-    Ok(plans)
+    Ok(VanillaPlan {
+        columns,
+        has_granularity_tracking,
+    })
 }
 
 // FIXME: For now custom granularities are not supported, only common ones.
@@ -476,38 +491,49 @@ fn compute_vanilla_granularity_track<'a>(
 
 /// Convert DB response object to the vanilla output format.
 pub fn get_vanilla_row(
-    plan: &[VanillaColumnPlan<'_>],
+    plan: &VanillaPlan<'_>,
     query_type: &QueryType,
     query: &NormalizedQuery,
     db_row: &[DBResponseValue],
 ) -> Result<IndexMap<String, DBResponsePrimitive>> {
     // +1 to cover the optional tail entry (compareDateRange / blending key).
-    let mut row = IndexMap::with_capacity(plan.len() + 1);
+    let mut row = IndexMap::with_capacity(plan.columns.len() + 1);
 
-    // FIXME: For now custom granularities are not supported, only common ones.
-    // There is no granularity type/class implementation in rust yet.
-    let mut minimal_granularities: HashMap<&str, (u8, DBResponsePrimitive)> = HashMap::new();
+    if plan.has_granularity_tracking {
+        // FIXME: For now custom granularities are not supported, only common ones.
+        // There is no granularity type/class implementation in rust yet.
+        let mut minimal_granularities: HashMap<&str, (u8, DBResponsePrimitive)> = HashMap::new();
 
-    for column in plan {
-        if let Some(value) = db_row.get(column.column_index) {
-            let transformed_value = transform_value(value.clone(), column.member_type);
-            row.insert(column.member_name.to_string(), transformed_value.clone());
+        for column in &plan.columns {
+            if let Some(value) = db_row.get(column.column_index) {
+                let transformed_value = transform_value(value.clone(), column.member_type);
+                row.insert(column.member_name.to_string(), transformed_value.clone());
 
-            if let Some(track) = &column.granularity_track {
-                match minimal_granularities.get(track.base_member) {
-                    Some((existing_level, _)) if *existing_level < track.level => {}
-                    _ => {
-                        minimal_granularities
-                            .insert(track.base_member, (track.level, transformed_value));
+                if let Some(track) = &column.granularity_track {
+                    match minimal_granularities.get(track.base_member) {
+                        Some((existing_level, _)) if *existing_level < track.level => {}
+                        _ => {
+                            minimal_granularities
+                                .insert(track.base_member, (track.level, transformed_value));
+                        }
                     }
                 }
             }
         }
-    }
 
-    // Handle deprecated time dimensions without granularity
-    for (base_member, (_, value)) in minimal_granularities {
-        row.insert(base_member.to_string(), value);
+        // Handle deprecated time dimensions without granularity
+        for (base_member, (_, value)) in minimal_granularities {
+            row.insert(base_member.to_string(), value);
+        }
+    } else {
+        // Fast path: no column needs granularity bookkeeping. Skip the HashMap
+        // entirely and move the transformed value straight into the row.
+        for column in &plan.columns {
+            if let Some(value) = db_row.get(column.column_index) {
+                let transformed_value = transform_value(value.clone(), column.member_type);
+                row.insert(column.member_name.to_string(), transformed_value);
+            }
+        }
     }
 
     match query_type {
@@ -699,7 +725,7 @@ impl TransformedData {
                 Ok(TransformedData::Columnar { members, columns })
             }
             _ => {
-                let plan = build_vanilla_column_plan(
+                let plan = build_vanilla_plan(
                     &cube_store_result.columns_pos,
                     alias_to_member_name_map,
                     annotation,
@@ -2910,7 +2936,7 @@ mod tests {
         let query = test_data.request.query.clone();
         let query_type = &test_data.request.query_type.clone().unwrap_or_default();
 
-        let plan = build_vanilla_column_plan(
+        let plan = build_vanilla_plan(
             &raw_data.columns_pos,
             alias_to_member_name_map,
             annotation,
@@ -2946,13 +2972,13 @@ mod tests {
         let annotation = &test_data.request.annotation;
         let query = test_data.request.query.clone();
 
-        match build_vanilla_column_plan(
+        match build_vanilla_plan(
             &raw_data.columns_pos,
             alias_to_member_name_map,
             annotation,
             &query,
         ) {
-            Ok(_) => Err(TestError("build_vanilla_column_plan() should fail ".to_string()).into()),
+            Ok(_) => Err(TestError("build_vanilla_plan() should fail ".to_string()).into()),
             Err(err) => {
                 assert!(err.to_string().contains("Missing member name for alias"));
                 Ok(())
@@ -2975,13 +3001,13 @@ mod tests {
         let annotation = &test_data.request.annotation;
         let query = test_data.request.query.clone();
 
-        match build_vanilla_column_plan(
+        match build_vanilla_plan(
             &raw_data.columns_pos,
             alias_to_member_name_map,
             annotation,
             &query,
         ) {
-            Ok(_) => Err(TestError("build_vanilla_column_plan() should fail ".to_string()).into()),
+            Ok(_) => Err(TestError("build_vanilla_plan() should fail ".to_string()).into()),
             Err(err) => {
                 assert!(err.to_string().contains("You requested hidden member"));
                 Ok(())

--- a/rust/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cubeorchestrator/src/query_result_transform.rs
@@ -403,7 +403,7 @@ pub struct VanillaColumnPlan<'a> {
     granularity_track: Option<VanillaGranularityTrack<'a>>,
 }
 
-pub struct VanillaGranularityTrack<'a> {
+pub(crate) struct VanillaGranularityTrack<'a> {
     /// Slice of `member_name` containing only the `{cube}.{dim}` prefix.
     base_member: &'a str,
     level: u8,


### PR DESCRIPTION
Build a VanillaColumnPlan once per request and walk it per row, instead of redoing alias->member, annotation, and member-name parsing per cell.

Pre-size the row IndexMap to skip incremental rehashes during fill.

Benchmark on my Apple M3 Max (TransformedData::transform vanilla path, cells/sec):

| cols × rows   | before    | after      | speedup |
| ------------- | --------- | ---------- | ------- |
| 8 × 1,000     | 5.51 Mc/s | 16.36 Mc/s | 2.97×   |
| 8 × 10,000    | 5.66 Mc/s | 17.45 Mc/s | 3.08×   |
| 8 × 50,000    | 5.16 Mc/s | 15.58 Mc/s | 3.02×   |
| 8 × 100,000   | 5.28 Mc/s | 16.47 Mc/s | 3.12×   |
| 16 × 1,000    | 5.70 Mc/s | 17.19 Mc/s | 3.02×   |
| 16 × 10,000   | 5.57 Mc/s | 17.52 Mc/s | 3.15×   |
| 16 × 50,000   | 5.60 Mc/s | 17.25 Mc/s | 3.08×   |
| 16 × 100,000  | 5.47 Mc/s | 17.39 Mc/s | 3.18×   |
| 32 × 1,000    | 5.76 Mc/s | 16.91 Mc/s | 2.94×   |
| 32 × 10,000   | 5.66 Mc/s | 16.25 Mc/s | 2.87×   |
| 32 × 50,000   | 5.90 Mc/s | 16.48 Mc/s | 2.79×   |
| 32 × 100,000  | 5.69 Mc/s | 16.80 Mc/s | 2.95×   |
| 64 × 1,000    | 5.05 Mc/s | 17.45 Mc/s | 3.45×   |
| 64 × 10,000   | 5.48 Mc/s | 16.54 Mc/s | 3.02×   |
| 64 × 50,000   | 5.71 Mc/s | 16.99 Mc/s | 2.97×   |
| 64 × 100,000  | 5.95 Mc/s | 16.80 Mc/s | 2.82×   |

Average ~3.0× throughput improvement (5.6 -> 16.8 Mcells/s), on the typical server it will be 6-8x.