### PR TITLE
fix(schema-compiler): invalidate Jinja render cache when imported macro file changes

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -28,6 +28,7 @@ const NATIVE_IS_SUPPORTED = isNativeSupported();
 const moduleFileCache = {};
 
 const JINJA_SYNTAX = /{%|%}|{{|}}/ig;
+const JINJA_MACRO_DEFINITION = /{%[-+]?\s*macro\s/;
 
 const getThreadsCount = () => {
   const envThreads = getEnv('transpilationWorkerThreadsCount');
@@ -100,6 +101,7 @@ export type TranspileOptions = {
   compilerId?: string;
   stage?: 0 | 1 | 2 | 3;
   jinjaUsed?: boolean;
+  jinjaMacrosFingerprint?: string;
 };
 
 export type CompileStage = 0 | 1 | 2 | 3;
@@ -280,6 +282,8 @@ export class DataSchemaCompiler {
       this.loadJinjaTemplates(jinjaTemplatedFiles);
     }
 
+    const jinjaMacrosFingerprint = DataSchemaCompiler.computeJinjaMacrosFingerprint(jinjaTemplatedFiles);
+
     const errorsReport = new ErrorReporter(null, [], this.errorReportOptions);
     this.errorsReporter = errorsReport;
 
@@ -328,11 +332,11 @@ export class DataSchemaCompiler {
         }
 
         const jinjaFilesTasks = jinjaTemplatedFiles
-          .map(f => this.transpileJinjaFile(f, errorsReport, { cubeNames, cubeSymbols, transpilerNames }));
+          .map(f => this.transpileJinjaFile(f, errorsReport, { cubeNames, cubeSymbols, transpilerNames, jinjaMacrosFingerprint }));
 
         results = (await Promise.all([...jsFilesTasks, ...yamlFilesTasks, ...jinjaFilesTasks])).flat();
       } else {
-        results = await Promise.all(toCompile.map(f => this.transpileFile(f, errorsReport, { cubeNames, cubeSymbols, transpilerNames })));
+        results = await Promise.all(toCompile.map(f => this.transpileFile(f, errorsReport, { cubeNames, cubeSymbols, transpilerNames, jinjaMacrosFingerprint })));
       }
 
       return results.filter(f => !!f) as FileContent[];
@@ -576,6 +580,33 @@ export class DataSchemaCompiler {
     });
   }
 
