### PR TITLE
perf(cubeorchestrator): Improve vanilla transform with StructuredObje…

### DIFF
--- a/rust/cube/cubeorchestrator/src/lib.rs
+++ b/rust/cube/cubeorchestrator/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod query_message_parser;
 pub mod query_result_transform;
+pub mod structured_object;
 pub mod transport;

--- a/rust/cube/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cube/cubeorchestrator/src/query_result_transform.rs
@@ -1,5 +1,6 @@
 use crate::{
     query_message_parser::QueryResult,
+    structured_object::{StructuredObject, StructuredObjectShape, StructuredObjectShapeRef},
     transport::{
         AnnotatedConfigItem, ConfigItem, MemberOrMemberExpression, MembersMap, NormalizedQuery,
         QueryTimeDimension, QueryType, ResultType, TransformDataRequest,
@@ -377,20 +378,32 @@ pub fn get_compact_row(
 /// and member-name parsing for every cell.
 pub struct VanillaColumnPlan<'a> {
     column_index: usize,
-    member_name: &'a str,
+    /// Position of `member_name` inside `VanillaPlan::shape`.
+    output_index: usize,
     member_type: &'a str,
-    granularity_track: Option<VanillaGranularityTrack<'a>>,
+    granularity_track: Option<VanillaGranularityTrack>,
 }
 
-pub(crate) struct VanillaGranularityTrack<'a> {
-    /// Slice of `member_name` containing only the `{cube}.{dim}` prefix.
-    base_member: &'a str,
+pub(crate) struct VanillaGranularityTrack {
+    /// Position of the granularity's base member (`{cube}.{dim}`) inside
+    /// `VanillaPlan::shape`.
+    base_output_index: usize,
     level: u8,
 }
 
 pub struct VanillaPlan<'a> {
     columns: Vec<VanillaColumnPlan<'a>>,
     has_granularity_tracking: bool,
+    /// Shared key list for every row in the result set. Wrapped in `Arc` so each
+    /// `StructuredObject` row only bumps a refcount instead of cloning keys.
+    shape: StructuredObjectShapeRef,
+    /// Pre-resolved output positions for query-type-specific tail keys, so
+    /// `get_vanilla_row` doesn't need to do per-row hash lookups.
+    compare_date_range_index: Option<usize>,
+    blending_key_index: Option<usize>,
+    /// Position of the response_key column to copy into `blending_key_index`.
+    /// `None` if the response key isn't part of the shape (no matching column).
+    blending_response_index: Option<usize>,
 }
 
 pub fn build_vanilla_plan<'a>(
@@ -398,10 +411,14 @@ pub fn build_vanilla_plan<'a>(
     alias_to_member_name_map: &'a HashMap<String, String>,
     annotation: &'a HashMap<String, ConfigItem>,
     query: &NormalizedQuery,
+    query_type: &QueryType,
 ) -> Result<VanillaPlan<'a>> {
     let mut columns = Vec::with_capacity(columns_pos.len());
     let mut has_granularity_tracking = false;
+    let mut shape_builder = StructuredObjectShape::builder();
 
