### PR TITLE
fix(schema-compiler): handle sqlTable in originalSql pre-aggregation

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4262,9 +4262,13 @@ export class BaseQuery {
             preAggregation
           );
           const cubeFromPath = this.cubeEvaluator.cubeFromPath(cube);
-          const cubeSqlFn = cubeFromPath.sqlTable || cubeFromPath.sql;
           return this.paramAllocator.buildSqlAndParams(originalSqlPreAggregationQuery.evaluateSymbolSqlWithContext(
-            () => originalSqlPreAggregationQuery.evaluateSql(cube, cubeSqlFn),
+            () => {
+              if (cubeFromPath.sqlTable) {
+                return `SELECT * FROM ${originalSqlPreAggregationQuery.cubeSql(cube)}`;
+              }
+              return originalSqlPreAggregationQuery.evaluateSql(cube, cubeFromPath.sql);
+            },
             { preAggregationQuery: true, collectOriginalSqlPreAggregations }
           ));
         }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4261,8 +4261,10 @@ export class BaseQuery {
             cube,
             preAggregation
           );
+          const cubeFromPath = this.cubeEvaluator.cubeFromPath(cube);
+          const cubeSqlFn = cubeFromPath.sqlTable || cubeFromPath.sql;
           return this.paramAllocator.buildSqlAndParams(originalSqlPreAggregationQuery.evaluateSymbolSqlWithContext(
-            () => originalSqlPreAggregationQuery.evaluateSql(cube, this.cubeEvaluator.cubeFromPath(cube).sql),
+            () => originalSqlPreAggregationQuery.evaluateSql(cube, cubeSqlFn),
             { preAggregationQuery: true, collectOriginalSqlPreAggregations }
           ));
         }

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations.test.ts
@@ -1234,6 +1234,43 @@ describe('PreAggregations', () => {
       }
     });
 
+    cube('sql_table_visitors', {
+      sqlTable: \`visitors\`,
+
+      measures: {
+        count: {
+          type: 'count'
+        },
+      },
+
+      dimensions: {
+        id: {
+          sql: 'id',
+          type: 'number',
+          primaryKey: true
+        },
+        source: {
+          sql: 'source',
+          type: 'string'
+        },
+        createdAt: {
+          sql: 'created_at',
+          type: 'time'
+        },
+      },
+
+      preAggregations: {
+        main: {
+          type: 'originalSql',
+        },
+        partitioned: {
+          type: 'originalSql',
+          partitionGranularity: 'month',
+          timeDimensionReference: createdAt,
+        },
+      },
+    });
+
   `);
 
   it('simple pre-aggregation', async () => {
@@ -3642,4 +3679,62 @@ describe('PreAggregations', () => {
       expect(() => query.buildSqlAndParams()).toThrow('No rollups found that can be used for a rollup join');
     });
   }
+
+  it('originalSql pre-aggregation with sqlTable', async () => {
+    await compiler.compile();
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: [
+        'sql_table_visitors.count'
+      ],
+      dimensions: [
+        'sql_table_visitors.source'
+      ],
+      timeDimensions: [{
+        dimension: 'sql_table_visitors.createdAt',
+        granularity: 'day',
+        dateRange: ['2017-01-01', '2017-01-30']
+      }],
+      timezone: 'America/Los_Angeles',
+      order: [{
+        id: 'sql_table_visitors.createdAt'
+      }],
+      preAggregationsSchema: ''
+    });
+
+    const queryAndParams = query.buildSqlAndParams();
+    console.log(queryAndParams);
+    const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+    console.log(preAggregationsDescription);
+    expect(preAggregationsDescription.length).toBeGreaterThanOrEqual(1);
+    expect(preAggregationsDescription[0].type).toEqual('originalSql');
+    expect(preAggregationsDescription[0].loadSql[0]).toMatch(/CREATE TABLE/);
+    expect(preAggregationsDescription[0].loadSql[0]).toMatch(/SELECT \* FROM visitors/);
+
+    return dbRunner.evaluateQueryWithPreAggregations(query).then(res => {
+      expect(res).toEqual(
+        [
+          {
+            sql_table_visitors__created_at_day: '2017-01-02T00:00:00.000Z',
+            sql_table_visitors__source: 'some',
+            sql_table_visitors__count: '1'
+          },
+          {
+            sql_table_visitors__created_at_day: '2017-01-04T00:00:00.000Z',
+            sql_table_visitors__source: 'some',
+            sql_table_visitors__count: '1'
+          },
+          {
+            sql_table_visitors__created_at_day: '2017-01-05T00:00:00.000Z',
+            sql_table_visitors__source: 'google',
+            sql_table_visitors__count: '1'
+          },
+          {
+            sql_table_visitors__created_at_day: '2017-01-06T00:00:00.000Z',
+            sql_table_visitors__source: null,
+            sql_table_visitors__count: '2'
+          }
+        ]
+      );
+    });
+  });
 });

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -750,4 +750,81 @@ describe('pre-aggregations', () => {
       expect(preAggregationsDescription[0].preAggregationId).toEqual('orders.pre_agg_with_multiplied_measures');
     });
   });
