### PR TITLE
refactor(native): Remove old load method

### DIFF
--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -194,34 +194,6 @@ export class SQLServer {
           }
         });
       },
-      load: async ({ request, session, query }) => {
-        const context = await contextByRequest(request, session);
-
-        // eslint-disable-next-line no-async-promise-executor
-        return new Promise(async (resolve, reject) => {
-          try {
-            await this.apiGateway.load({
-              query,
-              queryType: 'multi',
-              context,
-              res: (response) => {
-                if ('error' in response) {
-                  reject({
-                    message: response.error
-                  });
-
-                  return;
-                }
-
-                resolve(response);
-              },
-              apiType: 'sql',
-            });
-          } catch (e) {
-            reject(e);
-          }
-        });
-      },
       sqlApiLoad: async ({ request, session, query, queryKey, sqlQuery, streaming, cacheMode }) => {
         const context = await contextByRequest(request, session);
 

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -110,7 +110,6 @@ export type SQLInterfaceOptions = {
   contextToApiScopes: (payload: ContextToApiScopesPayload) => ContextToApiScopesResponse | Promise<ContextToApiScopesResponse>,
   checkAuth: (payload: CheckAuthPayload) => CheckAuthResponse | Promise<CheckAuthResponse>,
   checkSqlAuth: (payload: CheckSQLAuthPayload) => CheckSQLAuthResponse | Promise<CheckSQLAuthResponse>,
-  load: (payload: LoadPayload) => unknown | Promise<unknown>,
   sql: (payload: SqlPayload) => unknown | Promise<unknown>,
   meta: (payload: MetaPayload) => unknown | Promise<unknown>,
   stream: (payload: LoadPayload) => unknown | Promise<unknown>,
@@ -396,10 +395,6 @@ export const registerInterface = async (options: SQLInterfaceOptions): Promise<S
     throw new Error('options.checkSqlAuth must be a function');
   }
 
-  if (typeof options.load !== 'function') {
-    throw new Error('options.load must be a function');
-  }
-
   if (typeof options.meta !== 'function') {
     throw new Error('options.meta must be a function');
   }
@@ -426,7 +421,6 @@ export const registerInterface = async (options: SQLInterfaceOptions): Promise<S
     contextToApiScopes: wrapNativeFunctionWithChannelCallback(options.contextToApiScopes),
     checkAuth: wrapNativeFunctionWithChannelCallback(options.checkAuth),
     checkSqlAuth: wrapNativeFunctionWithChannelCallback(options.checkSqlAuth),
-    load: wrapNativeFunctionWithChannelCallback(options.load),
     sql: wrapNativeFunctionWithChannelCallback(options.sql),
     meta: wrapNativeFunctionWithChannelCallback(options.meta),
     stream: wrapNativeFunctionWithStream(options.stream),

--- a/packages/cubejs-backend-native/test/server.js
+++ b/packages/cubejs-backend-native/test/server.js
@@ -4,16 +4,6 @@ const native = require('../js/index');
 const meta_fixture = require('./meta');
 
 (async () => {
-  const load = async ({ request, session, query }) => {
-    console.log('[js] load', {
-      request,
-      session,
-      query,
-    });
-
-    throw new Error('load is not implemented');
-  };
-
   const sqlApiLoad = async ({ request, session, query, streaming }) => {
     console.log('[js] sqlApiLoad', {
       request,
@@ -122,7 +112,6 @@ const meta_fixture = require('./meta');
   const server = await native.registerInterface({
     // nonce: '12345678910111213141516'.substring(0, 20),
     checkAuth,
-    load,
     sql,
     meta,
     stream,

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -25,26 +25,8 @@ const _logger = jest.fn(({ event }) => {
 
 function interfaceMethods() {
   return {
-    load: jest.fn(async ({ request, session, query }) => {
-      console.log('[js] load', {
-        request,
-        session,
-        query,
-      });
-
-      expect(session).toEqual({
-        user: expect.toBeTypeOrNull(String),
-        superuser: expect.any(Boolean),
-        securityContext: { foo: 'bar' },
-      });
-
-      // It's just an emulation that ApiGateway returns error
-      return {
-        error: 'This error should be passed back to PostgreSQL client',
-      };
-    }),
     sqlApiLoad: jest.fn(async ({ request, session, query, streaming }) => {
-      console.log('[js] load', {
+      console.log('[js] sqlApiLoad', {
         request,
         session,
         query,
@@ -282,7 +264,6 @@ describe('SQLInterface', () => {
       });
 
       try {
-        // limit is used to router query to load method instead of stream
         await connection.query(
           'select * from KibanaSampleDataEcommerce LIMIT 1000'
         );


### PR DESCRIPTION
The `load` JS callback in registerInterface options was never invoked: the Rust side (node_export.rs::register_interface) only extracts sqlApiLoad, sql, meta, logLoadEvent, sqlGenerators, and canSwitchUserForSession. The TransportService::load impl in transport.rs routes through on_sql_api_load, not a separate on_load callback. Drop the field, validation, wrapper, and the SqlServer/test fixtures that fed it.