+    // Pass 1: regular columns + their output positions.
+    let mut pre_columns: Vec<(usize, &'a str, &'a str)> = Vec::with_capacity(columns_pos.len());
     for (alias, &index) in columns_pos {
         let member_name = match alias_to_member_name_map.get(alias) {
             Some(m) => m.as_str(),
@@ -410,18 +427,55 @@ pub fn build_vanilla_plan<'a>(
         ensure_member_in_annotation(member_name, annotation)?;
         let annotation_for_member = annotation.get(member_name).unwrap();
         let member_type = annotation_for_member.member_type.as_deref().unwrap_or("");
+        shape_builder.insert(member_name);
+        pre_columns.push((index, member_name, member_type));
+    }
 
-        // Handle deprecated time dimensions without granularity.
-        // Try to collect minimal granularity value for time dimensions without granularity
-        // as there might be more than one granularity column for the same dimension.
-        let granularity_track = compute_vanilla_granularity_track(member_name, query);
+    // Pass 2: granularity base members. These usually collide with an existing
+    // column key — the builder collapses duplicates and reuses the position.
+    for (_, member_name, _) in &pre_columns {
+        if let Some((base_member, _)) = compute_vanilla_granularity_track(member_name, query) {
+            shape_builder.insert(base_member);
+        }
+    }
+
+    // Pass 3: query-type-specific tail keys.
+    let compare_date_range_index = match query_type {
+        QueryType::CompareDateRangeQuery => Some(shape_builder.insert(COMPARE_DATE_RANGE_FIELD)),
+        _ => None,
+    };
+    let (blending_key_index, blending_response_index) = match query_type {
+        QueryType::BlendingQuery => {
+            let blending_key = get_blending_query_key(query.time_dimensions.as_ref())?;
+            let response_key = get_blending_response_key(query.time_dimensions.as_ref())?;
+            // The response_key may or may not appear as a regular column — only
+            // record its position if it's already in the shape.
+            let response_idx = shape_builder.position(&response_key);
+            let key_idx = shape_builder.insert(blending_key);
+            (Some(key_idx), response_idx)
+        }
+        _ => (None, None),
+    };
+
+    // Pass 4: assemble the column plans now that the shape is finalized.
+    for (column_index, member_name, member_type) in pre_columns {
+        let output_index = shape_builder.position(member_name).expect("inserted above");
+        let granularity_track =
+            compute_vanilla_granularity_track(member_name, query).map(|(base_member, level)| {
+                let base_output_index = shape_builder
+                    .position(base_member)
+                    .expect("base_member inserted above");
+                VanillaGranularityTrack {
+                    base_output_index,
+                    level,
+                }
+            });
         if granularity_track.is_some() {
             has_granularity_tracking = true;
         }
-
         columns.push(VanillaColumnPlan {
-            column_index: index,
-            member_name,
+            column_index,
+            output_index,
             member_type,
             granularity_track,
         });
@@ -430,6 +484,10 @@ pub fn build_vanilla_plan<'a>(
     Ok(VanillaPlan {
         columns,
         has_granularity_tracking,
+        shape: Arc::new(shape_builder.build()),
+        compare_date_range_index,
+        blending_key_index,
+        blending_response_index,
     })
 }
 
@@ -438,7 +496,7 @@ pub fn build_vanilla_plan<'a>(
 fn compute_vanilla_granularity_track<'a>(
     member_name: &'a str,
     query: &NormalizedQuery,
-) -> Option<VanillaGranularityTrack<'a>> {
+) -> Option<(&'a str, u8)> {
     // Require exactly two `.` separators — i.e. the `{cube}.{dim}.{granularity}` form.
     let mut indices = member_name.match_indices(MEMBER_SEPARATOR);
     indices.next()?;
@@ -464,7 +522,7 @@ fn compute_vanilla_granularity_track<'a>(
         .get(granularity)
         .cloned()
         .unwrap_or(DEFAULT_LEVEL_FOR_UNKNOWN);
-    Some(VanillaGranularityTrack { base_member, level })
+    Some((base_member, level))
 }
 
 /// Source for one output column when materializing the [`TransformedData::Columnar`] result.
