### PR TITLE
feat(cubestore): add stale-while-revalidate timeout for SQL query cache

### DIFF
--- a/rust/cubestore/cubestore/src/app_metrics.rs
+++ b/rust/cubestore/cubestore/src/app_metrics.rs
@@ -13,6 +13,8 @@ pub static WORKER_POOL_ERROR: Counter = metrics::counter("cs.worker_pool.errors"
 /// Incoming SQL queries that do data reads.
 pub static DATA_QUERIES: Counter = metrics::counter("cs.sql.query.data");
 pub static DATA_QUERIES_CACHE_HIT: Counter = metrics::counter("cs.sql.query.data.cache.hit");
+pub static DATA_QUERIES_CACHE_STALE_HIT: Counter =
+    metrics::counter("cs.sql.query.data.cache.stale_hit");
 // Approximate number of entries in this cache.
 pub static DATA_QUERIES_CACHE_SIZE: Gauge = metrics::gauge("cs.sql.query.data.cache.size");
 // Approximate total weighted size of entries in this cache.

--- a/rust/cubestore/cubestore/src/app_metrics.rs
+++ b/rust/cubestore/cubestore/src/app_metrics.rs
@@ -19,6 +19,10 @@ pub static DATA_QUERIES_CACHE_STALE_HIT: Counter =
 pub static DATA_QUERIES_CACHE_SIZE: Gauge = metrics::gauge("cs.sql.query.data.cache.size");
 // Approximate total weighted size of entries in this cache.
 pub static DATA_QUERIES_CACHE_WEIGHT: Gauge = metrics::gauge("cs.sql.query.data.cache.weight");
+pub static DATA_QUERIES_STALE_CACHE_SIZE: Gauge =
+    metrics::gauge("cs.sql.query.data.cache.stale.size");
+pub static DATA_QUERIES_STALE_CACHE_WEIGHT: Gauge =
+    metrics::gauge("cs.sql.query.data.cache.stale.weight");
 pub static DATA_QUERY_TIME_MS: Histogram = metrics::histogram("cs.sql.query.data.ms");
 pub static DATA_QUERY_LOGICAL_PLAN_TOTAL_CREATION_TIME_US: Histogram =
     metrics::histogram("cs.sql.query.data.planning.logical_plan.total_creation.us");

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -510,6 +510,8 @@ pub trait ConfigObj: DIService {
 
     fn query_cache_time_to_idle_secs(&self) -> Option<u64>;
 
+    fn query_cache_stale_while_revalidate_secs(&self) -> Option<u64>;
+
     fn metadata_cache_max_capacity_bytes(&self) -> u64;
 
     fn metadata_cache_time_to_idle_secs(&self) -> u64;
@@ -643,6 +645,7 @@ pub struct ConfigObjImpl {
     pub query_cache_max_capacity_bytes: u64,
     pub query_queue_cache_max_capacity: u64,
     pub query_cache_time_to_idle_secs: Option<u64>,
+    pub query_cache_stale_while_revalidate_secs: Option<u64>,
     pub metadata_cache_max_capacity_bytes: u64,
     pub metadata_cache_time_to_idle_secs: u64,
     pub stream_replay_check_interval_secs: u64,
@@ -956,6 +959,9 @@ impl ConfigObj for ConfigObjImpl {
     fn query_cache_time_to_idle_secs(&self) -> Option<u64> {
         self.query_cache_time_to_idle_secs
     }
+    fn query_cache_stale_while_revalidate_secs(&self) -> Option<u64> {
+        self.query_cache_stale_while_revalidate_secs
+    }
 
     fn metadata_cache_max_capacity_bytes(&self) -> u64 {
         self.metadata_cache_max_capacity_bytes
@@ -1233,6 +1239,8 @@ impl Config {
 
     pub fn default() -> Config {
         let query_timeout = env_parse("CUBESTORE_QUERY_TIMEOUT", 120);
+        let query_cache_stale_while_revalidate_secs: u64 =
+            env_parse("CUBESTORE_QUERY_CACHE_STALE_WHILE_REVALIDATE", 0);
         let query_cache_time_to_idle_secs = env_parse(
             "CUBESTORE_QUERY_CACHE_TIME_TO_IDLE",
             // 1 hour
@@ -1528,6 +1536,13 @@ impl Config {
                 } else {
                     Some(query_cache_time_to_idle_secs)
                 },
+                query_cache_stale_while_revalidate_secs: if query_cache_stale_while_revalidate_secs
+                    == 0
+                {
+                    None
+                } else {
+                    Some(query_cache_stale_while_revalidate_secs)
+                },
                 metadata_cache_max_capacity_bytes: env_parse(
                     "CUBESTORE_METADATA_CACHE_MAX_CAPACITY_BYTES",
                     0,
@@ -1740,6 +1755,7 @@ impl Config {
                 query_cache_max_capacity_bytes: 512 << 20,
                 query_queue_cache_max_capacity: 10000,
                 query_cache_time_to_idle_secs: Some(600),
+                query_cache_stale_while_revalidate_secs: None,
                 metadata_cache_max_capacity_bytes: 0,
                 metadata_cache_time_to_idle_secs: 1_000,
                 meta_store_log_upload_interval: 30,
@@ -2393,6 +2409,7 @@ impl Config {
             self.config_obj.query_cache_max_capacity_bytes(),
             self.config_obj.query_cache_time_to_idle_secs(),
             self.config_obj.query_queue_cache_max_capacity(),
+            self.config_obj.query_cache_stale_while_revalidate_secs(),
         ));
 
         let query_cache_to_move = query_cache.clone();

--- a/rust/cubestore/cubestore/src/queryplanner/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/mod.rs
@@ -1063,7 +1063,7 @@ pub mod tests {
             Arc::new(test_utils::MetaStoreMock {}),
             Arc::new(test_utils::CacheStoreMock {}),
             &vec![],
-            Arc::new(SqlResultCache::new(1 << 20, None, 10000)),
+            Arc::new(SqlResultCache::new(1 << 20, None, 10000, None)),
             Arc::new(SessionContext::new().state()),
         )
     }

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -393,6 +393,7 @@ mod tests {
     use datafusion::logical_expr::{EmptyRelation, LogicalPlan};
     use futures::future::join_all;
     use futures_timer::Delay;
+    use moka::future::ConcurrentCacheExt;
     use std::collections::HashMap;
     use std::sync::atomic::AtomicI64;
     use std::sync::atomic::Ordering;
@@ -519,6 +520,11 @@ mod tests {
             &TableValue::Int(1)
         );
 
+        // Simulate a partition change: clear the exact result cache so the next get()
+        // misses the exact key but still finds the stale entry (keyed by SQL only).
+        cache.result_cache.invalidate_all();
+        cache.result_cache.sync();
+
         let counter_clone2 = counter.clone();
         let exec2 = async move |_p| {
             Delay::new(Duration::from_millis(500)).await;
@@ -545,8 +551,12 @@ mod tests {
             "Should return stale result immediately"
         );
 
+        // Wait for the background refresh to complete.
         Delay::new(Duration::from_millis(800)).await;
 
+        // The background refresh should have populated the exact result cache.
+        // Verify by fetching again — this should hit the exact cache with the
+        // refreshed value, or at minimum the stale cache was updated.
         let counter_clone3 = counter.clone();
         let exec3 = async move |_p| {
             Ok(DataFrame::new(

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -88,6 +88,14 @@ pub fn sql_result_cache_sizeof(key: &SqlResultCacheKey, df: &Arc<DataFrame>) -> 
         .unwrap_or(u32::MAX)
 }
 
+fn stale_cache_sizeof(_key: &SqlQueueCacheKey, entry: &StaleEntry) -> u32 {
+    (std::mem::size_of::<SqlQueueCacheKey>()
+        + std::mem::size_of::<StaleEntry>()
+        + entry.result.deep_size_of())
+    .try_into()
+    .unwrap_or(u32::MAX)
+}
+
 impl SqlResultCache {
     pub fn new(
         capacity_bytes: u64,
@@ -101,13 +109,13 @@ impl SqlResultCache {
             Cache::builder()
         };
 
-        let stale_while_revalidate_timeout =
-            stale_while_revalidate_secs.map(|s| Duration::from_secs(s));
+        let stale_while_revalidate_timeout = stale_while_revalidate_secs.map(Duration::from_secs);
 
         let stale_cache = stale_while_revalidate_timeout.map(|timeout| {
             Cache::builder()
                 .time_to_idle(timeout * 2)
                 .max_capacity(capacity_bytes)
+                .weigher(stale_cache_sizeof)
                 .build()
         });
 
@@ -582,6 +590,137 @@ mod tests {
             val == TableValue::Int(2) || val == TableValue::Int(3),
             "Should see the updated value from background refresh: got {:?}",
             val
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_while_revalidate_background_failure() -> Result<(), CubeError> {
+        let cache = Arc::new(SqlResultCache::new(1 << 20, Some(120), 1000, Some(30)));
+        let schema = Arc::new(DFSchema::empty());
+        let plan = SerializedPlan::try_new(
+            LogicalPlan::EmptyRelation(EmptyRelation {
+                produce_one_row: false,
+                schema,
+            }),
+            PlanningMeta {
+                indices: Vec::new(),
+                multi_part_subtree: HashMap::new(),
+            },
+            None,
+        )
+        .await?;
+
+        let exec = async move |_p| {
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(42)])],
+            ))
+        };
+        cache
+            .get("SELECT 1", SqlQueryContext::default(), plan.clone(), exec)
+            .await?;
+
+        // Simulate partition change
+        cache.result_cache.invalidate_all();
+        cache.result_cache.sync();
+
+        let exec_fail = async move |_p| -> Result<DataFrame, CubeError> {
+            Err(CubeError::internal("background exec failed".to_string()))
+        };
+
+        let stale_result = cache
+            .get(
+                "SELECT 1",
+                SqlQueryContext::default(),
+                plan.clone(),
+                exec_fail,
+            )
+            .await?;
+        assert_eq!(
+            stale_result
+                .get_rows()
+                .get(0)
+                .unwrap()
+                .values()
+                .get(0)
+                .unwrap(),
+            &TableValue::Int(42),
+            "Should still return stale result when background refresh will fail"
+        );
+
+        Delay::new(Duration::from_millis(200)).await;
+
+        // Stale entry should still be intact after background failure
+        cache.result_cache.invalidate_all();
+        cache.result_cache.sync();
+
+        let exec_after = async move |_p| {
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(99)])],
+            ))
+        };
+        let result = cache
+            .get("SELECT 1", SqlQueryContext::default(), plan, exec_after)
+            .await?;
+        assert_eq!(
+            result.get_rows().get(0).unwrap().values().get(0).unwrap(),
+            &TableValue::Int(42),
+            "Stale entry should still be available after background failure"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_while_revalidate_timeout_expiry() -> Result<(), CubeError> {
+        let cache = Arc::new(SqlResultCache::new(1 << 20, Some(120), 1000, Some(1)));
+        let schema = Arc::new(DFSchema::empty());
+        let plan = SerializedPlan::try_new(
+            LogicalPlan::EmptyRelation(EmptyRelation {
+                produce_one_row: false,
+                schema,
+            }),
+            PlanningMeta {
+                indices: Vec::new(),
+                multi_part_subtree: HashMap::new(),
+            },
+            None,
+        )
+        .await?;
+
+        let exec = async move |_p| {
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(1)])],
+            ))
+        };
+        cache
+            .get("SELECT 1", SqlQueryContext::default(), plan.clone(), exec)
+            .await?;
+
+        // Simulate partition change
+        cache.result_cache.invalidate_all();
+        cache.result_cache.sync();
+
+        // Wait for the 1-second stale timeout to expire
+        Delay::new(Duration::from_millis(1200)).await;
+
+        let exec2 = async move |_p| {
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(99)])],
+            ))
+        };
+        let result = cache
+            .get("SELECT 1", SqlQueryContext::default(), plan, exec2)
+            .await?;
+        assert_eq!(
+            result.get_rows().get(0).unwrap().values().get(0).unwrap(),
+            &TableValue::Int(99),
+            "After stale timeout expires, should execute fresh query instead of serving stale"
         );
 
         Ok(())

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -10,7 +10,7 @@ use log::trace;
 use moka::future::{Cache, ConcurrentCacheExt, Iter};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{watch, Mutex};
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug, DeepSizeOf)]
@@ -65,11 +65,19 @@ impl SqlQueueCacheKey {
     }
 }
 
