### PR TITLE
feat: add scheduled Playwright tests workflow with shard approach

### DIFF
--- a/.github/workflows/scheduled-playwright.yml
+++ b/.github/workflows/scheduled-playwright.yml
@@ -1,0 +1,118 @@
+name: 'Scheduled Playwright Tests'
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      shard_count:
+        description: 'Number of shards to split tests across'
+        required: false
+        default: '4'
+
+jobs:
+  playwright:
+    name: 'Playwright (${{ matrix.shard }}/${{ strategy.job-total }})'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Restore yarn cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Set Yarn version
+        run: yarn policies set-version v1.22.22
+
+      - name: Yarn install
+        uses: nick-fields/retry@v3
+        env:
+          CUBESTORE_SKIP_POST_INSTALL: true
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 20
+          command: yarn install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Build
+        run: |
+          yarn build
+          yarn tsc
+
+      - name: Run Playwright tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
+        run: npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 1
+
+  merge-reports:
+    name: 'Merge Playwright Reports'
+    if: always()
+    needs: [playwright]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Slack Failure
+        if: failure()
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: oss-ci
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/scheduled-playwright.yml
+++ b/.github/workflows/scheduled-playwright.yml
@@ -9,17 +9,22 @@ on:
       shard_count:
         description: 'Number of shards to split tests across'
         required: false
-        default: '4'
+        default: '8'
+
+concurrency:
+  group: scheduled-playwright
+  cancel-in-progress: false
 
 jobs:
   playwright:
-    name: 'Playwright (${{ matrix.shard }}/${{ strategy.job-total }})'
-    runs-on: ubuntu-24.04
+    name: 'Playwright (${{ matrix.shard }}/8)'
+    runs-on: ubuntu-24.04-8core
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,8 +69,8 @@ jobs:
           yarn build
           yarn tsc
 
-      - name: Run Playwright tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
-        run: npx playwright test --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+      - name: Run Playwright tests (shard ${{ matrix.shard }}/8)
+        run: npx playwright test --shard=${{ matrix.shard }}/8
 
       - name: Upload blob report
         if: always()

--- a/.github/workflows/scheduled-playwright.yml
+++ b/.github/workflows/scheduled-playwright.yml
@@ -5,11 +5,9 @@ on:
     # Run daily at 06:00 UTC
     - cron: '0 6 * * *'
   workflow_dispatch:
-    inputs:
-      shard_count:
-        description: 'Number of shards to split tests across'
-        required: false
-        default: '8'
+
+permissions:
+  contents: read
 
 concurrency:
   group: scheduled-playwright
@@ -18,7 +16,7 @@ concurrency:
 jobs:
   playwright:
     name: 'Playwright (${{ matrix.shard }}/8)'
-    runs-on: ubuntu-24.04-8core
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -70,7 +68,7 @@ jobs:
           yarn tsc
 
       - name: Run Playwright tests (shard ${{ matrix.shard }}/8)
-        run: npx playwright test --shard=${{ matrix.shard }}/8
+        run: npx playwright test --shard=${{ matrix.shard }}/8 --reporter=blob
 
       - name: Upload blob report
         if: always()
@@ -113,7 +111,7 @@ jobs:
           retention-days: 14
 
       - name: Slack Failure
-        if: failure()
+        if: ${{ always() && needs.playwright.result == 'failure' }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
           channel: oss-ci


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Adds a new GitHub Actions workflow (`.github/workflows/scheduled-playwright.yml`) that runs Playwright tests on a daily schedule using the **shard approach** for parallelism.

### Key features:

- **Scheduled execution**: Runs daily at 06:00 UTC via cron
- **Manual trigger**: Can also be triggered via `workflow_dispatch`
- **8 shards on 8-core machines**: Splits tests across 8 parallel runners using Playwright's built-in `--shard` flag on `ubuntu-24.04-8core` runners
- **Max concurrency of 4**: Uses `max-parallel: 4` so at most 4 shards run simultaneously
- **Report merging**: A separate `merge-reports` job downloads all shard blob reports and merges them into a single HTML report artifact
- **Consistent patterns**: Uses the same Node.js, Yarn, and cache setup as the existing CI workflows
- **Failure notifications**: Posts to Slack on failure (consistent with other workflows)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-512fe20a-30b6-47b9-80e1-befd33fd042a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-512fe20a-30b6-47b9-80e1-befd33fd042a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