@@ -598,43 +656,44 @@ pub fn get_vanilla_row(
     query_type: &QueryType,
     query: &NormalizedQuery,
     db_row: &[DBResponseValue],
-) -> Result<IndexMap<String, DBResponsePrimitive>> {
-    // +1 to cover the optional tail entry (compareDateRange / blending key).
-    let mut row = IndexMap::with_capacity(plan.columns.len() + 1);
+) -> Result<StructuredObject> {
+    let mut row: StructuredObject = StructuredObject::with_shape_default(plan.shape.clone());
 
     if plan.has_granularity_tracking {
         // FIXME: For now custom granularities are not supported, only common ones.
         // There is no granularity type/class implementation in rust yet.
-        let mut minimal_granularities: HashMap<&str, (u8, DBResponsePrimitive)> = HashMap::new();
+        let mut minimal_granularities: HashMap<usize, (u8, DBResponsePrimitive)> = HashMap::new();
 
         for column in &plan.columns {
             if let Some(value) = db_row.get(column.column_index) {
                 let transformed_value = transform_value(value.clone(), column.member_type);
-                row.insert(column.member_name.to_string(), transformed_value.clone());
 
                 if let Some(track) = &column.granularity_track {
-                    match minimal_granularities.get(track.base_member) {
+                    match minimal_granularities.get(&track.base_output_index) {
                         Some((existing_level, _)) if *existing_level < track.level => {}
                         _ => {
-                            minimal_granularities
-                                .insert(track.base_member, (track.level, transformed_value));
+                            minimal_granularities.insert(
+                                track.base_output_index,
+                                (track.level, transformed_value.clone()),
+                            );
                         }
                     }
                 }
+
+                row.set_by_position(column.output_index, transformed_value);
             }
         }
 
         // Handle deprecated time dimensions without granularity
-        for (base_member, (_, value)) in minimal_granularities {
-            row.insert(base_member.to_string(), value);
+        for (base_output_index, (_, value)) in minimal_granularities {
+            row.set_by_position(base_output_index, value);
         }
     } else {
-        // Fast path: no column needs granularity bookkeeping. Skip the HashMap
-        // entirely and move the transformed value straight into the row.
+        // Fast path: no column needs granularity bookkeeping.
         for column in &plan.columns {
             if let Some(value) = db_row.get(column.column_index) {
                 let transformed_value = transform_value(value.clone(), column.member_type);
-                row.insert(column.member_name.to_string(), transformed_value);
+                row.set_by_position(column.output_index, transformed_value);
             }
         }
     }
@@ -642,14 +701,16 @@ pub fn get_vanilla_row(
     match query_type {
         QueryType::CompareDateRangeQuery => {
             let date_range_value = get_date_range_value(query.time_dimensions.as_ref())?;
-            row.insert("compareDateRange".to_string(), date_range_value);
+            if let Some(idx) = plan.compare_date_range_index {
+                row.set_by_position(idx, date_range_value);
+            }
         }
         QueryType::BlendingQuery => {
-            let blending_key = get_blending_query_key(query.time_dimensions.as_ref())?;
-            let response_key = get_blending_response_key(query.time_dimensions.as_ref())?;
-
-            if let Some(value) = row.get(&response_key) {
-                row.insert(blending_key, value.clone());
+            if let (Some(key_idx), Some(response_idx)) =
+                (plan.blending_key_index, plan.blending_response_index)
+            {
+                let value = row.values()[response_idx].clone();
+                row.set_by_position(key_idx, value);
             }
         }
         _ => {}
@@ -766,7 +827,7 @@ pub enum TransformedData {
         members: Vec<String>,
         columns: Vec<Vec<DBResponsePrimitive>>,
     },
-    Vanilla(Vec<IndexMap<String, DBResponsePrimitive>>),
+    Vanilla(Vec<StructuredObject>),
 }
 
 impl TransformedData {
@@ -826,6 +887,7 @@ impl TransformedData {
                     alias_to_member_name_map,
                     annotation,
                     query,
+                    query_type,
                 )?;
                 let dataset: Vec<_> = cube_store_result
                     .rows
@@ -933,6 +995,12 @@ pub enum DBResponsePrimitive {
     Number(f64),
     String(String),
     Uncommon(Value),
+}
+
+impl Default for DBResponsePrimitive {
+    fn default() -> Self {
+        DBResponsePrimitive::Null
+    }
 }
 
 impl Display for DBResponsePrimitive {
@@ -1860,7 +1928,7 @@ mod tests {
                         )));
                     }
 
-                    for (key, left_value) in left_record {
+                    for (key, left_value) in left_record.iter() {
                         if let Some(right_value) = right_record.get(key) {
                             if left_value != right_value {
                                 return Err(TestError(format!(
@@ -3037,18 +3105,20 @@ mod tests {
             alias_to_member_name_map,
             annotation,
             &query,
+            query_type,
         )?;
         let res = get_vanilla_row(&plan, query_type, &query, &raw_data.rows[0])?;
-        let expected = IndexMap::from([
-            (
-                "ECommerceRecordsUs2021.city".to_string(),
-                DBResponsePrimitive::String("Missouri City".to_string()),
-            ),
-            (
-                "ECommerceRecordsUs2021.avg_discount".to_string(),
-                DBResponsePrimitive::String("0.80000000000000000000".to_string()),
-            ),
-        ]);
+
+        let mut shape_builder = StructuredObjectShape::builder();
+        shape_builder.insert("ECommerceRecordsUs2021.city");
+        shape_builder.insert("ECommerceRecordsUs2021.avg_discount");
+        let shape = Arc::new(shape_builder.build());
+        let mut expected: StructuredObject = StructuredObject::with_shape_default(shape);
+        expected.set_by_position(0, DBResponsePrimitive::String("Missouri City".to_string()));
+        expected.set_by_position(
+            1,
+            DBResponsePrimitive::String("0.80000000000000000000".to_string()),
+        );
         assert_eq!(res, expected);
         Ok(())
     }
@@ -3073,6 +3143,7 @@ mod tests {
             alias_to_member_name_map,
             annotation,
             &query,
+            &QueryType::default(),
         ) {
             Ok(_) => Err(TestError("build_vanilla_plan() should fail ".to_string()).into()),
             Err(err) => {
@@ -3102,6 +3173,7 @@ mod tests {
             alias_to_member_name_map,
             annotation,
             &query,
+            &QueryType::default(),
         ) {
             Ok(_) => Err(TestError("build_vanilla_plan() should fail ".to_string()).into()),
             Err(err) => {
@@ -3215,10 +3287,10 @@ mod tests {
     #[test]
     fn test_compute_vanilla_granularity_track_known_granularity() {
         let q = make_query_with_dims(None);
-        let track = compute_vanilla_granularity_track("Cube.orderDate.day", &q)
+        let (base_member, level) = compute_vanilla_granularity_track("Cube.orderDate.day", &q)
             .expect("should produce a track");
-        assert_eq!(track.base_member, "Cube.orderDate");
-        assert_eq!(track.level, 4);
+        assert_eq!(base_member, "Cube.orderDate");
+        assert_eq!(level, 4);
     }
 
     #[test]
@@ -3235,14 +3307,10 @@ mod tests {
             ("Cube.t.year", 8),
         ];
         for (member, expected_level) in cases {
-            let track = compute_vanilla_granularity_track(member, &q)
+            let (base_member, level) = compute_vanilla_granularity_track(member, &q)
                 .unwrap_or_else(|| panic!("expected Some for {}", member));
-            assert_eq!(
-                track.level, *expected_level,
-                "level mismatch for {}",
-                member
-            );
-            assert_eq!(track.base_member, "Cube.t");
+            assert_eq!(level, *expected_level, "level mismatch for {}", member);
+            assert_eq!(base_member, "Cube.t");
         }
     }
 
@@ -3259,8 +3327,8 @@ mod tests {
         let q = make_query_with_dims(Some(vec![MemberOrMemberExpression::Member(
             "Cube.other".to_string(),
         )]));
-        let track = compute_vanilla_granularity_track("Cube.orderDate.day", &q)
+        let (base_member, _) = compute_vanilla_granularity_track("Cube.orderDate.day", &q)
             .expect("should produce a track");
-        assert_eq!(track.base_member, "Cube.orderDate");
+        assert_eq!(base_member, "Cube.orderDate");
     }
 }

--- a/rust/cube/cubeorchestrator/src/structured_object.rs
+++ b/rust/cube/cubeorchestrator/src/structured_object.rs
@@ -1,0 +1,288 @@
+//! IndexMap-shaped object with key names held once via `Arc<StructuredObjectShape>`
+//! and per-instance values stored in a position-aligned `Vec`.
+//!
+//! Built so result-set rows can share a single key list instead of cloning the
+//! same column names per row.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+/// Shared, refcounted handle to a `StructuredObjectShape`. Every
+/// `StructuredObject` row in a result set holds one of these instead of cloning
+/// the key list.
+pub type StructuredObjectShapeRef = Arc<StructuredObjectShape>;
+
+#[derive(Debug, Clone)]
+pub struct StructuredObjectShape {
+    keys: Vec<String>,
+    index: HashMap<String, usize>,
+}
+
+impl StructuredObjectShape {
+    pub fn builder() -> StructuredObjectShapeBuilder {
+        StructuredObjectShapeBuilder::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    pub fn keys(&self) -> &[String] {
+        &self.keys
+    }
+
+    pub fn position(&self, key: &str) -> Option<usize> {
+        self.index.get(key).copied()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct StructuredObjectShapeBuilder {
+    keys: Vec<String>,
+    index: HashMap<String, usize>,
+}
+
+impl StructuredObjectShapeBuilder {
+    /// Append a key. If the key already exists, its existing position is returned
+    /// — the shape stays a unique, ordered list.
+    pub fn insert(&mut self, key: impl Into<String>) -> usize {
+        let key = key.into();
+
+        if let Some(&i) = self.index.get(&key) {
+            return i;
+        }
+
+        let i = self.keys.len();
+        self.index.insert(key.clone(), i);
+        self.keys.push(key);
+        i
+    }
+
+    pub fn position(&self, key: &str) -> Option<usize> {
+        self.index.get(key).copied()
+    }
+
+    pub fn build(self) -> StructuredObjectShape {
+        StructuredObjectShape {
+            keys: self.keys,
+            index: self.index,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StructuredObject<V: Debug + Clone = crate::query_result_transform::DBResponsePrimitive> {
+    shape: StructuredObjectShapeRef,
+    values: Vec<V>,
+}
+
+impl<V: Debug + Clone> StructuredObject<V> {
+    pub fn shape(&self) -> &StructuredObjectShapeRef {
+        &self.shape
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&V> {
+        self.shape.position(key).map(|i| &self.values[i])
+    }
+
+    /// Overwrite the slot for `key`. Returns the previous value if `key` is in the
+    /// shape, or `None` (and leaves `self` unchanged) if it isn't.
+    pub fn insert(&mut self, key: &str, value: V) -> Option<V> {
+        let idx = self.shape.position(key)?;
+        Some(std::mem::replace(&mut self.values[idx], value))
+    }
+
+    /// Fast-path setter for callers that already know the position (e.g. via a plan).
+    /// Panics if `idx >= len()`.
+    pub fn set_by_position(&mut self, idx: usize, value: V) {
+        self.values[idx] = value;
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &V)> {
+        self.shape
+            .keys
+            .iter()
+            .map(|k| k.as_str())
+            .zip(self.values.iter())
+    }
+
+    pub fn values(&self) -> &[V] {
+        &self.values
+    }
+
+    pub fn with_shape_filled(shape: StructuredObjectShapeRef, fill: V) -> Self {
+        let len = shape.len();
+        Self {
+            shape,
+            values: vec![fill; len],
+        }
+    }
+}
+
+impl<V: Debug + Clone + Default> StructuredObject<V> {
+    pub fn with_shape_default(shape: StructuredObjectShapeRef) -> Self {
+        let len = shape.len();
+        Self {
+            shape,
+            values: vec![V::default(); len],
+        }
+    }
+}
+
+impl<V: Debug + Clone + Serialize> Serialize for StructuredObject<V> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(self.values.len()))?;
+        for (k, v) in self.iter() {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de, V> Deserialize<'de> for StructuredObject<V>
+where
+    V: Debug + Clone + Deserialize<'de>,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ObjectVisitor<V>(std::marker::PhantomData<V>);
+
+        impl<'de, V> Visitor<'de> for ObjectVisitor<V>
+        where
+            V: Debug + Clone + Deserialize<'de>,
+        {
+            type Value = StructuredObject<V>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a JSON object representing a StructuredObject")
+            }
+
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+                let mut shape = StructuredObjectShape::builder();
+                let mut values: Vec<V> = Vec::with_capacity(map.size_hint().unwrap_or(0));
+                while let Some((k, v)) = map.next_entry::<String, V>()? {
+                    let idx = shape.insert(k);
+                    if idx == values.len() {
+                        values.push(v);
+                    } else {
+                        // Duplicate key: overwrite the existing slot to mirror IndexMap.
+                        values[idx] = v;
+                    }
+                }
+                Ok(StructuredObject {
+                    shape: Arc::new(shape.build()),
+                    values,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(ObjectVisitor::<V>(std::marker::PhantomData))
+    }
+}
+
+impl<V: Debug + Clone + PartialEq> PartialEq for StructuredObject<V> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.values.len() != other.values.len() {
+            return false;
+        }
+        // Compare by (key, value) pairs in shape order. This avoids requiring shape
+        // pointer identity while still respecting key order — matches IndexMap semantics.
+        self.iter().eq(other.iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shape_of(keys: &[&str]) -> StructuredObjectShapeRef {
+        let mut b = StructuredObjectShape::builder();
+        for k in keys {
+            b.insert(*k);
+        }
+        Arc::new(b.build())
+    }
+
+    #[test]
+    fn shape_dedups_and_preserves_order() {
+        let mut b = StructuredObjectShape::builder();
+        assert_eq!(b.insert("a"), 0);
+        assert_eq!(b.insert("b"), 1);
+        assert_eq!(b.insert("a"), 0);
+        let s = b.build();
+        assert_eq!(s.keys(), &["a".to_string(), "b".to_string()]);
+        assert_eq!(s.position("a"), Some(0));
+        assert_eq!(s.position("b"), Some(1));
+        assert_eq!(s.position("c"), None);
+    }
+
+    #[test]
+    fn insert_and_get() {
+        let shape = shape_of(&["x", "y"]);
+        let mut obj: StructuredObject<i64> = StructuredObject::with_shape_default(shape);
+        assert_eq!(obj.get("x"), Some(&0));
+        let prev = obj.insert("x", 42);
+        assert_eq!(prev, Some(0));
+        assert_eq!(obj.get("x"), Some(&42));
+        assert_eq!(obj.insert("missing", 1), None);
+    }
+
+    #[test]
+    fn iter_in_shape_order() {
+        let shape = shape_of(&["a", "b", "c"]);
+        let mut obj: StructuredObject<i64> = StructuredObject::with_shape_default(shape);
+        obj.set_by_position(0, 1);
+        obj.set_by_position(1, 2);
+        obj.set_by_position(2, 3);
+        let collected: Vec<_> = obj.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+        assert_eq!(
+            collected,
+            vec![
+                ("a".to_string(), 1),
+                ("b".to_string(), 2),
+                ("c".to_string(), 3),
+            ]
+        );
+    }
+
+    #[test]
+    fn serializes_as_object_in_order() {
+        let shape = shape_of(&["beta", "alpha"]);
+        let mut obj: StructuredObject<i64> = StructuredObject::with_shape_default(shape);
+        obj.set_by_position(0, 1);
+        obj.set_by_position(1, 2);
+        let json = serde_json::to_string(&obj).unwrap();
+        // Order follows the shape, not lexicographic.
+        assert_eq!(json, r#"{"beta":1,"alpha":2}"#);
+    }
+
+    #[test]
+    fn equality_compares_pairs_in_order() {
+        let s1 = shape_of(&["a", "b"]);
+        let s2 = shape_of(&["a", "b"]);
+        let mut o1: StructuredObject<i64> = StructuredObject::with_shape_default(s1);
+        let mut o2: StructuredObject<i64> = StructuredObject::with_shape_default(s2);
+        o1.set_by_position(0, 1);
+        o1.set_by_position(1, 2);
+        o2.set_by_position(0, 1);
+        o2.set_by_position(1, 2);
+        assert_eq!(o1, o2);
+        o2.set_by_position(1, 3);
+        assert_ne!(o1, o2);
+    }
+}


### PR DESCRIPTION
…ct (−65%, 2.9x)

Replace per-row `IndexMap<String, DBResponsePrimitive>` in `get_vanilla_row` with a new `StructuredObject` that stores values in a position-aligned `Vec` and shares its key list across the whole result set via `Arc<StructuredObjectShape>`. Keys live once per result set instead of being cloned N×M times.

Build the shape inside `build_vanilla_plan` (regular columns + granularity base members + `compareDateRange`/blending tail keys, deduped) and stash precomputed output positions on the plan, so `get_vanilla_row` writes via `set_by_position` with no per-row hash lookups or string allocations.

Vanilla benchmark deltas on Apple M3 Max (criterion, cells/sec; all p < 0.05):

| Scenario                                         | Before     | After     | Δ time    |
| ------------------------------------------------ | ---------- | --------- | --------- |
| vanilla/c08_r1000                                | 469 µs     | 152 µs    | −67.5%    |
| vanilla/c08_r10000                               | 6.0 ms     | 1.56 ms   | −74.0%    |
| vanilla/c08_r50000                               | 24.9 ms    | 7.75 ms   | −68.9%    |
| vanilla/c08_r100000                              | 50.0 ms    | 16.05 ms  | −67.9%    |
| vanilla/c16_r1000                                | 856 µs     | 309 µs    | −63.9%    |
| vanilla/c16_r10000                               | 8.79 ms    | 3.07 ms   | −65.1%    |
| vanilla/c16_r50000                               | 43.6 ms    | 15.62 ms  | −64.2%    |
| vanilla/c32_r10000                               | 17.78 ms   | 6.4 ms    | −63.9%    |
| vanilla/c32_r100000                              | 171.7 ms   | 61.5 ms   | −64.2%    |
| vanilla/c64_r1000                                | 3.38 ms    | 1.15 ms   | −66.3%    |
| vanilla/c64_r10000                               | 34.0 ms    | 11.45 ms  | −66.4%    |
| vanilla/c64_r50000                               | 173.3 ms   | 59.2 ms   | −65.9%    |
| vanilla/c64_r100000                              | 340.2 ms   | 116.1 ms  | −65.9%    |
| scenarios/vanilla/no_time_dim/c16_r100000        | 87.0 ms    | 31.7 ms   | −63.5%    |
| scenarios/vanilla/one_time_dim_day/c16_r100000   | 173.1 ms   | 93.4 ms   | −46.1%    |
| scenarios/vanilla/one_time_dim_custom_granularity/c16_r100000 | 177.1 ms | 93.6 ms | −47.1% |
| scenarios/vanilla/two_time_dims/c16_r100000      | 257.1 ms   | 142.8 ms  | −44.5%    |