### PR TITLE
docs: rename infrastructure options to single-tenant / multi-tenant

### DIFF
--- a/.cursor/rules/namings-rule.mdc
+++ b/.cursor/rules/namings-rule.mdc
@@ -16,6 +16,42 @@ alwaysApply: true
 - **Production** — production deployment type (legacy: "Production cluster")
 - **Multi-cluster** — multi-cluster production deployment type (legacy: "Production multi-cluster")
 
+# Infrastructure Naming
+
+Infrastructure options are a separate, orthogonal concept from deployment types.
+A deployment of any type runs on top of one of these infrastructure options:
+
+- **Multi-tenant infrastructure** — deployments share compute and network with
+  other customers. Legacy: "Shared infrastructure".
+- **Single-tenant infrastructure** — deployments run in a dedicated VPC inside
+  a Cube Cloud account; not shared with any other customer. Legacy: "Dedicated
+  infrastructure".
+- **Single-tenant infrastructure with CSPS** — same as single-tenant, but
+  data at-rest is stored in a customer-supplied object store. Legacy:
+  "Dedicated infrastructure with CSPS".
+- **BYOC (Bring Your Own Cloud)** — Cube Cloud data plane is fully hosted in
+  the customer's cloud account.
+
+Guidance:
+
+- Always use **single-tenant** / **multi-tenant** in customer-facing prose,
+  headings, navigation labels, and card titles. These terms are an industry
+  standard and remove the naming collision with the **Shared** and **Dedicated**
+  deployment types.
+- Do **not** rename URL anchors (`#shared-infrastructure`,
+  `#dedicated-infrastructure`, `#dedicated-infrastructure-with-csps`) or
+  internal link reference IDs (e.g., `[ref-dedicated-infra]`); keep these
+  stable so external inbound links keep working. Use Mintlify's explicit
+  anchor syntax (`## Single-tenant infrastructure {#dedicated-infrastructure}`)
+  to preserve them.
+- Do **not** rename product/region identifier slugs that contain `shared`,
+  `dedicated`, or `byoc` (e.g., `aws-us-east-1-shared`, `aws-us-east-1-t-12345-prod`).
+  These are literal strings used by the product.
+- Avoid bare adjectives like "dedicated infrastructure" when you mean a
+  Dedicated **deployment type** running on its own compute. Prefer phrases
+  like "compute dedicated to your deployment" to avoid implying single-tenant
+  infrastructure.
+
 # Product Taxonomy
 Make sure to use correct terms.
 

--- a/.cursor/rules/namings-rule.mdc
+++ b/.cursor/rules/namings-rule.mdc
@@ -30,6 +30,26 @@ When describing plan availability:
   Enterprise. Use "Enterprise plan" (singular) instead.
 - For Enterprise-only features that require an additional purchase, use
   "Available as an add-on on the [Enterprise plan]".
+- For features that depend on another add-on, name the dependency:
+  "Available on the [Enterprise plan] with the [Single-tenant infrastructure]
+  add-on."
+
+## Plan availability callouts
+
+Use Mintlify's `<Note>` (gray) component — **not** `<Info>` (blue) — for
+plan-availability messages. `<Info>` is the catch-all blue callout used
+heavily throughout the docs for general "by the way" notes; using a different
+color for plan gating makes it visually distinct and scannable.
+
+```mdx
+<Note>
+
+Available on the [Enterprise plan](https://cube.dev/pricing).
+
+</Note>
+```
+
+Place the callout immediately after the section heading it applies to.
 
 # Infrastructure Naming
 

--- a/.cursor/rules/namings-rule.mdc
+++ b/.cursor/rules/namings-rule.mdc
@@ -16,6 +16,21 @@ alwaysApply: true
 - **Production** — production deployment type (legacy: "Production cluster")
 - **Multi-cluster** — multi-cluster production deployment type (legacy: "Production multi-cluster")
 
+# Plan Tier Naming
+
+Cube's commercial plan tiers, in order: **Free**, **Starter**, **Premium**,
+**Enterprise**. **Enterprise is the top tier — nothing is above it.**
+
+When describing plan availability:
+
+- ✅ "Available on the [Enterprise plan]" (single tier, top of stack)
+- ✅ "Available on [Premium and above plans]" (Premium + Enterprise)
+- ✅ "Available on [Starter and above plans]" (Starter + Premium + Enterprise)
+- ❌ Do **not** write "Enterprise and above plans" — there is nothing above
+  Enterprise. Use "Enterprise plan" (singular) instead.
+- For Enterprise-only features that require an additional purchase, use
+  "Available as an add-on on the [Enterprise plan]".
+
 # Infrastructure Naming
 
 Infrastructure options are a separate, orthogonal concept from deployment types.

--- a/docs-mintlify/admin/account-billing/budgets.mdx
+++ b/docs-mintlify/admin/account-billing/budgets.mdx
@@ -7,11 +7,11 @@ As an account administrator, you can define rules which trigger notifications
 when your account's usage exceeds a certain threshold. These rules are called
 "budgets".
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <video width="100%" controls>
   <source

--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -125,7 +125,7 @@ requests through [APIs & integrations][ref-apis] under the following tiers:
 
 You can upgrade to a chosen tier in the
 **Settings** of your deployment.
-Upgrading to the M tier is only available on [Enterprise and above][cube-pricing] product tiers.
+Upgrading to the M tier is only available on the [Enterprise][cube-pricing] product tier.
 
 ### Cube Store Worker tiers
 

--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -103,7 +103,7 @@ account_:
 
 | Resource type | CCUs per hour | Notes |
 | --- | :---: | --- |