+#[derive(Clone)]
+struct StaleEntry {
+    result: Arc<DataFrame>,
+    created_at: Instant,
+}
+
 pub struct SqlResultCache {
     queue_cache: Mutex<
         lru::LruCache<SqlQueueCacheKey, watch::Receiver<Option<Result<Arc<DataFrame>, CubeError>>>>,
     >,
     result_cache: Cache<SqlResultCacheKey, Arc<DataFrame>>,
+    stale_cache: Option<Cache<SqlQueueCacheKey, StaleEntry>>,
+    stale_while_revalidate_timeout: Option<Duration>,
     create_table_cache:
         Mutex<HashMap<(String, String), watch::Receiver<Option<Result<IdRow<Table>, CubeError>>>>>,
 }
@@ -85,6 +93,7 @@ impl SqlResultCache {
         capacity_bytes: u64,
         time_to_idle_secs: Option<u64>,
         queue_cache_max_capacity: u64,
+        stale_while_revalidate_secs: Option<u64>,
     ) -> Self {
         let cache_builder = if let Some(time_to_idle_secs) = time_to_idle_secs {
             Cache::builder().time_to_idle(Duration::from_secs(time_to_idle_secs))
@@ -92,12 +101,24 @@ impl SqlResultCache {
             Cache::builder()
         };
 
+        let stale_while_revalidate_timeout =
+            stale_while_revalidate_secs.map(|s| Duration::from_secs(s));
+
+        let stale_cache = stale_while_revalidate_timeout.map(|timeout| {
+            Cache::builder()
+                .time_to_idle(timeout * 2)
+                .max_capacity(capacity_bytes)
+                .build()
+        });
+
         Self {
             queue_cache: Mutex::new(lru::LruCache::new(queue_cache_max_capacity as usize)),
             result_cache: cache_builder
                 .max_capacity(capacity_bytes)
                 .weigher(sql_result_cache_sizeof)
                 .build(),
+            stale_cache,
+            stale_while_revalidate_timeout,
             create_table_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -107,6 +128,11 @@ impl SqlResultCache {
         self.result_cache.invalidate_all();
         // it doesnt flush all, blocking, but it's ok because it's used in one command.
         self.result_cache.sync();
+
+        if let Some(stale_cache) = &self.stale_cache {
+            stale_cache.invalidate_all();
+            stale_cache.sync();
+        }
 
         app_metrics::DATA_QUERIES_CACHE_SIZE.report(self.result_cache.entry_count() as i64);
         app_metrics::DATA_QUERIES_CACHE_WEIGHT.report(self.result_cache.weighted_size() as i64);
@@ -120,13 +146,38 @@ impl SqlResultCache {
         self.result_cache.iter()
     }
 
+    fn try_get_stale(&self, queue_key: &SqlQueueCacheKey) -> Option<Arc<DataFrame>> {
+        let stale_cache = self.stale_cache.as_ref()?;
+        let timeout = self.stale_while_revalidate_timeout?;
+        let entry = stale_cache.get(queue_key)?;
+        if entry.created_at.elapsed() <= timeout {
+            Some(entry.result)
+        } else {
+            None
+        }
+    }
+
+    async fn update_stale_cache(&self, queue_key: &SqlQueueCacheKey, result: &Arc<DataFrame>) {
+        if let Some(stale_cache) = &self.stale_cache {
+            stale_cache
+                .insert(
+                    queue_key.clone(),
+                    StaleEntry {
+                        result: result.clone(),
+                        created_at: Instant::now(),
+                    },
+                )
+                .await;
+        }
+    }
+
     #[tracing::instrument(level = "trace", skip(self, context, plan, exec))]
     pub async fn get<F>(
         &self,
         query: &str,
         context: SqlQueryContext,
         plan: SerializedPlan,
-        exec: impl FnOnce(SerializedPlan) -> F,
+        exec: impl FnOnce(SerializedPlan) -> F + Send + 'static,
     ) -> Result<Arc<DataFrame>, CubeError>
     where
         F: Future<Output = Result<DataFrame, CubeError>> + Send + 'static,
@@ -140,6 +191,47 @@ impl SqlResultCache {
         }
 
         let queue_key = SqlQueueCacheKey::from_query(query, &context.inline_tables);
+
+        if let Some(stale_result) = self.try_get_stale(&queue_key) {
+            app_metrics::DATA_QUERIES_CACHE_STALE_HIT.increment();
+            trace!(
+                "Using stale-while-revalidate cache for '{}', spawning background refresh",
+                query
+            );
+            let result_cache = self.result_cache.clone();
+            let stale_cache = self.stale_cache.clone();
+            let queue_key_bg = queue_key.clone();
+            let result_key_bg = result_key.clone();
+            tokio::spawn(async move {
+                match exec(plan).await {
+                    Ok(df) => {
+                        let arc_df = Arc::new(df);
+                        result_cache.insert(result_key_bg, arc_df.clone()).await;
+
+                        if let Some(sc) = &stale_cache {
+                            sc.insert(
+                                queue_key_bg,
+                                StaleEntry {
+                                    result: arc_df,
+                                    created_at: Instant::now(),
+                                },
+                            )
+                            .await;
+                        }
+
+                        app_metrics::DATA_QUERIES_CACHE_SIZE
+                            .report(result_cache.entry_count() as i64);
+                        app_metrics::DATA_QUERIES_CACHE_WEIGHT
+                            .report(result_cache.weighted_size() as i64);
+                    }
+                    Err(e) => {
+                        log::error!("Background stale-while-revalidate refresh failed: {}", e);
+                    }
+                }
+            });
+            return Ok(stale_result);
+        }
+
         let (sender, receiver) = {
             let key = queue_key.clone();
             let mut cache = self.queue_cache.lock().await;
@@ -191,6 +283,7 @@ impl SqlResultCache {
                         app_metrics::DATA_QUERIES_CACHE_WEIGHT
                             .report(self.result_cache.weighted_size() as i64);
                     }
+                    self.update_stale_cache(&queue_key, r).await;
                 }
                 Err(_) => {
                     trace!("Removing error result from cache");
@@ -310,7 +403,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple() -> Result<(), CubeError> {
-        let cache = SqlResultCache::new(1 << 20, Some(120), 1000);
+        let cache = SqlResultCache::new(1 << 20, Some(120), 1000, None);
         let schema = Arc::new(DFSchema::empty());
         let plan = SerializedPlan::try_new(
             LogicalPlan::EmptyRelation(EmptyRelation {
@@ -388,6 +481,101 @@ mod tests {
                 TableValue::Int(1),
             ]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_while_revalidate() -> Result<(), CubeError> {
+        let cache = SqlResultCache::new(1 << 20, Some(120), 1000, Some(30));
+        let schema = Arc::new(DFSchema::empty());
+        let plan = SerializedPlan::try_new(
+            LogicalPlan::EmptyRelation(EmptyRelation {
+                produce_one_row: false,
+                schema,
+            }),
+            PlanningMeta {
+                indices: Vec::new(),
+                multi_part_subtree: HashMap::new(),
+            },
+            None,
+        )
+        .await?;
+
+        let counter = Arc::new(AtomicI64::new(1));
+        let counter_clone = counter.clone();
+        let exec = async move |_p| {
+            Delay::new(Duration::from_millis(100)).await;
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(
+                    counter_clone.fetch_add(1, Ordering::Relaxed),
+                )])],
+            ))
+        };
+
+        let result = cache
+            .get("SELECT 1", SqlQueryContext::default(), plan.clone(), exec)
+            .await?;
+        assert_eq!(
+            result.get_rows().get(0).unwrap().values().get(0).unwrap(),
+            &TableValue::Int(1)
+        );
+
+        let counter_clone2 = counter.clone();
+        let exec2 = async move |_p| {
+            Delay::new(Duration::from_millis(500)).await;
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(
+                    counter_clone2.fetch_add(1, Ordering::Relaxed),
+                )])],
+            ))
+        };
+
+        let stale_result = cache
+            .get("SELECT 1", SqlQueryContext::default(), plan.clone(), exec2)
+            .await?;
+        assert_eq!(
+            stale_result
+                .get_rows()
+                .get(0)
+                .unwrap()
+                .values()
+                .get(0)
+                .unwrap(),
+            &TableValue::Int(1),
+            "Should return stale result immediately"
+        );
+
+        Delay::new(Duration::from_millis(800)).await;
+
+        let counter_clone3 = counter.clone();
+        let exec3 = async move |_p| {
+            Ok(DataFrame::new(
+                Vec::new(),
+                vec![Row::new(vec![TableValue::Int(
+                    counter_clone3.fetch_add(1, Ordering::Relaxed),
+                )])],
+            ))
+        };
+        let fresh_result = cache
+            .get("SELECT 1", SqlQueryContext::default(), plan, exec3)
+            .await?;
+
+        let val = fresh_result
+            .get_rows()
+            .get(0)
+            .unwrap()
+            .values()
+            .get(0)
+            .unwrap()
+            .clone();
+        assert!(
+            val == TableValue::Int(2) || val == TableValue::Int(3),
+            "Should see the updated value from background refresh: got {:?}",
+            val
+        );
+
         Ok(())
     }
 }

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -171,39 +171,9 @@ impl SqlResultCache {
         }
     }
 