+
+  describe('originalSql pre-aggregation with sqlTable', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+      cube(\`orders\`, {
+        sqlTable: \`public.orders\`,
+
+        measures: {
+          count: {
+            type: \`count\`,
+          },
+        },
+
+        dimensions: {
+          id: {
+            sql: \`id\`,
+            type: \`number\`,
+            primaryKey: true,
+          },
+          status: {
+            sql: \`status\`,
+            type: \`string\`,
+          },
+          created_at: {
+            sql: \`created_at\`,
+            type: \`time\`,
+          },
+        },
+
+        preAggregations: {
+          main: {
+            type: \`originalSql\`,
+          },
+          partitioned: {
+            type: \`originalSql\`,
+            partitionGranularity: \`month\`,
+            timeDimension: CUBE.created_at,
+          },
+        },
+      });
+    `);
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    it('generates loadSql for non-partitioned originalSql pre-aggregation', async () => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: ['orders.count'],
+        dimensions: ['orders.status'],
+        preAggregationsSchema: '',
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      expect(preAggregationsDescription.length).toBeGreaterThanOrEqual(1);
+      const originalSqlDesc = preAggregationsDescription.find((d: any) => d.type === 'originalSql');
+      expect(originalSqlDesc).toBeDefined();
+      expect(originalSqlDesc.loadSql[0]).toMatch(/public\.orders/);
+    });
+
+    it('generates loadSql for partitioned originalSql pre-aggregation', async () => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: ['orders.count'],
+        timeDimensions: [{
+          dimension: 'orders.created_at',
+          granularity: 'month',
+          dateRange: ['2017-01-01', '2017-03-31'],
+        }],
+        preAggregationsSchema: '',
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      expect(preAggregationsDescription.length).toBeGreaterThanOrEqual(1);
+      const originalSqlDesc = preAggregationsDescription.find((d: any) => d.type === 'originalSql');
+      expect(originalSqlDesc).toBeDefined();
+      expect(originalSqlDesc.loadSql[0]).toMatch(/public\.orders/);
+    });
+  });
 });

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -795,7 +795,7 @@ describe('pre-aggregations', () => {
       await compiler.compile();
     });
 
-    it('generates loadSql for non-partitioned originalSql pre-aggregation', async () => {
+    it('generates sql and loadSql for non-partitioned originalSql pre-aggregation', async () => {
       const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
         measures: ['orders.count'],
         dimensions: ['orders.status'],
@@ -806,10 +806,14 @@ describe('pre-aggregations', () => {
       expect(preAggregationsDescription.length).toBeGreaterThanOrEqual(1);
       const originalSqlDesc = preAggregationsDescription.find((d: any) => d.type === 'originalSql');
       expect(originalSqlDesc).toBeDefined();
-      expect(originalSqlDesc.loadSql[0]).toMatch(/public\.orders/);
+
+      // preAggregationSql() must produce a valid SELECT from the sqlTable
+      expect(originalSqlDesc.sql[0]).toMatch(/SELECT \* FROM public\.orders/);
+      expect(originalSqlDesc.loadSql[0]).toMatch(/CREATE TABLE/);
+      expect(originalSqlDesc.loadSql[0]).toMatch(/SELECT \* FROM public\.orders/);
     });
 
-    it('generates loadSql for partitioned originalSql pre-aggregation', async () => {
+    it('generates sql and loadSql for partitioned originalSql pre-aggregation', async () => {
       const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
         measures: ['orders.count'],
         timeDimensions: [{
@@ -824,7 +828,11 @@ describe('pre-aggregations', () => {
       expect(preAggregationsDescription.length).toBeGreaterThanOrEqual(1);
       const originalSqlDesc = preAggregationsDescription.find((d: any) => d.type === 'originalSql');
       expect(originalSqlDesc).toBeDefined();
-      expect(originalSqlDesc.loadSql[0]).toMatch(/public\.orders/);
+
+      // preAggregationSql() must produce a valid SELECT from the sqlTable
+      expect(originalSqlDesc.sql[0]).toMatch(/SELECT \* FROM public\.orders/);
+      expect(originalSqlDesc.loadSql[0]).toMatch(/CREATE TABLE/);
+      expect(originalSqlDesc.loadSql[0]).toMatch(/SELECT \* FROM public\.orders/);
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

When a cube uses `sqlTable` instead of `sql`, the `preAggregationSql` method for `originalSql` type pre-aggregations crashes with:

```
TypeError: Cannot read properties of undefined (reading 'apply')
    at CubeEvaluator.resolveSymbolsCall (CubeSymbols.ts:1015:24)
    at RedshiftQuery.evaluateSql (BaseQuery.js:3448:26)
    ...
```

This happens during `/cubejs-system/v1/pre-aggregations/partitions` calls when the cube definition uses `sqlTable` instead of `sql`.

**Root cause**: In `BaseQuery.preAggregationSql()`, the `originalSql` branch called `evaluateSql(cube, cubeFromPath.sql)` directly, but `cubeFromPath.sql` is `undefined` for cubes that use `sqlTable`.

**Fix**: For the `sqlTable` case, reuse the existing `cubeSql()` method (which already handles `sqlTable` correctly) to resolve the table name and wrap it in `SELECT * FROM`. For the `sql` case, keep the existing `evaluateSql()` call unchanged:

```js
if (cubeFromPath.sqlTable) {
  return `SELECT * FROM ${originalSqlPreAggregationQuery.cubeSql(cube)}`;
}
return originalSqlPreAggregationQuery.evaluateSql(cube, cubeFromPath.sql);
```

**Tests added**:
- **Unit tests**: Two tests covering non-partitioned and partitioned `originalSql` pre-aggregations on cubes that use `sqlTable`, verifying `preAggregationSql()` produces valid `SELECT * FROM` SQL.
- **Integration test**: A Postgres integration test that runs the full pre-aggregation query via `dbRunner.evaluateQueryWithPreAggregations()`, verifying correct data retrieval through the `originalSql` pre-aggregation with `sqlTable`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76cd31f9-0013-4148-8cd7-202b6e2782be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76cd31f9-0013-4148-8cd7-202b6e2782be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