-| [Dedicated infrastructure][ref-dedicated-infra] | 3 | — |
+| [Single-tenant infrastructure][ref-dedicated-infra] | 3 | — |
 | [Audit Log][ref-audit-log] | <nobr>4..6</nobr> | Depends on the [chosen tier](#audit-log-tiers) |
 
 The following resource types incur cost and apply to the _whole Cube Cloud account_:
@@ -207,7 +207,7 @@ increase it to continue using AI features.
 The following examples provide insight into the total cost to use Cube Cloud:
 - [Small-scale deployment](#small-scale-deployment) (Dedicated deployment, Premium product tier, S deployment tier).
 - [Medium-scale deployment](#medium-scale-deployment) (Dedicated deployment with auto-scaling, Enterprise product tier, S deployment tier).
-- [Large-scale deployment](#large-scale-deployment) (Multi-cluster deployment with dedicated infrastructure, Enterprise product tier, M deployment tier).
+- [Large-scale deployment](#large-scale-deployment) (Multi-cluster deployment with single-tenant infrastructure, Enterprise product tier, M deployment tier).
 
 ### Small-scale deployment
 
@@ -267,7 +267,7 @@ its globally distributed workforce, customer base, and (or) partners to operate 
 
 This organization:
 * Uses the Enterprise product tier of Cube Cloud.
-* Uses [dedicated infrastructure][ref-dedicated-infra].
+* Uses [single-tenant infrastructure][ref-dedicated-infra].
 * Runs a Multi-cluster deployment that is active 24/7, includes 3 Dedicated deployments (M tier), with each
 Dedicated deployment auto-scaling up to 10 API instances during a few peak hours every day.
 * Operates on a large volume of data that requires the usage of 16 Cube Store Workers to run
@@ -280,7 +280,7 @@ of data engineers.
 
 | Resource                                       | Usage per month                                                                                | CCU per month                                         |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| Dedicated infrastructure                       | 1 region ×<br/>24 hours per day ×<br/>30 days                                                  | 720 hours ×<br/>3 CCUs per hour =<br/>**2160 CCUs**   |
+| Single-tenant infrastructure                   | 1 region ×<br/>24 hours per day ×<br/>30 days                                                  | 720 hours ×<br/>3 CCUs per hour =<br/>**2160 CCUs**   |
 | Multi-cluster deployment                       | 3 Dedicated deployments ×<br/>24 hours per day ×<br/>30 days                                   | 2160 hours ×<br/>8 CCUs per hour =<br/>**17280 CCUs** |
 | Additional Cube API Instance                   | 3 Dedicated deployments ×<br/>(10 – 2) API Instances ×<br/>4 hours per day ×<br/>30 days       | 2880 hours ×<br/>2 CCU per hour =<br/>**5760 CCUs**   |
 | Cube Store Worker                              | 1 Multi-cluster deployment ×<br/>16 Cube Store Workers ×<br/>12 hours per day ×<br/>30 days    | 5760 hours ×<br/>1 CCU per hour =<br/>**5760 CCUs**   |

--- a/docs-mintlify/admin/ai/bring-your-own-model.mdx
+++ b/docs-mintlify/admin/ai/bring-your-own-model.mdx
@@ -4,11 +4,11 @@ sidebarTitle: Bring Your Own Model
 description: Configure custom LLM providers for AI agents in Cube, including supported providers, setup, and billing implications.
 ---
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Bring Your Own Model (BYOM) lets you connect your own LLM provider to power
 AI agents in Cube, instead of using the built-in models. This gives you full

--- a/docs-mintlify/admin/ai/memory-isolation.mdx
+++ b/docs-mintlify/admin/ai/memory-isolation.mdx
@@ -27,7 +27,7 @@ Even when using the SQL API or custom views, hidden members and non-public entit
 
 ### Optional Infrastructure Isolation
 
-Many customers run in shared multi-tenant regions, but dedicated infrastructure and BYOC (Bring Your Own Cloud) variants are available. These provide stronger blast-radius isolation at the cluster, storage, and key-management levels.
+Many customers run in multi-tenant regions, but single-tenant infrastructure and BYOC (Bring Your Own Cloud) variants are available. These provide stronger blast-radius isolation at the cluster, storage, and key-management levels.
 
 ## Practical Implications
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
@@ -66,7 +66,7 @@ the required fields:
 </Frame>
 
 Cube Cloud also supports connecting to data sources within private VPCs
-if [dedicated infrastructure][ref-dedicated-infra] is used. Check out the
+if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 [VPC connectivity guide][ref-cloud-conf-vpc] for details.
 
 [ref-dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/connect-to-data/data-sources/aws-redshift.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/aws-redshift.mdx
@@ -89,7 +89,7 @@ The following fields are required when creating an AWS Redshift connection:
 </Frame>
 
 Cube Cloud also supports connecting to data sources within private VPCs
-if [dedicated infrastructure][ref-dedicated-infra] is used. Check out the
+if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 [VPC connectivity guide][ref-cloud-conf-vpc] for details.
 
 [ref-dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/connect-to-data/data-sources/google-bigquery.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/google-bigquery.mdx
@@ -60,7 +60,7 @@ The following fields are required when creating a BigQuery connection:
 </Frame>
 
 Cube Cloud also supports connecting to data sources within private VPCs
-if [dedicated infrastructure][ref-dedicated-infra] is used. Check out the
+if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 [VPC connectivity guide][ref-cloud-conf-vpc] for details.
 
 [ref-dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/connect-to-data/data-sources/ksqldb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/ksqldb.mdx
@@ -6,12 +6,12 @@ description: ksqlDB is a purpose-built database for stream processing applicatio
 [ksqlDB](https://ksqldb.io) is a purpose-built database for stream processing
 applications, ingesting data from [Apache Kafka](https://kafka.apache.org).
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
-</Info>
+</Note>
 
 See how you can use ksqlDB and Cube Cloud to power real-time analytics in Power BI:
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/ms-fabric.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/ms-fabric.mdx
@@ -7,12 +7,12 @@ description: "Microsoft Fabric is an all-in-one analytics solution for enterpris
 enterprises. It offers a comprehensive suite of services, including a
 data warehouse.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
-</Info>
+</Note>
 
 ## Setup
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/singlestore.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/singlestore.mdx
@@ -6,12 +6,12 @@ description: "SingleStore is a distributed SQL database that offers high-through
 [SingleStore][link-singlestore] is a distributed SQL database that offers
 high-throughput transactions (inserts and upserts) and low-latency analytics.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
-</Info>
+</Note>
 
 ## Setup
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
@@ -64,7 +64,7 @@ The following fields are required when creating a Snowflake connection:
 </Frame>
 
 Cube Cloud also supports connecting to data sources within private VPCs
-if [dedicated infrastructure][ref-dedicated-infra] is used. Check out the
+if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 [VPC connectivity guide][ref-cloud-conf-vpc] for details.
 
 [ref-dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/index.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/index.mdx
@@ -17,33 +17,33 @@ page, please [file an issue](https://github.com/cube-js/cube/issues) on GitHub.
 ## BI & data exploration
 
 <CardGroup cols={2}>
-  <Card title="Amazon QuickSight" img="https://static.cube.dev/icons/quicksight.svg" href="visualization-tools/quicksight">
+  <Card title="Amazon QuickSight" img="https://static.cube.dev/icons/quicksight.svg" href="/admin/connect-to-data/visualization-tools/quicksight">
   </Card>
-  <Card title="Apache Superset" img="https://static.cube.dev/icons/superset.svg" href="visualization-tools/superset">
+  <Card title="Apache Superset" img="https://static.cube.dev/icons/superset.svg" href="/admin/connect-to-data/visualization-tools/superset">
   </Card>
-  <Card title="Hashboard" img="https://static.cube.dev/icons/hashboard.svg" href="visualization-tools/hashboard">
+  <Card title="Hashboard" img="https://static.cube.dev/icons/hashboard.svg" href="/admin/connect-to-data/visualization-tools/hashboard">
   </Card>
-  <Card title="Klipfolio" img="https://static.cube.dev/icons/klipfolio-light.svg" href="visualization-tools/klipfolio">
+  <Card title="Klipfolio" img="https://static.cube.dev/icons/klipfolio-light.svg" href="/admin/connect-to-data/visualization-tools/klipfolio">
   </Card>
-  <Card title="Looker Studio" img="https://static.cube.dev/icons/looker.svg" href="visualization-tools/looker-studio">
+  <Card title="Looker Studio" img="https://static.cube.dev/icons/looker.svg" href="/admin/connect-to-data/visualization-tools/looker-studio">
   </Card>
-  <Card title="Metabase" img="https://static.cube.dev/icons/metabase.svg" href="visualization-tools/metabase">
+  <Card title="Metabase" img="https://static.cube.dev/icons/metabase.svg" href="/admin/connect-to-data/visualization-tools/metabase">
   </Card>
-  <Card title="Microsoft Power BI" img="https://static.cube.dev/icons/power-bi-dark.svg" href="visualization-tools/powerbi">
+  <Card title="Microsoft Power BI" img="https://static.cube.dev/icons/power-bi-dark.svg" href="/admin/connect-to-data/visualization-tools/powerbi">
   </Card>
-  <Card title="Preset" img="https://static.cube.dev/icons/preset.svg" href="visualization-tools/superset">
+  <Card title="Preset" img="https://static.cube.dev/icons/preset.svg" href="/admin/connect-to-data/visualization-tools/superset">
   </Card>
-  <Card title="Push.ai" img="https://static.cube.dev/icons/push-ai-light.svg" href="visualization-tools/push-ai">
+  <Card title="Push.ai" img="https://static.cube.dev/icons/push-ai-light.svg" href="/admin/connect-to-data/visualization-tools/push-ai">
   </Card>
-  <Card title="Qlik Sense" img="https://static.cube.dev/icons/qlik-sense.svg" href="visualization-tools/qlik-sense">
+  <Card title="Qlik Sense" img="https://static.cube.dev/icons/qlik-sense.svg" href="/admin/connect-to-data/visualization-tools/qlik-sense">
   </Card>
-  <Card title="Sigma" img="https://static.cube.dev/icons/sigma.svg" href="visualization-tools/sigma">
+  <Card title="Sigma" img="https://static.cube.dev/icons/sigma.svg" href="/admin/connect-to-data/visualization-tools/sigma">
   </Card>
-  <Card title="Steep" img="https://static.cube.dev/icons/steep-light.svg" href="visualization-tools/steep">
+  <Card title="Steep" img="https://static.cube.dev/icons/steep-light.svg" href="/admin/connect-to-data/visualization-tools/steep">
   </Card>
-  <Card title="Tableau" img="https://static.cube.dev/icons/tableau.svg" href="visualization-tools/tableau">
+  <Card title="Tableau" img="https://static.cube.dev/icons/tableau.svg" href="/admin/connect-to-data/visualization-tools/tableau">
   </Card>
-  <Card title="ThoughtSpot" img="https://static.cube.dev/icons/thoughtspot.svg" href="visualization-tools/thoughtspot">
+  <Card title="ThoughtSpot" img="https://static.cube.dev/icons/thoughtspot.svg" href="/admin/connect-to-data/visualization-tools/thoughtspot">
   </Card>
 </CardGroup>
 
@@ -53,40 +53,40 @@ API](/reference/sql-api).
 ## Spreadsheets
 
 <CardGroup cols={2}>
-  <Card title="Google Sheets" img="https://static.cube.dev/icons/google-sheets.svg" href="visualization-tools/google-sheets">
+  <Card title="Google Sheets" img="https://static.cube.dev/icons/google-sheets.svg" href="/admin/connect-to-data/visualization-tools/google-sheets">
   </Card>
-  <Card title="Microsoft Excel" img="https://static.cube.dev/icons/excel.svg" href="visualization-tools/excel">
+  <Card title="Microsoft Excel" img="https://static.cube.dev/icons/excel.svg" href="/admin/connect-to-data/visualization-tools/excel">
   </Card>
 </CardGroup>
 
 ## Notebooks
 
 <CardGroup cols={2}>
-  <Card title="Deepnote" img="https://static.cube.dev/icons/deepnote.svg" href="visualization-tools/deepnote">
+  <Card title="Deepnote" img="https://static.cube.dev/icons/deepnote.svg" href="/admin/connect-to-data/visualization-tools/deepnote">
   </Card>
-  <Card title="Hex" img="https://static.cube.dev/icons/hex.svg" href="visualization-tools/hex">
+  <Card title="Hex" img="https://static.cube.dev/icons/hex.svg" href="/admin/connect-to-data/visualization-tools/hex">
   </Card>
-  <Card title="Jupyter" img="https://static.cube.dev/icons/jupyter.svg" href="visualization-tools/jupyter">
+  <Card title="Jupyter" img="https://static.cube.dev/icons/jupyter.svg" href="/admin/connect-to-data/visualization-tools/jupyter">
   </Card>
-  <Card title="Observable" img="https://static.cube.dev/icons/observable.svg" href="visualization-tools/observable">
+  <Card title="Observable" img="https://static.cube.dev/icons/observable.svg" href="/admin/connect-to-data/visualization-tools/observable">
   </Card>
-  <Card title="Streamlit" img="https://static.cube.dev/icons/streamlit.svg" href="visualization-tools/streamlit">
+  <Card title="Streamlit" img="https://static.cube.dev/icons/streamlit.svg" href="/admin/connect-to-data/visualization-tools/streamlit">
   </Card>
 </CardGroup>
 
 ## Customer data platforms
 
 <CardGroup cols={2}>
-  <Card title="Hightouch" img="https://static.cube.dev/icons/hightouch-dark.svg" href="visualization-tools/hightouch">
+  <Card title="Hightouch" img="https://static.cube.dev/icons/hightouch-dark.svg" href="/admin/connect-to-data/visualization-tools/hightouch">
   </Card>
-  <Card title="RudderStack" img="https://static.cube.dev/icons/rudderstack.svg" href="visualization-tools/rudderstack">
+  <Card title="RudderStack" img="https://static.cube.dev/icons/rudderstack.svg" href="/admin/connect-to-data/visualization-tools/rudderstack">
   </Card>
 </CardGroup>
 
 ## Data governance
 
 <CardGroup cols={2}>
-  <Card title="Databricks Unity Catalog" img="https://static.cube.dev/icons/databricks.svg" href="visualization-tools/unity-catalog">
+  <Card title="Databricks Unity Catalog" img="https://static.cube.dev/icons/databricks.svg" href="/admin/connect-to-data/visualization-tools/unity-catalog">
   </Card>
 </CardGroup>
 
@@ -96,20 +96,20 @@ The following tools deliver data insights closer to end users, e.g., by
 providing a conversational interface for semantic layer:
 
 <CardGroup cols={2}>
-  <Card title="LangChain" img="https://static.cube.dev/icons/langchain.svg" href="visualization-tools/langchain">
+  <Card title="LangChain" img="https://static.cube.dev/icons/langchain.svg" href="/admin/connect-to-data/visualization-tools/langchain">
   </Card>
 </CardGroup>
 
 ## Low-code tools
 
 <CardGroup cols={2}>
-  <Card title="Appsmith" img="https://static.cube.dev/icons/appsmith.svg" href="visualization-tools/appsmith">
+  <Card title="Appsmith" img="https://static.cube.dev/icons/appsmith.svg" href="/admin/connect-to-data/visualization-tools/appsmith">
   </Card>
-  <Card title="Bubble" img="https://static.cube.dev/icons/bubble.svg" href="visualization-tools/bubble">
+  <Card title="Bubble" img="https://static.cube.dev/icons/bubble.svg" href="/admin/connect-to-data/visualization-tools/bubble">
   </Card>
-  <Card title="Budibase" img="https://static.cube.dev/icons/budibase.svg" href="visualization-tools/budibase">
+  <Card title="Budibase" img="https://static.cube.dev/icons/budibase.svg" href="/admin/connect-to-data/visualization-tools/budibase">
   </Card>
-  <Card title="Retool" img="https://static.cube.dev/icons/retool.svg" href="visualization-tools/retool">
+  <Card title="Retool" img="https://static.cube.dev/icons/retool.svg" href="/admin/connect-to-data/visualization-tools/retool">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -4,11 +4,11 @@ description: Available on Starter and above plans.
 hidden: true
 ---
 
-<Info>
+<Note>
 
 Available on [Starter and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Cube Cloud can automatically suspend deployments when not in use to reduce
 [resource consumption][ref-deployment-pricing], which helps manage your spend.

--- a/docs-mintlify/admin/deployment/byoc/aws/index.mdx
+++ b/docs-mintlify/admin/deployment/byoc/aws/index.mdx
@@ -9,12 +9,12 @@ sidebarTitle: AWS
 With Bring Your Own Cloud (BYOC) on AWS, all the components interacting with private data are deployed on
 the customer infrastructure on AWS and managed by the Cube Cloud Control Plane via the Cube Cloud Operator.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
-</Info>
+</Note>
 
 Learn about [deploying BYOC on AWS][deployment] or setting up [private connectivity][privatelink].
 

--- a/docs-mintlify/admin/deployment/byoc/aws/privatelink.mdx
+++ b/docs-mintlify/admin/deployment/byoc/aws/privatelink.mdx
@@ -6,12 +6,12 @@ description: Private HTTP and SQL API access for AWS BYOC via VPC PrivateLink se
 
 Cube Cloud BYOC deployments on AWS support private connectivity for Cube API endpoints using AWS PrivateLink. This enables secure, private access to your Cube deployment without exposing endpoints to the public internet.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing) with BYOC deployments.
 [Contact us](https://cube.dev/contact) for details.
 
-</Info>
+</Note>
 
 ## Overview
 

--- a/docs-mintlify/admin/deployment/byoc/index.mdx
+++ b/docs-mintlify/admin/deployment/byoc/index.mdx
@@ -9,12 +9,12 @@ This guide outlines the Bring Your Own Cloud (BYOC) deployment configuration for
 With BYOC, all the components interacting with private data are deployed on the customer infrastructure 
 on a platform of choice (AWS/Azure/GCP) and managed by the Cube Cloud Control Plane via the Cube Cloud Operator.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
-</Info>
+</Note>
 
 Cube Cloud supports BYOC on AWS, GCP, and Azure. Below, you can find documentation for AWS. Reach out to your account team for Azure or GCP BYOC documentation.
 

--- a/docs-mintlify/admin/deployment/byoc/index.mdx
+++ b/docs-mintlify/admin/deployment/byoc/index.mdx
@@ -19,9 +19,9 @@ Available on the [Enterprise plan](https://cube.dev/pricing).
 Cube Cloud supports BYOC on AWS, GCP, and Azure. Below, you can find documentation for AWS. Reach out to your account team for Azure or GCP BYOC documentation.
 
 <CardGroup cols={2}>
-  <Card title="Amazon Web Services" img="https://static.cube.dev/icons/aws.svg" href="byoc/aws">
+  <Card title="Amazon Web Services" img="https://static.cube.dev/icons/aws.svg" href="/admin/deployment/byoc/aws">
   </Card>
-  <Card title="Microsoft Azure" img="https://static.cube.dev/icons/azure.svg" href="byoc/azure">
+  <Card title="Microsoft Azure" img="https://static.cube.dev/icons/azure.svg" href="/admin/deployment/byoc/azure">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/deployment/custom-domains.mdx
+++ b/docs-mintlify/admin/deployment/custom-domains.mdx
@@ -7,11 +7,11 @@ By default, Cube Cloud deployments and their API endpoints use auto-generated
 anonymized domain names, e.g., `emerald-llama.gcp-us-central1.cubecloudapp.dev`.
 You can also assign a custom domain to your deployment.
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 To set up a custom domain, go to your deployment's settings page. Under
 the **Custom Domain** section, type in your custom domain and

--- a/docs-mintlify/admin/deployment/deployment-types.mdx
+++ b/docs-mintlify/admin/deployment/deployment-types.mdx
@@ -29,10 +29,10 @@ for you exclusively.
 
 <Note>
 
-If your account uses [dedicated infrastructure][ref-dedicated-infra], Shared
-deployments are only shared with your other deployments on that infrastructure
-— never with other customers. Your environment remains fully isolated at the
-infrastructure level.
+If your account uses [single-tenant infrastructure][ref-dedicated-infra],
+Shared deployments are only shared with your other deployments on that
+infrastructure — never with other customers. Your environment remains fully
+isolated at the infrastructure level.
 
 </Note>
 
@@ -71,9 +71,9 @@ giving you predictable performance and full control over capacity.
 Dedicated deployments are designed to support high-availability production
 workloads. It consists of several key components, including starting with 2 Cube
 API instances, 1 Cube Refresh Worker and 2 Cube Store Routers - all of which run
-on dedicated infrastructure. The deployment can automatically scale to meet the
-needs of your workload by adding more components as necessary; check the page on
-[scalability][ref-scalability] to learn more.
+on compute dedicated to your deployment. The deployment can automatically scale
+to meet the needs of your workload by adding more components as necessary;
+check the page on [scalability][ref-scalability] to learn more.
 
 ## Multi-cluster {#multi-cluster}
 

--- a/docs-mintlify/admin/deployment/deployment-types.mdx
+++ b/docs-mintlify/admin/deployment/deployment-types.mdx
@@ -14,13 +14,13 @@ Runs on multiple Dedicated deployments.
 
 ## Shared {#shared}
 
-<Info>
+<Note>
 
 Available for free, no credit card required. Your free trial is limited to 2
 Shared deployments and only 1,000 queries per day. Upgrade to
 [any paid plan](https://cube.dev/pricing) to unlock all features.
 
-</Info>
+</Note>
 
 
 Shared deployments run on compute shared with other deployments within the
@@ -58,11 +58,11 @@ You can try a Shared deployment by
 
 ## Dedicated {#dedicated}
 
-<Info>
+<Note>
 
 Available on [all paid plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 
 Dedicated deployments run on compute dedicated exclusively to your deployment,
@@ -81,11 +81,11 @@ Multi-cluster deployments are designed for demanding production workloads,
 high-scalability, high-availability, and large [multi-tenancy][ref-multitenancy]
 configurations, e.g., with more than 100 tenants.
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 It provides you with two options:
 * Scale the number of [Dedicated](#dedicated) deployments serving your

--- a/docs-mintlify/admin/deployment/encryption-keys.mdx
+++ b/docs-mintlify/admin/deployment/encryption-keys.mdx
@@ -3,12 +3,12 @@ title: Encryption keys
 description: "The Encryption Keys page in Cube Cloud allows to manage data-at-rest encryption in Cube Store."
 ---
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 Also requires the M [Cube Store Worker tier](/admin/account-billing/pricing#cube-store-worker-tiers).
 
-</Info>
+</Note>
  
 Navigate to **Settings → Encryption Keys** in your Cube Cloud deployment
 to [provide](#add-a-key), [rotate](#rotate-a-key), or [drop](#drop-a-key)

--- a/docs-mintlify/admin/deployment/environments.mdx
+++ b/docs-mintlify/admin/deployment/environments.mdx
@@ -1,6 +1,7 @@
 ---
-title: Environments
-description: Outlines production, staging, and per-developer environments and how they differ inside one Cube Cloud deployment.
+title: Deployment environments
+sidebarTitle: Deployment environments
+description: Outlines production, staging, and per-developer environments and how they differ inside one Cube deployment.
 ---
 
 Every Cube Cloud deployment provides a number of environments:

--- a/docs-mintlify/admin/deployment/environments.mdx
+++ b/docs-mintlify/admin/deployment/environments.mdx
@@ -8,11 +8,11 @@ Every Cube Cloud deployment provides a number of environments:
 - Multiple [staging environments](#staging-environments).
 - Per-user [development environments](#development-environments).
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Production environment
 

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -3,25 +3,25 @@ title: Infrastructure Options
 description: "Cube Cloud provides four infrastructure options to host your Cube deployments:"
 ---
 
-* [Shared infrastructure](#shared-infrastructure) - your
-deployments are sharing compute resources and network with other customers.
+* [Multi-tenant infrastructure](#shared-infrastructure) - your
+deployments share compute resources and network with other customers.
 Data in-motion and data at-rest are both on the Cube Cloud side.
-* [Dedicated infrastructure](#dedicated-infrastructure) - your
+* [Single-tenant infrastructure](#dedicated-infrastructure) - your
 deployments reside in a dedicated VPC inside a Cube Cloud account and do not
 share resources with anyone else. Data in-motion and data at-rest are both on
 the Cube Cloud side.
-* [Dedicated infrastructure with CSPS](#dedicated-infrastructure-with-csps) -
-same as dedicated infrastructure, but data at-rest is stored in a customer-supplied
+* [Single-tenant infrastructure with CSPS](#dedicated-infrastructure-with-csps) -
+same as single-tenant infrastructure, but data at-rest is stored in a customer-supplied
 object store.
 * [Bring Your Own Cloud (BYOC)](#byoc) - Cube Cloud data plane is fully hosted
 in your cloud account.
 
 
-## Shared infrastructure
+## Multi-tenant infrastructure {#shared-infrastructure}
 
 This is the most common deployment option that is the easiest to get started with.
 In this scenario, everything is deployed on the Cube Cloud infrastructure in
-one of our **shared** VPCs. Cube Cloud Control Plane takes care of creating,
+one of our **multi-tenant** VPCs. Cube Cloud Control Plane takes care of creating,
 scaling, and monitoring your Cube Deployments, as well as managing Cube Store
 and persisting pre-aggregated data. This option requires the least effort to
 set up.
@@ -33,19 +33,19 @@ Available on [all plans](https://cube.dev/pricing).
 </Info>
 
 Please note that some Enterprise features, such as VPC peering or PrivateLink are
-not available on the shared infrastructure. There's also a possibility of resource
-contention ("noisy neighbor") problem.
+not available on the multi-tenant infrastructure. There's also a possibility of
+resource contention ("noisy neighbor") problem.
 
 <div style={{ textAlign: "center" }}>
   <img
-    alt="High-level diagram of the fully managed Cube Cloud Infrastructure option (shared)"
+    alt="High-level diagram of the fully managed Cube Cloud Infrastructure option (multi-tenant)"
     src="https://ucarecdn.com/35329e6b-3829-44dd-85c1-25250a8c9461/"
     style={{ border: "none" }}
     width="100%"
   />
 </div>
 
-## Dedicated infrastructure
+## Single-tenant infrastructure {#dedicated-infrastructure}
 
 It is similar to the previous option, but each customer gets a
 [Dedicated][ref-dedicated-vpc] VPC within one of Cube Cloud's own cloud
@@ -61,14 +61,14 @@ Available on [Enterprise and above plans](https://cube.dev/pricing).
 
 <div style={{ textAlign: "center" }}>
   <img
-    alt="High-level diagram of the fully managed Cube Cloud Infrastructure option (dedicated)"
+    alt="High-level diagram of the fully managed Cube Cloud Infrastructure option (single-tenant)"
     src="https://ucarecdn.com/2cc55ee4-5598-41ce-a15a-69ca683e8412/"
     style={{ border: "none" }}
     width="100%"
   />
 </div>
 
-## Dedicated infrastructure with CSPS
+## Single-tenant infrastructure with CSPS {#dedicated-infrastructure-with-csps}
 
 Cube Cloud offers a **customer-supplied pre-aggregation storage (CSPS)** that
 allows moving all data at rest to the customer
@@ -124,16 +124,16 @@ A **Cube Cloud Region** refers to a specific cloud infrastructure instance used 
 Each Cube Cloud Region is identified by a unique identifier that contains several components:
 - **Cloud provider** (AWS, GCP, or Azure)
 - **Geographical region** (e.g., us-east-1, eu-west-1)
-- **Infrastructure type** (shared, dedicated, or BYOC)
-- **Tenant identifier** (for dedicated infrastructure)
+- **Infrastructure type** (`shared`, `dedicated`, or `byoc` — corresponding to multi-tenant, single-tenant, and BYOC infrastructure, respectively)
+- **Tenant identifier** (for single-tenant infrastructure)
 - **Environment** (e.g., prod, staging)
 
 For example, a region identifier might look like:
-- `aws-us-east-1-shared` for shared infrastructure in AWS US East
-- `aws-us-east-1-t-12345-prod` for dedicated infrastructure with tenant ID 12345
+- `aws-us-east-1-shared` for multi-tenant infrastructure in AWS US East
+- `aws-us-east-1-t-12345-prod` for single-tenant infrastructure with tenant ID 12345
 - `gcp-europe-west1-t-12345-byoc` for a BYOC deployment in GCP Europe
 
-Each region also has a human-readable display name that's visible in the Cube Cloud UI. For dedicated infrastructure regions, these display names typically include the customer name and/or environment name (e.g., "Acme Corp Production (N. Virginia)" or "Acme Corp Staging (Iowa)") to help distinguish between different infrastructure instances.
+Each region also has a human-readable display name that's visible in the Cube Cloud UI. For single-tenant infrastructure regions, these display names typically include the customer name and/or environment name (e.g., "Acme Corp Production (N. Virginia)" or "Acme Corp Staging (Iowa)") to help distinguish between different infrastructure instances.
 
 <Frame>
   <img src="https://lgo0ecceic.ucarecd.net/01212311-b1c5-48ce-80a2-06a923fe4eac/" />
@@ -154,7 +154,7 @@ Understanding your Cube Cloud Region is important for:
 1. **API endpoints**: Your deployment's API endpoints include the region identifier (e.g., `<deployment-id>.<region>.cubecloudapp.dev`)
 2. **Network configuration**: When setting up VPC peering, PrivateLink, or custom domains, you'll need the exact region identifier
 3. **Support requests**: Providing the correct region identifier helps Cube support team quickly locate and assist with your deployment
-4. **Infrastructure planning**: Different region types offer different capabilities (e.g., PrivateLink is only available in dedicated and BYOC regions)
+4. **Infrastructure planning**: Different region types offer different capabilities (e.g., PrivateLink is only available in single-tenant and BYOC regions)
 
 ### Finding your region identifier
 

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -125,7 +125,7 @@ A **Cube Cloud Region** refers to a specific cloud infrastructure instance used 
 Each Cube Cloud Region is identified by a unique identifier that contains several components:
 - **Cloud provider** (AWS, GCP, or Azure)
 - **Geographical region** (e.g., us-east-1, eu-west-1)
-- **Infrastructure type** (`shared`, `dedicated`, or `byoc` — corresponding to multi-tenant, single-tenant, and BYOC infrastructure, respectively)
+- **Infrastructure type** (multi-tenant, single-tenant, or BYOC)
 - **Tenant identifier** (for single-tenant infrastructure)
 - **Environment** (e.g., prod, staging)
 

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -100,7 +100,7 @@ on a platform of choice (AWS/Azure/GCP) and managed by the Cube Cloud Control Pl
 
 <Info>
 
-Available on the [Enterprise plan](https://cube.dev/pricing).
+Available as an add-on on the [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -55,7 +55,7 @@ performance, as well as additional security and isolation.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available as an add-on on the [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -79,7 +79,8 @@ processing highly critical business or personal information.
 
 <Info>
 
-Available on the [Enterprise plan](https://cube.dev/pricing).
+Available on the [Enterprise plan](https://cube.dev/pricing) with the
+[Single-tenant infrastructure](#dedicated-infrastructure) add-on.
 
 </Info>
 

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -26,11 +26,11 @@ scaling, and monitoring your Cube Deployments, as well as managing Cube Store
 and persisting pre-aggregated data. This option requires the least effort to
 set up.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Please note that some Enterprise features, such as VPC peering or PrivateLink are
 not available on the multi-tenant infrastructure. There's also a possibility of
@@ -53,11 +53,11 @@ accounts that hosts only that customer's deployments. This option is great for
 most of the typical Enterprise use-cases as it provides a higher level of
 performance, as well as additional security and isolation.
 
-<Info>
+<Note>
 
 Available as an add-on on the [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <div style={{ textAlign: "center" }}>
   <img
@@ -77,12 +77,12 @@ side. However, Cube Store uses a customer-provided object store for reading and
 persisting pre-aggregated data. This provides additional peace of mind when
 processing highly critical business or personal information.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing) with the
 [Single-tenant infrastructure](#dedicated-infrastructure) add-on.
 
-</Info>
+</Note>
 
 
 <div style={{ textAlign: "center" }}>
@@ -99,11 +99,11 @@ Available on the [Enterprise plan](https://cube.dev/pricing) with the
 With [Bring Your Own Cloud](/docs/deployment/cloud/byoc) (BYOC) all the components interacting with private data are deployed on the customer infrastructure
 on a platform of choice (AWS/Azure/GCP) and managed by the Cube Cloud Control Plane via the Cube Cloud Operator.
 
-<Info>
+<Note>
 
 Available as an add-on on the [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <div style={{ textAlign: "center" }}>
   <img

--- a/docs-mintlify/admin/deployment/providers/index.mdx
+++ b/docs-mintlify/admin/deployment/providers/index.mdx
@@ -14,7 +14,7 @@ Cube Cloud works with all three major cloud providers:
 <Info>
 
 AWS and GCP are available on [all plans](https://cube.dev/pricing).
-Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/admin/deployment/providers/index.mdx
+++ b/docs-mintlify/admin/deployment/providers/index.mdx
@@ -31,11 +31,11 @@ your choice and use [VPC peering][ref-vpc].
 See provider-specific pages for a list of services Cube Cloud integrates with.
 
 <CardGroup cols={2}>
-  <Card title="Amazon Web Services" img="https://static.cube.dev/icons/aws.svg" href="providers/aws">
+  <Card title="Amazon Web Services" img="https://static.cube.dev/icons/aws.svg" href="/admin/deployment/providers/aws">
   </Card>
-  <Card title="Google Cloud Platform" img="https://static.cube.dev/icons/google-cloud.svg" href="providers/gcp">
+  <Card title="Google Cloud Platform" img="https://static.cube.dev/icons/google-cloud.svg" href="/admin/deployment/providers/gcp">
   </Card>
-  <Card title="Microsoft Azure" img="https://static.cube.dev/icons/azure.svg" href="providers/azure">
+  <Card title="Microsoft Azure" img="https://static.cube.dev/icons/azure.svg" href="/admin/deployment/providers/azure">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/deployment/providers/index.mdx
+++ b/docs-mintlify/admin/deployment/providers/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cloud Providers
-description: Learn about AWS, GCP, and Azure support in Cube Cloud, including available regions and dedicated infrastructure.
+description: Learn about AWS, GCP, and Azure support in Cube Cloud, including available regions and single-tenant infrastructure.
 ---
 
  Cloud providers in Cube Cloud
@@ -23,7 +23,7 @@ Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
 
 You can create [deployments][ref-deployments] in any available shared region of any provider.
 
-You can also use [dedicated infrastructure][ref-dedicated-infra] in a region of
+You can also use [single-tenant infrastructure][ref-dedicated-infra] in a region of
 your choice and use [VPC peering][ref-vpc].
 
 ## Services

--- a/docs-mintlify/admin/deployment/vpc/aws/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/aws/index.mdx
@@ -5,7 +5,7 @@ description: Establish a private network connection between Cube Cloud and your 
 
  Connecting with a VPC on AWS
 
-[Dedicated infrastructure][dedicated-infrastructure] in Cube Cloud comes with
+[Single-tenant infrastructure][dedicated-infrastructure] in Cube Cloud comes with
 an option of setting up a direct network connection between
 an AWS VPC on the Cube Cloud side and your own VPC(s). Such a connection allows you to
 access internal datasources without the need to expose any ports publicly.

--- a/docs-mintlify/admin/deployment/vpc/aws/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/aws/index.mdx
@@ -15,6 +15,6 @@ On AWS, Cube Cloud supports two main ways of establishing a private network conn
 - [AWS PrivateLink][aws-private-link]
 - [VPC Peering][aws-vpc-peering]
 
-[dedicated-infrastructure]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[dedicated-infrastructure]: /admin/deployment/infrastructure#dedicated-infrastructure
 [aws-private-link]: /docs/deployment/cloud/vpc/aws/private-link
 [aws-vpc-peering]: /docs/deployment/cloud/vpc/aws/vpc-peering

--- a/docs-mintlify/admin/deployment/vpc/aws/private-link.mdx
+++ b/docs-mintlify/admin/deployment/vpc/aws/private-link.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connecting to your VPC using AWS PrivateLink
 sidebarTitle: AWS PrivateLink
-description: How to expose an AWS endpoint service and coordinate PrivateLink so Cube dedicated infrastructure reaches your VPC privately.
+description: How to expose an AWS endpoint service and coordinate PrivateLink so Cube single-tenant infrastructure reaches your VPC privately.
 ---
 
 [AWS PrivateLink][aws-docs-private-link] provides private connectivity between virtual private clouds (VPCs), supported services and resources, and your on-premises networks, without exposing your traffic to the public internet.
@@ -36,8 +36,8 @@ To request establishing a PrivateLink connection, please share the following inf
 - **Ports**: a list of ports that will be accessed through this connection
 - **DNS Name** (optional): an internal DNS name of the upstream service in case SSL needs to be supported
 - **Dedicated Infrastructure Region:** VPC Peering requires Cube to be hosted in
-    [dedicated infrastructure][dedicated-infra]. Please specify what region the Cube Cloud
-    dedicated infrastructure should be hosted in.
+    [single-tenant infrastructure][dedicated-infra]. Please specify what region the Cube Cloud
+    single-tenant infrastructure should be hosted in.
 
 
 If a DNS name is provided, an internal DNS record will be created pointing at the established PrivateLink

--- a/docs-mintlify/admin/deployment/vpc/aws/private-link.mdx
+++ b/docs-mintlify/admin/deployment/vpc/aws/private-link.mdx
@@ -56,4 +56,4 @@ supplied DNS Name or an AWS internal DNS name returned to you by the Cube team.
 
 [aws-docs-private-link]: https://aws.amazon.com/privatelink/
 [aws-docs-endpoint-service]: https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html
-[dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/deployment/vpc/aws/vpc-peering.mdx
+++ b/docs-mintlify/admin/deployment/vpc/aws/vpc-peering.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setting up a VPC Peering connection on AWS
-sidebarTitle: VCP Peering
+sidebarTitle: VPC Peering
 description: End-to-end checklist for VPC peering Cube Cloud single-tenant infrastructure with your AWS VPC for private data access.
 ---
 
@@ -136,7 +136,7 @@ Customer Success Manager and share with them the following:
 [aws-docs-vpc-peering]:
   https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
 [aws-docs-vpc-security-group]: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html
-[dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure
 [wiki-cidr-block]:
   https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_blocks
 

--- a/docs-mintlify/admin/deployment/vpc/aws/vpc-peering.mdx
+++ b/docs-mintlify/admin/deployment/vpc/aws/vpc-peering.mdx
@@ -1,7 +1,7 @@
 ---
 title: Setting up a VPC Peering connection on AWS
 sidebarTitle: VCP Peering
-description: End-to-end checklist for VPC peering Cube Cloud dedicated infrastructure with your AWS VPC for private data access.
+description: End-to-end checklist for VPC peering Cube Cloud single-tenant infrastructure with your AWS VPC for private data access.
 ---
 
 To set up AWS VPC Peering, you need to collect the necessary information and
@@ -23,8 +23,8 @@ information is required:
 - **AWS VPC CIDR:** The [CIDR block][wiki-cidr-block] of the VPC that Cube Cloud
   will connect to, for example, `10.0.0.0/16`
 - **Dedicated Infrastructure Region:** VPC Peering requires Cube to be hosted in 
-  [dedicated infrastructure][dedicated-infra]. Please specify what region the Cube Cloud 
-  dedicated infrastructure should be hosted in.
+  [single-tenant infrastructure][dedicated-infra]. Please specify what region the Cube Cloud
+  single-tenant infrastructure should be hosted in.
 
 ## Setup
 

--- a/docs-mintlify/admin/deployment/vpc/azure/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/azure/index.mdx
@@ -5,7 +5,7 @@ description: Establish a private network connection between Cube Cloud and your 
 
  Connecting with a VNet on Azure
 
-[Dedicated infrastructure][dedicated-infrastructure] in Cube Cloud comes with
+[Single-tenant infrastructure][dedicated-infrastructure] in Cube Cloud comes with
 an option of setting up a direct network connection between
 an Azure VNet on the Cube Cloud side and your own VNet(s). Such a connection allows you to
 access internal datasources without the need to expose any ports publicly.

--- a/docs-mintlify/admin/deployment/vpc/azure/private-link.mdx
+++ b/docs-mintlify/admin/deployment/vpc/azure/private-link.mdx
@@ -5,7 +5,7 @@ description: Configure Azure Private Link visibility and approvals so Cube singl
 ---
 
 [Azure Private Link][azure-docs-private-link] enables you to access Azure PaaS services and Azure hosted customer-owned/partner services over a private endpoint in your virtual network.
-To set up a Private Link connection between Cube Cloud Dedicated Infrastructure and your own VNet,
+To set up a Private Link connection between Cube Cloud single-tenant infrastructure and your own VNet,
 you'll need to prepare a Private Link Service,
 share service details with the Cube team, and approve the incoming connection request.
 
@@ -40,7 +40,7 @@ To request establishing a Private Link connection, please share the following in
 - **Reference Name** for the record (such as "Snowflake-prod" or "databricks-dev")
 - **Ports**: a list of ports that will be accessed through this connection
 - **DNS Name** (optional): an internal DNS name of the upstream service in case SSL needs to be supported
-- **Dedicated Infrastructure Region:** Private Link requires Cube to be hosted in
+- **Single-tenant Infrastructure Region:** Private Link requires Cube to be hosted in
     [single-tenant infrastructure][dedicated-infra]. Please specify what region the Cube Cloud
     single-tenant infrastructure should be hosted in.
 
@@ -76,4 +76,4 @@ The Private Link Service and Private Endpoint must be in the same region as the 
 
 [azure-docs-private-link]: https://docs.microsoft.com/azure/private-link/
 [azure-docs-private-link-service]: https://docs.microsoft.com/azure/private-link/create-private-link-service-portal
-[dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/deployment/vpc/azure/private-link.mdx
+++ b/docs-mintlify/admin/deployment/vpc/azure/private-link.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connecting to your VNet using Azure Private Link
 sidebarTitle: Azure Private Link
-description: Configure Azure Private Link visibility and approvals so Cube dedicated infrastructure connects to services in your VNet.
+description: Configure Azure Private Link visibility and approvals so Cube single-tenant infrastructure connects to services in your VNet.
 ---
 
 [Azure Private Link][azure-docs-private-link] enables you to access Azure PaaS services and Azure hosted customer-owned/partner services over a private endpoint in your virtual network.
@@ -41,8 +41,8 @@ To request establishing a Private Link connection, please share the following in
 - **Ports**: a list of ports that will be accessed through this connection
 - **DNS Name** (optional): an internal DNS name of the upstream service in case SSL needs to be supported
 - **Dedicated Infrastructure Region:** Private Link requires Cube to be hosted in
-    [dedicated infrastructure][dedicated-infra]. Please specify what region the Cube Cloud
-    dedicated infrastructure should be hosted in.
+    [single-tenant infrastructure][dedicated-infra]. Please specify what region the Cube Cloud
+    single-tenant infrastructure should be hosted in.
 
 If a DNS name is provided, an internal DNS record will be created pointing at the established Private Link
 connection, and the service will be addressable by that name inside the Cube Cloud infrastructure.
@@ -71,7 +71,7 @@ supplied DNS Name or an Azure internal DNS name returned to you by the Cube team
 
 ## Supported Regions
 
-Private Link connections are supported in all Azure regions where Cube Cloud dedicated infrastructure is available.
+Private Link connections are supported in all Azure regions where Cube Cloud single-tenant infrastructure is available.
 The Private Link Service and Private Endpoint must be in the same region as the Cube Cloud infrastructure.
 
 [azure-docs-private-link]: https://docs.microsoft.com/azure/private-link/

--- a/docs-mintlify/admin/deployment/vpc/azure/vpc-peering.mdx
+++ b/docs-mintlify/admin/deployment/vpc/azure/vpc-peering.mdx
@@ -86,8 +86,8 @@ information:
   →&nbsp;**Properties** →&nbsp;**Tenant ID** section of
   [Azure Portal][azure-console].
 - **Dedicated Infrastructure Region:** VPC Peering requires Cube to be hosted 
-  in [dedicated infrastructure][dedicated-infra]. Please specify what region 
-  the Cube Cloud dedicated infrastructure should be hosted in.
+  in [single-tenant infrastructure][dedicated-infra]. Please specify what region
+  the Cube Cloud single-tenant infrastructure should be hosted in.
 
 ## Supported Regions
 

--- a/docs-mintlify/admin/deployment/vpc/azure/vpc-peering.mdx
+++ b/docs-mintlify/admin/deployment/vpc/azure/vpc-peering.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connecting with a VNet on Azure
-sidebarTitle: VPC Peering
+sidebarTitle: VNet Peering
 description: For cross-tenant peering in Azure, you are supposed to assign the peering role to the service principal of the peering party.
 ---
 
@@ -85,7 +85,7 @@ information:
 - **Tenant ID:** You can find it in&nbsp;**Azure Active Directory**
   →&nbsp;**Properties** →&nbsp;**Tenant ID** section of
   [Azure Portal][azure-console].
-- **Dedicated Infrastructure Region:** VPC Peering requires Cube to be hosted 
+- **Single-tenant Infrastructure Region:** VNet Peering requires Cube to be hosted 
   in [single-tenant infrastructure][dedicated-infra]. Please specify what region
   the Cube Cloud single-tenant infrastructure should be hosted in.
 
@@ -96,4 +96,4 @@ We support all general-purpose regions. Cube Store is currently located only in
 proximity to it.
 
 [azure-console]: https://portal.azure.com
-[dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/deployment/vpc/gcp.mdx
+++ b/docs-mintlify/admin/deployment/vpc/gcp.mdx
@@ -52,4 +52,4 @@ run the [Cloud SQL Auth Proxy][gcp-cloudsql-auth-proxy].
 [gcp-docs-projects]:
   https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin
 [gcp-docs-vpc-peering]: https://cloud.google.com/vpc/docs/vpc-peering
-[dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/deployment/vpc/gcp.mdx
+++ b/docs-mintlify/admin/deployment/vpc/gcp.mdx
@@ -4,9 +4,9 @@ sidebarTitle: GCP
 description: Work with your Cube sales or customer success team to initiate this process.
 ---
 
-- VPC Peering requires Cube to be hosted in [dedicated infrastructure][dedicated-infra]. 
+- VPC Peering requires Cube to be hosted in [single-tenant infrastructure][dedicated-infra]. 
 Let the Cube team know your Cube Cloud tenant name (e.g. example.cubecloud.dev) and what region 
-the dedicated infrastructure should be hosted in. 
+the single-tenant infrastructure should be hosted in. 
 For best performance, select one of the "Supported Regions" listed below.
 - Cube will provision the dedicated VPC and provide the following 
 information you can use to create the peering request:

--- a/docs-mintlify/admin/deployment/vpc/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/index.mdx
@@ -4,7 +4,8 @@ description: Connect Cube Cloud to your private cloud network on AWS, GCP, or Az
 ---
 
 For improved stability and security, Cube Cloud supports connecting to one or
-more VPCs (virtual private clouds) in your Azure, AWS, or GCP accounts.
+more VPCs (virtual private clouds) in your AWS or GCP accounts, or VNets
+(virtual networks) in your Azure accounts.
 
 <Note>
 
@@ -25,7 +26,7 @@ routed through the public internet.
     Connect via VPC on GCP.
   </Card>
   <Card title="Microsoft Azure" icon="microsoft" href="/admin/deployment/vpc/azure">
-    Connect via VPC on Azure.
+    Connect via VNet on Azure.
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/deployment/vpc/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Dedicated Infrastructure (VPC)
+title: Single-tenant Infrastructure (VPC)
 description: Connect Cube Cloud to your private cloud network on AWS, GCP, or Azure for secure access to internal data sources.
 ---
 
@@ -10,12 +10,12 @@ more VPCs (virtual private clouds) in your Azure, AWS, or GCP accounts.
 
 <Info>
 
-Requires [dedicated infrastructure][ref-dedicated-infra].
+Requires [single-tenant infrastructure][ref-dedicated-infra].
 Available on [Enterprise and above plans](https://cube.dev/pricing).
 
 </Info>
 
-VPC connection improves stability through dedicated infrastructure for a
+VPC connection improves stability through single-tenant infrastructure for a
 deployment and improves security by preventing your database traffic from being
 routed through the public internet.
 

--- a/docs-mintlify/admin/deployment/vpc/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/index.mdx
@@ -11,7 +11,7 @@ more VPCs (virtual private clouds) in your Azure, AWS, or GCP accounts.
 <Info>
 
 Requires [single-tenant infrastructure][ref-dedicated-infra].
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/deployment/vpc/index.mdx
+++ b/docs-mintlify/admin/deployment/vpc/index.mdx
@@ -3,33 +3,31 @@ title: Single-tenant Infrastructure (VPC)
 description: Connect Cube Cloud to your private cloud network on AWS, GCP, or Azure for secure access to internal data sources.
 ---
 
- Connecting with a VPC in Cube Cloud
-
 For improved stability and security, Cube Cloud supports connecting to one or
 more VPCs (virtual private clouds) in your Azure, AWS, or GCP accounts.
 
-<Info>
+<Note>
 
-Requires [single-tenant infrastructure][ref-dedicated-infra].
-Available on [Enterprise plan](https://cube.dev/pricing).
+Available on the [Enterprise plan](https://cube.dev/pricing) with the
+[Single-tenant infrastructure][ref-dedicated-infra] add-on.
 
-</Info>
+</Note>
 
 VPC connection improves stability through single-tenant infrastructure for a
 deployment and improves security by preventing your database traffic from being
 routed through the public internet.
 
 <CardGroup cols={3}>
-  <Card title="Amazon Web Services" icon="brand-aws" href="vpc/aws">
+  <Card title="Amazon Web Services" icon="brand-aws" href="/admin/deployment/vpc/aws">
     Connect via VPC on AWS.
   </Card>
-  <Card title="Google Cloud Platform" icon="google" href="vpc/gcp">
+  <Card title="Google Cloud Platform" icon="google" href="/admin/deployment/vpc/gcp">
     Connect via VPC on GCP.
   </Card>
-  <Card title="Microsoft Azure" icon="microsoft" href="vpc/azure">
+  <Card title="Microsoft Azure" icon="microsoft" href="/admin/deployment/vpc/azure">
     Connect via VPC on Azure.
   </Card>
 </CardGroup>
 
 
-[ref-dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
+[ref-dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/deployment/warm-up.mdx
+++ b/docs-mintlify/admin/deployment/warm-up.mdx
@@ -7,11 +7,11 @@ Deployment warm-up improves querying performance by executing time-consuming
 tasks after a Cube Cloud deployment is spun up but before it's exposed to
 requests from users.
 
-<Info>
+<Note>
 
 Available on [Starter and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <Info>
 

--- a/docs-mintlify/admin/monitoring/audit-log.mdx
+++ b/docs-mintlify/admin/monitoring/audit-log.mdx
@@ -7,11 +7,11 @@ Audit Log collects, stores, and displays security-related events within a Cube C
 account, across all deployments. You can use it to maintain and review a historical
 record of activity for compliance purposes.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Read below about [collected events](#event-types). Also, see how you can [enable](#configuration)
 Audit Log, [view events](#viewing-events), and [download](#downloading-events) them.

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -48,15 +48,15 @@ Monitoring integrations work with various popular monitoring tools. Check the
 following guides and configuration examples to get tool-specific instructions:
 
 <CardGroup cols={2}>
-  <Card title="Amazon CloudWatch" img="https://static.cube.dev/icons/aws.svg" href="monitoring/cloudwatch">
+  <Card title="Amazon CloudWatch" img="https://static.cube.dev/icons/aws.svg" href="/admin/monitoring/monitoring-integrations/cloudwatch">
   </Card>
-  <Card title="Amazon S3" img="https://static.cube.dev/icons/aws.svg" href="monitoring/s3">
+  <Card title="Amazon S3" img="https://static.cube.dev/icons/aws.svg" href="/admin/monitoring/monitoring-integrations/s3">
   </Card>
-  <Card title="Datadog" img="https://static.cube.dev/icons/datadog.svg" href="monitoring/datadog">
+  <Card title="Datadog" img="https://static.cube.dev/icons/datadog.svg" href="/admin/monitoring/monitoring-integrations/datadog">
   </Card>
-  <Card title="Grafana Cloud" img="https://static.cube.dev/icons/grafana.svg" href="monitoring/grafana-cloud">
+  <Card title="Grafana Cloud" img="https://static.cube.dev/icons/grafana.svg" href="/admin/monitoring/monitoring-integrations/grafana-cloud">
   </Card>
-  <Card title="New Relic" img="https://static.cube.dev/icons/new-relic.svg" href="monitoring/new-relic">
+  <Card title="New Relic" img="https://static.cube.dev/icons/new-relic.svg" href="/admin/monitoring/monitoring-integrations/new-relic">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -11,7 +11,7 @@ long term.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 You can also choose a [Monitoring Integrations tier](/admin/account-billing/pricing#monitoring-integrations-tiers).
 
 </Info>

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -9,12 +9,12 @@ Cube Cloud allows exporting logs and metrics to external monitoring tools so you
 can leverage your existing monitoring stack and retain logs and metrics for the
 long term.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 You can also choose a [Monitoring Integrations tier](/admin/account-billing/pricing#monitoring-integrations-tiers).
 
-</Info>
+</Note>
 
 <Warning>
 

--- a/docs-mintlify/admin/monitoring/performance.mdx
+++ b/docs-mintlify/admin/monitoring/performance.mdx
@@ -8,12 +8,12 @@ analyze the performance of your deployment and fine-tune its configuration.
 It's recommended to review Performance Insights when the workload changes
 or if you face any performance-related issues with your deployment.
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 You can also choose a [Query History tier](/admin/account-billing/pricing#query-history-tiers).
 
-</Info>
+</Note>
 
 ## Charts
 

--- a/docs-mintlify/admin/monitoring/pre-aggregations.mdx
+++ b/docs-mintlify/admin/monitoring/pre-aggregations.mdx
@@ -9,11 +9,11 @@ can see which pre-aggregations are accelerating queries, if they are [being
 refreshed][ref-caching-using-preaggs-refresh], along with the last 24 hours of
 build history.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <Frame>
   <img src="https://ucarecdn.com/eb10de99-4ff6-4a9f-abd5-736971497583/" />

--- a/docs-mintlify/admin/monitoring/query-history.mdx
+++ b/docs-mintlify/admin/monitoring/query-history.mdx
@@ -8,12 +8,12 @@ Cube Cloud deployment, so you can check whether queries were accelerated with
 [pre-aggregations][ref-caching-gs-preaggs], how long they took to execute, and if they
 failed.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 You can also choose a [Query History tier](/admin/account-billing/pricing#query-history-tiers).
 
-</Info>
+</Note>
 
 You can set the [time range](#setting-the-time-range), [explore queries](#exploring-queries)
 and filter them, drill down on specific queries to [see more details](#inspecting-api-queries).

--- a/docs-mintlify/admin/sso/google-workspace.mdx
+++ b/docs-mintlify/admin/sso/google-workspace.mdx
@@ -11,7 +11,7 @@ Google Workspace to access the Admin Console and create a SAML integration.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/sso/google-workspace.mdx
+++ b/docs-mintlify/admin/sso/google-workspace.mdx
@@ -9,11 +9,11 @@ guide will walk you through the steps of configuring SAML authentication in Cube
 Cloud with Google Workspace. You **must** be a super administrator in your
 Google Workspace to access the Admin Console and create a SAML integration.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Enable SAML in Cube Cloud
 

--- a/docs-mintlify/admin/sso/index.mdx
+++ b/docs-mintlify/admin/sso/index.mdx
@@ -14,7 +14,7 @@ Cube Cloud also provides single sign-on (SSO) via identity providers supporting
 
 <Info>
 
-[SAML](#saml) is available on [Enterprise and above plans](https://cube.dev/pricing).
+[SAML](#saml) is available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/sso/index.mdx
+++ b/docs-mintlify/admin/sso/index.mdx
@@ -39,11 +39,11 @@ Once it's enabled, you'll see the **SAML Settings** section directly below.
 Check the following guides to get tool-specific instructions on configuration:
 
 <CardGroup cols={2}>
-  <Card title="Google Workspace" img="https://static.cube.dev/icons/google-cloud.svg" href="sso/google-workspace">
+  <Card title="Google Workspace" img="https://static.cube.dev/icons/google-cloud.svg" href="/admin/sso/google-workspace">
   </Card>
-  <Card title="Microsoft Entra ID" img="https://static.cube.dev/icons/azure.svg" href="sso/microsoft-entra-id">
+  <Card title="Microsoft Entra ID" img="https://static.cube.dev/icons/azure.svg" href="/admin/sso/microsoft-entra-id">
   </Card>
-  <Card title="Okta" img="https://static.cube.dev/icons/okta.svg" href="sso/okta">
+  <Card title="Okta" img="https://static.cube.dev/icons/okta.svg" href="/admin/sso/okta">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/index.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/index.mdx
@@ -18,9 +18,9 @@ Available on [Enterprise plan](https://cube.dev/pricing).
 ## Setup guides
 
 <CardGroup cols={2}>
-  <Card title="SAML" img="https://static.cube.dev/icons/azure.svg" href="microsoft-entra-id/saml">
+  <Card title="SAML" img="https://static.cube.dev/icons/azure.svg" href="/admin/sso/microsoft-entra-id/saml">
   </Card>
-  <Card title="SCIM" img="https://static.cube.dev/icons/azure.svg" href="microsoft-entra-id/scim">
+  <Card title="SCIM" img="https://static.cube.dev/icons/azure.svg" href="/admin/sso/microsoft-entra-id/scim">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/index.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/index.mdx
@@ -11,7 +11,7 @@ useful when you want your users to access Cube Cloud using single sign-on.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/index.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/index.mdx
@@ -9,11 +9,11 @@ Cube Cloud supports authenticating users through [Microsoft Entra
 ID][ext-ms-entra-id] (formerly Azure Active Directory), which is
 useful when you want your users to access Cube Cloud using single sign-on.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Setup guides
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
@@ -8,11 +8,11 @@ With SAML (Security Assertion Markup Language) enabled, you can authenticate
 users in Cube through Microsoft Entra ID (formerly Azure Active Directory),
 allowing your team to access Cube using single sign-on.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Prerequisites
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/saml.mdx
@@ -10,7 +10,7 @@ allowing your team to access Cube using single sign-on.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/scim.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/scim.mdx
@@ -10,7 +10,7 @@ with Microsoft Entra ID (formerly Azure Active Directory).
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/sso/microsoft-entra-id/scim.mdx
+++ b/docs-mintlify/admin/sso/microsoft-entra-id/scim.mdx
@@ -8,11 +8,11 @@ With SCIM (System for Cross-domain Identity Management) enabled, you can
 automate user provisioning in Cube and keep user groups synchronized
 with Microsoft Entra ID (formerly Azure Active Directory).
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Prerequisites
 

--- a/docs-mintlify/admin/sso/okta/saml.mdx
+++ b/docs-mintlify/admin/sso/okta/saml.mdx
@@ -8,11 +8,11 @@ With SAML (Security Assertion Markup Language) enabled, you can authenticate
 users in Cube Cloud through Okta, allowing your team to access Cube Cloud
 using single sign-on.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Prerequisites
 

--- a/docs-mintlify/admin/sso/okta/saml.mdx
+++ b/docs-mintlify/admin/sso/okta/saml.mdx
@@ -10,7 +10,7 @@ using single sign-on.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/admin/sso/okta/scim.mdx
+++ b/docs-mintlify/admin/sso/okta/scim.mdx
@@ -4,11 +4,11 @@ sidebarTitle: SCIM
 description: With SCIM (System for Cross-domain Identity Management) enabled, you can automate user provisioning in Cube Cloud and keep user groups synchronized with Okta.
 ---
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 ## Prerequisites
 

--- a/docs-mintlify/admin/sso/okta/scim.mdx
+++ b/docs-mintlify/admin/sso/okta/scim.mdx
@@ -6,7 +6,7 @@ description: With SCIM (System for Cross-domain Identity Management) enabled, yo
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/cube-core/migrate-from-core/import-bitbucket-repository-via-ssh.mdx
+++ b/docs-mintlify/cube-core/migrate-from-core/import-bitbucket-repository-via-ssh.mdx
@@ -29,7 +29,7 @@ choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/cube-core/migrate-from-core/import-git-repository-via-ssh.mdx
+++ b/docs-mintlify/cube-core/migrate-from-core/import-git-repository-via-ssh.mdx
@@ -25,7 +25,7 @@ your choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/cube-core/migrate-from-core/import-github-repository.mdx
+++ b/docs-mintlify/cube-core/migrate-from-core/import-github-repository.mdx
@@ -25,7 +25,7 @@ choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/cube-core/migrate-from-core/import-gitlab-repository-via-ssh.mdx
+++ b/docs-mintlify/cube-core/migrate-from-core/import-gitlab-repository-via-ssh.mdx
@@ -29,7 +29,7 @@ choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/cube-core/migrate-from-core/upload-with-cli.mdx
+++ b/docs-mintlify/cube-core/migrate-from-core/upload-with-cli.mdx
@@ -28,7 +28,7 @@ provider and region of your choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/cube-core/running-in-production.mdx
+++ b/docs-mintlify/cube-core/running-in-production.mdx
@@ -237,11 +237,11 @@ discouraged and can lead to consistency and data corruption errors.
 
 </Warning>
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <Info>
 
@@ -361,12 +361,12 @@ persistent storage. Pre-aggregation data is secured using the [AES cipher][link-
 with 256-bit keys. Data encyption and decryption are completely seamless to Cube
 Store operations.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 Also requires the M [Cube Store Worker tier](/admin/account-billing/pricing#cube-store-worker-tiers).
 
-</Info>
+</Note>
 
 You can provide, rotate, or drop your own [customer-managed keys][ref-cmk] (CMK)
 for Cube Store via the **Encryption Keys** page in Cube Cloud.

--- a/docs-mintlify/cube-core/running-in-production.mdx
+++ b/docs-mintlify/cube-core/running-in-production.mdx
@@ -239,7 +239,7 @@ discouraged and can lead to consistency and data corruption errors.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -304,8 +304,8 @@
             "pages": [
               "admin/deployment/index",
               "admin/deployment/deployment-types",
-              "admin/deployment/infrastructure",
               "admin/deployment/environments",
+              "admin/deployment/infrastructure",
               "admin/deployment/continuous-deployment",
               "admin/deployment/custom-domains",
               "admin/deployment/warm-up",

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -305,7 +305,6 @@
               "admin/deployment/index",
               "admin/deployment/deployment-types",
               "admin/deployment/environments",
-              "admin/deployment/infrastructure",
               "admin/deployment/continuous-deployment",
               "admin/deployment/custom-domains",
               "admin/deployment/warm-up",
@@ -313,6 +312,7 @@
               "admin/deployment/scalability",
               "admin/deployment/encryption-keys",
               "admin/deployment/limits",
+              "admin/deployment/infrastructure",
               {
                 "group": "VPC",
                 "root": "admin/deployment/vpc/index",

--- a/docs-mintlify/docs/data-modeling/access-control/context.mdx
+++ b/docs-mintlify/docs/data-modeling/access-control/context.mdx
@@ -300,11 +300,11 @@ enrich the security context with additional attributes.
 When using Cube Cloud, you can enrich the security context with information about
 an authenticated user, obtained during their authentication.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 You can enable the authentication integration by navigating to the **Settings → Configuration**
 of your Cube Cloud deployment and using the **Enable Cloud Auth Integration** toggle.

--- a/docs-mintlify/docs/data-modeling/data-model-ide.mdx
+++ b/docs-mintlify/docs/data-modeling/data-model-ide.mdx
@@ -9,11 +9,11 @@ Data model editor provides the code-first experience for building and enhancing 
 Unlike the [Visual Modeler][ref-visual-model] editor, it provides the freedom to use all
 available data modeling features at the expense of a code-centric experience.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Cube Cloud can create branch-based development API instances to quickly test
 changes in the data model in your frontend applications before pushing them into

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -6,11 +6,11 @@ description: Outlines development mode in Cube Cloud—branch-scoped APIs, save 
 Development mode allows to test and debug the data model in an isolated
 [development environment][ref-environments-dev] before releasing any changes to production.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 When you enter the development mode, you'll have access to your personal API endpoints
 that will track the branch you're on and will be updated automatically when you make

--- a/docs-mintlify/docs/data-modeling/sql-runner.mdx
+++ b/docs-mintlify/docs/data-modeling/sql-runner.mdx
@@ -8,11 +8,11 @@ on your data source or Cube Store. It can be used to inform the development of
 the data model, for ad-hoc querying as well as debugging SQL queries generated
 by Cube to execute against the data source.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <video width="100%" controls>
   <source

--- a/docs-mintlify/docs/data-modeling/visual-modeler.mdx
+++ b/docs-mintlify/docs/data-modeling/visual-modeler.mdx
@@ -10,11 +10,11 @@ Unlike the code-first [data model][ref-data-model] editor, Visual Modeler allows
 users to participate in data modeling without writing code. However, it does not support
 some advanced data modeling features listed as known [limitations](#limitations).
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <Info>
 

--- a/docs-mintlify/docs/getting-started/cloud/connect-to-snowflake.mdx
+++ b/docs-mintlify/docs/getting-started/cloud/connect-to-snowflake.mdx
@@ -22,7 +22,7 @@ and click **Next**:
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/getting-started/databricks/connect-to-databricks.mdx
+++ b/docs-mintlify/docs/getting-started/databricks/connect-to-databricks.mdx
@@ -22,7 +22,7 @@ and click **Next**:
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/getting-started/index.mdx
+++ b/docs-mintlify/docs/getting-started/index.mdx
@@ -19,7 +19,7 @@ Cube Core is a headless, open-source semantic layer that powers the Cube Busines
 Cube Core is packaged and distributed as Docker images that can be run in a containerized environment. You can run Cube Core on your own infrastructure with Docker.
 
 <CardGroup cols={2}>
-  <Card title="Cube Core" img="https://static.cube.dev/icons/docker.svg" href="getting-started/core">
+  <Card title="Cube Core" img="https://static.cube.dev/icons/docker.svg" href="/cube-core/getting-started">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/docs/getting-started/migrate-from-core/import-bitbucket-repository-via-ssh.mdx
+++ b/docs-mintlify/docs/getting-started/migrate-from-core/import-bitbucket-repository-via-ssh.mdx
@@ -29,7 +29,7 @@ choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/getting-started/migrate-from-core/import-git-repository-via-ssh.mdx
+++ b/docs-mintlify/docs/getting-started/migrate-from-core/import-git-repository-via-ssh.mdx
@@ -25,7 +25,7 @@ your choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/getting-started/migrate-from-core/import-github-repository.mdx
+++ b/docs-mintlify/docs/getting-started/migrate-from-core/import-github-repository.mdx
@@ -25,7 +25,7 @@ choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/getting-started/migrate-from-core/import-gitlab-repository-via-ssh.mdx
+++ b/docs-mintlify/docs/getting-started/migrate-from-core/import-gitlab-repository-via-ssh.mdx
@@ -29,7 +29,7 @@ choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/getting-started/migrate-from-core/upload-with-cli.mdx
+++ b/docs-mintlify/docs/getting-started/migrate-from-core/upload-with-cli.mdx
@@ -28,7 +28,7 @@ provider and region of your choice.
 
 <Info>
 
-Microsoft Azure is available on [Enterprise and above plans](https://cube.dev/pricing).
+Microsoft Azure is available on [Enterprise plan](https://cube.dev/pricing).
 [Contact us](https://cube.dev/contact) for details.
 
 </Info>

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -3,11 +3,11 @@ title: Cube Cloud for Sheets
 description: "Cube Cloud for Sheets is the native Google Sheets add-on for Cube Cloud."
 ---
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 After [configuring](#configuration), [installing](#installation), and
 [authenticating](#authentication) this add-on, you will be able to [create

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -8,11 +8,11 @@ including macOS, and all platforms, including web and mobile. It doesn't integra
 with the native [PivotTable][link-pivottable] in Excel but provides a custom
 [pivot table](#create-reports-via-pivot-table) UI.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 After [configuring](#configuration), [installing](#installation), and
 [authenticating](#authentication) this add-in, you will be able to [create

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -10,7 +10,7 @@ with the native [PivotTable][link-pivottable] in Excel but provides a custom
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
@@ -8,7 +8,7 @@ It can be used to authenticate requests to [DAX API][ref-dax-api].
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
@@ -6,11 +6,11 @@ description: "Kerberos is the most common authentication method for Windows envi
 [Kerberos][link-kerberos] is the most common authentication method for Windows environments.
 It can be used to authenticate requests to [DAX API][ref-dax-api].
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 On the diagram below, Kerberos is used to authenticate requests from Power BI Desktop (step 2):
 

--- a/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
@@ -6,11 +6,11 @@ description: "NTLM is an authentication method developed by Microsoft that can b
 [NTLM][link-ntlm] is an authentication method developed by Microsoft that can be used to
 authenticate requests to [DAX API][ref-dax-api].
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 On the diagram below, NTLM is used to authenticate requests from Power BI Service that
 come through the [on-premises data gateway][link-power-bi-opdg] (step 6):

--- a/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
@@ -8,7 +8,7 @@ authenticate requests to [DAX API][ref-dax-api].
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
@@ -11,7 +11,7 @@ layer from Cube to BI tools. It's the easiest way to connect a BI tool to Cube.
 <Info>
 
 Support for Preset and Superset is available on [all plans](https://cube.dev/pricing).
-Support for Tableau is available on [Enterprise and above plans](https://cube.dev/pricing).
+Support for Tableau is available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
@@ -34,11 +34,11 @@ Semantic Layer Sync supports the following BI tools. Check relevant pages for de
 on configuration and features for specific tools:
 
 <CardGroup cols={2}>
-  <Card title="Apache Superset" img="https://static.cube.dev/icons/superset.svg" href="semantic-layer-sync/superset">
+  <Card title="Apache Superset" img="https://static.cube.dev/icons/superset.svg" href="/docs/integrations/semantic-layer-sync/superset">
   </Card>
-  <Card title="Preset" img="https://static.cube.dev/icons/preset.svg" href="semantic-layer-sync/preset">
+  <Card title="Preset" img="https://static.cube.dev/icons/preset.svg" href="/docs/integrations/semantic-layer-sync/preset">
   </Card>
-  <Card title="Tableau" img="https://static.cube.dev/icons/tableau.svg" href="semantic-layer-sync/tableau">
+  <Card title="Tableau" img="https://static.cube.dev/icons/tableau.svg" href="/docs/integrations/semantic-layer-sync/tableau">
   </Card>
 </CardGroup>
 

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
@@ -9,7 +9,7 @@ in [Semantic Layer Sync](/docs/integrations/semantic-layer-sync).
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
@@ -7,11 +7,11 @@ description: This page details the support for Tableau in Semantic Layer Sync.
 This page details the support for [Tableau](https://www.tableau.com)
 in [Semantic Layer Sync](/docs/integrations/semantic-layer-sync).
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Semantic Layer Sync works with Tableau Cloud, Tableau Desktop, and Tableau Server.
 

--- a/docs-mintlify/docs/integrations/slack.mdx
+++ b/docs-mintlify/docs/integrations/slack.mdx
@@ -3,11 +3,11 @@ title: Slack
 description: Connect Cube to Slack for notifications and AI-powered analytics chat.
 ---
 
-<Info>
+<Note>
 
 Available on [Premium and above plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Cube's Slack integration enables two capabilities:
 

--- a/docs-mintlify/docs/integrations/tableau.mdx
+++ b/docs-mintlify/docs/integrations/tableau.mdx
@@ -14,7 +14,7 @@ update Tableau data sources that are connected to Cube via the
 <Info>
 
 Semantic Layer Sync with Tableau is available on
-[Enterprise and above plans](https://cube.dev/pricing).
+[Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
+++ b/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
@@ -237,11 +237,11 @@ discouraged and can lead to consistency and data corruption errors.
 
 </Warning>
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <Info>
 
@@ -361,12 +361,12 @@ persistent storage. Pre-aggregation data is secured using the [AES cipher][link-
 with 256-bit keys. Data encyption and decryption are completely seamless to Cube
 Store operations.
 
-<Info>
+<Note>
 
 Available on the [Enterprise plan](https://cube.dev/pricing).
 Also requires the M [Cube Store Worker tier](/admin/account-billing/pricing#cube-store-worker-tiers).
 
-</Info>
+</Note>
 
 You can provide, rotate, or drop your own [customer-managed keys][ref-cmk] (CMK)
 for Cube Store via the **Encryption Keys** page in Cube Cloud.

--- a/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
+++ b/docs-mintlify/docs/pre-aggregations/running-in-production.mdx
@@ -239,7 +239,7 @@ discouraged and can lead to consistency and data corruption errors.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/embedding/authentication/security-context.mdx
+++ b/docs-mintlify/embedding/authentication/security-context.mdx
@@ -300,11 +300,11 @@ enrich the security context with additional attributes.
 When using Cube Cloud, you can enrich the security context with information about
 an authenticated user, obtained during their authentication.
 
-<Info>
+<Note>
 
 Available on [all plans](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 You can enable the authentication integration by navigating to the **Settings → Configuration**
 of your Cube Cloud deployment and using the **Enable Cloud Auth Integration** toggle.

--- a/docs-mintlify/embedding/index.mdx
+++ b/docs-mintlify/embedding/index.mdx
@@ -7,9 +7,9 @@ Cube provides multiple approaches for embedding AI-powered analytics into your a
 
 ## Iframe embedding
 
-<Info>
+<Note>
   Available on [Premium and Enterprise plans](https://cube.dev/pricing).
-</Info>
+</Note>
 
 Embed Cube content using iframes for the fastest integration with minimal code. This approach works with any frontend framework and requires no additional dependencies.
 
@@ -21,9 +21,9 @@ Iframe embedding supports [dashboards](/embedding/iframe/dashboards), [Analytics
 
 ## SDK embedding
 
-<Info>
+<Note>
   Available on [Premium and Enterprise plans](https://cube.dev/pricing).
-</Info>
+</Note>
 
 Embed Cube using the [React Embed SDK](/embedding/react-embed-sdk) for tighter integration with your React applications. Components provide more control over styling, theming, and user interactions.
 

--- a/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
@@ -12,11 +12,11 @@ for Power BI and SQL Server Analysis Services.
 Unlike the [SQL API][ref-sql-api], it provides a native experience and superior
 support for Power BI features.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 Read below about the DAX API [configuration](#configuration),
 [authentication](#authentication), and [using it](#using-dax-api-with-power-bi) with Power BI.

--- a/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
@@ -14,7 +14,7 @@ support for Power BI features.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/reference/core-data-apis/mdx-api.mdx
+++ b/docs-mintlify/reference/core-data-apis/mdx-api.mdx
@@ -13,7 +13,7 @@ native [PivotTable][link-pivottable] in Excel.
 
 <Info>
 
-Available on [Enterprise and above plans](https://cube.dev/pricing).
+Available on [Enterprise plan](https://cube.dev/pricing).
 
 </Info>
 

--- a/docs-mintlify/reference/core-data-apis/mdx-api.mdx
+++ b/docs-mintlify/reference/core-data-apis/mdx-api.mdx
@@ -11,11 +11,11 @@ Unlike [Cube Cloud for Excel][ref-cube-cloud-for-excel], it only works with Exce
 on Microsoft Windows. However, it allows using the data from the MDX API with the
 native [PivotTable][link-pivottable] in Excel.
 
-<Info>
+<Note>
 
 Available on [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <Warning>
 

--- a/docs-mintlify/reference/orchestration-api/index.mdx
+++ b/docs-mintlify/reference/orchestration-api/index.mdx
@@ -31,11 +31,11 @@ orchestration tools. Check the following guides to get tool-specific
 instructions:
 
 <CardGroup cols={2}>
-  <Card title="Apache Airflow" img="https://static.cube.dev/icons/airflow.svg" href="orchestration-api/airflow">
+  <Card title="Apache Airflow" img="https://static.cube.dev/icons/airflow.svg" href="/reference/orchestration-api/airflow">
   </Card>
-  <Card title="Dagster" img="https://static.cube.dev/icons/dagster.svg" href="orchestration-api/dagster">
+  <Card title="Dagster" img="https://static.cube.dev/icons/dagster.svg" href="/reference/orchestration-api/dagster">
   </Card>
-  <Card title="Prefect" img="https://static.cube.dev/icons/prefect.svg" href="orchestration-api/prefect">
+  <Card title="Prefect" img="https://static.cube.dev/icons/prefect.svg" href="/reference/orchestration-api/prefect">
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Renames the customer-facing display text for the infrastructure options to use industry-standard single-tenant / multi-tenant terminology and removes the naming collision with the Shared / Dedicated deployment types.

- "Shared infrastructure" -> "Multi-tenant infrastructure"
- "Dedicated infrastructure" -> "Single-tenant infrastructure"
- "Dedicated infrastructure with CSPS" -> "Single-tenant infrastructure with CSPS"

URL anchors (#shared-infrastructure, #dedicated-infrastructure, #dedicated-infrastructure-with-csps), reference link IDs, and product region identifier slugs (aws-us-east-1-shared, etc.) are intentionally left unchanged so external inbound links and product identifiers keep working. Mintlify explicit anchor syntax is used to preserve them under the renamed headings.

Also documents the new terminology in .cursor/rules/namings-rule.mdc.

Made-with: Cursor

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
