### PR TITLE
feat: conditional data masking with row-level filters in access policies

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1343,6 +1343,8 @@ class ApiGateway {
         currentQuery = this.parseMemberExpressionsInQuery(currentQuery);
       }
 
+      delete (currentQuery as any).maskedMembers;
+
       return {
         normalizedQuery: (normalizeQuery(currentQuery, persistent, cacheMode)),
         hasExpressionsInQuery
@@ -1371,6 +1373,8 @@ class ApiGateway {
             queryWithRlsFilters,
             context
           ) : queryWithRlsFilters;
+
+          rewrittenQuery.maskedMembers = queryWithRlsFilters.maskedMembers;
 
           // applyRowLevelSecurity may add new filters which may contain raw member expressions
           // if that's the case, we should run an extra pass of parsing here to make sure

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1343,7 +1343,9 @@ class ApiGateway {
         currentQuery = this.parseMemberExpressionsInQuery(currentQuery);
       }
 
-      delete (currentQuery as any).maskedMembers;
+      if ((currentQuery as any).maskedMembers) {
+        throw new UserError('maskedMembers cannot be provided in the query');
+      }
 
       return {
         normalizedQuery: (normalizeQuery(currentQuery, persistent, cacheMode)),

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -195,8 +195,15 @@ const querySchema = Joi.object().keys({
   responseFormat: Joi.valid('default', 'compact', 'columnar'),
   subqueryJoins: Joi.array().items(subqueryJoin),
   joinHints: Joi.array().items(joinHint),
-  maskedMembers: Joi.array().items(Joi.string()),
-  memberMaskFilters: Joi.object().pattern(Joi.string(), Joi.any()),
+  maskedMembers: Joi.array().items(
+    Joi.alternatives().try(
+      Joi.string(),
+      Joi.object().keys({
+        member: Joi.string().required(),
+        filter: Joi.any().required(),
+      })
+    )
+  ),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -195,7 +195,10 @@ const querySchema = Joi.object().keys({
   responseFormat: Joi.valid('default', 'compact', 'columnar'),
   subqueryJoins: Joi.array().items(subqueryJoin),
   joinHints: Joi.array().items(joinHint),
-  maskedMembers: Joi.array().items(Joi.object()),
+  maskedMembers: Joi.array().items(Joi.object().keys({
+    member: Joi.string().required(),
+    filter: Joi.object(),
+  })),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -195,15 +195,6 @@ const querySchema = Joi.object().keys({
   responseFormat: Joi.valid('default', 'compact', 'columnar'),
   subqueryJoins: Joi.array().items(subqueryJoin),
   joinHints: Joi.array().items(joinHint),
-  maskedMembers: Joi.array().items(
-    Joi.alternatives().try(
-      Joi.string(),
-      Joi.object().keys({
-        member: Joi.string().required(),
-        filter: Joi.any().required(),
-      })
-    )
-  ),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -195,6 +195,7 @@ const querySchema = Joi.object().keys({
   responseFormat: Joi.valid('default', 'compact', 'columnar'),
   subqueryJoins: Joi.array().items(subqueryJoin),
   joinHints: Joi.array().items(joinHint),
+  maskedMembers: Joi.array().items(Joi.object()),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -196,6 +196,7 @@ const querySchema = Joi.object().keys({
   subqueryJoins: Joi.array().items(subqueryJoin),
   joinHints: Joi.array().items(joinHint),
   maskedMembers: Joi.array().items(Joi.string()),
+  memberMaskFilters: Joi.object().pattern(Joi.string(), Joi.any()),
 });
 
 const normalizeQueryOrder = order => {

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -166,7 +166,7 @@ interface NormalizedQuery extends Query {
   filters?: NormalizedQueryFilter[];
   rowLimit?: null | number;
   order?: { id: string; desc: boolean }[];
-  maskedMembers?: (string | { member: string; filter: any })[];
+  maskedMembers?: { member: string; filter?: any }[];
 }
 
 export {

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -167,6 +167,7 @@ interface NormalizedQuery extends Query {
   rowLimit?: null | number;
   order?: { id: string; desc: boolean }[];
   maskedMembers?: string[];
+  memberMaskFilters?: Record<string, any>;
 }
 
 export {

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -166,8 +166,7 @@ interface NormalizedQuery extends Query {
   filters?: NormalizedQueryFilter[];
   rowLimit?: null | number;
   order?: { id: string; desc: boolean }[];
-  maskedMembers?: string[];
-  memberMaskFilters?: Record<string, any>;
+  maskedMembers?: (string | { member: string; filter: any })[];
 }
 
 export {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3312,7 +3312,7 @@ export class BaseQuery {
     this.safeEvaluateSymbolContext().currentMember = memberPath;
     try {
       if (this.maskedMembers && this.maskedMembers.has(memberPath) && !memberExpressionType &&
-          this.safeEvaluateSymbolContext().skipMaskFor !== memberPath) {
+          !this.safeEvaluateSymbolContext().skipMasking) {
         // In ungrouped queries, only apply static masks to measures.
         // SQL masks (mask.sql) reference columns that don't apply per-row.
         const isMeasure = type === 'measure';
@@ -3505,16 +3505,18 @@ export class BaseQuery {
 
   conditionalMemberMaskSql(cubeName, name, symbol, memberPathArray, maskFilter) {
     const maskedSql = this.memberMaskSql(cubeName, name, symbol);
-    const filterSql = this.maskFilterToSql(maskFilter);
-    if (!filterSql) {
-      return maskedSql;
-    }
-    const memberPath = this.cubeEvaluator.pathFromArray(memberPathArray);
-    const originalSql = this.evaluateSymbolSqlWithContext(
-      () => this.autoPrefixAndEvaluateSql(cubeName, symbol.sql),
-      { skipMaskFor: memberPath }
+    const result = this.evaluateSymbolSqlWithContext(
+      () => {
+        const filterSql = this.maskFilterToSql(maskFilter);
+        if (!filterSql) {
+          return maskedSql;
+        }
+        const originalSql = this.autoPrefixAndEvaluateSql(cubeName, symbol.sql);
+        return `CASE WHEN ${filterSql} THEN ${originalSql} ELSE ${maskedSql} END`;
+      },
+      { skipMasking: true, currentMember: null }
     );
-    return `CASE WHEN ${filterSql} THEN ${originalSql} ELSE ${maskedSql} END`;
+    return result;
   }
 
   maskFilterToSql(filter) {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3311,7 +3311,8 @@ export class BaseQuery {
 
     this.safeEvaluateSymbolContext().currentMember = memberPath;
     try {
-      if (this.maskedMembers && this.maskedMembers.has(memberPath) && !memberExpressionType) {
+      if (this.maskedMembers && this.maskedMembers.has(memberPath) && !memberExpressionType &&
+          this.safeEvaluateSymbolContext().skipMaskFor !== memberPath) {
         // In ungrouped queries, only apply static masks to measures.
         // SQL masks (mask.sql) reference columns that don't apply per-row.
         const isMeasure = type === 'measure';
@@ -3508,7 +3509,11 @@ export class BaseQuery {
     if (!filterSql) {
       return maskedSql;
     }
-    const originalSql = this.autoPrefixAndEvaluateSql(cubeName, symbol.sql);
+    const memberPath = this.cubeEvaluator.pathFromArray(memberPathArray);
+    const originalSql = this.evaluateSymbolSqlWithContext(
+      () => this.autoPrefixAndEvaluateSql(cubeName, symbol.sql),
+      { skipMaskFor: memberPath }
+    );
     return `CASE WHEN ${filterSql} THEN ${originalSql} ELSE ${maskedSql} END`;
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -253,17 +253,12 @@ export class BaseQuery {
       securityContext: {},
       ...this.options.contextSymbols,
     };
-    const maskedMembersInput = this.options.maskedMembers || [];
     this.maskedMembers = new Set();
     this.memberMaskFilters = {};
-    for (const item of maskedMembersInput) {
-      if (typeof item === 'string') {
-        this.maskedMembers.add(item);
-      } else if (item && typeof item === 'object' && item.member) {
-        this.maskedMembers.add(item.member);
-        if (item.filter) {
-          this.memberMaskFilters[item.member] = item.filter;
-        }
+    for (const item of this.options.maskedMembers || []) {
+      this.maskedMembers.add(item.member);
+      if (item.filter) {
+        this.memberMaskFilters[item.member] = item.filter;
       }
     }
     this.compilerCache = this.compilers.compiler.compilerCache;

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -253,8 +253,19 @@ export class BaseQuery {
       securityContext: {},
       ...this.options.contextSymbols,
     };
-    this.maskedMembers = new Set(this.options.maskedMembers || []);
-    this.memberMaskFilters = this.options.memberMaskFilters || {};
+    const maskedMembersInput = this.options.maskedMembers || [];
+    this.maskedMembers = new Set();
+    this.memberMaskFilters = {};
+    for (const item of maskedMembersInput) {
+      if (typeof item === 'string') {
+        this.maskedMembers.add(item);
+      } else if (item && typeof item === 'object' && item.member) {
+        this.maskedMembers.add(item.member);
+        if (item.filter) {
+          this.memberMaskFilters[item.member] = item.filter;
+        }
+      }
+    }
     this.compilerCache = this.compilers.compiler.compilerCache;
     this.queryCache = this.compilerCache.getQueryCache({
       measures: this.options.measures,
@@ -287,7 +298,6 @@ export class BaseQuery {
       subqueryJoins: this.options.subqueryJoins,
       joinHints: this.options.joinHints,
       maskedMembers: this.options.maskedMembers,
-      memberMaskFilters: this.options.memberMaskFilters,
     });
     this.from = this.options.from;
     this.multiStageQuery = this.options.multiStageQuery;
@@ -955,7 +965,6 @@ export class BaseQuery {
       disableExternalPreAggregations: !!this.options.disableExternalPreAggregations,
       convertTzForRawTimeDimension: !!this.options.convertTzForRawTimeDimension,
       maskedMembers: this.options.maskedMembers,
-      memberMaskFilters: this.options.memberMaskFilters,
       memberToAlias: this.options.memberToAlias,
     };
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3519,24 +3519,11 @@ export class BaseQuery {
 
   maskFilterToSql(filter) {
     if (!filter) return null;
-    if (filter.and) {
-      const parts = filter.and.map(f => this.maskFilterToSql(f)).filter(Boolean);
-      return parts.length ? parts.map(p => `(${p})`).join(' AND ') : null;
-    }
-    if (filter.or) {
-      const parts = filter.or.map(f => this.maskFilterToSql(f)).filter(Boolean);
-      return parts.length ? parts.map(p => `(${p})`).join(' OR ') : null;
-    }
-    if (filter.member && filter.operator) {
-      const filterObj = this.initFilter({
-        dimension: filter.member,
-        operator: filter.operator,
-        values: filter.values,
-        measure: null,
-      });
-      return filterObj.filterToWhere();
-    }
-    return null;
+    const filterItems = this.extractFiltersAsTree([filter]);
+    if (!filterItems.length) return null;
+    const initialized = filterItems.map(this.initFilter.bind(this));
+    const clauses = initialized.map(f => f.filterToWhere()).filter(Boolean);
+    return clauses.length ? clauses.map(c => `(${c})`).join(' AND ') : null;
   }
 
   defaultMaskSql(memberType) {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3316,7 +3316,7 @@ export class BaseQuery {
         if (!isMeasure || !isUngrouped || !hasSqlMask) {
           const maskFilter = this.memberMaskFilters && this.memberMaskFilters[memberPath];
           if (maskFilter) {
-            return this.conditionalMemberMaskSql(cubeName, name, symbol, memberPathArray, maskFilter);
+            return this.conditionalMemberMaskSql(cubeName, name, symbol, maskFilter);
           }
           return this.memberMaskSql(cubeName, name, symbol);
         }
@@ -3498,7 +3498,7 @@ export class BaseQuery {
     return this.defaultMaskSql(symbol.type);
   }
 
-  conditionalMemberMaskSql(cubeName, name, symbol, memberPathArray, maskFilter) {
+  conditionalMemberMaskSql(cubeName, name, symbol, maskFilter) {
     const maskedSql = this.memberMaskSql(cubeName, name, symbol);
     const result = this.evaluateSymbolSqlWithContext(
       () => {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -254,6 +254,7 @@ export class BaseQuery {
       ...this.options.contextSymbols,
     };
     this.maskedMembers = new Set(this.options.maskedMembers || []);
+    this.memberMaskFilters = this.options.memberMaskFilters || {};
     this.compilerCache = this.compilers.compiler.compilerCache;
     this.queryCache = this.compilerCache.getQueryCache({
       measures: this.options.measures,
@@ -286,6 +287,7 @@ export class BaseQuery {
       subqueryJoins: this.options.subqueryJoins,
       joinHints: this.options.joinHints,
       maskedMembers: this.options.maskedMembers,
+      memberMaskFilters: this.options.memberMaskFilters,
     });
     this.from = this.options.from;
     this.multiStageQuery = this.options.multiStageQuery;
@@ -953,6 +955,7 @@ export class BaseQuery {
       disableExternalPreAggregations: !!this.options.disableExternalPreAggregations,
       convertTzForRawTimeDimension: !!this.options.convertTzForRawTimeDimension,
       maskedMembers: this.options.maskedMembers,
+      memberMaskFilters: this.options.memberMaskFilters,
       memberToAlias: this.options.memberToAlias,
     };
 
@@ -3306,6 +3309,10 @@ export class BaseQuery {
         const isUngrouped = this.options.ungrouped;
         const hasSqlMask = symbol.mask && typeof symbol.mask === 'object' && symbol.mask.sql;
         if (!isMeasure || !isUngrouped || !hasSqlMask) {
+          const maskFilter = this.memberMaskFilters && this.memberMaskFilters[memberPath];
+          if (maskFilter) {
+            return this.conditionalMemberMaskSql(cubeName, name, symbol, memberPathArray, maskFilter);
+          }
           return this.memberMaskSql(cubeName, name, symbol);
         }
       }
@@ -3484,6 +3491,38 @@ export class BaseQuery {
       }
     }
     return this.defaultMaskSql(symbol.type);
+  }
+
+  conditionalMemberMaskSql(cubeName, name, symbol, memberPathArray, maskFilter) {
+    const maskedSql = this.memberMaskSql(cubeName, name, symbol);
+    const filterSql = this.maskFilterToSql(maskFilter);
+    if (!filterSql) {
+      return maskedSql;
+    }
+    const originalSql = this.autoPrefixAndEvaluateSql(cubeName, symbol.sql);
+    return `CASE WHEN ${filterSql} THEN ${originalSql} ELSE ${maskedSql} END`;
+  }
+
+  maskFilterToSql(filter) {
+    if (!filter) return null;
+    if (filter.and) {
+      const parts = filter.and.map(f => this.maskFilterToSql(f)).filter(Boolean);
+      return parts.length ? parts.map(p => `(${p})`).join(' AND ') : null;
+    }
+    if (filter.or) {
+      const parts = filter.or.map(f => this.maskFilterToSql(f)).filter(Boolean);
+      return parts.length ? parts.map(p => `(${p})`).join(' OR ') : null;
+    }
+    if (filter.member && filter.operator) {
+      const filterObj = this.initFilter({
+        dimension: filter.member,
+        operator: filter.operator,
+        values: filter.values,
+        measure: null,
+      });
+      return filterObj.filterToWhere();
+    }
+    return null;
   }
 
   defaultMaskSql(memberType) {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3519,8 +3519,14 @@ export class BaseQuery {
     const filterItems = this.extractFiltersAsTree([filter]);
     if (!filterItems.length) return null;
     const initialized = filterItems.map(this.initFilter.bind(this));
-    const clauses = initialized.map(f => f.filterToWhere()).filter(Boolean);
-    return clauses.length ? clauses.map(c => `(${c})`).join(' AND ') : null;
+    if (initialized.length === 1) {
+      return initialized[0].filterToWhere();
+    }
+    const groupFilter = this.newGroupFilter({
+      operator: 'and',
+      values: initialized,
+    });
+    return groupFilter.filterToWhere();
   }
 
   defaultMaskSql(memberType) {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3507,7 +3507,7 @@ export class BaseQuery {
           return maskedSql;
         }
         const originalSql = this.autoPrefixAndEvaluateSql(cubeName, symbol.sql);
-        return `CASE WHEN ${filterSql} THEN ${originalSql} ELSE ${maskedSql} END`;
+        return this.caseWhenStatement([{ sql: filterSql, label: originalSql }], maskedSql);
       },
       { skipMasking: true, currentMember: null }
     );

--- a/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
@@ -410,7 +410,7 @@ describe('Transpilers', () => {
       {
         measures: ['Test.count'],
         dimensions: ['Test.secret'],
-        maskedMembers: ['Test.secret'],
+        maskedMembers: [{ member: 'Test.secret' }],
       }
     );
     const sql = query.buildSqlAndParams();

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -2010,5 +2010,49 @@ cubes:
       expect(sql).not.toContain('CASE WHEN');
       expect(sql).toContain('NULL');
     });
+
+    it('does not recurse when filter member is also masked', async () => {
+      const compilers = prepareYamlCompiler(`
+cubes:
+  - name: items
+    sql_table: public.items
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: product_id
+        sql: product_id
+        type: number
+      - name: price
+        sql: price
+        type: number
+        mask: -1
+    measures:
+      - name: count
+        type: count
+      `);
+
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['items.count'],
+        dimensions: ['items.product_id', 'items.price'],
+        maskedMembers: [
+          {
+            member: 'items.product_id',
+            filter: { member: 'items.product_id', operator: 'lte', values: ['3'] }
+          },
+          {
+            member: 'items.price',
+            filter: { member: 'items.product_id', operator: 'lte', values: ['3'] }
+          },
+        ],
+      });
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toContain('CASE WHEN');
+      expect(sql).toMatch(/product_id/);
+      expect(sql).not.toMatch(/Maximum call stack/);
+    });
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -1883,8 +1883,8 @@ cubes:
         }],
       });
       const [sql] = query.buildSqlAndParams();
-      expect(sql).toContain('CASE WHEN');
-      expect(sql).toMatch(/CASE WHEN.*data_region.*THEN.*city.*ELSE.*NULL.*END/s);
+      expect(sql).toMatch(/CASE\s+WHEN/);
+      expect(sql).toMatch(/WHEN.*data_region.*THEN.*city.*ELSE.*NULL.*END/s);
     });
 
     it('generates CASE WHEN with AND row filter for multiple filter conditions', async () => {
@@ -1935,8 +1935,8 @@ cubes:
         }],
       });
       const [sql] = query.buildSqlAndParams();
-      expect(sql).toContain('CASE WHEN');
-      expect(sql).toMatch(/CASE WHEN.*AND.*THEN.*city.*ELSE.*NULL.*END/s);
+      expect(sql).toMatch(/CASE\s+WHEN/);
+      expect(sql).toMatch(/WHEN.*AND.*THEN.*city.*ELSE.*NULL.*END/s);
     });
 
     it('uses mask.sql as the ELSE branch when dimension has a custom mask', async () => {
@@ -1977,8 +1977,8 @@ cubes:
         }],
       });
       const [sql] = query.buildSqlAndParams();
-      expect(sql).toContain('CASE WHEN');
-      expect(sql).toMatch(/CASE WHEN.*data_region.*THEN.*city.*ELSE.*MASKED.*END/s);
+      expect(sql).toMatch(/CASE\s+WHEN/);
+      expect(sql).toMatch(/WHEN.*data_region.*THEN.*city.*ELSE.*MASKED.*END/s);
     });
 
     it('applies regular masking (no CASE WHEN) when no memberMaskFilters', async () => {
@@ -2007,7 +2007,7 @@ cubes:
         maskedMembers: [{ member: 'users.city' }],
       });
       const [sql] = query.buildSqlAndParams();
-      expect(sql).not.toContain('CASE WHEN');
+      expect(sql).not.toMatch(/CASE\s+WHEN/);
       expect(sql).toContain('NULL');
     });
 
@@ -2050,7 +2050,7 @@ cubes:
         ],
       });
       const [sql] = query.buildSqlAndParams();
-      expect(sql).toContain('CASE WHEN');
+      expect(sql).toMatch(/CASE\s+WHEN/);
       expect(sql).toMatch(/product_id/);
       expect(sql).not.toMatch(/Maximum call stack/);
     });

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -1665,7 +1665,7 @@ cubes:
         {
           measures: ['orders.count'],
           dimensions: ['orders.status'],
-          maskedMembers: ['orders.status'],
+          maskedMembers: [{ member: 'orders.status' }],
           contextSymbols: {
             securityContext: { cubeCloud: { userAttributes: { hasStatusAccess: true } } }
           }
@@ -1806,7 +1806,7 @@ views:
         const query = new PostgresQuery(compilers, {
           measures: ['users_secure_view.users_count'],
           dimensions: ['users_secure_view.users_city_sensitive_masked'],
-          maskedMembers: ['users_secure_view.users_city_sensitive_masked'],
+          maskedMembers: [{ member: 'users_secure_view.users_city_sensitive_masked' }],
           contextSymbols: {
             securityContext: { cubeCloud: { groups } }
           },
@@ -2004,7 +2004,7 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: ['users.city'],
+        maskedMembers: [{ member: 'users.city' }],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).not.toContain('CASE WHEN');

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -1873,14 +1873,11 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: ['users.city'],
-        memberMaskFilters: {
-          'users.city': {
-            member: 'users.data_region',
-            operator: 'equals',
-            values: ['RESEARCH', 'DEMO'],
-          }
-        },
+        maskedMembers: [{ member: 'users.city', filter: {
+          member: 'users.data_region',
+          operator: 'equals',
+          values: ['RESEARCH', 'DEMO'],
+        }}],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).toContain('CASE WHEN');
@@ -1916,23 +1913,20 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: ['users.city'],
-        memberMaskFilters: {
-          'users.city': {
-            and: [
-              {
-                member: 'users.data_region',
-                operator: 'equals',
-                values: ['RESEARCH'],
-              },
-              {
-                member: 'users.region_lock',
-                operator: 'equals',
-                values: ['0'],
-              }
-            ]
-          }
-        },
+        maskedMembers: [{ member: 'users.city', filter: {
+          and: [
+            {
+              member: 'users.data_region',
+              operator: 'equals',
+              values: ['RESEARCH'],
+            },
+            {
+              member: 'users.region_lock',
+              operator: 'equals',
+              values: ['0'],
+            }
+          ]
+        }}],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).toContain('CASE WHEN');
@@ -1967,14 +1961,11 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: ['users.city'],
-        memberMaskFilters: {
-          'users.city': {
-            member: 'users.data_region',
-            operator: 'equals',
-            values: ['RESEARCH'],
-          }
-        },
+        maskedMembers: [{ member: 'users.city', filter: {
+          member: 'users.data_region',
+          operator: 'equals',
+          values: ['RESEARCH'],
+        }}],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).toContain('CASE WHEN');

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -1873,11 +1873,14 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: [{ member: 'users.city', filter: {
-          member: 'users.data_region',
-          operator: 'equals',
-          values: ['RESEARCH', 'DEMO'],
-        }}],
+        maskedMembers: [{
+          member: 'users.city',
+          filter: {
+            member: 'users.data_region',
+            operator: 'equals',
+            values: ['RESEARCH', 'DEMO'],
+          }
+        }],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).toContain('CASE WHEN');
@@ -1913,20 +1916,23 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: [{ member: 'users.city', filter: {
-          and: [
-            {
-              member: 'users.data_region',
-              operator: 'equals',
-              values: ['RESEARCH'],
-            },
-            {
-              member: 'users.region_lock',
-              operator: 'equals',
-              values: ['0'],
-            }
-          ]
-        }}],
+        maskedMembers: [{
+          member: 'users.city',
+          filter: {
+            and: [
+              {
+                member: 'users.data_region',
+                operator: 'equals',
+                values: ['RESEARCH'],
+              },
+              {
+                member: 'users.region_lock',
+                operator: 'equals',
+                values: ['0'],
+              }
+            ]
+          }
+        }],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).toContain('CASE WHEN');
@@ -1961,11 +1967,14 @@ cubes:
       const query = new PostgresQuery(compilers, {
         measures: ['users.count'],
         dimensions: ['users.city'],
-        maskedMembers: [{ member: 'users.city', filter: {
-          member: 'users.data_region',
-          operator: 'equals',
-          values: ['RESEARCH'],
-        }}],
+        maskedMembers: [{
+          member: 'users.city',
+          filter: {
+            member: 'users.data_region',
+            operator: 'equals',
+            values: ['RESEARCH'],
+          }
+        }],
       });
       const [sql] = query.buildSqlAndParams();
       expect(sql).toContain('CASE WHEN');

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -1845,4 +1845,170 @@ views:
       });
     });
   });
+
+  describe('Conditional masking with row-level filters (memberMaskFilters)', () => {
+    it('generates CASE WHEN with row filter for masked members that have conditional full access', async () => {
+      const compilers = prepareYamlCompiler(`
+cubes:
+  - name: users
+    sql_table: public.users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: city
+        sql: city
+        type: string
+      - name: data_region
+        sql: data_region
+        type: string
+    measures:
+      - name: count
+        type: count
+      `);
+
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['users.count'],
+        dimensions: ['users.city'],
+        maskedMembers: ['users.city'],
+        memberMaskFilters: {
+          'users.city': {
+            member: 'users.data_region',
+            operator: 'equals',
+            values: ['RESEARCH', 'DEMO'],
+          }
+        },
+      });
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toContain('CASE WHEN');
+      expect(sql).toMatch(/CASE WHEN.*data_region.*THEN.*city.*ELSE.*NULL.*END/s);
+    });
+
+    it('generates CASE WHEN with AND row filter for multiple filter conditions', async () => {
+      const compilers = prepareYamlCompiler(`
+cubes:
+  - name: users
+    sql_table: public.users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: city
+        sql: city
+        type: string
+      - name: data_region
+        sql: data_region
+        type: string
+      - name: region_lock
+        sql: region_lock
+        type: number
+    measures:
+      - name: count
+        type: count
+      `);
+
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['users.count'],
+        dimensions: ['users.city'],
+        maskedMembers: ['users.city'],
+        memberMaskFilters: {
+          'users.city': {
+            and: [
+              {
+                member: 'users.data_region',
+                operator: 'equals',
+                values: ['RESEARCH'],
+              },
+              {
+                member: 'users.region_lock',
+                operator: 'equals',
+                values: ['0'],
+              }
+            ]
+          }
+        },
+      });
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toContain('CASE WHEN');
+      expect(sql).toMatch(/CASE WHEN.*AND.*THEN.*city.*ELSE.*NULL.*END/s);
+    });
+
+    it('uses mask.sql as the ELSE branch when dimension has a custom mask', async () => {
+      const compilers = prepareYamlCompiler(`
+cubes:
+  - name: users
+    sql_table: public.users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: city
+        sql: city
+        type: string
+        mask:
+          sql: "'***MASKED***'"
+      - name: data_region
+        sql: data_region
+        type: string
+    measures:
+      - name: count
+        type: count
+      `);
+
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['users.count'],
+        dimensions: ['users.city'],
+        maskedMembers: ['users.city'],
+        memberMaskFilters: {
+          'users.city': {
+            member: 'users.data_region',
+            operator: 'equals',
+            values: ['RESEARCH'],
+          }
+        },
+      });
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toContain('CASE WHEN');
+      expect(sql).toMatch(/CASE WHEN.*data_region.*THEN.*city.*ELSE.*MASKED.*END/s);
+    });
+
+    it('applies regular masking (no CASE WHEN) when no memberMaskFilters', async () => {
+      const compilers = prepareYamlCompiler(`
+cubes:
+  - name: users
+    sql_table: public.users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: city
+        sql: city
+        type: string
+    measures:
+      - name: count
+        type: count
+      `);
+
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: ['users.count'],
+        dimensions: ['users.city'],
+        maskedMembers: ['users.city'],
+      });
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).not.toContain('CASE WHEN');
+      expect(sql).toContain('NULL');
+    });
+  });
 });

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -548,6 +548,7 @@ export class CompilerApi {
     const viewFiltersPerCubePerRole: Record<string, Record<string, any[]>> = {};
     const hasAllowAllForCube: Record<string, boolean> = {};
     const maskedMembersSet = new Set<string>();
+    const memberMaskFiltersMap: Record<string, any> = {};
 
     for (const cubeName of queryCubes) {
       const cube = cubeEvaluator.cubeFromPath(cubeName);
@@ -680,21 +681,53 @@ export class CompilerApi {
         });
 
         // Determine which members need masking: a member is masked if no covering
-        // policy grants it full access via memberLevel AND at least one covering
-        // policy defines memberMasking that includes the member.
-        // Masking follows the same pattern as row-level security: it is applied
-        // at both cube and view levels. When a cube is accessed through a view,
-        // both the cube's and the view's masking policies are evaluated.
+        // policy grants it unconditional full access via memberLevel AND at least
+        // one covering policy defines memberMasking that includes the member.
+        //
+        // When a policy grants full memberLevel access but also has row_level filters,
+        // the full access is conditional on the row filter. In that case, we track
+        // the row filters so that the generated SQL uses:
+        //   CASE WHEN {rowFilter} THEN {originalValue} ELSE {maskedValue} END
+        // This ensures that rows outside the filter range see masked values.
         const cubeMembersInQuery = Array.from(queryMemberNames).filter(
           memberName => memberName.startsWith(`${cubeName}.`)
         );
         for (const memberName of cubeMembersInQuery) {
-          const hasFullAccessInAnyPolicy = policiesWithMemberAccess.some(policy => {
-            if (!policy.memberLevel) return true;
-            return policy.memberLevel.includesMembers.includes(memberName) &&
+          const hasUnconditionalFullAccess = policiesWithMemberAccess.some(policy => {
+            if (!policy.memberLevel) {
+              return !policy.rowLevel || policy.rowLevel.allowAll;
+            }
+            const inIncludes = policy.memberLevel.includesMembers.includes(memberName) &&
                    !policy.memberLevel.excludesMembers.includes(memberName);
+            return inIncludes && (!policy.rowLevel || policy.rowLevel.allowAll);
           });
-          if (!hasFullAccessInAnyPolicy && policiesWithMemberAccess.length > 0) {
+
+          if (hasUnconditionalFullAccess) {
+            continue;
+          }
+
+          const conditionalFullAccessPolicies = policiesWithMemberAccess.filter(policy => {
+            if (!policy.memberLevel) {
+              return policy.rowLevel && !policy.rowLevel.allowAll && policy.rowLevel.filters?.length > 0;
+            }
+            const inIncludes = policy.memberLevel.includesMembers.includes(memberName) &&
+                   !policy.memberLevel.excludesMembers.includes(memberName);
+            return inIncludes && policy.rowLevel && !policy.rowLevel.allowAll && policy.rowLevel.filters?.length > 0;
+          });
+
+          if (conditionalFullAccessPolicies.length > 0 && policiesWithMemberAccess.length > 0) {
+            maskedMembersSet.add(memberName);
+            const evaluatedFilters = conditionalFullAccessPolicies.flatMap(
+              policy => (policy.rowLevel.filters || []).map(
+                (filter: any) => this.evaluateNestedFilter(filter, cube, context, cubeEvaluator)
+              )
+            );
+            if (evaluatedFilters.length > 0) {
+              memberMaskFiltersMap[memberName] = evaluatedFilters.length === 1
+                ? evaluatedFilters[0]
+                : { and: evaluatedFilters };
+            }
+          } else if (policiesWithMemberAccess.length > 0) {
             const isMaskedByAnyPolicy = policiesWithMemberAccess.some(
               (policy) => policy.memberMasking && policy.memberMasking.includesMembers.includes(memberName) && !policy.memberMasking.excludesMembers.includes(memberName)
             );
@@ -747,6 +780,9 @@ export class CompilerApi {
     }
     if (maskedMembersSet.size > 0) {
       query.maskedMembers = Array.from(maskedMembersSet);
+    }
+    if (Object.keys(memberMaskFiltersMap).length > 0) {
+      query.memberMaskFilters = memberMaskFiltersMap;
     }
     return { query, denied: false };
   }

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -779,10 +779,13 @@ export class CompilerApi {
       query.filters.push(rlsFilter);
     }
     if (maskedMembersSet.size > 0) {
-      query.maskedMembers = Array.from(maskedMembersSet);
-    }
-    if (Object.keys(memberMaskFiltersMap).length > 0) {
-      query.memberMaskFilters = memberMaskFiltersMap;
+      query.maskedMembers = Array.from(maskedMembersSet).map(member => {
+        const filter = memberMaskFiltersMap[member];
+        if (filter) {
+          return { member, filter };
+        }
+        return member;
+      });
     }
     return { query, denied: false };
   }

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -706,16 +706,26 @@ export class CompilerApi {
             continue;
           }
 
+          const hasMaskingPolicy = policiesWithMemberAccess.some(
+            (policy) => policy.memberMasking &&
+              policy.memberMasking.includesMembers.includes(memberName) &&
+              !policy.memberMasking.excludesMembers.includes(memberName)
+          );
+
+          if (!hasMaskingPolicy) {
+            continue;
+          }
+
           const conditionalFullAccessPolicies = policiesWithMemberAccess.filter(policy => {
-            if (!policy.memberLevel) {
-              return policy.rowLevel && !policy.rowLevel.allowAll && policy.rowLevel.filters?.length > 0;
-            }
-            const inIncludes = policy.memberLevel.includesMembers.includes(memberName) &&
-                   !policy.memberLevel.excludesMembers.includes(memberName);
-            return inIncludes && policy.rowLevel && !policy.rowLevel.allowAll && policy.rowLevel.filters?.length > 0;
+            const hasFullMemberAccess = !policy.memberLevel ||
+              (policy.memberLevel.includesMembers.includes(memberName) &&
+               !policy.memberLevel.excludesMembers.includes(memberName));
+            return hasFullMemberAccess &&
+              policy.rowLevel && !policy.rowLevel.allowAll &&
+              policy.rowLevel.filters?.length > 0;
           });
 
-          if (conditionalFullAccessPolicies.length > 0 && policiesWithMemberAccess.length > 0) {
+          if (conditionalFullAccessPolicies.length > 0) {
             maskedMembersSet.add(memberName);
             const evaluatedFilters = conditionalFullAccessPolicies.flatMap(
               policy => (policy.rowLevel.filters || []).map(
@@ -727,13 +737,8 @@ export class CompilerApi {
                 ? evaluatedFilters[0]
                 : { and: evaluatedFilters };
             }
-          } else if (policiesWithMemberAccess.length > 0) {
-            const isMaskedByAnyPolicy = policiesWithMemberAccess.some(
-              (policy) => policy.memberMasking && policy.memberMasking.includesMembers.includes(memberName) && !policy.memberMasking.excludesMembers.includes(memberName)
-            );
-            if (isMaskedByAnyPolicy) {
-              maskedMembersSet.add(memberName);
-            }
+          } else {
+            maskedMembersSet.add(memberName);
           }
         }
 

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -702,43 +702,37 @@ export class CompilerApi {
             return inIncludes && (!policy.rowLevel || policy.rowLevel.allowAll);
           });
 
-          if (hasUnconditionalFullAccess) {
-            continue;
-          }
-
-          const hasMaskingPolicy = policiesWithMemberAccess.some(
-            (policy) => policy.memberMasking &&
-              policy.memberMasking.includesMembers.includes(memberName) &&
-              !policy.memberMasking.excludesMembers.includes(memberName)
-          );
-
-          if (!hasMaskingPolicy) {
-            continue;
-          }
-
-          const conditionalFullAccessPolicies = policiesWithMemberAccess.filter(policy => {
-            const hasFullMemberAccess = !policy.memberLevel ||
-              (policy.memberLevel.includesMembers.includes(memberName) &&
-               !policy.memberLevel.excludesMembers.includes(memberName));
-            return hasFullMemberAccess &&
-              policy.rowLevel && !policy.rowLevel.allowAll &&
-              policy.rowLevel.filters?.length > 0;
-          });
-
-          if (conditionalFullAccessPolicies.length > 0) {
-            maskedMembersSet.add(memberName);
-            const evaluatedFilters = conditionalFullAccessPolicies.flatMap(
-              policy => (policy.rowLevel.filters || []).map(
-                (filter: any) => this.evaluateNestedFilter(filter, cube, context, cubeEvaluator)
-              )
+          if (!hasUnconditionalFullAccess) {
+            const hasMaskingPolicy = policiesWithMemberAccess.some(
+              (policy) => policy.memberMasking &&
+                policy.memberMasking.includesMembers.includes(memberName) &&
+                !policy.memberMasking.excludesMembers.includes(memberName)
             );
-            if (evaluatedFilters.length > 0) {
-              memberMaskFiltersMap[memberName] = evaluatedFilters.length === 1
-                ? evaluatedFilters[0]
-                : { and: evaluatedFilters };
+
+            if (hasMaskingPolicy) {
+              const conditionalFullAccessPolicies = policiesWithMemberAccess.filter(policy => {
+                const hasFullMemberAccess = !policy.memberLevel ||
+                  (policy.memberLevel.includesMembers.includes(memberName) &&
+                   !policy.memberLevel.excludesMembers.includes(memberName));
+                return hasFullMemberAccess &&
+                  policy.rowLevel && !policy.rowLevel.allowAll &&
+                  policy.rowLevel.filters?.length > 0;
+              });
+
+              maskedMembersSet.add(memberName);
+              if (conditionalFullAccessPolicies.length > 0) {
+                const evaluatedFilters = conditionalFullAccessPolicies.flatMap(
+                  policy => (policy.rowLevel.filters || []).map(
+                    (filter: any) => this.evaluateNestedFilter(filter, cube, context, cubeEvaluator)
+                  )
+                );
+                if (evaluatedFilters.length > 0) {
+                  memberMaskFiltersMap[memberName] = evaluatedFilters.length === 1
+                    ? evaluatedFilters[0]
+                    : { and: evaluatedFilters };
+                }
+              }
             }
-          } else {
-            maskedMembersSet.add(memberName);
           }
         }
 

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -778,13 +778,10 @@ export class CompilerApi {
       query.filters.push(rlsFilter);
     }
     if (maskedMembersSet.size > 0) {
-      query.maskedMembers = Array.from(maskedMembersSet).map(member => {
-        const filter = memberMaskFiltersMap[member];
-        if (filter) {
-          return { member, filter };
-        }
-        return member;
-      });
+      query.maskedMembers = Array.from(maskedMembersSet).map(member => ({
+        member,
+        filter: memberMaskFiltersMap[member],
+      }));
     }
     return { query, denied: false };
   }

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -721,15 +721,16 @@ export class CompilerApi {
 
               maskedMembersSet.add(memberName);
               if (conditionalFullAccessPolicies.length > 0) {
-                const evaluatedFilters = conditionalFullAccessPolicies.flatMap(
-                  policy => (policy.rowLevel.filters || []).map(
+                const policyFilters = conditionalFullAccessPolicies.map(policy => {
+                  const filters = (policy.rowLevel.filters || []).map(
                     (filter: any) => this.evaluateNestedFilter(filter, cube, context, cubeEvaluator)
-                  )
-                );
-                if (evaluatedFilters.length > 0) {
-                  memberMaskFiltersMap[memberName] = evaluatedFilters.length === 1
-                    ? evaluatedFilters[0]
-                    : { and: evaluatedFilters };
+                  );
+                  return filters.length === 1 ? filters[0] : { and: filters };
+                });
+                if (policyFilters.length > 0) {
+                  memberMaskFiltersMap[memberName] = policyFilters.length === 1
+                    ? policyFilters[0]
+                    : { or: policyFilters };
                 }
               }
             }

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
@@ -245,6 +245,23 @@ module.exports = {
         },
       };
     }
+    if (user === 'conditional_mask_user') {
+      if (password && password !== 'conditional_mask_password') {
+        throw new Error(`Password doesn't match for ${user}`);
+      }
+      return {
+        password,
+        superuser: false,
+        securityContext: {
+          auth: {
+            username: 'conditional_mask_user',
+            userAttributes: {},
+            roles: ['conditional_mask_role'],
+            groups: [],
+          },
+        },
+      };
+    }
     throw new Error(`User "${user}" doesn't exist`);
   }
 };

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
@@ -262,6 +262,23 @@ module.exports = {
         },
       };
     }
+    if (user === 'conditional_mask_multi_user') {
+      if (password && password !== 'conditional_mask_multi_password') {
+        throw new Error(`Password doesn't match for ${user}`);
+      }
+      return {
+        password,
+        superuser: false,
+        securityContext: {
+          auth: {
+            username: 'conditional_mask_multi_user',
+            userAttributes: {},
+            roles: ['conditional_mask_role', 'conditional_mask_role_extra'],
+            groups: [],
+          },
+        },
+      };
+    }
     throw new Error(`User "${user}" doesn't exist`);
   }
 };

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
@@ -1,0 +1,43 @@
+cubes:
+  - name: conditional_masking_test
+    sql_table: public.line_items
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: product_id
+        sql: product_id
+        type: number
+
+      - name: price
+        sql: price
+        type: number
+        mask: -1
+
+    measures:
+      - name: count
+        type: count
+
+      - name: total_price
+        sql: price
+        type: sum
+
+    access_policy:
+      - role: "*"
+        member_level:
+          includes: []
+        member_masking:
+          includes: "*"
+
+      - role: "conditional_mask_role"
+        member_level:
+          includes: "*"
+        row_level:
+          filters:
+            - member: product_id
+              operator: lte
+              values:
+                - "3"

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
@@ -41,3 +41,13 @@ cubes:
               operator: lte
               values:
                 - "3"
