### PR TITLE
perf(cubeorchestrator): Improve columnar transform (−77%, 4.4x)

### DIFF
--- a/rust/cube/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cube/cubeorchestrator/src/query_result_transform.rs
@@ -322,27 +322,6 @@ pub fn get_members(
     Ok((members_map, members_arr))
 }
 
-pub fn transpose_to_columns(
-    members: &[String],
-    dataset: Vec<Vec<DBResponsePrimitive>>,
-) -> Vec<Vec<DBResponsePrimitive>> {
-    let row_count = dataset.len();
-    let col_count = members.len();
-
-    let mut columns: Vec<Vec<DBResponsePrimitive>> = (0..col_count)
-        .map(|_| Vec::with_capacity(row_count))
-        .collect();
-
-    for row in dataset {
-        let mut row_iter = row.into_iter();
-        for col in columns.iter_mut().take(col_count) {
-            col.push(row_iter.next().unwrap_or(DBResponsePrimitive::Null));
-        }
-    }
-
-    columns
-}
-
 /// Convert DB response object to the compact output format.
 pub fn get_compact_row(
     members_to_alias_map: &IndexMap<String, String>,
@@ -496,8 +475,7 @@ pub(crate) enum ColumnarColumnSource {
     /// `compareDateRange` column for [`QueryType::CompareDateRangeQuery`]).
     Constant(DBResponsePrimitive),
     /// Lookup chain failed for this member; fill the output column with `Null`
-    /// to keep one column per member (matches the null-padding behaviour of
-    /// [`transpose_to_columns`] when a row is shorter than `members`).
+    /// to keep one column per member.
     NullFilled,
 }
 
@@ -3199,49 +3177,6 @@ mod tests {
     #[test]
     fn test_blending_query_multiple_granularities_columnar() -> Result<()> {
         assert_columnar_matches_compact("blending_query_multiple_granularities")
-    }
-
-    #[test]
-    fn test_transpose_to_columns_basic() {
-        let members = vec!["a".to_string(), "b".to_string()];
-        let dataset = vec![
-            vec![
-                DBResponsePrimitive::Number(1.0),
-                DBResponsePrimitive::String("x".to_string()),
-            ],
-            vec![
-                DBResponsePrimitive::Number(2.0),
-                DBResponsePrimitive::String("y".to_string()),
-            ],
-        ];
-        let columns = transpose_to_columns(&members, dataset);
-        assert_eq!(columns.len(), 2);
-        assert_eq!(
-            columns[0],
-            vec![
-                DBResponsePrimitive::Number(1.0),
-                DBResponsePrimitive::Number(2.0),
-            ]
-        );
-        assert_eq!(
-            columns[1],
-            vec![
-                DBResponsePrimitive::String("x".to_string()),
-                DBResponsePrimitive::String("y".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn test_transpose_to_columns_pads_short_rows_with_null() {
-        let members = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-        let dataset = vec![vec![
-            DBResponsePrimitive::Number(1.0),
-            DBResponsePrimitive::String("x".to_string()),
-        ]];
-        let columns = transpose_to_columns(&members, dataset);
-        assert_eq!(columns.len(), 3);
-        assert_eq!(columns[2], vec![DBResponsePrimitive::Null]);
     }
 
     fn make_query_with_dims(dimensions: Option<Vec<MemberOrMemberExpression>>) -> NormalizedQuery {

--- a/rust/cube/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cube/cubeorchestrator/src/query_result_transform.rs
@@ -488,6 +488,132 @@ fn compute_vanilla_granularity_track<'a>(
     Some(VanillaGranularityTrack { base_member, level })
 }
 
+/// Source for one output column when materializing the [`TransformedData::Columnar`] result.
+pub(crate) enum ColumnarColumnSource {
+    /// Pull `db_row[index]` from every input row and run [`transform_value`].
+    DbColumn { index: usize },
+    /// Constant value replicated across every output row (e.g. the synthetic
+    /// `compareDateRange` column for [`QueryType::CompareDateRangeQuery`]).
+    Constant(DBResponsePrimitive),
+    /// Lookup chain failed for this member; fill the output column with `Null`
+    /// to keep one column per member (matches the null-padding behaviour of
+    /// [`transpose_to_columns`] when a row is shorter than `members`).
+    NullFilled,
+}
+
+pub(crate) struct ColumnarColumnPlan<'a> {
+    member_type: &'a str,
+    source: ColumnarColumnSource,
+}
+
+fn build_columnar_plan<'a>(
+    members: &[String],
+    members_to_alias_map: &IndexMap<String, String>,
+    annotation: &'a HashMap<String, ConfigItem>,
+    columns_pos: &IndexMap<String, usize>,
+    query_type: &QueryType,
+    time_dimensions: Option<&Vec<QueryTimeDimension>>,
+) -> Result<Vec<ColumnarColumnPlan<'a>>> {
+    let mut plan: Vec<ColumnarColumnPlan<'a>> = Vec::with_capacity(members.len());
+
+    for (i, m) in members.iter().enumerate() {
+        let is_last = i + 1 == members.len();
+
+        let resolved =
+            annotation
+                .get(m)
+                .and_then(|annotation_item| match members_to_alias_map.get(m) {
+                    Some(alias) => columns_pos
+                        .get(alias)
+                        .map(|&index| (annotation_item, index)),
+                    None => None,
+                });
+
+        if let Some((annotation_item, index)) = resolved {
+            plan.push(ColumnarColumnPlan {
+                member_type: annotation_item.member_type.as_deref().unwrap_or(""),
+                source: ColumnarColumnSource::DbColumn { index },
+            });
+            continue;
+        }
+
+        // Synthetic tail column added by `get_members` for these query types.
+        if is_last {
+            match query_type {
+                QueryType::CompareDateRangeQuery => {
+                    plan.push(ColumnarColumnPlan {
+                        member_type: "",
+                        source: ColumnarColumnSource::Constant(get_date_range_value(
+                            time_dimensions,
+                        )?),
+                    });
+                    continue;
+                }
+                QueryType::BlendingQuery => {
+                    let response_key = get_blending_response_key(time_dimensions)?;
+                    if let Some(alias) = members_to_alias_map.get(&response_key) {
+                        if let Some(&index) = columns_pos.get(alias) {
+                            // Preserve the (likely-quirky) lookup at
+                            // `get_compact_row`: member_type comes from
+                            // `annotation[alias]`, not `annotation[member]`.
+                            let member_type = annotation
+                                .get(alias)
+                                .map_or("", |a| a.member_type.as_deref().unwrap_or(""));
+                            plan.push(ColumnarColumnPlan {
+                                member_type,
+                                source: ColumnarColumnSource::DbColumn { index },
+                            });
+                            continue;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        plan.push(ColumnarColumnPlan {
+            member_type: "",
+            source: ColumnarColumnSource::NullFilled,
+        });
+    }
+
+    Ok(plan)
+}
+
+/// Materialize [`TransformedData::Columnar`] columns directly from the
+/// row-major `cube_store_result.rows` matrix.
+fn build_columnar_columns(
+    plan: &[ColumnarColumnPlan<'_>],
+    rows: &[Vec<DBResponseValue>],
+) -> Vec<Vec<DBResponsePrimitive>> {
+    let row_count = rows.len();
+    let mut columns: Vec<Vec<DBResponsePrimitive>> =
+        plan.iter().map(|_| Vec::with_capacity(row_count)).collect();
+
+    for (col_idx, plan_entry) in plan.iter().enumerate() {
+        let out = &mut columns[col_idx];
+        match &plan_entry.source {
+            ColumnarColumnSource::DbColumn { index } => {
+                for row in rows {
+                    let cell = row
+                        .get(*index)
+                        .cloned()
+                        .unwrap_or(DBResponseValue::Primitive(DBResponsePrimitive::Null));
+                    out.push(transform_value(cell, plan_entry.member_type));
+                }
+            }
+            ColumnarColumnSource::Constant(v) => {
+                out.resize(row_count, v.clone());
+            }
+            ColumnarColumnSource::NullFilled => {
+                out.resize(row_count, DBResponsePrimitive::Null);
+            }
+        }
+    }
+
+    columns
+}
+
 /// Convert DB response object to the vanilla output format.
 pub fn get_vanilla_row(
     plan: &VanillaPlan<'_>,
@@ -705,22 +831,15 @@ impl TransformedData {
                 Ok(TransformedData::Compact { members, dataset })
             }
             Some(ResultType::Columnar) => {
-                let dataset: Vec<Vec<DBResponsePrimitive>> = cube_store_result
-                    .rows
-                    .iter()
-                    .map(|row| {
-                        get_compact_row(
-                            &members_to_alias_map,
-                            annotation,
-                            query_type,
-                            &members,
-                            query.time_dimensions.as_ref(),
-                            row,
-                            &cube_store_result.columns_pos,
-                        )
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                let columns = transpose_to_columns(&members, dataset);
+                let plan = build_columnar_plan(
+                    &members,
+                    &members_to_alias_map,
+                    annotation,
+                    &cube_store_result.columns_pos,
+                    query_type,
+                    query.time_dimensions.as_ref(),
+                )?;
+                let columns = build_columnar_columns(&plan, &cube_store_result.rows);
                 Ok(TransformedData::Columnar { members, columns })
             }
             _ => {


### PR DESCRIPTION
Bench on Apple M3 Max (`TransformedData::transform/columnar`):

| shape         | time delta | speed-up |
| ------------- | ---------- | -------- |
| c32_r1000     | −77.3%     | 4.4x     |
| c64_r1000     | −78.5%     | 4.6x     |
| c32_r10000    | −72.2%     | 3.6x     |
| c64_r10000    | −49.6%     | 2.0x     |
| c32_r50000    | −40.7%     | 1.7x     |
| c64_r50000    | −35.2%     | 1.5x     |
| c32_r100000   | −29.0%     | 1.4x     |
| c64_r100000   | −27.7%     | 1.4x     |