### PR TITLE
fix(playground): stabilize onQueryChange callback to prevent stale closures

### DIFF
--- a/packages/cubejs-playground/src/QueryBuilderV2/hooks/query-builder.ts
+++ b/packages/cubejs-playground/src/QueryBuilderV2/hooks/query-builder.ts
@@ -129,6 +129,10 @@ export function useQueryBuilder(props: UseQueryBuilderProps) {
     onQueryChange,
   } = props;
 
+  const onQueryChangeStable = useEvent((...args: Parameters<NonNullable<typeof onQueryChange>>) => {
+    onQueryChange?.(...args);
+  });
+
   function queryValidation(query: Query) {
     let validatedQuery = validateQuery(query);
 
@@ -1024,7 +1028,7 @@ export function useQueryBuilder(props: UseQueryBuilderProps) {
   }, [queryHash, chartType, meta]);
 
   useEffect(() => {
-    onQueryChange?.({ query, chartType, pivotConfig });
+    onQueryChangeStable({ query, chartType, pivotConfig });
   }, [queryHash, chartType, pivotConfig]);
 
   // Update invalidation markers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

CUB-2396 — Handle report creation that does not save in IDE

**Description of Changes Made**

The `onQueryChange` callback in the `useQueryBuilder` hook was captured in a `useEffect` closure but **not** included in the dependency array. This is a classic React stale-closure bug.

When the parent component (e.g., the IDE's Explore or report creation view) provides a new `onQueryChange` callback — for example, after creating a new exploration or switching between reports — the old callback was still invoked instead of the new one. This caused report creation in the IDE to appear to succeed (the chart renders because the Core Data API query works fine) while the save/persist callback, provided by the parent, was stale and pointed to the wrong context.

**Fix:** Wrap `onQueryChange` with the existing `useEvent` hook (a `useCallback`+ref pattern already available in the codebase) to ensure the latest callback is always invoked without adding it to the `useEffect` dependency array (which would cause unnecessary re-fires on every parent render).

**Changed file:**
- `packages/cubejs-playground/src/QueryBuilderV2/hooks/query-builder.ts`

The `useEvent` hook is a shim of the React RFC for `useEvent` — it stores the latest callback in a ref and returns a stable function identity, solving both the stale closure and unnecessary effect re-triggering problems.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CUB-2396](https://linear.app/cube-d3/issue/CUB-2396/handle-report-creation-that-does-not-save-in-ide)

<div><a href="https://cursor.com/agents/bc-955cf7b7-5329-47c8-8560-c2114c5b07f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-955cf7b7-5329-47c8-8560-c2114c5b07f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