+
+      - role: "conditional_mask_role_extra"
+        member_level:
+          includes: "*"
+        row_level:
+          filters:
+            - member: product_id
+              operator: equals
+              values:
+                - "5"

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -492,6 +492,46 @@ describe('Cube RBAC Engine', () => {
   });
 
   /**
+   * Conditional masking: when a policy grants full member_level access WITH
+   * row_level filters, the masking is conditional on the row filter.
+   * Rows matching the filter see unmasked values; other rows see masked values.
+   *
+   * conditional_masking_test cube:
+   *   - role "*": member_level includes=[], member_masking includes="*"
+   *   - role "conditional_mask_role": member_level includes="*", row_level filter product_id <= 3
+   *
+   * For conditional_mask_user (role: conditional_mask_role):
+   *   - product_id dimension: rows with product_id <= 3 show real value, others show masked (-1 for price)
+   */
+  describe('RBAC conditional masking with row-level filters via SQL API', () => {
+    let connection: PgClient;
+
+    beforeAll(async () => {
+      connection = await createPostgresClient('conditional_mask_user', 'conditional_mask_password');
+    });
+
+    afterAll(async () => {
+      await connection.end();
+    }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+    test('conditional_masking_test returns CASE WHEN masked values based on row filter', async () => {
+      const res = await connection.query(
+        'SELECT product_id, price FROM conditional_masking_test ORDER BY product_id LIMIT 10'
+      );
+      expect(res.rows.length).toBeGreaterThan(0);
+      for (const row of res.rows) {
+        if (Number(row.product_id) <= 3) {
+          // Rows matching the row filter should have real (unmasked) price
+          expect(Number(row.price)).not.toBe(-1);
+        } else {
+          // Rows NOT matching the row filter should have masked price (-1)
+          expect(Number(row.price)).toBe(-1);
+        }
+      }
+    });
+  });
+
+  /**
    * View masking tests — masking follows the RLS pattern and is applied at
    * both cube and view levels. If a cube masks a member, it stays masked
    * even when accessed through a view that grants full access.

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -532,6 +532,43 @@ describe('Cube RBAC Engine', () => {
   });
 
   /**
+   * Multiple conditional policies use OR across policies:
+   *   - role "conditional_mask_role": product_id <= 3
+   *   - role "conditional_mask_role_extra": product_id = 5
+   *
+   * For conditional_mask_multi_user (both roles):
+   *   Unmasked when product_id <= 3 OR product_id = 5, masked otherwise.
+   */
+  describe('RBAC conditional masking with multiple policies (OR across policies)', () => {
+    let connection: PgClient;
+
+    beforeAll(async () => {
+      connection = await createPostgresClient('conditional_mask_multi_user', 'conditional_mask_multi_password');
+    });
+
+    afterAll(async () => {
+      await connection.end();
+    }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+    test('unmasked when any policy filter matches (OR across policies)', async () => {
+      const res = await connection.query(
+        'SELECT product_id, price FROM conditional_masking_test ORDER BY product_id LIMIT 10'
+      );
+      expect(res.rows.length).toBeGreaterThan(0);
+      for (const row of res.rows) {
+        const pid = Number(row.product_id);
+        if (pid <= 3 || pid === 5) {
+          // Matches either policy filter → unmasked
+          expect(Number(row.price)).not.toBe(-1);
+        } else {
+          // Matches neither policy filter → masked
+          expect(Number(row.price)).toBe(-1);
+        }
+      }
+    });
+  });
+
+  /**
    * View masking tests — masking follows the RLS pattern and is applied at
    * both cube and view levels. If a cube masks a member, it stays masked
    * even when accessed through a view that grants full access.

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
@@ -18,10 +18,7 @@ use std::rc::Rc;
 #[serde(untagged)]
 pub enum MaskedMemberItem {
     Simple(String),
-    WithFilter {
-        member: String,
-        filter: FilterItem,
-    },
+    WithFilter { member: String, filter: FilterItem },
 }
 
 impl MaskedMemberItem {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
@@ -15,6 +15,32 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum MaskedMemberItem {
+    Simple(String),
+    WithFilter {
+        member: String,
+        filter: FilterItem,
+    },
+}
+
+impl MaskedMemberItem {
+    pub fn member_name(&self) -> &str {
+        match self {
+            MaskedMemberItem::Simple(s) => s.as_str(),
+            MaskedMemberItem::WithFilter { member, .. } => member.as_str(),
+        }
+    }
+
+    pub fn filter(&self) -> Option<&FilterItem> {
+        match self {
+            MaskedMemberItem::Simple(_) => None,
+            MaskedMemberItem::WithFilter { filter, .. } => Some(filter),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TimeDimension {
     pub dimension: String,
     pub granularity: Option<String>,
@@ -77,7 +103,7 @@ pub struct BaseQueryOptionsStatic {
     #[serde(rename = "convertTzForRawTimeDimension")]
     pub convert_tz_for_raw_time_dimension: Option<bool>,
     #[serde(rename = "maskedMembers")]
-    pub masked_members: Option<Vec<String>>,
+    pub masked_members: Option<Vec<MaskedMemberItem>>,
     #[serde(rename = "memberToAlias", default)]
     pub member_to_alias: Option<HashMap<String, String>>,
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
@@ -15,26 +15,9 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum MaskedMemberItem {
-    Simple(String),
-    WithFilter { member: String, filter: FilterItem },
-}
-
-impl MaskedMemberItem {
-    pub fn member_name(&self) -> &str {
-        match self {
-            MaskedMemberItem::Simple(s) => s.as_str(),
-            MaskedMemberItem::WithFilter { member, .. } => member.as_str(),
-        }
-    }
-
-    pub fn filter(&self) -> Option<&FilterItem> {
-        match self {
-            MaskedMemberItem::Simple(_) => None,
-            MaskedMemberItem::WithFilter { filter, .. } => Some(filter),
-        }
-    }
+pub struct MaskedMemberItem {
+    pub member: String,
+    pub filter: Option<FilterItem>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
@@ -1,5 +1,6 @@
 use super::sql_evaluator::Compiler;
 use super::ParamsAllocator;
+use crate::cube_bridge::base_query_options::{FilterItem, MaskedMemberItem};
 use crate::cube_bridge::base_tools::BaseTools;
 use crate::cube_bridge::evaluator::CubeEvaluator;
 use crate::cube_bridge::join_definition::JoinDefinition;
@@ -32,6 +33,7 @@ pub struct QueryTools {
     timezone: Tz,
     convert_tz_for_raw_time_dimension: bool,
     masked_members: HashSet<String>,
+    member_mask_filters: HashMap<String, FilterItem>,
 }
 
 impl QueryTools {
@@ -43,7 +45,7 @@ impl QueryTools {
         timezone_name: Option<String>,
         export_annotated_sql: bool,
         convert_tz_for_raw_time_dimension: bool,
-        masked_members: Option<Vec<String>>,
+        masked_members: Option<Vec<MaskedMemberItem>>,
         member_to_alias: Option<HashMap<String, String>>,
     ) -> Result<Rc<Self>, CubeError> {
         let templates_render = base_tools.sql_templates()?;
@@ -61,6 +63,17 @@ impl QueryTools {
             timezone.clone(),
             member_to_alias,
         )));
+        let mut masked_set = HashSet::new();
+        let mut mask_filters = HashMap::new();
+        if let Some(items) = masked_members {
+            for item in items {
+                let name = item.member_name().to_string();
+                masked_set.insert(name.clone());
+                if let Some(filter) = item.filter() {
+                    mask_filters.insert(name, filter.clone());
+                }
+            }
+        }
         Ok(Rc::new(Self {
             cube_evaluator,
             base_tools,
@@ -70,12 +83,17 @@ impl QueryTools {
             evaluator_compiler,
             timezone,
             convert_tz_for_raw_time_dimension,
-            masked_members: masked_members.unwrap_or_default().into_iter().collect(),
+            masked_members: masked_set,
+            member_mask_filters: mask_filters,
         }))
     }
 
     pub fn is_member_masked(&self, member_path: &str) -> bool {
         self.masked_members.contains(member_path)
+    }
+
+    pub fn member_mask_filter(&self, member_path: &str) -> Option<&FilterItem> {
+        self.member_mask_filters.get(member_path)
     }
 
     pub fn cube_evaluator(&self) -> &Rc<dyn CubeEvaluator> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_tools.rs
@@ -67,10 +67,9 @@ impl QueryTools {
         let mut mask_filters = HashMap::new();
         if let Some(items) = masked_members {
             for item in items {
-                let name = item.member_name().to_string();
-                masked_set.insert(name.clone());
-                if let Some(filter) = item.filter() {
-                    mask_filters.insert(name, filter.clone());
+                masked_set.insert(item.member.clone());
+                if let Some(filter) = item.filter {
+                    mask_filters.insert(item.member, filter);
                 }
             }
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
@@ -75,10 +75,11 @@ impl MaskedSqlNode {
             let filter_sql =
                 self.compile_filter_to_sql(&filter_item, query_tools.clone(), templates)?;
             if let Some(filter_sql) = filter_sql {
-                Ok(Some(format!(
-                    "CASE WHEN {} THEN {} ELSE {} END",
-                    filter_sql, original_sql, masked_sql
-                )))
+                Ok(Some(templates.case(
+                    None,
+                    vec![(filter_sql, original_sql)],
+                    Some(masked_sql),
+                )?))
             } else {
                 Ok(Some(masked_sql))
             }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
@@ -1,4 +1,5 @@
 use super::SqlNode;
+use crate::cube_bridge::base_query_options::FilterItem as NativeFilterItem;
 use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_evaluator::MemberSymbol;
 use crate::planner::sql_evaluator::SqlEvaluatorVisitor;
@@ -39,9 +40,10 @@ impl MaskedSqlNode {
         if !query_tools.is_member_masked(&full_name) {
             return Ok(None);
         }
-        if let Some(mask_call) = node.mask_sql() {
-            // In ungrouped mode, skip SQL masks (has deps) on measures
-            // since they reference aggregated columns not meaningful per-row.
+
+        let mask_filter = query_tools.member_mask_filter(&full_name).cloned();
+
+        let masked_sql = if let Some(mask_call) = node.mask_sql() {
             if self.ungrouped {
                 if let MemberSymbol::Measure(_) = node.as_ref() {
                     if mask_call.dependencies_count() > 0 {
@@ -49,14 +51,124 @@ impl MaskedSqlNode {
                     }
                 }
             }
-            Ok(Some(mask_call.eval(
+            mask_call.eval(
                 visitor,
-                node_processor,
-                query_tools,
+                node_processor.clone(),
+                query_tools.clone(),
                 templates,
-            )?))
+            )?
         } else {
-            Ok(Some("(NULL)".to_string()))
+            "(NULL)".to_string()
+        };
+
+        if let Some(filter_item) = mask_filter {
+            let original_sql = self.input.to_sql(
+                visitor,
+                node,
+                query_tools.clone(),
+                node_processor.clone(),
+                templates,
+            )?;
+            let filter_sql = self.compile_filter_to_sql(&filter_item, visitor, node_processor, query_tools.clone(), templates)?;
+            if let Some(filter_sql) = filter_sql {
+                Ok(Some(format!("CASE WHEN {} THEN {} ELSE {} END", filter_sql, original_sql, masked_sql)))
+            } else {
+                Ok(Some(masked_sql))
+            }
+        } else {
+            Ok(Some(masked_sql))
+        }
+    }
+
+    fn compile_filter_to_sql(
+        &self,
+        filter_item: &NativeFilterItem,
+        visitor: &SqlEvaluatorVisitor,
+        node_processor: Rc<dyn SqlNode>,
+        query_tools: Rc<QueryTools>,
+        templates: &PlanSqlTemplates,
+    ) -> Result<Option<String>, CubeError> {
+        self.render_native_filter(filter_item, visitor, node_processor, query_tools, templates)
+    }
+
+    fn render_native_filter(
+        &self,
+        item: &NativeFilterItem,
+        visitor: &SqlEvaluatorVisitor,
+        node_processor: Rc<dyn SqlNode>,
+        query_tools: Rc<QueryTools>,
+        templates: &PlanSqlTemplates,
+    ) -> Result<Option<String>, CubeError> {
+        if let Some(items) = &item.or {
+            let parts: Vec<String> = items
+                .iter()
+                .filter_map(|i| self.render_native_filter(i, visitor, node_processor.clone(), query_tools.clone(), templates).transpose())
+                .collect::<Result<Vec<_>, _>>()?;
+            if parts.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(parts.iter().map(|p| format!("({})", p)).collect::<Vec<_>>().join(" OR ")))
+        } else if let Some(items) = &item.and {
+            let parts: Vec<String> = items
+                .iter()
+                .filter_map(|i| self.render_native_filter(i, visitor, node_processor.clone(), query_tools.clone(), templates).transpose())
+                .collect::<Result<Vec<_>, _>>()?;
+            if parts.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(parts.iter().map(|p| format!("({})", p)).collect::<Vec<_>>().join(" AND ")))
+        } else if let (Some(member), Some(operator)) = (item.member(), &item.operator) {
+            let member_symbol = query_tools.evaluator_compiler()
+                .borrow_mut()
+                .add_dimension_evaluator(member.clone())?;
+            let column_sql = self.input.to_sql(visitor, &member_symbol, query_tools.clone(), node_processor, templates)?;
+            let filter_sql = self.render_filter_condition(&column_sql, operator, &item.values, &query_tools)?;
+            Ok(Some(filter_sql))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn render_filter_condition(
+        &self,
+        column_sql: &str,
+        operator: &str,
+        values: &Option<Vec<Option<String>>>,
+        query_tools: &Rc<QueryTools>,
+    ) -> Result<String, CubeError> {
+        let vals: Vec<String> = values
+            .as_ref()
+            .map(|v| v.iter().filter_map(|x| x.clone()).collect())
+            .unwrap_or_default();
+
+        match operator {
+            "equals" => {
+                if vals.len() == 1 {
+                    Ok(format!("{} = {}", column_sql, query_tools.allocate_param(&vals[0])))
+                } else if vals.len() > 1 {
+                    let params: Vec<String> = vals.iter().map(|v| query_tools.allocate_param(v)).collect();
+                    Ok(format!("{} IN ({})", column_sql, params.join(", ")))
+                } else {
+                    Ok(format!("{} IS NULL", column_sql))
+                }
+            }
+            "notEquals" => {
+                if vals.len() == 1 {
+                    Ok(format!("{} <> {}", column_sql, query_tools.allocate_param(&vals[0])))
+                } else if vals.len() > 1 {
+                    let params: Vec<String> = vals.iter().map(|v| query_tools.allocate_param(v)).collect();
+                    Ok(format!("{} NOT IN ({})", column_sql, params.join(", ")))
+                } else {
+                    Ok(format!("{} IS NOT NULL", column_sql))
+                }
+            }
+            "set" => Ok(format!("{} IS NOT NULL", column_sql)),
+            "notSet" => Ok(format!("{} IS NULL", column_sql)),
+            "gt" => Ok(format!("{} > {}", column_sql, query_tools.allocate_param(&vals[0]))),
+            "gte" => Ok(format!("{} >= {}", column_sql, query_tools.allocate_param(&vals[0]))),
+            "lt" => Ok(format!("{} < {}", column_sql, query_tools.allocate_param(&vals[0]))),
+            "lte" => Ok(format!("{} <= {}", column_sql, query_tools.allocate_param(&vals[0]))),
+            _ => Ok("1 = 1".to_string()),
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
@@ -1,9 +1,13 @@
 use super::SqlNode;
+use super::SqlNodesFactory;
 use crate::cube_bridge::base_query_options::FilterItem as NativeFilterItem;
+use crate::plan::filter::FilterItem;
+use crate::planner::filter::compiler::FilterCompiler;
 use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_evaluator::MemberSymbol;
 use crate::planner::sql_evaluator::SqlEvaluatorVisitor;
 use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::VisitorContext;
 use cubenativeutils::CubeError;
 use std::any::Any;
 use std::rc::Rc;
@@ -66,16 +70,11 @@ impl MaskedSqlNode {
                 visitor,
                 node,
                 query_tools.clone(),
-                node_processor.clone(),
-                templates,
-            )?;
-            let filter_sql = self.compile_filter_to_sql(
-                &filter_item,
-                visitor,
                 node_processor,
-                query_tools.clone(),
                 templates,
             )?;
+            let filter_sql =
+                self.compile_filter_to_sql(&filter_item, query_tools.clone(), templates)?;
             if let Some(filter_sql) = filter_sql {
                 Ok(Some(format!(
                     "CASE WHEN {} THEN {} ELSE {} END",
@@ -91,157 +90,36 @@ impl MaskedSqlNode {
 
     fn compile_filter_to_sql(
         &self,
-        filter_item: &NativeFilterItem,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
+        native_filter: &NativeFilterItem,
         query_tools: Rc<QueryTools>,
         templates: &PlanSqlTemplates,
     ) -> Result<Option<String>, CubeError> {
-        self.render_native_filter(filter_item, visitor, node_processor, query_tools, templates)
-    }
-
-    fn render_native_filter(
-        &self,
-        item: &NativeFilterItem,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<Option<String>, CubeError> {
-        if let Some(items) = &item.or {
-            let parts: Vec<String> = items
-                .iter()
-                .filter_map(|i| {
-                    self.render_native_filter(
-                        i,
-                        visitor,
-                        node_processor.clone(),
-                        query_tools.clone(),
-                        templates,
-                    )
-                    .transpose()
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            if parts.is_empty() {
-                return Ok(None);
-            }
-            Ok(Some(
-                parts
-                    .iter()
-                    .map(|p| format!("({})", p))
-                    .collect::<Vec<_>>()
-                    .join(" OR "),
-            ))
-        } else if let Some(items) = &item.and {
-            let parts: Vec<String> = items
-                .iter()
-                .filter_map(|i| {
-                    self.render_native_filter(
-                        i,
-                        visitor,
-                        node_processor.clone(),
-                        query_tools.clone(),
-                        templates,
-                    )
-                    .transpose()
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            if parts.is_empty() {
-                return Ok(None);
-            }
-            Ok(Some(
-                parts
-                    .iter()
-                    .map(|p| format!("({})", p))
-                    .collect::<Vec<_>>()
-                    .join(" AND "),
-            ))
-        } else if let (Some(member), Some(operator)) = (item.member(), &item.operator) {
-            let member_symbol = query_tools
-                .evaluator_compiler()
-                .borrow_mut()
-                .add_dimension_evaluator(member.clone())?;
-            let column_sql = self.input.to_sql(
-                visitor,
-                &member_symbol,
-                query_tools.clone(),
-                node_processor,
-                templates,
-            )?;
-            let filter_sql =
-                self.render_filter_condition(&column_sql, operator, &item.values, &query_tools)?;
-            Ok(Some(filter_sql))
-        } else {
-            Ok(None)
+        let mut compiler = query_tools.evaluator_compiler().borrow_mut();
+        let mut filter_compiler = FilterCompiler::new(&mut compiler, query_tools.clone());
+        filter_compiler.add_item(native_filter)?;
+        let (dimension_filters, _, _) = filter_compiler.extract_result();
+        if dimension_filters.is_empty() {
+            return Ok(None);
         }
-    }
-
-    fn render_filter_condition(
-        &self,
-        column_sql: &str,
-        operator: &str,
-        values: &Option<Vec<Option<String>>>,
-        query_tools: &Rc<QueryTools>,
-    ) -> Result<String, CubeError> {
-        let vals: Vec<String> = values
-            .as_ref()
-            .map(|v| v.iter().filter_map(|x| x.clone()).collect())
-            .unwrap_or_default();
-
-        match operator {
-            "equals" => {
-                if vals.len() == 1 {
-                    Ok(format!(
-                        "{} = {}",
-                        column_sql,
-                        query_tools.allocate_param(&vals[0])
-                    ))
-                } else if vals.len() > 1 {
-                    let params: Vec<String> =
-                        vals.iter().map(|v| query_tools.allocate_param(v)).collect();
-                    Ok(format!("{} IN ({})", column_sql, params.join(", ")))
-                } else {
-                    Ok(format!("{} IS NULL", column_sql))
-                }
-            }
-            "notEquals" => {
-                if vals.len() == 1 {
-                    Ok(format!(
-                        "{} <> {}",
-                        column_sql,
-                        query_tools.allocate_param(&vals[0])
-                    ))
-                } else if vals.len() > 1 {
-                    let params: Vec<String> =
-                        vals.iter().map(|v| query_tools.allocate_param(v)).collect();
-                    Ok(format!("{} NOT IN ({})", column_sql, params.join(", ")))
-                } else {
-                    Ok(format!("{} IS NOT NULL", column_sql))
-                }
-            }
-            "set" => Ok(format!("{} IS NOT NULL", column_sql)),
-            "notSet" => Ok(format!("{} IS NULL", column_sql)),
-            "gt" => Ok(format!(
-                "{} > {}",
-                column_sql,
-                query_tools.allocate_param(&vals[0])
-            )),
-            "gte" => Ok(format!(
-                "{} >= {}",
-                column_sql,
-                query_tools.allocate_param(&vals[0])
-            )),
-            "lt" => Ok(format!(
-                "{} < {}",
-                column_sql,
-                query_tools.allocate_param(&vals[0])
-            )),
-            "lte" => Ok(format!(
-                "{} <= {}",
-                column_sql,
-                query_tools.allocate_param(&vals[0])
-            )),
-            _ => Ok("1 = 1".to_string()),
+        let filter_item = if dimension_filters.len() == 1 {
+            dimension_filters.into_iter().next().unwrap()
+        } else {
+            FilterItem::Group(Rc::new(crate::plan::filter::FilterGroup::new(
+                crate::plan::filter::FilterGroupOperator::And,
+                dimension_filters,
+            )))
+        };
+        let nodes_factory = SqlNodesFactory::new();
+        let context = Rc::new(VisitorContext::new(
+            query_tools.clone(),
+            &nodes_factory,
+            None,
+        ));
+        let sql = filter_item.to_sql(templates, context)?;
+        if sql.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(sql))
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
@@ -111,6 +111,8 @@ impl MaskedSqlNode {
                 )))
             }
         };
+        // TODO: support FILTER_PARAMS in mask filter SQL by passing
+        // proper FiltersContext with filter_params_columns
         let context = Rc::new(VisitorContext::new_with_node_processor(
             query_tools.clone(),
             self.input.clone(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
@@ -69,9 +69,18 @@ impl MaskedSqlNode {
                 node_processor.clone(),
                 templates,
             )?;
-            let filter_sql = self.compile_filter_to_sql(&filter_item, visitor, node_processor, query_tools.clone(), templates)?;
+            let filter_sql = self.compile_filter_to_sql(
+                &filter_item,
+                visitor,
+                node_processor,
+                query_tools.clone(),
+                templates,
+            )?;
             if let Some(filter_sql) = filter_sql {
-                Ok(Some(format!("CASE WHEN {} THEN {} ELSE {} END", filter_sql, original_sql, masked_sql)))
+                Ok(Some(format!(
+                    "CASE WHEN {} THEN {} ELSE {} END",
+                    filter_sql, original_sql, masked_sql
+                )))
             } else {
                 Ok(Some(masked_sql))
             }
@@ -102,27 +111,65 @@ impl MaskedSqlNode {
         if let Some(items) = &item.or {
             let parts: Vec<String> = items
                 .iter()
-                .filter_map(|i| self.render_native_filter(i, visitor, node_processor.clone(), query_tools.clone(), templates).transpose())
+                .filter_map(|i| {
+                    self.render_native_filter(
+                        i,
+                        visitor,
+                        node_processor.clone(),
+                        query_tools.clone(),
+                        templates,
+                    )
+                    .transpose()
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             if parts.is_empty() {
                 return Ok(None);
             }
-            Ok(Some(parts.iter().map(|p| format!("({})", p)).collect::<Vec<_>>().join(" OR ")))
+            Ok(Some(
+                parts
+                    .iter()
+                    .map(|p| format!("({})", p))
+                    .collect::<Vec<_>>()
+                    .join(" OR "),
+            ))
         } else if let Some(items) = &item.and {
             let parts: Vec<String> = items
                 .iter()
-                .filter_map(|i| self.render_native_filter(i, visitor, node_processor.clone(), query_tools.clone(), templates).transpose())
+                .filter_map(|i| {
+                    self.render_native_filter(
+                        i,
+                        visitor,
+                        node_processor.clone(),
+                        query_tools.clone(),
+                        templates,
+                    )
+                    .transpose()
+                })
                 .collect::<Result<Vec<_>, _>>()?;
             if parts.is_empty() {
                 return Ok(None);
             }
-            Ok(Some(parts.iter().map(|p| format!("({})", p)).collect::<Vec<_>>().join(" AND ")))
+            Ok(Some(
+                parts
+                    .iter()
+                    .map(|p| format!("({})", p))
+                    .collect::<Vec<_>>()
+                    .join(" AND "),
+            ))
         } else if let (Some(member), Some(operator)) = (item.member(), &item.operator) {
-            let member_symbol = query_tools.evaluator_compiler()
+            let member_symbol = query_tools
+                .evaluator_compiler()
                 .borrow_mut()
                 .add_dimension_evaluator(member.clone())?;
-            let column_sql = self.input.to_sql(visitor, &member_symbol, query_tools.clone(), node_processor, templates)?;
-            let filter_sql = self.render_filter_condition(&column_sql, operator, &item.values, &query_tools)?;
+            let column_sql = self.input.to_sql(
+                visitor,
+                &member_symbol,
+                query_tools.clone(),
+                node_processor,
+                templates,
+            )?;
+            let filter_sql =
+                self.render_filter_condition(&column_sql, operator, &item.values, &query_tools)?;
             Ok(Some(filter_sql))
         } else {
             Ok(None)
@@ -144,9 +191,14 @@ impl MaskedSqlNode {
         match operator {
             "equals" => {
                 if vals.len() == 1 {
-                    Ok(format!("{} = {}", column_sql, query_tools.allocate_param(&vals[0])))
+                    Ok(format!(
+                        "{} = {}",
+                        column_sql,
+                        query_tools.allocate_param(&vals[0])
+                    ))
                 } else if vals.len() > 1 {
-                    let params: Vec<String> = vals.iter().map(|v| query_tools.allocate_param(v)).collect();
+                    let params: Vec<String> =
+                        vals.iter().map(|v| query_tools.allocate_param(v)).collect();
                     Ok(format!("{} IN ({})", column_sql, params.join(", ")))
                 } else {
                     Ok(format!("{} IS NULL", column_sql))
@@ -154,9 +206,14 @@ impl MaskedSqlNode {
             }
             "notEquals" => {
                 if vals.len() == 1 {
-                    Ok(format!("{} <> {}", column_sql, query_tools.allocate_param(&vals[0])))
+                    Ok(format!(
+                        "{} <> {}",
+                        column_sql,
+                        query_tools.allocate_param(&vals[0])
+                    ))
                 } else if vals.len() > 1 {
-                    let params: Vec<String> = vals.iter().map(|v| query_tools.allocate_param(v)).collect();
+                    let params: Vec<String> =
+                        vals.iter().map(|v| query_tools.allocate_param(v)).collect();
                     Ok(format!("{} NOT IN ({})", column_sql, params.join(", ")))
                 } else {
                     Ok(format!("{} IS NOT NULL", column_sql))
@@ -164,10 +221,26 @@ impl MaskedSqlNode {
             }
             "set" => Ok(format!("{} IS NOT NULL", column_sql)),
             "notSet" => Ok(format!("{} IS NULL", column_sql)),
-            "gt" => Ok(format!("{} > {}", column_sql, query_tools.allocate_param(&vals[0]))),
-            "gte" => Ok(format!("{} >= {}", column_sql, query_tools.allocate_param(&vals[0]))),
-            "lt" => Ok(format!("{} < {}", column_sql, query_tools.allocate_param(&vals[0]))),
-            "lte" => Ok(format!("{} <= {}", column_sql, query_tools.allocate_param(&vals[0]))),
+            "gt" => Ok(format!(
+                "{} > {}",
+                column_sql,
+                query_tools.allocate_param(&vals[0])
+            )),
+            "gte" => Ok(format!(
+                "{} >= {}",
+                column_sql,
+                query_tools.allocate_param(&vals[0])
+            )),
+            "lt" => Ok(format!(
+                "{} < {}",
+                column_sql,
+                query_tools.allocate_param(&vals[0])
+            )),
+            "lte" => Ok(format!(
+                "{} <= {}",
+                column_sql,
+                query_tools.allocate_param(&vals[0])
+            )),
             _ => Ok("1 = 1".to_string()),
         }
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/masked.rs
@@ -1,5 +1,4 @@
 use super::SqlNode;
-use super::SqlNodesFactory;
 use crate::cube_bridge::base_query_options::FilterItem as NativeFilterItem;
 use crate::plan::filter::FilterItem;
 use crate::planner::filter::compiler::FilterCompiler;
@@ -94,26 +93,26 @@ impl MaskedSqlNode {
         query_tools: Rc<QueryTools>,
         templates: &PlanSqlTemplates,
     ) -> Result<Option<String>, CubeError> {
-        let mut compiler = query_tools.evaluator_compiler().borrow_mut();
-        let mut filter_compiler = FilterCompiler::new(&mut compiler, query_tools.clone());
-        filter_compiler.add_item(native_filter)?;
-        let (dimension_filters, _, _) = filter_compiler.extract_result();
-        if dimension_filters.is_empty() {
-            return Ok(None);
-        }
-        let filter_item = if dimension_filters.len() == 1 {
-            dimension_filters.into_iter().next().unwrap()
-        } else {
-            FilterItem::Group(Rc::new(crate::plan::filter::FilterGroup::new(
-                crate::plan::filter::FilterGroupOperator::And,
-                dimension_filters,
-            )))
+        let filter_item = {
+            let mut compiler = query_tools.evaluator_compiler().borrow_mut();
+            let mut filter_compiler = FilterCompiler::new(&mut compiler, query_tools.clone());
+            filter_compiler.add_item(native_filter)?;
+            let (dimension_filters, _, _) = filter_compiler.extract_result();
+            if dimension_filters.is_empty() {
+                return Ok(None);
+            }
+            if dimension_filters.len() == 1 {
+                dimension_filters.into_iter().next().unwrap()
+            } else {
+                FilterItem::Group(Rc::new(crate::plan::filter::FilterGroup::new(
+                    crate::plan::filter::FilterGroupOperator::And,
+                    dimension_filters,
+                )))
+            }
         };
-        let nodes_factory = SqlNodesFactory::new();
-        let context = Rc::new(VisitorContext::new(
+        let context = Rc::new(VisitorContext::new_with_node_processor(
             query_tools.clone(),
-            &nodes_factory,
-            None,
+            self.input.clone(),
         ));
         let sql = filter_item.to_sql(templates, context)?;
         if sql.is_empty() {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/visitor_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/visitor_context.rs
@@ -60,6 +60,19 @@ impl VisitorContext {
         }
     }
 
+    pub fn new_with_node_processor(
+        query_tools: Rc<QueryTools>,
+        node_processor: Rc<dyn SqlNode>,
+    ) -> Self {
+        Self {
+            query_tools,
+            node_processor,
+            cube_ref_evaluator: Rc::new(CubeRefEvaluator::new(HashMap::new(), HashMap::new())),
+            all_filters: None,
+            filters_context: FiltersContext::default(),
+        }
+    }
+
     pub fn make_visitor(&self, query_tools: Rc<QueryTools>) -> SqlEvaluatorVisitor {
         SqlEvaluatorVisitor::new(
             query_tools,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
@@ -8,7 +8,7 @@ use typed_builder::TypedBuilder;
 use crate::{
     cube_bridge::{
         base_query_options::{
-            BaseQueryOptions, BaseQueryOptionsStatic, FilterItem, OrderByItem, TimeDimension,
+            BaseQueryOptions, BaseQueryOptionsStatic, FilterItem, MaskedMemberItem, OrderByItem, TimeDimension,
         },
         base_tools::BaseTools,
         evaluator::CubeEvaluator,
@@ -71,7 +71,7 @@ pub struct MockBaseQueryOptions {
     #[builder(default)]
     convert_tz_for_raw_time_dimension: Option<bool>,
     #[builder(default)]
-    masked_members: Option<Vec<String>>,
+    masked_members: Option<Vec<MaskedMemberItem>>,
     #[builder(default)]
     member_to_alias: Option<HashMap<String, String>>,
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
@@ -8,7 +8,8 @@ use typed_builder::TypedBuilder;
 use crate::{
     cube_bridge::{
         base_query_options::{
-            BaseQueryOptions, BaseQueryOptionsStatic, FilterItem, MaskedMemberItem, OrderByItem, TimeDimension,
+            BaseQueryOptions, BaseQueryOptionsStatic, FilterItem, MaskedMemberItem, OrderByItem,
+            TimeDimension,
         },
         base_tools::BaseTools,
         evaluator::CubeEvaluator,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/base_query_options.rs
@@ -1,4 +1,4 @@
-use crate::cube_bridge::base_query_options::{FilterItem, OrderByItem, TimeDimension};
+use crate::cube_bridge::base_query_options::{FilterItem, MaskedMemberItem, OrderByItem, TimeDimension};
 use serde::de;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
@@ -44,7 +44,7 @@ pub struct YamlBaseQueryOptions {
     #[serde(default)]
     pub timezone: Option<String>,
     #[serde(default, rename = "maskedMembers")]
-    pub masked_members: Option<Vec<String>>,
+    pub masked_members: Option<Vec<MaskedMemberItem>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/base_query_options.rs
@@ -1,4 +1,6 @@
-use crate::cube_bridge::base_query_options::{FilterItem, MaskedMemberItem, OrderByItem, TimeDimension};
+use crate::cube_bridge::base_query_options::{
+    FilterItem, MaskedMemberItem, OrderByItem, TimeDimension,
+};
 use serde::de;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
@@ -78,7 +78,10 @@ impl TestContext {
         schema: MockSchema,
         masked_members: Vec<String>,
     ) -> Result<Self, CubeError> {
-        let items: Vec<MaskedMemberItem> = masked_members.into_iter().map(MaskedMemberItem::Simple).collect();
+        let items: Vec<MaskedMemberItem> = masked_members
+            .into_iter()
+            .map(MaskedMemberItem::Simple)
+            .collect();
         Self::new_with_options(schema, Tz::UTC, Some(items), None, false, false)
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
@@ -1,4 +1,4 @@
-use crate::cube_bridge::base_query_options::BaseQueryOptions;
+use crate::cube_bridge::base_query_options::{BaseQueryOptions, MaskedMemberItem};
 use crate::cube_bridge::join_hints::JoinHintItem;
 use crate::logical_plan::PreAggregationUsage;
 #[cfg(feature = "integration-postgres")]
@@ -78,7 +78,8 @@ impl TestContext {
         schema: MockSchema,
         masked_members: Vec<String>,
     ) -> Result<Self, CubeError> {
-        Self::new_with_options(schema, Tz::UTC, Some(masked_members), None, false, false)
+        let items: Vec<MaskedMemberItem> = masked_members.into_iter().map(MaskedMemberItem::Simple).collect();
+        Self::new_with_options(schema, Tz::UTC, Some(items), None, false, false)
     }
 
     fn for_options(&self, options: &dyn BaseQueryOptions) -> Result<Self, CubeError> {
@@ -104,7 +105,7 @@ impl TestContext {
     fn new_with_options(
         schema: MockSchema,
         timezone: Tz,
-        masked_members: Option<Vec<String>>,
+        masked_members: Option<Vec<MaskedMemberItem>>,
         member_to_alias: Option<std::collections::HashMap<String, String>>,
         export_annotated_sql: bool,
         convert_tz_for_raw_time_dimension: bool,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
@@ -80,7 +80,10 @@ impl TestContext {
     ) -> Result<Self, CubeError> {
         let items: Vec<MaskedMemberItem> = masked_members
             .into_iter()
-            .map(MaskedMemberItem::Simple)
+            .map(|member| MaskedMemberItem {
+                member,
+                filter: None,
+            })
             .collect();
         Self::new_with_options(schema, Tz::UTC, Some(items), None, false, false)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Tests for the changes have been added if not covered yet
- [ ] Linter has been run for changed code
- [ ] Docs have been added / updated if required

**Description of Changes Made**

When an access policy grants full `member_level` access **with** `row_level` filters, and another policy provides masked access, the masking should be conditional on the row filter. Previously, masking was skipped entirely when any policy granted "full access" for a member, even if that full access was gated by row-level filters.

### Problem

Given an access policy like:

```yaml
access_policy:
  - group: sensitive_data_access
    member_level:
      includes:
        - users_id
        - users_first_name
    member_masking:
      includes: '*'
  
  - group: very_sensitive_data_access
    member_level:
      includes: "*"
    row_level:
      filters:
        - member: users_data_region
          operator: equals
          values:
            - RESEARCH
            - DEMO
```

The `very_sensitive_data_access` policy grants full access but only to rows matching the filter. Previously, the system saw "full access exists in some policy" and skipped masking entirely — exposing unmasked values for **all** rows, including those outside the filter.

### Solution

The `maskedMembers` type is extended to support both simple strings and objects with filter info:

```typescript
maskedMembers?: (string | { member: string; filter: any })[]
```

When a member has an associated filter, the generated SQL uses:

```sql
CASE WHEN {rowFilter} THEN {originalValue} ELSE {maskedValue} END
```

This ensures:
- Rows matching the row filter see **unmasked** values (full access applies)
- Rows outside the filter range see **masked** values (fallback to mask)

### Tesseract Support

The Rust native SQL planner (`MaskedSqlNode`) is updated to support the new `maskedMembers` format with `MaskedMemberItem` enum (untagged serde), and generates `CASE WHEN` SQL for conditional masks.

### Changes

| File | Change |
|------|--------|
| `packages/cubejs-server-core/src/core/CompilerApi.ts` | Distinguish unconditional vs conditional full access; emit `maskedMembers` with inline filter objects |
| `packages/cubejs-schema-compiler/src/adapter/BaseQuery.js` | Parse both string and object formats from `maskedMembers`; add `conditionalMemberMaskSql()` and `maskFilterToSql()` |
| `packages/cubejs-api-gateway/src/types/query.ts` | Update `maskedMembers` type to `(string \| { member, filter })[]` |
| `packages/cubejs-api-gateway/src/query.js` | Update Joi validation for new format |
| `rust/.../base_query_options.rs` | Add `MaskedMemberItem` enum with untagged serde |
| `rust/.../query_tools.rs` | Store mask filters alongside masked members set |
| `rust/.../masked.rs` | Generate `CASE WHEN` for conditional masks in `MaskedSqlNode` |
| `rust/.../test_fixtures/` | Update to use `MaskedMemberItem` type |
| `packages/cubejs-testing/.../conditional_masking_test.yaml` | New fixture for smoke test |
| `packages/cubejs-testing/test/smoke-rbac.test.ts` | Add conditional masking smoke test |
| `packages/cubejs-testing/birdbox-fixtures/rbac/cube.js` | Add `conditional_mask_user` auth |
| `packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts` | 4 unit tests for conditional masking |

### Test Results

- All 73 yaml-schema unit tests pass (including 4 new tests)
- All 899 Rust unit tests pass
- Smoke test added for integration validation (requires Docker)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36dc2c21-6101-4a85-9c33-d725d213032b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36dc2c21-6101-4a85-9c33-d725d213032b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