+  /**
+   * Macro files are hidden dependencies of any cube file that imports them —
+   * minijinja resolves `{% import %}` lazily against its template store, so
+   * the per-file Jinja render cache must be invalidated when *any* macro file
+   * changes. Hashing all macro files together rather than tracking per-cube
+   * imports keeps the implementation simple at the cost of over-invalidating
+   * when macro edits happen (which is rare). CUB-2357.
+   */
+  private static computeJinjaMacrosFingerprint(files: FileContent[]): string {
+    const macroFiles = files
+      .filter((f) => JINJA_MACRO_DEFINITION.test(f.content))
+      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+
+    if (macroFiles.length === 0) {
+      return '';
+    }
+
+    const hash = crypto.createHash('md5');
+    for (const f of macroFiles) {
+      hash.update(f.fileName);
+      hash.update('\0');
+      hash.update(f.content);
+      hash.update('\0');
+    }
+    return hash.digest('hex');
+  }
+
   private prepareTranspileSymbols() {
     const cubeNames: string[] = this.cubeDictionary.cubeNames();
     // We need only cubes and all its member names for transpiling.
@@ -802,7 +833,11 @@ export class DataSchemaCompiler {
     errorsReport: ErrorReporter,
     options: TranspileOptions
   ): Promise<(FileContent | undefined)> {
-    const cacheKey = crypto.createHash('md5').update(file.content).digest('hex');
+    const cacheKey = crypto.createHash('md5')
+      .update(file.content)
+      .update('|')
+      .update(options.jinjaMacrosFingerprint || '')
+      .digest('hex');
 
     let renderedFileContent: string;
 

--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -835,7 +835,7 @@ export class DataSchemaCompiler {
   ): Promise<(FileContent | undefined)> {
     const cacheKey = crypto.createHash('md5')
       .update(file.content)
-      .update('|')
+      .update('\0')
       .update(options.jinjaMacrosFingerprint || '')
       .digest('hex');
 

--- a/packages/cubejs-schema-compiler/test/integration/postgres/jinja-macro-cache.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/jinja-macro-cache.test.ts
@@ -1,0 +1,98 @@
+import { LRUCache } from 'lru-cache';
+import { FileContent, isNativeSupported } from '@cubejs-backend/shared';
+
+import { prepareCompiler } from '../../../src/compiler/PrepareCompiler';
+
+const suite = isNativeSupported() === true ? describe : xdescribe;
+
+const cubeFile = (name: string, extraDimsBlock: string): string => `{% import 'macros.yml' as macros %}
+
+cubes:
+  - name: ${name}
+    sql: >
+      SELECT 1 AS id
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+${extraDimsBlock}
+`;
+
+const macroFile = (dimensionName: string) => `{% macro dimensions() %}
+      - name: ${dimensionName}
+        sql: ${dimensionName}
+        type: string
+{% endmacro %}
+`;
+
+async function compileWith(files: FileContent[], compiledJinjaCache: LRUCache<string, string>) {
+  const repo = {
+    localPath: () => __dirname,
+    dataSchemaFiles: () => Promise.resolve(files),
+  };
+
+  const { compiler, metaTransformer } = prepareCompiler(repo, {
+    adapter: 'postgres',
+    compiledJinjaCache,
+  } as any);
+
+  await compiler.compile();
+
+  return { metaTransformer };
+}
+
+function dimensionNames(metaTransformer: any, cubeName: string): string[] {
+  const cube = metaTransformer.cubes.find((c: any) => c.config.name === cubeName);
+  return cube.config.dimensions.map((d: any) => d.name);
+}
+
+suite('Jinja macro cache invalidation', () => {
+  it('invalidates the cube file render cache when a macro file changes (CUB-2357)', async () => {
+    const sharedCache = new LRUCache<string, string>({ max: 250 });
+
+    const filesV1: FileContent[] = [
+      { fileName: 'orders.yml', content: cubeFile('orders', '{{ macros.dimensions() }}') },
+      { fileName: 'macros.yml', content: macroFile('status') },
+    ];
+
+    const v1 = await compileWith(filesV1, sharedCache);
+    expect(dimensionNames(v1.metaTransformer, 'orders')).toEqual(['orders.id', 'orders.status']);
+
+    const filesV2: FileContent[] = [
+      filesV1[0],
+      { fileName: 'macros.yml', content: macroFile('priority') },
+    ];
+
+    const v2 = await compileWith(filesV2, sharedCache);
+    expect(dimensionNames(v2.metaTransformer, 'orders')).toEqual(['orders.id', 'orders.priority']);
+  });
+
+  it('reuses the render cache for unchanged cube files when a sibling cube file changes', async () => {
+    const sharedCache = new LRUCache<string, string>({ max: 250 });
+
+    const filesV1: FileContent[] = [
+      { fileName: 'orders.yml', content: cubeFile('orders', '') },
+      { fileName: 'products.yml', content: cubeFile('products', '') },
+      { fileName: 'macros.yml', content: macroFile('unused') },
+    ];
+    await compileWith(filesV1, sharedCache);
+
+    const cacheSizeAfterFirstCompile = sharedCache.size;
+
+    const filesV2: FileContent[] = [
+      {
+        fileName: 'orders.yml',
+        content: cubeFile('orders', '      - name: status\n        sql: status\n        type: string\n'),
+      },
+      filesV1[1],
+      filesV1[2],
+    ];
+    await compileWith(filesV2, sharedCache);
+
+    // Only the changed orders.yml should miss the cache; products.yml and
+    // macros.yml are byte-identical and the macros fingerprint is unchanged.
+    expect(sharedCache.size).toBe(cacheSizeAfterFirstCompile + 1);
+  });
+});


### PR DESCRIPTION
## Summary

- The per-file Jinja render cache in \`DataSchemaCompiler.transpileJinjaFile()\` was keyed on the importing file's content alone. When a YAML cube file imported a Jinja macro file via \`{% import 'macros.yml' as macros %}\`, edits to the macro file did not change the importer's content hash, so the cached rendered output was reused and new macro-defined dimensions never reached the YAML compiler.
- This change folds a fingerprint of all files containing \`{% macro %}\` definitions into the cache key. Macro-file edits now invalidate cached renders of all cube files (over-invalidating slightly, but macro edits are rare). Cube-file edits still hit the cache for unchanged sibling files.
- Approach is intentionally simple: no Jinja AST traversal, no per-file dependency graph. Trade-off documented in the JSDoc on \`computeJinjaMacrosFingerprint\`.

## Test plan

- [x] Added integration test \`packages/cubejs-schema-compiler/test/integration/postgres/jinja-macro-cache.test.ts\` with two cases: bug regression (macro edit invalidates importer cache) and cache effectiveness (cube-file edit does not invalidate sibling caches).
- [x] Verified test #1 fails on master baseline and passes with the fix.
- [x] Manually verified end-to-end with a Cube + DuckDB \`docker-compose\` setup using a freshly built \`cubejs/cube:dev\` image: macro file edits propagate to \`/meta\` within ~5s without touching the importing cube file.
- [ ] CI must pass.