### PR TITLE
docs: add view groups documentation

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -137,7 +137,8 @@
                 "group": "Views",
                 "root": "docs/data-modeling/views",
                 "pages": [
-                  "docs/data-modeling/multi-fact-views"
+                  "docs/data-modeling/multi-fact-views",
+                  "docs/data-modeling/view-groups"
                 ]
               },
               {

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -456,6 +456,7 @@
             "pages": [
               "reference/data-modeling/cube",
               "reference/data-modeling/view",
+              "reference/data-modeling/view-group",
               "reference/data-modeling/measures",
               "reference/data-modeling/dimensions",
               "reference/data-modeling/hierarchies",

--- a/docs-mintlify/docs/data-modeling/concepts/syntax.mdx
+++ b/docs-mintlify/docs/data-modeling/concepts/syntax.mdx
@@ -17,7 +17,8 @@ option][ref-config-repository-factory] to dynamically define the folder name and
 data model file contents.
 
 It's recommended to place each cube or view in a separate file, in `model/cubes`
-and `model/views` folders, respectively. Example:
+and `model/views` folders, respectively. [View groups][ref-view-groups] can be
+defined alongside views or in their own files. Example:
 
 ```tree
 model
@@ -26,7 +27,8 @@ model
 │   ├── products.yml
 │   └── users.yml
 └── views
-    └── revenue.yml
+    ├── revenue.yml
+    └── view_groups.yml
 ```
 
 ## Model syntax
@@ -998,6 +1000,7 @@ string values in time dimensions.
 [ref-dax-api-date-hierarchies]: /reference/dax-api#date-hierarchies
 [ref-time-dimension]: /docs/data-modeling/dimensions#time-dimensions
 [ref-recipe-string-time-dimensions]: /recipes/data-modeling/string-time-dimensions
+[ref-view-groups]: /reference/data-modeling/view-group
 [ref-views]: /docs/data-modeling/views
 [ref-preaggs]: /reference/data-modeling/pre-aggregations
 [ref-join-paths]: /docs/data-modeling/joins#join-paths

--- a/docs-mintlify/docs/data-modeling/view-groups.mdx
+++ b/docs-mintlify/docs/data-modeling/view-groups.mdx
@@ -1,0 +1,165 @@
+---
+title: View groups
+description: View groups organize views into named collections by domain or purpose, helping downstream consumers — including AI agents and embedded analytics — navigate large data models.
+---
+
+When a data model contains many [views][ref-views], view groups help organize
+them into named collections by domain or purpose — for example, `sales`,
+`finance`, or `people`. View groups are exposed through the
+[`/v1/meta`][ref-meta-endpoint] API, making it easier for downstream tools,
+AI agents, and embedded analytics to present a navigable catalog.
+
+<Note>
+
+See the [view group reference][ref-view-group-ref] for the full list of
+parameters and configuration options.
+
+</Note>
+
+## Defining a view group
+
+A view group is a top-level entity, defined alongside views. At minimum it
+needs a `name`; `title` and `description` make it easier to navigate in
+downstream tools.
+
+<CodeGroup>
+
+```yaml title="YAML"
+view_groups:
+  - name: sales
+    title: Sales
+    description: Revenue and order views for the sales team
+```
+
+```javascript title="JavaScript"
+view_group(`sales`, {
+  title: `Sales`,
+  description: `Revenue and order views for the sales team`
+})
+```
+
+</CodeGroup>
+
+## Assigning views to a group
+
+There are two ways to assign a view to a group, and both can be combined.
+Pick whichever keeps group membership co-located with the entity you'd
+rather edit — the group definition for a curated catalog, or the view
+definition for ad-hoc additions.
+
+### From the group side
+
+List views on the group via the [`views`][ref-view-group-views] parameter.
+This keeps the full membership in one place, which is convenient when you
+want to review a group at a glance.
+
+<CodeGroup>
+
+```yaml title="YAML"
+view_groups:
+  - name: sales
+    title: Sales
+    views:
+      - orders_overview
+      - revenue
+```
+
+```javascript title="JavaScript"
+view_group(`sales`, {
+  title: `Sales`,
+  views: [`orders_overview`, `revenue`]
+})
+```
+
+</CodeGroup>
+
+### From the view side
+
+Set [`view_group`][ref-view-view-group] on the view itself. The view
+declares which group it belongs to, without touching the group definition.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: revenue
+    view_group: sales
+    cubes:
+      - join_path: order_items
+        includes:
+          - total_sale_price
+          - created_at
+```
+
+```javascript title="JavaScript"
+view(`revenue`, {
+  view_group: sales,
+  cubes: [
+    {
+      join_path: order_items,
+      includes: [`total_sale_price`, `created_at`]
+    }
+  ]
+})
+```
+
+</CodeGroup>
+
+### Belonging to multiple groups
+
+A view can belong to more than one group. Use
+[`view_groups`][ref-view-view-groups] (plural) on the view to list every
+group it should appear in.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: revenue
+    view_groups:
+      - sales
+      - finance
+    cubes:
+      - join_path: order_items
+        includes:
+          - total_sale_price
+          - created_at
+```
+
+```javascript title="JavaScript"
+view(`revenue`, {
+  view_groups: [sales, finance],
+  cubes: [
+    {
+      join_path: order_items,
+      includes: [`total_sale_price`, `created_at`]
+    }
+  ]
+})
+```
+
+</CodeGroup>
+
+## Where view groups live in the model
+
+By [convention][ref-syntax], view groups are typically defined alongside
+views in the `model/views` folder — for example, in a dedicated
+`view_groups.yml` file. They behave like any other top-level data model
+entity and can be split across multiple files as your model grows.
+
+## Next steps
+
+- See the [view group reference][ref-view-group-ref] for the full list of
+  parameters
+- Learn about [views][ref-views] and how they curate cubes for downstream
+  consumers
+- Explore [AI context][ref-ai-context] to improve AI query accuracy
+
+[ref-views]: /docs/data-modeling/views
+[ref-syntax]: /docs/data-modeling/concepts/syntax
+[ref-ai-context]: /docs/data-modeling/ai-context
+[ref-view-group-ref]: /reference/data-modeling/view-group
+[ref-view-group-views]: /reference/data-modeling/view-group#views
+[ref-view-view-group]: /reference/data-modeling/view#view_group
+[ref-view-view-groups]: /reference/data-modeling/view#view_groups
+[ref-meta-endpoint]: /reference/core-data-apis/rest-api/reference

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -485,7 +485,7 @@ view(`orders_overview`, {
 })
 
 view(`revenue`, {
-  viewGroup: sales,
+  view_group: sales,
   cubes: [
     {
       join_path: order_items,

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -423,10 +423,117 @@ Check [APIs & Integrations][ref-apis-support] for details on folder
 support. For tools that don't support nested folders, the structure is
 automatically flattened.
 
+## Grouping views with view groups
+
+When a data model contains many views, [view groups][ref-view-groups] help
+organize them into named collections by domain or purpose — for example,
+`sales`, `finance`, or `people`. View groups are exposed through the
+[`/v1/meta`][ref-meta-endpoint] API, making it easier for downstream tools,
+AI agents, and embedded analytics to present a navigable catalog.
+
+You define view groups as standalone entities and then associate views with
+them — either by listing views on the group or by setting
+[`view_group`][ref-view-view-group] / [`view_groups`][ref-view-view-groups]
+on individual views. Both approaches can be combined.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: orders_overview
+    cubes:
+      - join_path: order_items
+        includes:
+          - count
+          - total_sale_price
+          - status
+
+  - name: revenue
+    view_group: sales
+    cubes:
+      - join_path: order_items
+        includes:
+          - total_sale_price
+          - created_at
+
+  - name: customers_view
+    cubes:
+      - join_path: users
+        includes: "*"
+
+view_groups:
+  - name: sales
+    title: Sales
+    description: Revenue and order views for the sales team
+    views:
+      - orders_overview
+
+  - name: people
+    title: People
+    views:
+      - customers_view
+```
+
+```javascript title="JavaScript"
+view(`orders_overview`, {
+  cubes: [
+    {
+      join_path: order_items,
+      includes: [`count`, `total_sale_price`, `status`]
+    }
+  ]
+})
+
+view(`revenue`, {
+  viewGroup: sales,
+  cubes: [
+    {
+      join_path: order_items,
+      includes: [`total_sale_price`, `created_at`]
+    }
+  ]
+})
+
+view(`customers_view`, {
+  cubes: [
+    {
+      join_path: users,
+      includes: `*`
+    }
+  ]
+})
+
+view_group(`sales`, {
+  title: `Sales`,
+  description: `Revenue and order views for the sales team`,
+  views: [`orders_overview`]
+})
+
+view_group(`people`, {
+  title: `People`,
+  views: [`customers_view`]
+})
+```
+
+</CodeGroup>
+
+In this example, the `sales` group contains both `orders_overview`
+(listed on the group) and `revenue` (which references the group via
+`view_group`). The `people` group contains `customers_view`.
+
+<Note>
+
+See the [view group reference][ref-view-groups] for the full list of
+parameters and configuration options.
+
+</Note>
+
 ## Next steps
 
 - See the [view reference][ref-view-reference] for the full list of
   parameters
+- Learn about [view groups][ref-view-groups] to organize views into
+  named collections
 - Learn about [access policies][ref-access-policies] to govern view access
 - Explore [AI context][ref-ai-context] to improve AI query accuracy
 - Use the [Semantic Model IDE][ref-ide] to develop views interactively
@@ -446,4 +553,8 @@ automatically flattened.
 [ref-ide]: /docs/data-modeling/data-model-ide
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools
 [ref-apis-support]: /reference#data-modeling
+[ref-view-groups]: /reference/data-modeling/view-group
+[ref-view-view-group]: /reference/data-modeling/view#view_group
+[ref-view-view-groups]: /reference/data-modeling/view#view_groups
+[ref-meta-endpoint]: /reference/core-data-apis/rest-api/reference
 [wiki-dry]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -427,106 +427,13 @@ automatically flattened.
 
 When a data model contains many views, [view groups][ref-view-groups] help
 organize them into named collections by domain or purpose — for example,
-`sales`, `finance`, or `people`. View groups are exposed through the
-[`/v1/meta`][ref-meta-endpoint] API, making it easier for downstream tools,
-AI agents, and embedded analytics to present a navigable catalog.
+`sales`, `finance`, or `people`. They're exposed through the
+[`/v1/meta`][ref-meta-endpoint] API so downstream tools, AI agents, and
+embedded analytics can present a navigable catalog.
 
-You define view groups as standalone entities and then associate views with
-them — either by listing views on the group or by setting
-[`view_group`][ref-view-view-group] / [`view_groups`][ref-view-view-groups]
-on individual views. Both approaches can be combined.
-
-<CodeGroup>
-
-```yaml title="YAML"
-views:
-  - name: orders_overview
-    cubes:
-      - join_path: order_items
-        includes:
-          - count
-          - total_sale_price
-          - status
-
-  - name: revenue
-    view_group: sales
-    cubes:
-      - join_path: order_items
-        includes:
-          - total_sale_price
-          - created_at
-
-  - name: customers_view
-    cubes:
-      - join_path: users
-        includes: "*"
-
-view_groups:
-  - name: sales
-    title: Sales
-    description: Revenue and order views for the sales team
-    views:
-      - orders_overview
-
-  - name: people
-    title: People
-    views:
-      - customers_view
-```
-
-```javascript title="JavaScript"
-view(`orders_overview`, {
-  cubes: [
-    {
-      join_path: order_items,
-      includes: [`count`, `total_sale_price`, `status`]
-    }
-  ]
-})
-
-view(`revenue`, {
-  view_group: sales,
-  cubes: [
-    {
-      join_path: order_items,
-      includes: [`total_sale_price`, `created_at`]
-    }
-  ]
-})
-
-view(`customers_view`, {
-  cubes: [
-    {
-      join_path: users,
-      includes: `*`
-    }
-  ]
-})
-
-view_group(`sales`, {
-  title: `Sales`,
-  description: `Revenue and order views for the sales team`,
-  views: [`orders_overview`]
-})
-
-view_group(`people`, {
-  title: `People`,
-  views: [`customers_view`]
-})
-```
-
-</CodeGroup>
-
-In this example, the `sales` group contains both `orders_overview`
-(listed on the group) and `revenue` (which references the group via
-`view_group`). The `people` group contains `customers_view`.
-
-<Note>
-
-See the [view group reference][ref-view-groups] for the full list of
-parameters and configuration options.
-
-</Note>
+See [View groups][ref-view-groups] for the full guide and the
+[view group reference][ref-view-group-ref] for the complete list of
+parameters.
 
 ## Next steps
 
@@ -553,8 +460,7 @@ parameters and configuration options.
 [ref-ide]: /docs/data-modeling/data-model-ide
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools
 [ref-apis-support]: /reference#data-modeling
-[ref-view-groups]: /reference/data-modeling/view-group
-[ref-view-view-group]: /reference/data-modeling/view#view_group
-[ref-view-view-groups]: /reference/data-modeling/view#view_groups
+[ref-view-groups]: /docs/data-modeling/view-groups
+[ref-view-group-ref]: /reference/data-modeling/view-group
 [ref-meta-endpoint]: /reference/core-data-apis/rest-api/reference
 [wiki-dry]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

--- a/docs-mintlify/reference/data-modeling/view-group.mdx
+++ b/docs-mintlify/reference/data-modeling/view-group.mdx
@@ -1,0 +1,348 @@
+---
+title: View groups
+description: View groups organize views into named collections, making it easier for data consumers to navigate and discover related views.
+---
+
+View groups let you organize [views][ref-views] into named collections.
+When a data model contains many views, grouping them by domain or purpose
+helps downstream consumers — including AI agents, embedded analytics, and
+visualization tools — discover the right dataset faster.
+
+View groups are returned as a top-level `viewGroups` array in the
+[`/v1/meta`][ref-meta-endpoint] response, alongside the `cubes` array.
+Each view that belongs to at least one group also carries a `viewGroups`
+string array on its own entry.
+
+A view group should have the following parameter: [`name`](#name).
+
+## Parameters
+
+### `name`
+
+The `name` parameter serves as the identifier of a view group. It must be
+unique among all view groups within a deployment and follow the [naming
+conventions][ref-naming].
+
+<CodeGroup>
+
+```yaml title="YAML"
+view_groups:
+  - name: sales
+```
+
+```javascript title="JavaScript"
+view_group(`sales`, {})
+```
+
+</CodeGroup>
+
+### `title`
+
+Use the `title` parameter to set a human-readable display name for the
+view group.
+
+<CodeGroup>
+
+```yaml title="YAML"
+view_groups:
+  - name: sales
+    title: Sales
+```
+
+```javascript title="JavaScript"
+view_group(`sales`, {
+  title: `Sales`
+})
+```
+
+</CodeGroup>
+
+### `description`
+
+This parameter provides a human-readable description of the view group.
+
+<CodeGroup>
+
+```yaml title="YAML"
+view_groups:
+  - name: sales
+    title: Sales
+    description: Revenue, order, and customer views for the sales team
+```
+
+```javascript title="JavaScript"
+view_group(`sales`, {
+  title: `Sales`,
+  description: `Revenue, order, and customer views for the sales team`
+})
+```
+
+</CodeGroup>
+
+### `views`
+
+A list of view names that belong to this group. Views listed here are
+merged with any views that reference this group via their own
+[`view_group`][ref-view-view-group] or
+[`view_groups`][ref-view-view-groups] parameter.
+
+<CodeGroup>
+
+```yaml title="YAML"
+view_groups:
+  - name: sales
+    title: Sales
+    views:
+      - orders_overview
+      - revenue
+```
+
+```javascript title="JavaScript"
+view_group(`sales`, {
+  title: `Sales`,
+  views: [`orders_overview`, `revenue`]
+})
+```
+
+</CodeGroup>
+
+## Assigning views to groups
+
+There are two complementary ways to associate a view with a view group:
+
+1. **On the view group** — list view names in the [`views`](#views) parameter.
+2. **On the view** — set [`view_group`][ref-view-view-group] (singular) or
+   [`view_groups`][ref-view-view-groups] (plural) on the view itself.
+
+Both approaches can be combined. Cube merges the membership from all
+sources, so a view listed under a group's `views` *and* referencing that
+group via `view_group` will appear only once.
+
+### Example
+
+The following model defines two view groups. The `sales` group lists
+`orders_overview` in its `views` parameter; `revenue` joins the same
+group via its own `view_group` property. The `customers_view` belongs to
+`people` through the group-level `views` list.
+
+<CodeGroup>
+
+```yaml title="YAML"
+cubes:
+  - name: order_items
+    sql_table: ECOMMERCE.ORDER_ITEMS
+
+    measures:
+      - name: count
+        type: count
+
+      - name: total_sale_price
+        sql: sale_price
+        type: sum
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: status
+        sql: status
+        type: string
+
+      - name: created_at
+        sql: created_at
+        type: time
+
+  - name: users
+    sql_table: ECOMMERCE.USERS
+
+    measures:
+      - name: count
+        type: count
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: city
+        sql: city
+        type: string
+
+views:
+  - name: orders_overview
+    cubes:
+      - join_path: order_items
+        includes:
+          - count
+          - total_sale_price
+          - status
+          - created_at
+
+  - name: revenue
+    view_group: sales
+    cubes:
+      - join_path: order_items
+        includes:
+          - total_sale_price
+          - created_at
+
+  - name: customers_view
+    cubes:
+      - join_path: users
+        includes: "*"
+
+view_groups:
+  - name: sales
+    title: Sales
+    description: Revenue and order views for the sales team
+    views:
+      - orders_overview
+
+  - name: people
+    title: People
+    description: Customer and user views
+    views:
+      - customers_view
+```
+
+```javascript title="JavaScript"
+cube(`order_items`, {
+  sql_table: `ECOMMERCE.ORDER_ITEMS`,
+
+  measures: {
+    count: {
+      type: `count`
+    },
+
+    total_sale_price: {
+      sql: `sale_price`,
+      type: `sum`
+    }
+  },
+
+  dimensions: {
+    id: {
+      sql: `id`,
+      type: `number`,
+      primary_key: true
+    },
+
+    status: {
+      sql: `status`,
+      type: `string`
+    },
+
+    created_at: {
+      sql: `created_at`,
+      type: `time`
+    }
+  }
+})
+
+cube(`users`, {
+  sql_table: `ECOMMERCE.USERS`,
+
+  measures: {
+    count: {
+      type: `count`
+    }
+  },
+
+  dimensions: {
+    id: {
+      sql: `id`,
+      type: `number`,
+      primary_key: true
+    },
+
+    city: {
+      sql: `city`,
+      type: `string`
+    }
+  }
+})
+
+view(`orders_overview`, {
+  cubes: [
+    {
+      join_path: order_items,
+      includes: [
+        `count`,
+        `total_sale_price`,
+        `status`,
+        `created_at`
+      ]
+    }
+  ]
+})
+
+view(`revenue`, {
+  viewGroup: sales,
+  cubes: [
+    {
+      join_path: order_items,
+      includes: [
+        `total_sale_price`,
+        `created_at`
+      ]
+    }
+  ]
+})
+
+view(`customers_view`, {
+  cubes: [
+    {
+      join_path: users,
+      includes: `*`
+    }
+  ]
+})
+
+view_group(`sales`, {
+  title: `Sales`,
+  description: `Revenue and order views for the sales team`,
+  views: [`orders_overview`]
+})
+
+view_group(`people`, {
+  title: `People`,
+  description: `Customer and user views`,
+  views: [`customers_view`]
+})
+```
+
+</CodeGroup>
+
+With this model, the `/v1/meta` response includes a `viewGroups` array:
+
+```json
+{
+  "viewGroups": [
+    {
+      "name": "sales",
+      "title": "Sales",
+      "description": "Revenue and order views for the sales team",
+      "views": ["orders_overview", "revenue"]
+    },
+    {
+      "name": "people",
+      "title": "People",
+      "description": "Customer and user views",
+      "views": ["customers_view"]
+    }
+  ]
+}
+```
+
+Notice that `revenue` appears in the `sales` group even though it was not
+listed in the group's `views` — it was added because the view itself set
+`view_group: sales`.
+
+[ref-views]: /docs/data-modeling/views
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
+[ref-meta-endpoint]: /reference/core-data-apis/rest-api/reference
+[ref-view-view-group]: /reference/data-modeling/view#view_group
+[ref-view-view-groups]: /reference/data-modeling/view#view_groups

--- a/docs-mintlify/reference/data-modeling/view-group.mdx
+++ b/docs-mintlify/reference/data-modeling/view-group.mdx
@@ -280,7 +280,7 @@ view(`orders_overview`, {
 })
 
 view(`revenue`, {
-  viewGroup: sales,
+  view_group: sales,
   cubes: [
     {
       join_path: order_items,

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -230,6 +230,72 @@ view(`active_users`, {
 
 </CodeGroup>
 
+### `view_group`
+
+Assigns this view to a single [view group][ref-ref-view-group]. The referenced
+view group must be defined with `view_group()` elsewhere in the data model.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: revenue
+    view_group: sales
+    cubes:
+      - join_path: order_items
+        includes: "*"
+```
+
+```javascript title="JavaScript"
+view(`revenue`, {
+  viewGroup: sales,
+  cubes: [
+    {
+      join_path: order_items,
+      includes: `*`
+    }
+  ]
+})
+```
+
+</CodeGroup>
+
+### `view_groups`
+
+Assigns this view to multiple [view groups][ref-ref-view-group] at once.
+Each referenced view group must be defined with `view_group()` elsewhere
+in the data model.
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: revenue
+    view_groups:
+      - sales
+      - finance
+    cubes:
+      - join_path: order_items
+        includes: "*"
+```
+
+```javascript title="JavaScript"
+view(`revenue`, {
+  viewGroups: [`sales`, `finance`],
+  cubes: [
+    {
+      join_path: order_items,
+      includes: `*`
+    }
+  ]
+})
+```
+
+</CodeGroup>
+
+You can use both `view_group` and `view_groups` on the same view. Cube
+merges them and removes duplicates.
+
 ### `cubes`
 
 Use `cubes` parameter in view to include exposed cubes in bulk. You can build
@@ -666,3 +732,4 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 [ref-dim-description]: /reference/data-modeling/dimensions#description
 [ref-dim-format]: /reference/data-modeling/dimensions#format
 [ref-dim-meta]: /reference/data-modeling/dimensions#meta
+[ref-ref-view-group]: /reference/data-modeling/view-group

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -248,7 +248,7 @@ views:
 
 ```javascript title="JavaScript"
 view(`revenue`, {
-  viewGroup: sales,
+  view_group: sales,
   cubes: [
     {
       join_path: order_items,
@@ -281,7 +281,7 @@ views:
 
 ```javascript title="JavaScript"
 view(`revenue`, {
-  viewGroups: [`sales`, `finance`],
+  view_groups: [`sales`, `finance`],
   cubes: [
     {
       join_path: order_items,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Adds documentation for the `view_group` feature introduced in v1.6.43 (#10768). View groups let data model authors organize views into named collections by domain or purpose (e.g., `sales`, `finance`, `people`), making it easier for downstream consumers — AI agents, embedded analytics, and visualization tools — to discover the right dataset.

### Changes

**New reference page** (`reference/data-modeling/view-group.mdx`)
- Documents all view group parameters: `name`, `title`, `description`, `views`
- Explains the two complementary ways to assign views to groups (group-level `views` list vs. view-level `view_group`/`view_groups` properties)
- Includes a full end-to-end example using the ecommerce data model with the resulting `/v1/meta` response

**View reference page** (`reference/data-modeling/view.mdx`)
- Adds `view_group` (singular) and `view_groups` (plural) parameter sections with YAML and JavaScript examples

**Conceptual views page** (`docs/data-modeling/views.mdx`)
- New "Grouping views with view groups" section before "Next steps"
- Updated "Next steps" list to link to view groups

**Syntax page** (`docs/data-modeling/concepts/syntax.mdx`)
- Updated folder structure example to show `view_groups.yml`

**Navigation** (`docs.json`)
- Added `reference/data-modeling/view-group` to Reference > Data Modeling, right after the view page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b10386e-f2f6-405c-a095-9993c15df5a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b10386e-f2f6-405c-a095-9993c15df5a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

