### PR TITLE
perf(cubesql): Migrate to columnar format in transport (~5x)

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -129,6 +129,40 @@ function systemAsyncHandler(handler: (req: Request & { context: ExtendedRequestC
   };
 }
 
+function rowsToColumnar(rawData: any): { members: string[]; columns: any[][] } {
+  let rows: any[];
+
+  if (Array.isArray(rawData)) {
+    rows = rawData;
+  } else if (rawData) {
+    rows = Array.from(rawData as Iterable<any>);
+  } else {
+    rows = [];
+  }
+
+  const rowCount = rows.length;
+  if (rowCount === 0) {
+    return { members: [], columns: [] };
+  }
+
+  const members = Object.keys(rows[0]);
+  const memberCount = members.length;
+  const columns: any[][] = new Array(memberCount);
+
+  for (let j = 0; j < memberCount; j++) {
+    const member = members[j];
+    const col = new Array(rowCount);
+
+    for (let i = 0; i < rowCount; i++) {
+      col[i] = rows[i][member];
+    }
+
+    columns[j] = col;
+  }
+
+  return { members, columns };
+}
+
 // Prepared CheckAuthFn, default or from config: always async
 type PreparedCheckAuthFn = (ctx: any, authorization?: string) => Promise<{
   securityContext: any;
@@ -2125,7 +2159,16 @@ class ApiGateway {
 
           // TODO Can we just pass through data? Ensure hidden members can't be queried
           results = [{
-            data: response.data,
+            /**
+             * I am still working on improving cpu/memory performance of moving results from ResultWrapper
+             * into RecordBatch on a rust side. Right now, it's slower then doing transpose and JSON serialize on JS side +
+             * deserializing on Rust.
+             *
+             * Right now, it's a temporary solution, which means it will probably outlive us all.
+             *
+             * TODO(ovr): You must finish it, move to ResultWrapper after optimizing it.
+             */
+            data: rowsToColumnar(response.data),
             annotation
           }];
         }

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -2061,11 +2061,6 @@ class ApiGateway {
       await this.assertApiScope('data', context.securityContext);
 
       query = this.parseQueryParam(request.query);
-      let resType: ResultType = ResultType.DEFAULT;
-
-      if (!Array.isArray(query) && query.responseFormat) {
-        resType = query.responseFormat;
-      }
 
       const [queryType, normalizedQueries] =
         await this.getNormalizedQueries(query, context, request.streaming, request.memberExpressions, cacheMode);
@@ -2163,7 +2158,7 @@ class ApiGateway {
               sqlQueries[index],
               annotation,
               response,
-              resType,
+              ResultType.COLUMNAR,
             );
           })
         );

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -123,6 +123,7 @@ type BaseRequest = {
 type RequestQuery = Record<string, any> | Record<string, any>[] & {
   renewQuery?: boolean;
   cacheMode?: CacheMode;
+  responseFormat?: string;
 };
 
 /**
@@ -131,7 +132,6 @@ type RequestQuery = Record<string, any> | Record<string, any>[] & {
 type QueryRequest = BaseRequest & {
   query: RequestQuery;
   queryType?: RequestType;
-  responseFormat?: string;
   apiType?: ApiType;
   resType?: ResultType
   memberToAlias?: Record<string, string>;

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -123,7 +123,6 @@ type BaseRequest = {
 type RequestQuery = Record<string, any> | Record<string, any>[] & {
   renewQuery?: boolean;
   cacheMode?: CacheMode;
-  responseFormat?: string;
 };
 
 /**

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -131,6 +131,7 @@ type RequestQuery = Record<string, any> | Record<string, any>[] & {
 type QueryRequest = BaseRequest & {
   query: RequestQuery;
   queryType?: RequestType;
+  responseFormat?: string;
   apiType?: ApiType;
   resType?: ResultType
   memberToAlias?: Record<string, string>;

--- a/packages/cubejs-backend-native/src/orchestrator.rs
+++ b/packages/cubejs-backend-native/src/orchestrator.rs
@@ -6,7 +6,7 @@ use cubeorchestrator::query_result_transform::{
     TransformedData,
 };
 use cubeorchestrator::transport::{JsRawData, TransformDataRequest};
-use cubesql::compile::engine::df::scan::{FieldValue, ValueObject};
+use cubesql::compile::engine::df::scan::{ColumnarValueObject, FieldValue, ValueObject};
 use cubesql::CubeError;
 use neon::context::{Context, FunctionContext, ModuleContext};
 use neon::handle::Handle;
@@ -141,6 +141,18 @@ impl ResultWrapper {
     }
 }
 
+fn db_primitive_to_field_value(value: &DBResponsePrimitive) -> FieldValue<'_> {
+    match value {
+        DBResponsePrimitive::String(s) => FieldValue::String(Cow::Borrowed(s)),
+        DBResponsePrimitive::Number(n) => FieldValue::Number(*n),
+        DBResponsePrimitive::Boolean(b) => FieldValue::Bool(*b),
+        DBResponsePrimitive::Uncommon(v) => FieldValue::String(Cow::Owned(
+            serde_json::to_string(&v).unwrap_or_else(|_| v.to_string()),
+        )),
+        DBResponsePrimitive::Null => FieldValue::Null,
+    }
+}
+
 impl ValueObject for ResultWrapper {
     fn len(&mut self) -> Result<usize, CubeError> {
         if self.transformed_data.is_none() {
@@ -223,15 +235,59 @@ impl ValueObject for ResultWrapper {
             }
         };
 
-        Ok(match value {
-            DBResponsePrimitive::String(s) => FieldValue::String(Cow::Borrowed(s)),
-            DBResponsePrimitive::Number(n) => FieldValue::Number(*n),
-            DBResponsePrimitive::Boolean(b) => FieldValue::Bool(*b),
-            DBResponsePrimitive::Uncommon(v) => FieldValue::String(Cow::Owned(
-                serde_json::to_string(&v).unwrap_or_else(|_| v.to_string()),
-            )),
-            DBResponsePrimitive::Null => FieldValue::Null,
-        })
+        Ok(db_primitive_to_field_value(value))
+    }
+}
+
+impl ColumnarValueObject for ResultWrapper {
+    fn len(&mut self) -> Result<usize, CubeError> {
+        if self.transformed_data.is_none() {
+            self.transform_result()?;
+        }
+
+        let TransformedData::Columnar { columns, .. } = self.transformed_data.as_ref().unwrap()
+        else {
+            return Err(CubeError::internal(
+                "ColumnarValueObject is only supported for columnar TransformedData".to_string(),
+            ));
+        };
+
+        Ok(columns.first().map(|c| c.len()).unwrap_or(0))
+    }
+
+    fn column<'a>(
+        &'a mut self,
+        field_name: &str,
+    ) -> Result<Box<dyn Iterator<Item = Result<FieldValue<'a>, CubeError>> + 'a>, CubeError> {
+        if self.transformed_data.is_none() {
+            self.transform_result()?;
+        }
+
+        let TransformedData::Columnar { members, columns } =
+            self.transformed_data.as_ref().unwrap()
+        else {
+            return Err(CubeError::internal(
+                "ColumnarValueObject is only supported for columnar TransformedData".to_string(),
+            ));
+        };
+
+        let Some(member_index) = members.iter().position(|m| m == field_name) else {
+            return Err(CubeError::user(format!(
+                "Field name '{}' not found in members",
+                field_name
+            )));
+        };
+
+        let Some(column) = columns.get(member_index) else {
+            return Err(CubeError::user(format!(
+                "Unexpected response from Cube, missing column for '{}'",
+                field_name
+            )));
+        };
+
+        Ok(Box::new(
+            column.iter().map(|v| Ok(db_primitive_to_field_value(v))),
+        ))
     }
 }
 

--- a/packages/cubejs-backend-native/src/orchestrator.rs
+++ b/packages/cubejs-backend-native/src/orchestrator.rs
@@ -191,20 +191,16 @@ impl ValueObject for ResultWrapper {
                 };
 
                 let Some(member_index) = members.iter().position(|m| m == field_name) else {
-                    return Err(CubeError::user(format!(
-                        "Field name '{}' not found in members",
-                        field_name
-                    )));
+                    // Missing field → NULL, matching `Vanilla` semantics below.
+                    return Ok(FieldValue::Null);
                 };
 
                 row.get(member_index).unwrap_or(&DBResponsePrimitive::Null)
             }
             TransformedData::Columnar { members, columns } => {
                 let Some(member_index) = members.iter().position(|m| m == field_name) else {
-                    return Err(CubeError::user(format!(
-                        "Field name '{}' not found in members",
-                        field_name
-                    )));
+                    // Missing field → NULL, matching `Vanilla` semantics below.
+                    return Ok(FieldValue::Null);
                 };
 
                 let Some(column) = columns.get(member_index) else {
@@ -272,10 +268,9 @@ impl ColumnarValueObject for ResultWrapper {
         };
 
         let Some(member_index) = members.iter().position(|m| m == field_name) else {
-            return Err(CubeError::user(format!(
-                "Field name '{}' not found in members",
-                field_name
-            )));
+            // Missing field → column of NULLs. See JsonColumnarValueObject::column.
+            let len = columns.first().map(|c| c.len()).unwrap_or(0);
+            return Ok(Box::new((0..len).map(|_| Ok(FieldValue::Null))));
         };
 
         let Some(column) = columns.get(member_index) else {

--- a/packages/cubejs-backend-native/src/transport.rs
+++ b/packages/cubejs-backend-native/src/transport.rs
@@ -16,11 +16,12 @@ use async_trait::async_trait;
 use cubeorchestrator::query_result_transform::RequestResultData;
 use cubesql::compile::arrow::datatypes::Schema;
 use cubesql::compile::engine::df::scan::{
-    convert_transport_response, transform_response, CacheMode, MemberField, RecordBatch, SchemaRef,
+    convert_transport_response_columnar, transform_columnar_response, CacheMode, MemberField,
+    RecordBatch, SchemaRef,
 };
 use cubesql::compile::engine::df::wrapper::SqlQuery;
 use cubesql::transport::{
-    SpanId, SqlGenerator, SqlResponse, TransportLoadRequestQuery, TransportLoadResponse,
+    SpanId, SqlGenerator, SqlResponse, TransportLoadRequestQuery, TransportLoadResponseColumnar,
     TransportMetaResponse,
 };
 use cubesql::{
@@ -469,17 +470,17 @@ impl TransportService for NodeBridgeTransport {
                 }
             }
 
+            #[cfg(debug_assertions)]
+            trace!("[transport] Request <- {:?}", result);
+            #[cfg(not(debug_assertions))]
+            trace!("[transport] Request <- <hidden>");
+
             match result? {
                 ValueFromJs::String(result) => {
                     let response: serde_json::Value = match serde_json::from_str(&result) {
                         Ok(json) => json,
                         Err(err) => return Err(CubeError::internal(err.to_string())),
                     };
-
-                    #[cfg(debug_assertions)]
-                    trace!("[transport] Request <- {:?}", response);
-                    #[cfg(not(debug_assertions))]
-                    trace!("[transport] Request <- <hidden>");
 
                     if let Some(error_value) = response.get("error") {
                         match error_value {
@@ -517,15 +518,20 @@ impl TransportService for NodeBridgeTransport {
                         }
                     };
 
-                    let response = match serde_json::from_value::<TransportLoadResponse>(response) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            return Err(CubeError::user(err.to_string()));
-                        }
-                    };
+                    let response =
+                        match serde_json::from_value::<TransportLoadResponseColumnar>(response) {
+                            Ok(v) => v,
+                            Err(err) => {
+                                return Err(CubeError::user(err.to_string()));
+                            }
+                        };
 
-                    break convert_transport_response(response, schema.clone(), member_fields)
-                        .map_err(|err| CubeError::user(err.to_string()));
+                    break convert_transport_response_columnar(
+                        response,
+                        schema.clone(),
+                        member_fields,
+                    )
+                    .map_err(|err| CubeError::user(err.to_string()));
                 }
                 ValueFromJs::ResultWrapper(result_wrappers) => {
                     break result_wrappers
@@ -544,7 +550,11 @@ impl TransportService for NodeBridgeTransport {
                                 schema.clone()
                             };
 
-                            transform_response(&mut wrapper, updated_schema, &member_fields)
+                            transform_columnar_response(
+                                &mut wrapper,
+                                updated_schema,
+                                &member_fields,
+                            )
                         })
                         .collect::<Result<Vec<_>, _>>();
                 }

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -87,6 +87,10 @@ harness = false
 name = "large_model"
 harness = false
 
+[[bench]]
+name = "transform_response"
+harness = false
+
 # Code in cubesql workspace is not ready for full-blown clippy
 # So we disable some rules to enable per-rule latch in CI, not for a whole clippy run
 # Feel free to remove any rule from here and fix all warnings with it

--- a/rust/cubesql/cubesql/benches/transform_response.rs
+++ b/rust/cubesql/cubesql/benches/transform_response.rs
@@ -87,8 +87,6 @@ fn build_member_fields(kinds: &[ColKind]) -> Vec<MemberField> {
         .collect()
 }
 
-/// Build one primitive cell value, in the encoding that real Cube responses use:
-/// timestamps and ints arrive as JSON strings, floats as JSON numbers, strings as quoted.
 fn cell_value(row: usize, col: usize, kind: ColKind) -> serde_json::Value {
     match kind {
         ColKind::TimeDim => {
@@ -96,12 +94,11 @@ fn cell_value(row: usize, col: usize, kind: ColKind) -> serde_json::Value {
             let n = row % (12 * 28);
             let month = (n / 28) + 1;
             let day = (n % 28) + 1;
+
             // ISO-8601 with no offset, parseable by `parse_date_str`.
             json!(format!("2024-{:02}-{:02}T00:00:00.000", month, day))
         }
-        // Integer-valued floats are common in Cube responses.
         ColKind::Float => json!(row as f64 + (col as f64) / 100.0),
-        // Cube returns numeric measures as JSON strings.
         ColKind::Int => json!(row.wrapping_mul(31).wrapping_add(col).to_string()),
         ColKind::Str => json!(format!("row-{}-c{}", row, col)),
     }

--- a/rust/cubesql/cubesql/benches/transform_response.rs
+++ b/rust/cubesql/cubesql/benches/transform_response.rs
@@ -1,0 +1,271 @@
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use cubesql::compile::engine::df::scan::{
+    convert_transport_response, convert_transport_response_columnar, DataType, MemberField, Schema,
+    SchemaRef,
+};
+use cubesql::transport::{TransportLoadResponse, TransportLoadResponseColumnar};
+use datafusion::arrow::datatypes::{Field, TimeUnit};
+use serde_json::json;
+
+const ROWS: &[usize] = &[1_000, 5_000, 10_000, 50_000, 100_000];
+const COLS: &[usize] = &[8, 16, 32, 64];
+const TIME_DIMS: &[usize] = &[0, 1, 2];
+
+#[derive(Clone, Copy)]
+enum ColKind {
+    TimeDim,
+    Float,
+    Int,
+    Str,
+}
+
+fn col_kinds(cols: usize, time_dims: usize) -> Vec<ColKind> {
+    let mut out = Vec::with_capacity(cols);
+    for i in 0..cols {
+        if i < time_dims {
+            out.push(ColKind::TimeDim);
+        } else {
+            // Rotate through Float/Int/Str so the row mix is realistic and
+            // independent of `cols` modulo 3.
+            out.push(match (i - time_dims) % 3 {
+                0 => ColKind::Float,
+                1 => ColKind::Int,
+                _ => ColKind::Str,
+            });
+        }
+    }
+    out
+}
+
+fn member_name(idx: usize, kind: ColKind) -> String {
+    match kind {
+        ColKind::TimeDim => format!("Cube.t{}", idx),
+        ColKind::Float => format!("Cube.f{}", idx),
+        ColKind::Int => format!("Cube.i{}", idx),
+        ColKind::Str => format!("Cube.s{}", idx),
+    }
+}
+
+/// Field name as it appears in the Cube response (and so in `MemberField::field_name`).
+/// Matches `MemberField::time_dimension` which appends `.<granularity>` to the member.
+fn field_name(idx: usize, kind: ColKind) -> String {
+    let base = member_name(idx, kind);
+    match kind {
+        ColKind::TimeDim => format!("{}.day", base),
+        _ => base,
+    }
+}
+
+fn build_schema(kinds: &[ColKind]) -> SchemaRef {
+    let fields = kinds
+        .iter()
+        .enumerate()
+        .map(|(i, k)| {
+            let name = field_name(i, *k);
+            let dt = match k {
+                ColKind::TimeDim => DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ColKind::Float => DataType::Float64,
+                ColKind::Int => DataType::Int64,
+                ColKind::Str => DataType::Utf8,
+            };
+            Field::new(&name, dt, true)
+        })
+        .collect();
+    Arc::new(Schema::new(fields))
+}
+
+fn build_member_fields(kinds: &[ColKind]) -> Vec<MemberField> {
+    kinds
+        .iter()
+        .enumerate()
+        .map(|(i, k)| match k {
+            ColKind::TimeDim => MemberField::time_dimension(member_name(i, *k), "day".to_string()),
+            _ => MemberField::regular(member_name(i, *k)),
+        })
+        .collect()
+}
+
+/// Build one primitive cell value, in the encoding that real Cube responses use:
+/// timestamps and ints arrive as JSON strings, floats as JSON numbers, strings as quoted.
+fn cell_value(row: usize, col: usize, kind: ColKind) -> serde_json::Value {
+    match kind {
+        ColKind::TimeDim => {
+            // Spread rows over a 12 x 28 grid of always-valid dates.
+            let n = row % (12 * 28);
+            let month = (n / 28) + 1;
+            let day = (n % 28) + 1;
+            // ISO-8601 with no offset, parseable by `parse_date_str`.
+            json!(format!("2024-{:02}-{:02}T00:00:00.000", month, day))
+        }
+        // Integer-valued floats are common in Cube responses.
+        ColKind::Float => json!(row as f64 + (col as f64) / 100.0),
+        // Cube returns numeric measures as JSON strings.
+        ColKind::Int => json!(row.wrapping_mul(31).wrapping_add(col).to_string()),
+        ColKind::Str => json!(format!("row-{}-c{}", row, col)),
+    }
+}
+
+fn annotation_value() -> serde_json::Value {
+    json!({
+        "measures": {},
+        "dimensions": {},
+        "segments": {},
+        "timeDimensions": {},
+    })
+}
+
+fn build_row_json(rows: usize, kinds: &[ColKind]) -> String {
+    let names: Vec<String> = kinds
+        .iter()
+        .enumerate()
+        .map(|(i, k)| field_name(i, *k))
+        .collect();
+
+    let data: Vec<serde_json::Value> = (0..rows)
+        .map(|r| {
+            let mut row_obj = serde_json::Map::with_capacity(kinds.len());
+            for (c, kind) in kinds.iter().enumerate() {
+                row_obj.insert(names[c].clone(), cell_value(r, c, *kind));
+            }
+            serde_json::Value::Object(row_obj)
+        })
+        .collect();
+
+    let response = json!({
+        "results": [{
+            "annotation": annotation_value(),
+            "data": data,
+        }]
+    });
+
+    serde_json::to_string(&response).expect("serialize row json")
+}
+
+fn build_columnar_json(rows: usize, kinds: &[ColKind]) -> String {
+    let names: Vec<String> = kinds
+        .iter()
+        .enumerate()
+        .map(|(i, k)| field_name(i, *k))
+        .collect();
+
+    let columns: Vec<Vec<serde_json::Value>> = kinds
+        .iter()
+        .enumerate()
+        .map(|(c, kind)| (0..rows).map(|r| cell_value(r, c, *kind)).collect())
+        .collect();
+
+    let response = json!({
+        "results": [{
+            "annotation": annotation_value(),
+            "data": {
+                "members": names,
+                "columns": columns,
+            },
+        }]
+    });
+
+    serde_json::to_string(&response).expect("serialize columnar json")
+}
+
+struct Inputs {
+    schema: SchemaRef,
+    member_fields: Vec<MemberField>,
+    row_json: String,
+    columnar_json: String,
+}
+
+fn build_inputs(rows: usize, cols: usize, time_dims: usize) -> Inputs {
+    let kinds = col_kinds(cols, time_dims);
+    Inputs {
+        schema: build_schema(&kinds),
+        member_fields: build_member_fields(&kinds),
+        row_json: build_row_json(rows, &kinds),
+        columnar_json: build_columnar_json(rows, &kinds),
+    }
+}
+
+fn sample_size_for(rows: usize) -> usize {
+    // Default Criterion sample size is 100; trim for the heavy shapes so
+    // a full matrix run completes in reasonable wall time.
+    if rows >= 50_000 {
+        10
+    } else if rows >= 10_000 {
+        20
+    } else {
+        50
+    }
+}
+
+fn bench_transform_response(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transform_response");
+
+    for &rows in ROWS {
+        let sample = sample_size_for(rows);
+        group.sample_size(sample);
+        group.throughput(Throughput::Elements(rows as u64));
+
+        for &cols in COLS {
+            for &td in TIME_DIMS {
+                if td > cols {
+                    continue;
+                }
+                let inputs = build_inputs(rows, cols, td);
+                let Inputs {
+                    schema,
+                    member_fields,
+                    row_json,
+                    columnar_json,
+                } = &inputs;
+
+                let row_id = format!("row/rows={}/cols={}/td={}", rows, cols, td);
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(&row_id),
+                    row_json.as_str(),
+                    |b, json| {
+                        b.iter(|| {
+                            let value: serde_json::Value =
+                                serde_json::from_str(json).expect("row from_str");
+                            let response: TransportLoadResponse =
+                                serde_json::from_value(value).expect("row from_value");
+                            convert_transport_response(
+                                response,
+                                schema.clone(),
+                                member_fields.clone(),
+                            )
+                            .expect("convert_transport_response")
+                        })
+                    },
+                );
+
+                let col_id = format!("columnar/rows={}/cols={}/td={}", rows, cols, td);
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(&col_id),
+                    columnar_json.as_str(),
+                    |b, json| {
+                        b.iter(|| {
+                            let value: serde_json::Value =
+                                serde_json::from_str(json).expect("columnar from_str");
+                            let response: TransportLoadResponseColumnar =
+                                serde_json::from_value(value).expect("columnar from_value");
+                            convert_transport_response_columnar(
+                                response,
+                                schema.clone(),
+                                member_fields.clone(),
+                            )
+                            .expect("convert_transport_response_columnar")
+                        })
+                    },
+                );
+
+                drop(inputs);
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_transform_response);
+criterion_main!(benches);

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -11,7 +11,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use chrono::{Datelike, NaiveDate};
-use cubeclient::models::{V1LoadRequestQuery, V1LoadResponse, V1LoadResult};
+use cubeclient::models::{
+    V1LoadRequestQuery, V1LoadResponse, V1LoadResult, V1LoadResultDataColumnar,
+};
 pub use datafusion::{
     arrow::{
         array::{
@@ -318,6 +320,18 @@ pub trait ValueObject {
     ) -> std::result::Result<FieldValue<'_>, CubeError>;
 }
 
+pub trait ColumnarValueObject {
+    fn len(&mut self) -> std::result::Result<usize, CubeError>;
+
+    fn column<'a>(
+        &'a mut self,
+        field_name: &str,
+    ) -> std::result::Result<
+        Box<dyn Iterator<Item = std::result::Result<FieldValue<'a>, CubeError>> + 'a>,
+        CubeError,
+    >;
+}
+
 pub struct JsonValueObject {
     rows: Vec<Value>,
 }
@@ -326,6 +340,23 @@ impl JsonValueObject {
     pub fn new(rows: Vec<Value>) -> Self {
         JsonValueObject { rows }
     }
+}
+
+fn json_value_to_field_value(value: &Value) -> std::result::Result<FieldValue<'_>, CubeError> {
+    Ok(match value {
+        Value::String(s) => FieldValue::String(Cow::Borrowed(s)),
+        Value::Number(n) => FieldValue::Number(n.as_f64().ok_or_else(|| {
+            DataFusionError::Execution(format!("Can't convert {:?} to float", n))
+        })?),
+        Value::Bool(b) => FieldValue::Bool(*b),
+        Value::Null => FieldValue::Null,
+        x => {
+            return Err(CubeError::user(format!(
+                "Expected primitive value but found: {:?}",
+                x
+            )));
+        }
+    })
 }
 
 impl ValueObject for JsonValueObject {
@@ -346,40 +377,82 @@ impl ValueObject for JsonValueObject {
         };
 
         let value = as_object.get(field_name).unwrap_or(&Value::Null);
-
-        Ok(match value {
-            Value::String(s) => FieldValue::String(Cow::Borrowed(s)),
-            Value::Number(n) => FieldValue::Number(n.as_f64().ok_or(
-                DataFusionError::Execution(format!("Can't convert {:?} to float", n)),
-            )?),
-            Value::Bool(b) => FieldValue::Bool(*b),
-            Value::Null => FieldValue::Null,
-            x => {
-                return Err(CubeError::user(format!(
-                    "Expected primitive value but found: {:?}",
-                    x
-                )));
-            }
-        })
+        json_value_to_field_value(value)
     }
 }
 
+pub struct JsonColumnarValueObject {
+    members: Vec<String>,
+    columns: Vec<Vec<Value>>,
+}
+
+impl JsonColumnarValueObject {
+    pub fn new(members: Vec<String>, columns: Vec<Vec<Value>>) -> Self {
+        Self { members, columns }
+    }
+}
+
+impl ColumnarValueObject for JsonColumnarValueObject {
+    fn len(&mut self) -> std::result::Result<usize, CubeError> {
+        Ok(self.columns.first().map(|c| c.len()).unwrap_or(0))
+    }
+
+    fn column<'a>(
+        &'a mut self,
+        field_name: &str,
+    ) -> std::result::Result<
+        Box<dyn Iterator<Item = std::result::Result<FieldValue<'a>, CubeError>> + 'a>,
+        CubeError,
+    > {
+        let Some(idx) = self.members.iter().position(|m| m == field_name) else {
+            return Err(CubeError::user(format!(
+                "Field name '{}' not found in members",
+                field_name
+            )));
+        };
+        let Some(column) = self.columns.get(idx) else {
+            return Err(CubeError::user(format!(
+                "Unexpected response from Cube, missing column for '{}'",
+                field_name
+            )));
+        };
+        Ok(Box::new(column.iter().map(json_value_to_field_value)))
+    }
+}
+
+// `$mode` is one of `row` or `columnar`. The `row` arm calls `$response.get(i, field_name)?`
+// per cell; the `columnar` arm fetches the entire column slice once via
+// `$response.column(field_name)?` and iterates it.
+macro_rules! build_column_iter_loop {
+    (row, $response:expr, $len:expr, $field_name:expr, $value:ident, $body:block) => {{
+        for i in 0..$len {
+            let $value = $response.get(i, $field_name)?;
+            $body
+        }
+    }};
+    (columnar, $response:expr, $len:expr, $field_name:expr, $value:ident, $body:block) => {{
+        for cell in $response.column($field_name)? {
+            let $value = cell?;
+            $body
+        }
+    }};
+}
+
 macro_rules! build_column {
-    ($data_type:expr, $builder_ty:ty, $response:expr, $field_name:expr, { $($builder_block:tt)* }, { $($scalar_block:tt)* }) => {{
+    ($data_type:expr, $builder_ty:ty, $mode:tt, $response:expr, $field_name:expr, { $($builder_block:tt)* }, { $($scalar_block:tt)* }) => {{
         let len = $response.len()?;
         let mut builder = <$builder_ty>::new(len);
 
-        build_column_custom_builder!($data_type, len, builder, $response, $field_name, { $($builder_block)* }, { $($scalar_block)* })
+        build_column_custom_builder!($data_type, $mode, len, builder, $response, $field_name, { $($builder_block)* }, { $($scalar_block)* })
     }}
 }
 
 macro_rules! build_column_custom_builder {
-    ($data_type:expr, $len:expr, $builder:expr, $response:expr, $field_name: expr, { $($builder_block:tt)* }, { $($scalar_block:tt)* }) => {{
+    ($data_type:expr, $mode:tt, $len:expr, $builder:expr, $response:expr, $field_name: expr, { $($builder_block:tt)* }, { $($scalar_block:tt)* }) => {{
         match $field_name {
             MemberField::Member(member) => {
                 let field_name = &member.field_name;
-                for i in 0..$len {
-                    let value = $response.get(i, &field_name)?;
+                build_column_iter_loop!($mode, $response, $len, &field_name, value, {
                     match (value, &mut $builder) {
                         (FieldValue::Null, builder) => builder.append_null()?,
                         $($builder_block)*
@@ -392,7 +465,7 @@ macro_rules! build_column_custom_builder {
                             )));
                         }
                     };
-                }
+                });
             }
             MemberField::Literal(value) => {
                 for _ in 0..$len {
@@ -813,377 +886,409 @@ fn load_to_stream_sync(one_shot_stream: &mut CubeScanOneShotStream) -> Result<()
     Ok(())
 }
 
-pub fn transform_response<V: ValueObject>(
-    response: &mut V,
-    schema: SchemaRef,
-    member_fields: &Vec<MemberField>,
-) -> std::result::Result<RecordBatch, CubeError> {
-    let mut columns = vec![];
+// Body of `transform_response` / `transform_columnar_response`. The two functions differ
+// only in how they iterate per-cell values: row-major (`$mode = row`) goes through
+// `ValueObject::get` per cell, columnar (`$mode = columnar`) fetches the whole column once
+// via `ColumnarValueObject::column`. Per-`DataType` coercion arms are shared.
+macro_rules! transform_response_body {
+    ($mode:tt, $response:expr, $schema:expr, $member_fields:expr) => {{
+        let mut columns = vec![];
 
-    for (i, schema_field) in schema.fields().iter().enumerate() {
-        let field_name = &member_fields[i];
-        let column = match schema_field.data_type() {
-            DataType::Utf8 => {
-                build_column!(
-                    DataType::Utf8,
-                    StringBuilder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::String(v), builder) => builder.append_value(v)?,
-                        (FieldValue::Bool(v), builder) => builder.append_value(if v { "true" } else { "false" })?,
-                        (FieldValue::Number(v), builder) => builder.append_value(v.to_string())?,
-                    },
-                    {
-                        (ScalarValue::Utf8(v), builder) => builder.append_option(v.as_ref())?,
-                    }
-                )
-            }
-            DataType::Int16 => {
-                build_column!(
-                    DataType::Int16,
-                    Int16Builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::Number(number), builder) => builder.append_value(number.round() as i16)?,
-                        (FieldValue::String(s), builder) => match s.parse::<i16>() {
-                            Ok(v) => builder.append_value(v)?,
-                            Err(error) => {
-                                warn!(
-                                    "Unable to parse value as i16: {}",
-                                    error.to_string()
-                                );
-
-                                builder.append_null()?
-                            }
+        for (i, schema_field) in $schema.fields().iter().enumerate() {
+            let field_name = &$member_fields[i];
+            let column = match schema_field.data_type() {
+                DataType::Utf8 => {
+                    build_column!(
+                        DataType::Utf8,
+                        StringBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::String(v), builder) => builder.append_value(v)?,
+                            (FieldValue::Bool(v), builder) => builder.append_value(if v { "true" } else { "false" })?,
+                            (FieldValue::Number(v), builder) => builder.append_value(v.to_string())?,
                         },
-                    },
-                    {
-                        (ScalarValue::Int16(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Int32 => {
-                build_column!(
-                    DataType::Int32,
-                    Int32Builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::Number(number), builder) => builder.append_value(number.round() as i32)?,
-                        (FieldValue::String(s), builder) => match s.parse::<i32>() {
-                            Ok(v) => builder.append_value(v)?,
-                            Err(error) => {
-                                warn!(
-                                    "Unable to parse value as i32: {}",
-                                    error.to_string()
-                                );
-
-                                builder.append_null()?
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::Int32(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Int64 => {
-                build_column!(
-                    DataType::Int64,
-                    Int64Builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::Number(number), builder) => builder.append_value(number.round() as i64)?,
-                        (FieldValue::String(s), builder)  => match s.parse::<i64>() {
-                            Ok(v) => builder.append_value(v)?,
-                            Err(error) => {
-                                warn!(
-                                    "Unable to parse value as i64: {}",
-                                    error.to_string()
-                                );
-
-                                builder.append_null()?
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::Int64(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Float32 => {
-                build_column!(
-                    DataType::Float32,
-                    Float32Builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::Number(number), builder) => builder.append_value(number as f32)?,
-                        (FieldValue::String(s), builder) => match s.parse::<f32>() {
-                            Ok(v) => builder.append_value(v)?,
-                            Err(error) => {
-                                warn!(
-                                    "Unable to parse value as f32: {}",
-                                    error.to_string()
-                                );
-
-                                builder.append_null()?
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::Float32(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Float64 => {
-                build_column!(
-                    DataType::Float64,
-                    Float64Builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::Number(number), builder) => builder.append_value(number)?,
-                        (FieldValue::String(s), builder) => match s.parse::<f64>() {
-                            Ok(v) => builder.append_value(v)?,
-                            Err(error) => {
-                                warn!(
-                                    "Unable to parse value as f64: {}",
-                                    error.to_string()
-                                );
-
-                                builder.append_null()?
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::Float64(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Boolean => {
-                build_column!(
-                    DataType::Boolean,
-                    BooleanBuilder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::Bool(v), builder) => builder.append_value(v)?,
-                        (FieldValue::String(v), builder)  => match v.as_ref() {
-                            "true" | "1" => builder.append_value(true)?,
-                            "false" | "0" => builder.append_value(false)?,
-                            _ => {
-                                log::error!("Unable to map value {:?} to DataType::Boolean (returning null)", v);
-
-                                builder.append_null()?
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::Boolean(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Timestamp(TimeUnit::Nanosecond, None) => {
-                build_column!(
-                    DataType::Timestamp(TimeUnit::Nanosecond, None),
-                    TimestampNanosecondBuilder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::String(s), builder) => {
-                            let timestamp = parse_date_str(s.as_ref())?;
-                            // TODO switch parsing to microseconds
-                            if timestamp.and_utc().timestamp_millis() > (((1i64) << 62) / 1_000_000) {
-                                builder.append_null()?;
-                            } else if let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() {
-                                builder.append_value(nanos)?;
-                            } else {
-                                log::error!(
-                                    "Unable to cast timestamp value to nanoseconds: {}",
-                                    timestamp.to_string()
-                                );
-                                builder.append_null()?;
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::TimestampNanosecond(v, None), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Timestamp(TimeUnit::Millisecond, None) => {
-                build_column!(
-                    DataType::Timestamp(TimeUnit::Millisecond, None),
-                    TimestampMillisecondBuilder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::String(s), builder) => {
-                            let timestamp = parse_date_str(s.as_ref())?;
-                            // TODO switch parsing to microseconds
-                            if timestamp.and_utc().timestamp_millis() > (((1 as i64) << 62) / 1_000_000) {
-                                builder.append_null()?;
-                            } else {
-                                builder.append_value(timestamp.and_utc().timestamp_millis())?;
-                            }
-                        },
-                    },
-                    {
-                        (ScalarValue::TimestampMillisecond(v, None), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Date32 => {
-                build_column!(
-                    DataType::Date32,
-                    Date32Builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::String(s), builder) => {
-                            let date = NaiveDate::parse_from_str(s.as_ref(), "%Y-%m-%d")
-                                // FIXME: temporary solution for cases when expected type is Date32
-                                // but underlying data is a Timestamp
-                                .or_else(|_| NaiveDate::parse_from_str(s.as_ref(), "%Y-%m-%dT00:00:00.000"))
-                                .map_err(|e| {
-                                    DataFusionError::Execution(format!(
-                                        "Can't parse date: '{}': {}",
-                                        s, e
-                                    ))
-                                });
-                            match date {
-                                Ok(date) => {
-                                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                                    let days_since_epoch = date.num_days_from_ce()  - epoch.num_days_from_ce();
-                                    builder.append_value(days_since_epoch)?;
-                                }
+                        {
+                            (ScalarValue::Utf8(v), builder) => builder.append_option(v.as_ref())?,
+                        }
+                    )
+                }
+                DataType::Int16 => {
+                    build_column!(
+                        DataType::Int16,
+                        Int16Builder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::Number(number), builder) => builder.append_value(number.round() as i16)?,
+                            (FieldValue::String(s), builder) => match s.parse::<i16>() {
+                                Ok(v) => builder.append_value(v)?,
                                 Err(error) => {
-                                    log::error!(
-                                        "Unable to parse value as Date32: {}",
+                                    warn!(
+                                        "Unable to parse value as i16: {}",
                                         error.to_string()
                                     );
 
                                     builder.append_null()?
                                 }
-                            }
+                            },
+                        },
+                        {
+                            (ScalarValue::Int16(v), builder) => builder.append_option(*v)?,
                         }
-                    },
-                    {
-                        (ScalarValue::Date32(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Decimal(precision, scale) => {
-                let len = response.len()?;
-                let mut builder = DecimalBuilder::new(len, *precision, *scale);
+                    )
+                }
+                DataType::Int32 => {
+                    build_column!(
+                        DataType::Int32,
+                        Int32Builder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::Number(number), builder) => builder.append_value(number.round() as i32)?,
+                            (FieldValue::String(s), builder) => match s.parse::<i32>() {
+                                Ok(v) => builder.append_value(v)?,
+                                Err(error) => {
+                                    warn!(
+                                        "Unable to parse value as i32: {}",
+                                        error.to_string()
+                                    );
 
-                build_column_custom_builder!(
-                    DataType::Decimal(*precision, *scale),
-                    len,
-                    builder,
-                    response,
-                    field_name,
-                    {
-                        (FieldValue::String(s), builder) => {
-                            let mut parts = s.split(".");
-                            match parts.next() {
-                                None => builder.append_null()?,
-                                Some(int_part) => {
-                                    let frac_part = format!("{:0<width$}", parts.next().unwrap_or(""), width=scale);
-                                    if frac_part.len() > *scale {
-                                        Err(DataFusionError::Execution(format!("Decimal scale is higher than requested: expected {}, got {}", scale, frac_part.len())))?;
+                                    builder.append_null()?
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::Int32(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Int64 => {
+                    build_column!(
+                        DataType::Int64,
+                        Int64Builder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::Number(number), builder) => builder.append_value(number.round() as i64)?,
+                            (FieldValue::String(s), builder)  => match s.parse::<i64>() {
+                                Ok(v) => builder.append_value(v)?,
+                                Err(error) => {
+                                    warn!(
+                                        "Unable to parse value as i64: {}",
+                                        error.to_string()
+                                    );
+
+                                    builder.append_null()?
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::Int64(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Float32 => {
+                    build_column!(
+                        DataType::Float32,
+                        Float32Builder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::Number(number), builder) => builder.append_value(number as f32)?,
+                            (FieldValue::String(s), builder) => match s.parse::<f32>() {
+                                Ok(v) => builder.append_value(v)?,
+                                Err(error) => {
+                                    warn!(
+                                        "Unable to parse value as f32: {}",
+                                        error.to_string()
+                                    );
+
+                                    builder.append_null()?
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::Float32(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Float64 => {
+                    build_column!(
+                        DataType::Float64,
+                        Float64Builder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::Number(number), builder) => builder.append_value(number)?,
+                            (FieldValue::String(s), builder) => match s.parse::<f64>() {
+                                Ok(v) => builder.append_value(v)?,
+                                Err(error) => {
+                                    warn!(
+                                        "Unable to parse value as f64: {}",
+                                        error.to_string()
+                                    );
+
+                                    builder.append_null()?
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::Float64(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Boolean => {
+                    build_column!(
+                        DataType::Boolean,
+                        BooleanBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::Bool(v), builder) => builder.append_value(v)?,
+                            (FieldValue::String(v), builder)  => match v.as_ref() {
+                                "true" | "1" => builder.append_value(true)?,
+                                "false" | "0" => builder.append_value(false)?,
+                                _ => {
+                                    log::error!("Unable to map value {:?} to DataType::Boolean (returning null)", v);
+
+                                    builder.append_null()?
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::Boolean(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Timestamp(TimeUnit::Nanosecond, None) => {
+                    build_column!(
+                        DataType::Timestamp(TimeUnit::Nanosecond, None),
+                        TimestampNanosecondBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::String(s), builder) => {
+                                let timestamp = parse_date_str(s.as_ref())?;
+                                // TODO switch parsing to microseconds
+                                if timestamp.and_utc().timestamp_millis() > (((1i64) << 62) / 1_000_000) {
+                                    builder.append_null()?;
+                                } else if let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() {
+                                    builder.append_value(nanos)?;
+                                } else {
+                                    log::error!(
+                                        "Unable to cast timestamp value to nanoseconds: {}",
+                                        timestamp.to_string()
+                                    );
+                                    builder.append_null()?;
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::TimestampNanosecond(v, None), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Timestamp(TimeUnit::Millisecond, None) => {
+                    build_column!(
+                        DataType::Timestamp(TimeUnit::Millisecond, None),
+                        TimestampMillisecondBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::String(s), builder) => {
+                                let timestamp = parse_date_str(s.as_ref())?;
+                                // TODO switch parsing to microseconds
+                                if timestamp.and_utc().timestamp_millis() > (((1 as i64) << 62) / 1_000_000) {
+                                    builder.append_null()?;
+                                } else {
+                                    builder.append_value(timestamp.and_utc().timestamp_millis())?;
+                                }
+                            },
+                        },
+                        {
+                            (ScalarValue::TimestampMillisecond(v, None), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Date32 => {
+                    build_column!(
+                        DataType::Date32,
+                        Date32Builder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::String(s), builder) => {
+                                let date = NaiveDate::parse_from_str(s.as_ref(), "%Y-%m-%d")
+                                    // FIXME: temporary solution for cases when expected type is Date32
+                                    // but underlying data is a Timestamp
+                                    .or_else(|_| NaiveDate::parse_from_str(s.as_ref(), "%Y-%m-%dT00:00:00.000"))
+                                    .map_err(|e| {
+                                        DataFusionError::Execution(format!(
+                                            "Can't parse date: '{}': {}",
+                                            s, e
+                                        ))
+                                    });
+                                match date {
+                                    Ok(date) => {
+                                        let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+                                        let days_since_epoch = date.num_days_from_ce()  - epoch.num_days_from_ce();
+                                        builder.append_value(days_since_epoch)?;
                                     }
-                                    if let Some(_) = parts.next() {
-                                        Err(DataFusionError::Execution(format!("Unable to parse decimal, value contains two dots: {}", s)))?;
-                                    }
-                                    let decimal_str = format!("{}{}", int_part, frac_part);
-                                    if decimal_str.len() > *precision {
-                                        Err(DataFusionError::Execution(format!("Decimal precision is higher than requested: expected {}, got {}", precision, decimal_str.len())))?;
-                                    }
-                                    if let Ok(value) = decimal_str.parse::<i128>() {
-                                        builder.append_value(value)?;
-                                    } else {
-                                        Err(DataFusionError::Execution(format!("Unable to parse decimal as an i128: {}", decimal_str)))?;
+                                    Err(error) => {
+                                        log::error!(
+                                            "Unable to parse value as Date32: {}",
+                                            error.to_string()
+                                        );
+
+                                        builder.append_null()?
                                     }
                                 }
-                            };
-                        },
-                    },
-                    {
-                        (ScalarValue::Decimal128(v, _, _), builder) => {
-                            // TODO: check precision and scale, adjust accordingly
-                            if let Some(v) = v {
-                                builder.append_value(*v)?;
-                            } else {
-                                builder.append_null()?;
                             }
                         },
-                    }
-                )
-            }
-            DataType::Interval(IntervalUnit::YearMonth) => {
-                build_column!(
-                    DataType::Interval(IntervalUnit::YearMonth),
-                    IntervalYearMonthBuilder,
-                    response,
-                    field_name,
-                    {
-                        // TODO
-                    },
-                    {
-                        (ScalarValue::IntervalYearMonth(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Interval(IntervalUnit::DayTime) => {
-                build_column!(
-                    DataType::Interval(IntervalUnit::DayTime),
-                    IntervalDayTimeBuilder,
-                    response,
-                    field_name,
-                    {
-                        // TODO
-                    },
-                    {
-                        (ScalarValue::IntervalDayTime(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Interval(IntervalUnit::MonthDayNano) => {
-                build_column!(
-                    DataType::Interval(IntervalUnit::MonthDayNano),
-                    IntervalMonthDayNanoBuilder,
-                    response,
-                    field_name,
-                    {
-                        // TODO
-                    },
-                    {
-                        (ScalarValue::IntervalMonthDayNano(v), builder) => builder.append_option(*v)?,
-                    }
-                )
-            }
-            DataType::Null => {
-                let len = response.len()?;
-                let array = NullArray::new(len);
-                Arc::new(array)
-            }
-            t => {
-                return Err(CubeError::user(format!(
-                    "Type {} is not supported in response transformation from Cube",
-                    t,
-                )))
-            }
-        };
+                        {
+                            (ScalarValue::Date32(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Decimal(precision, scale) => {
+                    let len = $response.len()?;
+                    let mut builder = DecimalBuilder::new(len, *precision, *scale);
 
-        columns.push(column);
-    }
+                    build_column_custom_builder!(
+                        DataType::Decimal(*precision, *scale),
+                        $mode,
+                        len,
+                        builder,
+                        $response,
+                        field_name,
+                        {
+                            (FieldValue::String(s), builder) => {
+                                let mut parts = s.split(".");
+                                match parts.next() {
+                                    None => builder.append_null()?,
+                                    Some(int_part) => {
+                                        let frac_part = format!("{:0<width$}", parts.next().unwrap_or(""), width=scale);
+                                        if frac_part.len() > *scale {
+                                            Err(DataFusionError::Execution(format!("Decimal scale is higher than requested: expected {}, got {}", scale, frac_part.len())))?;
+                                        }
+                                        if let Some(_) = parts.next() {
+                                            Err(DataFusionError::Execution(format!("Unable to parse decimal, value contains two dots: {}", s)))?;
+                                        }
+                                        let decimal_str = format!("{}{}", int_part, frac_part);
+                                        if decimal_str.len() > *precision {
+                                            Err(DataFusionError::Execution(format!("Decimal precision is higher than requested: expected {}, got {}", precision, decimal_str.len())))?;
+                                        }
+                                        if let Ok(value) = decimal_str.parse::<i128>() {
+                                            builder.append_value(value)?;
+                                        } else {
+                                            Err(DataFusionError::Execution(format!("Unable to parse decimal as an i128: {}", decimal_str)))?;
+                                        }
+                                    }
+                                };
+                            },
+                        },
+                        {
+                            (ScalarValue::Decimal128(v, _, _), builder) => {
+                                // TODO: check precision and scale, adjust accordingly
+                                if let Some(v) = v {
+                                    builder.append_value(*v)?;
+                                } else {
+                                    builder.append_null()?;
+                                }
+                            },
+                        }
+                    )
+                }
+                DataType::Interval(IntervalUnit::YearMonth) => {
+                    build_column!(
+                        DataType::Interval(IntervalUnit::YearMonth),
+                        IntervalYearMonthBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            // TODO
+                        },
+                        {
+                            (ScalarValue::IntervalYearMonth(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Interval(IntervalUnit::DayTime) => {
+                    build_column!(
+                        DataType::Interval(IntervalUnit::DayTime),
+                        IntervalDayTimeBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            // TODO
+                        },
+                        {
+                            (ScalarValue::IntervalDayTime(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Interval(IntervalUnit::MonthDayNano) => {
+                    build_column!(
+                        DataType::Interval(IntervalUnit::MonthDayNano),
+                        IntervalMonthDayNanoBuilder,
+                        $mode,
+                        $response,
+                        field_name,
+                        {
+                            // TODO
+                        },
+                        {
+                            (ScalarValue::IntervalMonthDayNano(v), builder) => builder.append_option(*v)?,
+                        }
+                    )
+                }
+                DataType::Null => {
+                    let len = $response.len()?;
+                    let array = NullArray::new(len);
+                    Arc::new(array)
+                }
+                t => {
+                    return Err(CubeError::user(format!(
+                        "Type {} is not supported in response transformation from Cube",
+                        t,
+                    )))
+                }
+            };
 
-    Ok(RecordBatch::try_new(schema.clone(), columns)?)
+            columns.push(column);
+        }
+
+        Ok(RecordBatch::try_new($schema.clone(), columns)?)
+    }};
+}
+
+pub fn transform_response<V: ValueObject>(
+    response: &mut V,
+    schema: SchemaRef,
+    member_fields: &Vec<MemberField>,
+) -> std::result::Result<RecordBatch, CubeError> {
+    transform_response_body!(row, response, schema, member_fields)
+}
+
+pub fn transform_columnar_response<C: ColumnarValueObject>(
+    response: &mut C,
+    schema: SchemaRef,
+    member_fields: &Vec<MemberField>,
+) -> std::result::Result<RecordBatch, CubeError> {
+    transform_response_body!(columnar, response, schema, member_fields)
 }
 
 pub fn convert_transport_response(
@@ -1214,6 +1319,39 @@ pub fn convert_transport_response(
             };
 
             transform_response(&mut response, updated_schema, &member_fields)
+        })
+        .collect::<std::result::Result<Vec<RecordBatch>, CubeError>>()
+}
+
+pub fn convert_transport_response_columnar(
+    response: V1LoadResponse<V1LoadResultDataColumnar>,
+    schema: SchemaRef,
+    member_fields: Vec<MemberField>,
+) -> std::result::Result<Vec<RecordBatch>, CubeError> {
+    response
+        .results
+        .into_iter()
+        .map(|result| {
+            let V1LoadResult {
+                data,
+                last_refresh_time,
+                ..
+            } = result;
+            let V1LoadResultDataColumnar { members, columns } = data;
+
+            let mut response = JsonColumnarValueObject::new(members, columns);
+            let updated_schema = if let Some(last_refresh_time) = last_refresh_time {
+                let mut metadata = schema.metadata().clone();
+                metadata.insert("lastRefreshTime".to_string(), last_refresh_time);
+                Arc::new(Schema::new_with_metadata(
+                    schema.fields().to_vec(),
+                    metadata,
+                ))
+            } else {
+                schema.clone()
+            };
+
+            transform_columnar_response(&mut response, updated_schema, &member_fields)
         })
         .collect::<std::result::Result<Vec<RecordBatch>, CubeError>>()
 }

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -831,8 +831,8 @@ async fn load_data(
                 }
                 ArrowError::ExternalError(Box::new(err))
             })?;
-        let response = result.first();
-        if let Some(data) = response.cloned() {
+
+        if let Some(data) = result.into_iter().next() {
             match (options.max_records, data.num_rows()) {
                 (Some(max_records), len) if len >= max_records => {
                     return Err(ArrowError::ExternalError(Box::new(CubeError::user(

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -410,17 +410,19 @@ impl ColumnarValueObject for JsonColumnarValueObject {
         CubeError,
     > {
         let Some(idx) = self.members.iter().position(|m| m == field_name) else {
-            return Err(CubeError::user(format!(
-                "Field name '{}' not found in members",
-                field_name
-            )));
+            // Match the row-mode `JsonValueObject::get` semantics: a missing field
+            // is treated as a column of NULLs.
+            let len = self.columns.first().map(|c| c.len()).unwrap_or(0);
+            return Ok(Box::new((0..len).map(|_| Ok(FieldValue::Null))));
         };
+
         let Some(column) = self.columns.get(idx) else {
             return Err(CubeError::user(format!(
                 "Unexpected response from Cube, missing column for '{}'",
                 field_name
             )));
         };
+
         Ok(Box::new(column.iter().map(json_value_to_field_value)))
     }
 }

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -388,6 +388,11 @@ pub struct JsonColumnarValueObject {
 
 impl JsonColumnarValueObject {
     pub fn new(members: Vec<String>, columns: Vec<Vec<Value>>) -> Self {
+        debug_assert!(
+            columns.windows(2).all(|w| w[0].len() == w[1].len()),
+            "columnar response has ragged columns"
+        );
+
         Self { members, columns }
     }
 }

--- a/rust/cubesql/cubesql/src/transport/mod.rs
+++ b/rust/cubesql/cubesql/src/transport/mod.rs
@@ -26,6 +26,8 @@ pub type CubeMetaDimensionOrder = cubeclient::models::V1CubeMetaDimensionOrder;
 pub type CubeMetaFormat = cubeclient::models::V1CubeMetaFormat;
 // Request/Response
 pub type TransportLoadResponse = cubeclient::models::V1LoadResponse;
+pub type TransportLoadResponseColumnar =
+    cubeclient::models::V1LoadResponse<cubeclient::models::V1LoadResultDataColumnar>;
 pub type TransportLoadRequestQuery = cubeclient::models::V1LoadRequestQuery;
 pub type TransportLoadRequest = cubeclient::models::V1LoadRequest;
 pub type TransportLoadRequestCacheMode = cubeclient::models::Cache;


### PR DESCRIPTION
Switch the JS-bridge `TransportService::load` path from row-oriented to columnar Cube REST responses, and add a parallel transform path in `cubesql` that consumes `{members, columns}` directly. Per-`DataType` coercion arms are deduplicated between row and columnar via a shared `transform_response_body!` macro (`build_column_iter_loop!` selects between `response.get(i, name)` per cell vs. one column slice fetched up front).

End-to-end median time, `String -> Value -> typed -> Vec<RecordBatch>`, selected shapes (td = number of time dimensions):

| rows   | cols | td | row (ms) | columnar (ms) | speedup |
|-------:|-----:|---:|---------:|--------------:|--------:|
|   1000 |    8 |  0 |     1.46 |          0.29 |   5.11× |
|   1000 |   64 |  0 |    11.07 |          2.40 |   4.62× |
|  10000 |    8 |  0 |    15.46 |          2.97 |   5.20× |
|  10000 |   64 |  0 |   162.30 |         23.93 |   6.78× |
|  10000 |   64 |  1 |   171.67 |         29.55 |   5.81× |
|  10000 |   64 |  2 |   174.06 |         34.76 |   5.01× |
|  50000 |   64 |  0 |  1041.10 |        166.99 |   6.23× |
| 100000 |    8 |  0 |   199.93 |         45.98 |   4.35× |
| 100000 |   64 |  0 |  2062.20 |        350.98 |   5.88× |
| 100000 |   64 |  2 |  2200.40 |        423.01 |   5.20× |

Patterns:

- Columnar always wins (1.9× – 6.8× across the full 60-shape matrix).
- More columns → bigger win (per-cell key parsing amortizes over longer column slices).
- More time dimensions → smaller win (timestamp parsing dominates both variants equally).
- Linear in row count → speedup is stable across the rows axis at fixed (cols, td).

Reproduce: `cargo bench -p cubesql --bench transform_response`.