-    /// Tries to register this query in the queue cache for background execution.
-    /// Returns `Some(sender)` if we became the leader (no one else is running this query),
-    /// or `None` if another execution is already in flight.
-    async fn try_register_background(
-        &self,
-        queue_key: &SqlQueueCacheKey,
-    ) -> Option<watch::Sender<Option<Result<Arc<DataFrame>, CubeError>>>> {
-        let mut cache = self.queue_cache.lock().await;
-
-        if cache.contains(queue_key) {
-            if let Some(receiver) = cache.get(queue_key) {
-                if receiver.has_changed().is_err() {
-                    cache.pop(queue_key);
-                } else {
-                    return None;
-                }
-            } else {
-                cache.pop(queue_key);
-            }
-        }
-
-        if !cache.contains(queue_key) {
-            let (tx, rx) = watch::channel(None);
-            cache.put(queue_key.clone(), rx);
-            Some(tx)
-        } else {
-            None
-        }
-    }
-
     #[tracing::instrument(level = "trace", skip(self, context, plan, exec))]
     pub async fn get<F>(
-        &self,
+        self: &Arc<Self>,
         query: &str,
         context: SqlQueryContext,
         plan: SerializedPlan,
@@ -212,145 +182,122 @@ impl SqlResultCache {
     where
         F: Future<Output = Result<DataFrame, CubeError>> + Send + 'static,
     {
-        let result_key = SqlResultCacheKey::from_plan(query, &context.inline_tables, &plan);
+        Arc::clone(self)
+            .get_inner(query.to_string(), context, plan, exec, false)
+            .await
+    }
 
-        if let Some(result) = self.result_cache.get(&result_key) {
-            app_metrics::DATA_QUERIES_CACHE_HIT.increment();
-            trace!("Using result cache for '{}'", query);
-            return Ok(result);
-        }
+    fn get_inner<F>(
+        self: Arc<Self>,
+        query: String,
+        context: SqlQueryContext,
+        plan: SerializedPlan,
+        exec: impl FnOnce(SerializedPlan) -> F + Send + 'static,
+        is_background_refresh: bool,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Arc<DataFrame>, CubeError>> + Send>>
+    where
+        F: Future<Output = Result<DataFrame, CubeError>> + Send + 'static,
+    {
+        Box::pin(async move {
+            let result_key = SqlResultCacheKey::from_plan(&query, &context.inline_tables, &plan);
 
-        let queue_key = SqlQueueCacheKey::from_query(query, &context.inline_tables);
-
-        if let Some(stale_result) = self.try_get_stale(&queue_key) {
-            app_metrics::DATA_QUERIES_CACHE_STALE_HIT.increment();
-            trace!(
-                "Using stale-while-revalidate cache for '{}', spawning background refresh",
-                query
-            );
-
-            // Try to register in queue cache. If another execution is already in flight
-            // (from a previous stale hit or a concurrent foreground request), we skip
-            // spawning — that execution will update the caches for us.
-            if let Some(sender) = self.try_register_background(&queue_key).await {
-                let result_cache = self.result_cache.clone();
-                let stale_cache = self.stale_cache.clone();
-                let queue_key_bg = queue_key.clone();
-                let query_owned = query.to_string();
-                tokio::spawn(async move {
-                    trace!("Background refresh starting for '{}'", query_owned);
-                    let result = exec(plan).await.map(|d| Arc::new(d));
-                    match &result {
-                        Ok(arc_df) => {
-                            result_cache.insert(result_key, arc_df.clone()).await;
-
-                            if let Some(sc) = &stale_cache {
-                                sc.insert(
-                                    queue_key_bg,
-                                    StaleEntry {
-                                        result: arc_df.clone(),
-                                        created_at: Instant::now(),
-                                    },
-                                )
-                                .await;
-                            }
-
-                            app_metrics::DATA_QUERIES_CACHE_SIZE
-                                .report(result_cache.entry_count() as i64);
-                            app_metrics::DATA_QUERIES_CACHE_WEIGHT
-                                .report(result_cache.weighted_size() as i64);
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "Background stale-while-revalidate refresh failed for '{}': {}",
-                                query_owned,
-                                e
-                            );
-                        }
-                    }
-                    // Notify any waiters that joined via the queue cache.
-                    let _ = sender.send(Some(result));
-                    // sender is dropped here, closing the channel. The queue_cache entry
-                    // will be cleaned up lazily on the next get() for this key.
-                });
-            } else {
-                trace!(
-                    "Background refresh already in flight for '{}', skipping",
-                    query
-                );
+            if let Some(result) = self.result_cache.get(&result_key) {
+                app_metrics::DATA_QUERIES_CACHE_HIT.increment();
+                trace!("Using result cache for '{}'", query);
+                return Ok(result);
             }
 
-            return Ok(stale_result);
-        }
+            let queue_key = SqlQueueCacheKey::from_query(&query, &context.inline_tables);
 
-        let (sender, receiver) = {
-            let key = queue_key.clone();
-            let mut cache = self.queue_cache.lock().await;
+            if !is_background_refresh {
+                if let Some(stale_result) = self.try_get_stale(&queue_key) {
+                    app_metrics::DATA_QUERIES_CACHE_STALE_HIT.increment();
+                    trace!(
+                        "Using stale-while-revalidate cache for '{}', spawning background refresh",
+                        query
+                    );
+                    let this = Arc::clone(&self);
+                    let query_clone = query.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = this.get_inner(query_clone, context, plan, exec, true).await
+                        {
+                            log::error!("Background stale-while-revalidate refresh failed: {}", e);
+                        }
+                    });
+                    return Ok(stale_result);
+                }
+            }
 
-            if cache.contains(&key) {
-                if let Some(receiver) = cache.get(&key) {
-                    if receiver.has_changed().is_err() {
-                        log::error!("Queue cache contains closed channel");
+            let (sender, receiver) = {
+                let key = queue_key.clone();
+                let mut cache = self.queue_cache.lock().await;
+
+                if cache.contains(&key) {
+                    if let Some(receiver) = cache.get(&key) {
+                        if receiver.has_changed().is_err() {
+                            log::error!("Queue cache contains closed channel");
+                            cache.pop(&key);
+                        }
+                    } else {
+                        log::error!("Queue cache doesn't contains channel");
                         cache.pop(&key);
                     }
+                }
+
+                if !cache.contains(&key) {
+                    let (tx, rx) = watch::channel(None);
+                    cache.put(key, rx);
+
+                    app_metrics::DATA_QUERIES_CACHE_SIZE
+                        .report(self.result_cache.entry_count() as i64);
+                    app_metrics::DATA_QUERIES_CACHE_WEIGHT
+                        .report(self.result_cache.weighted_size() as i64);
+
+                    (Some(tx), None)
                 } else {
-                    log::error!("Queue cache doesn't contains channel");
-                    cache.pop(&key);
+                    (None, cache.get(&key).cloned())
                 }
-            }
+            };
 
-            if !cache.contains(&key) {
-                let (tx, rx) = watch::channel(None);
-                cache.put(key, rx);
+            if let Some(sender) = sender {
+                trace!("Missing cache for '{}'", query);
+                let result = exec(plan).await.map(|d| Arc::new(d));
+                if let Err(e) = sender.send(Some(result.clone())) {
+                    trace!(
+                        "Failed to set cached query result, possibly flushed from LRU cache: {}",
+                        e
+                    );
+                }
+                match &result {
+                    Ok(r) => {
+                        if !self.result_cache.contains_key(&result_key) {
+                            self.result_cache
+                                .insert(result_key.clone(), r.clone())
+                                .await;
 
-                app_metrics::DATA_QUERIES_CACHE_SIZE.report(self.result_cache.entry_count() as i64);
-                app_metrics::DATA_QUERIES_CACHE_WEIGHT
-                    .report(self.result_cache.weighted_size() as i64);
-
-                (Some(tx), None)
-            } else {
-                (None, cache.get(&key).cloned())
-            }
-        };
-
-        if let Some(sender) = sender {
-            trace!("Missing cache for '{}'", query);
-            let result = exec(plan).await.map(|d| Arc::new(d));
-            if let Err(e) = sender.send(Some(result.clone())) {
-                trace!(
-                    "Failed to set cached query result, possibly flushed from LRU cache: {}",
-                    e
-                );
-            }
-            match &result {
-                Ok(r) => {
-                    if !self.result_cache.contains_key(&result_key) {
-                        self.result_cache
-                            .insert(result_key.clone(), r.clone())
-                            .await;
-
-                        app_metrics::DATA_QUERIES_CACHE_SIZE
-                            .report(self.result_cache.entry_count() as i64);
-                        app_metrics::DATA_QUERIES_CACHE_WEIGHT
-                            .report(self.result_cache.weighted_size() as i64);
+                            app_metrics::DATA_QUERIES_CACHE_SIZE
+                                .report(self.result_cache.entry_count() as i64);
+                            app_metrics::DATA_QUERIES_CACHE_WEIGHT
+                                .report(self.result_cache.weighted_size() as i64);
+                        }
+                        self.update_stale_cache(&queue_key, r).await;
                     }
-                    self.update_stale_cache(&queue_key, r).await;
+                    Err(_) => {
+                        trace!("Removing error result from cache");
+                    }
                 }
-                Err(_) => {
-                    trace!("Removing error result from cache");
-                }
+
+                self.queue_cache.lock().await.pop(&queue_key);
+
+                return result;
             }
 
-            self.queue_cache.lock().await.pop(&queue_key);
+            std::mem::drop(plan);
+            std::mem::drop(result_key);
+            std::mem::drop(context);
 
-            return result;
-        }
-
-        std::mem::drop(plan);
-        std::mem::drop(result_key);
-        std::mem::drop(context);
-
-        self.wait_for_queue(receiver, query).await
+            self.wait_for_queue(receiver, &query).await
+        })
     }
 
     pub async fn create_table<F>(
@@ -454,7 +401,7 @@ mod tests {
 
     #[tokio::test]
     async fn simple() -> Result<(), CubeError> {
-        let cache = SqlResultCache::new(1 << 20, Some(120), 1000, None);
+        let cache = Arc::new(SqlResultCache::new(1 << 20, Some(120), 1000, None));
         let schema = Arc::new(DFSchema::empty());
         let plan = SerializedPlan::try_new(
             LogicalPlan::EmptyRelation(EmptyRelation {
@@ -537,7 +484,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_while_revalidate() -> Result<(), CubeError> {
-        let cache = SqlResultCache::new(1 << 20, Some(120), 1000, Some(30));
+        let cache = Arc::new(SqlResultCache::new(1 << 20, Some(120), 1000, Some(30)));
         let schema = Arc::new(DFSchema::empty());
         let plan = SerializedPlan::try_new(
             LogicalPlan::EmptyRelation(EmptyRelation {

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -131,6 +131,13 @@ impl SqlResultCache {
         }
     }
 
+    fn report_stale_cache_metrics(&self) {
+        if let Some(stale_cache) = &self.stale_cache {
+            app_metrics::DATA_QUERIES_STALE_CACHE_SIZE.report(stale_cache.entry_count() as i64);
+            app_metrics::DATA_QUERIES_STALE_CACHE_WEIGHT.report(stale_cache.weighted_size() as i64);
+        }
+    }
+
     pub async fn clear(&self) {
         // invalidation will be done in the background
         self.result_cache.invalidate_all();
@@ -144,6 +151,7 @@ impl SqlResultCache {
 
         app_metrics::DATA_QUERIES_CACHE_SIZE.report(self.result_cache.entry_count() as i64);
         app_metrics::DATA_QUERIES_CACHE_WEIGHT.report(self.result_cache.weighted_size() as i64);
+        self.report_stale_cache_metrics();
     }
 
     pub fn entry_count(&self) -> u64 {
@@ -260,6 +268,7 @@ impl SqlResultCache {
                         .report(self.result_cache.entry_count() as i64);
                     app_metrics::DATA_QUERIES_CACHE_WEIGHT
                         .report(self.result_cache.weighted_size() as i64);
+                    self.report_stale_cache_metrics();
 
                     (Some(tx), None)
                 } else {
@@ -289,6 +298,7 @@ impl SqlResultCache {
                                 .report(self.result_cache.weighted_size() as i64);
                         }
                         self.update_stale_cache(&queue_key, r).await;
+                        self.report_stale_cache_metrics();
                     }
                     Err(_) => {
                         trace!("Removing error result from cache");
@@ -385,6 +395,8 @@ impl Drop for SqlResultCache {
     fn drop(&mut self) {
         app_metrics::DATA_QUERIES_CACHE_SIZE.report(0);
         app_metrics::DATA_QUERIES_CACHE_WEIGHT.report(0);
+        app_metrics::DATA_QUERIES_STALE_CACHE_SIZE.report(0);
+        app_metrics::DATA_QUERIES_STALE_CACHE_WEIGHT.report(0);
     }
 }
 

--- a/rust/cubestore/cubestore/src/sql/cache.rs
+++ b/rust/cubestore/cubestore/src/sql/cache.rs
@@ -171,6 +171,36 @@ impl SqlResultCache {
         }
     }
 
+    /// Tries to register this query in the queue cache for background execution.
+    /// Returns `Some(sender)` if we became the leader (no one else is running this query),
+    /// or `None` if another execution is already in flight.
+    async fn try_register_background(
+        &self,
+        queue_key: &SqlQueueCacheKey,
+    ) -> Option<watch::Sender<Option<Result<Arc<DataFrame>, CubeError>>>> {
+        let mut cache = self.queue_cache.lock().await;
+
+        if cache.contains(queue_key) {
+            if let Some(receiver) = cache.get(queue_key) {
+                if receiver.has_changed().is_err() {
+                    cache.pop(queue_key);
+                } else {
+                    return None;
+                }
+            } else {
+                cache.pop(queue_key);
+            }
+        }
+
+        if !cache.contains(queue_key) {
+            let (tx, rx) = watch::channel(None);
+            cache.put(queue_key.clone(), rx);
+            Some(tx)
+        } else {
+            None
+        }
+    }
+
     #[tracing::instrument(level = "trace", skip(self, context, plan, exec))]
     pub async fn get<F>(
         &self,
@@ -198,37 +228,58 @@ impl SqlResultCache {
                 "Using stale-while-revalidate cache for '{}', spawning background refresh",
                 query
             );
-            let result_cache = self.result_cache.clone();
-            let stale_cache = self.stale_cache.clone();
-            let queue_key_bg = queue_key.clone();
-            let result_key_bg = result_key.clone();
-            tokio::spawn(async move {
-                match exec(plan).await {
-                    Ok(df) => {
-                        let arc_df = Arc::new(df);
-                        result_cache.insert(result_key_bg, arc_df.clone()).await;
 
-                        if let Some(sc) = &stale_cache {
-                            sc.insert(
-                                queue_key_bg,
-                                StaleEntry {
-                                    result: arc_df,
-                                    created_at: Instant::now(),
-                                },
-                            )
-                            .await;
+            // Try to register in queue cache. If another execution is already in flight
+            // (from a previous stale hit or a concurrent foreground request), we skip
+            // spawning — that execution will update the caches for us.
+            if let Some(sender) = self.try_register_background(&queue_key).await {
+                let result_cache = self.result_cache.clone();
+                let stale_cache = self.stale_cache.clone();
+                let queue_key_bg = queue_key.clone();
+                let query_owned = query.to_string();
+                tokio::spawn(async move {
+                    trace!("Background refresh starting for '{}'", query_owned);
+                    let result = exec(plan).await.map(|d| Arc::new(d));
+                    match &result {
+                        Ok(arc_df) => {
+                            result_cache.insert(result_key, arc_df.clone()).await;
+
+                            if let Some(sc) = &stale_cache {
+                                sc.insert(
+                                    queue_key_bg,
+                                    StaleEntry {
+                                        result: arc_df.clone(),
+                                        created_at: Instant::now(),
+                                    },
+                                )
+                                .await;
+                            }
+
+                            app_metrics::DATA_QUERIES_CACHE_SIZE
+                                .report(result_cache.entry_count() as i64);
+                            app_metrics::DATA_QUERIES_CACHE_WEIGHT
+                                .report(result_cache.weighted_size() as i64);
                         }
+                        Err(e) => {
+                            log::error!(
+                                "Background stale-while-revalidate refresh failed for '{}': {}",
+                                query_owned,
+                                e
+                            );
+                        }
+                    }
+                    // Notify any waiters that joined via the queue cache.
+                    let _ = sender.send(Some(result));
+                    // sender is dropped here, closing the channel. The queue_cache entry
+                    // will be cleaned up lazily on the next get() for this key.
+                });
+            } else {
+                trace!(
+                    "Background refresh already in flight for '{}', skipping",
+                    query
+                );
+            }
 
-                        app_metrics::DATA_QUERIES_CACHE_SIZE
-                            .report(result_cache.entry_count() as i64);
-                        app_metrics::DATA_QUERIES_CACHE_WEIGHT
-                            .report(result_cache.weighted_size() as i64);
-                    }
-                    Err(e) => {
-                        log::error!("Background stale-while-revalidate refresh failed: {}", e);
-                    }
-                }
-            });
             return Ok(stale_result);
         }
 

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -1958,6 +1958,7 @@ mod tests {
                     config.config_obj().query_cache_max_capacity_bytes(),
                     config.config_obj().query_cache_time_to_idle_secs(),
                     1000,
+                    None,
                 )),
                 BasicProcessRateLimiter::new(),
             );
@@ -2042,6 +2043,7 @@ mod tests {
                     config.config_obj().query_cache_max_capacity_bytes(),
                     config.config_obj().query_cache_time_to_idle_secs(),
                     1000,
+                    None,
                 )),
                 BasicProcessRateLimiter::new(),
             );
@@ -2161,6 +2163,7 @@ mod tests {
                     config.config_obj().query_cache_max_capacity_bytes(),
                     config.config_obj().query_cache_time_to_idle_secs(),
                     1000,
+                    None,
                 )),
                 BasicProcessRateLimiter::new(),
             );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Adds a new `CUBESTORE_QUERY_CACHE_STALE_WHILE_REVALIDATE` environment variable to CubeStore that enables stale-while-revalidate behavior for the SQL result cache.

## Problem

CubeStore's SQL result cache key includes the current snapshot of partition and chunk IDs. When compaction or partition changes occur, the cache key changes even though the underlying query data may not have materially changed. This causes cache misses and forces queries to wait for full re-execution.

## Solution

When enabled (set to a number of seconds, e.g. `30`), the cache maintains a secondary lookup keyed only by SQL query text + inline tables (ignoring partition/chunk IDs). The behavior is:

1. **Exact cache hit** (SQL + partitions + chunks match): Serve immediately (existing behavior, unchanged)
2. **Exact miss, stale hit within timeout**: Return the stale result immediately and spawn a background task to re-execute the query and update both caches
3. **No hit at all**: Execute the query normally (existing behavior)

This is **disabled by default** (`0` = disabled). Setting it to e.g. `30` allows serving stale results for up to 30 seconds while refreshing in the background.

## Implementation approach

The implementation uses a single `get_inner()` method with an `is_background_refresh` flag:

- `get()` is a thin public wrapper that calls `get_inner(false)`
- On stale hit, the background refresh spawns `get_inner(true)` — which skips the stale cache check but goes through the **entire queue cache dedup flow** naturally
- This means if two concurrent stale hits try to refresh the same query, the second one joins the queue as a waiter instead of starting a duplicate execution
- `get()` takes `self: &Arc<Self>` so the Arc can be cloned into the spawned task
- `get_inner()` returns `Pin<Box<dyn Future + Send>>` to satisfy `tokio::spawn` bounds

## Changes

| File | Change |
|---|---|
| `config/mod.rs` | Added `query_cache_stale_while_revalidate_secs` to `ConfigObj` trait and `ConfigObjImpl`, parsed from `CUBESTORE_QUERY_CACHE_STALE_WHILE_REVALIDATE` env var |
| `sql/cache.rs` | Added `stale_cache` (Moka cache with byte weigher, keyed by `SqlQueueCacheKey`), extracted `get_inner()` with `is_background_refresh` flag, stale-while-revalidate lookup, background refresh via `tokio::spawn` calling back into `get_inner(true)` |
| `app_metrics.rs` | Added `DATA_QUERIES_CACHE_STALE_HIT` counter, `DATA_QUERIES_STALE_CACHE_SIZE` and `DATA_QUERIES_STALE_CACHE_WEIGHT` gauges |

## Metrics

| Metric | Type | Description |
|---|---|---|
| `cs.sql.query.data.cache.stale_hit` | Counter | Queries served from stale cache with background refresh triggered |
| `cs.sql.query.data.cache.stale.size` | Gauge | Approximate number of entries in stale cache |
| `cs.sql.query.data.cache.stale.weight` | Gauge | Approximate total weighted size (bytes) of stale cache |

## Unit tests

| Test | What it verifies |
|---|---|
| `stale_while_revalidate` | Stale result served immediately on exact cache miss; background refresh updates cache |
| `stale_while_revalidate_background_failure` | Stale entry preserved when background refresh fails; subsequent requests still get stale result |
| `stale_while_revalidate_timeout_expiry` | After timeout expires, stale path is bypassed and fresh execution runs |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12010d4f-a9d5-4dfa-aa52-9fcbda22e465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12010d4f-a9d5-4dfa-aa52-9fcbda22e465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

