### PR TITLE
fix(client-core): make CJS consumers work for main entry and /format …

### DIFF
--- a/packages/cubejs-client-core/package.json
+++ b/packages/cubejs-client-core/package.json
@@ -21,7 +21,8 @@
     },
     "./format": {
       "types": "./dist/src/format.d.ts",
-      "import": "./dist/src/format.js"
+      "import": "./dist/src/format.js",
+      "require": "./dist/format.cjs"
     }
   },
   "typesVersions": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ const bundle = (
       babel({
         extensions: ['.js', '.jsx', '.ts', '.tsx'],
         exclude: ['node_modules/**', /\/core-js\//],
-        babelHelpers: 'runtime',
+        babelHelpers: 'bundled',
         presets: [
           '@babel/preset-react',
           '@babel/preset-typescript',
@@ -37,17 +37,6 @@ const bundle = (
               shippedProposals: true,
               useBuiltIns: 'usage',
               corejs: 3,
-            },
-          ],
-        ],
-        plugins: [
-          [
-            '@babel/plugin-transform-runtime',
-            {
-              corejs: false,
-              helpers: true,
-              regenerator: true,
-              useESModules: false,
             },
           ],
         ],
@@ -96,7 +85,7 @@ const bundle = (
         babel({
           extensions: ['.js', '.jsx', '.ts', '.tsx'],
           exclude: 'node_modules/**',
-          babelHelpers: 'runtime',
+          babelHelpers: 'bundled',
           presets: [
             '@babel/preset-react',
             '@babel/preset-typescript',
@@ -106,17 +95,6 @@ const bundle = (
                 shippedProposals: true,
                 useBuiltIns: 'usage',
                 corejs: 3,
-              },
-            ],
-          ],
-          plugins: [
-            [
-              '@babel/plugin-transform-runtime',
-              {
-                corejs: false,
-                helpers: true,
-                regenerator: true,
-                useESModules: false,
               },
             ],
           ],
@@ -193,4 +171,42 @@ export default bundle(
         vue: 'Vue',
       },
     })
-  );
+  )
+  .concat([
+    {
+      input: 'packages/cubejs-client-core/src/format.ts',
+      plugins: [
+        json(),
+        tsconfigPaths(),
+        resolve({
+          extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
+          resolveOnly: [/^\.\.?/, /^d3-format/, /^d3-time-format/, /^d3-time/, /^d3-array/, /^internmap/],
+        }),
+        commonjs(),
+        babel({
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+          exclude: 'node_modules/**',
+          babelHelpers: 'bundled',
+          presets: [
+            '@babel/preset-typescript',
+            [
+              '@babel/preset-env',
+              {
+                shippedProposals: true,
+                useBuiltIns: 'usage',
+                corejs: 3,
+              },
+            ],
+          ],
+        }),
+      ],
+      output: [
+        {
+          file: 'packages/cubejs-client-core/dist/format.cjs',
+          format: 'cjs',
+          exports: 'named',
+          sourcemap: true,
+        },
+      ],
+    },
+  ]);


### PR DESCRIPTION
…subpath

Two regressions made @cubejs-client/core unusable from CommonJS under strict resolvers (Yarn PnP, pnpm). Loose node_modules layouts masked both via hoisting.

Bug 1: main CJS bundle requires @babel/runtime but doesn't declare it.

  The rollup config applies @babel/plugin-transform-runtime with
  helpers: true to the CJS/UMD outputs, which rewrites Babel helpers
  into `require('@babel/runtime/helpers/*')` calls. PR #5917 (v0.31.34)
  declared @babel/runtime in dependencies for exactly this reason.
  The TS migration in #9562 removed that declaration on the assumption
  that tsc was now the only build, missing that rollup still produces
  the CJS/UMD bundles and still externalizes helpers.

  Fix: switch the rollup babel plugin to `babelHelpers: 'bundled'` and
  drop @babel/plugin-transform-runtime. Helpers are now inlined into
  each bundle (CJS bundle grows ~1KB), and the package no longer has
  an undeclared runtime dependency. Same change applies to the
  ws-transport, react, and vue3 bundles built from the same config.

Bug 2: `@cubejs-client/core/format` is unreachable from CommonJS.

  The ./format exports map has only `import` (ESM), no `require`, and
  formatValue is intentionally not re-exported from the main entry to
  avoid bloating the CJS/UMD bundles with d3-format/d3-time-format.
  As a result `require('@cubejs-client/core/format')` fails with
  "Package subpath './format' is not defined".

  Fix: add a dedicated CJS bundle at dist/format.cjs (rollup, with
  d3-format/d3-time-format inlined since both are ESM-only and can't
  be required) and add a `require` condition to the ./format exports.
  ESM consumers continue to get dist/src/format.js (tree-shakable,
  deps externalized); CJS consumers now get a self-contained 50KB
  bundle. The main entry is unchanged — no size regression for users
  who don't import ./format.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
