### PR TITLE
perf(cubesql): Fast path for timespamp parsing for cube results

### DIFF
--- a/rust/cubesql/cubesql/src/compile/date_parser.rs
+++ b/rust/cubesql/cubesql/src/compile/date_parser.rs
@@ -2,20 +2,180 @@ use crate::compile::engine::df::scan::DataFusionError;
 use chrono::{NaiveDate, NaiveDateTime};
 
 pub fn parse_date_str(s: &str) -> Result<NaiveDateTime, DataFusionError> {
-    let parsed = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
-        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f"))
-        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S"))
-        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f UTC"))
-        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f"))
-        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.fZ"))
-        .or_else(|_| {
-            NaiveDate::parse_from_str(s, "%Y-%m-%d").map(|date| date.and_hms_opt(0, 0, 0).unwrap())
-        });
+    if let Some(parsed) = parse_fast(s) {
+        return Ok(parsed);
+    }
 
-    parsed.map_err(|e| {
+    parse_with_chrono(s).map_err(|e| {
         DataFusionError::Internal(format!(
             "Can't parse date/time string literal {:?}: {}",
             s, e
         ))
     })
+}
+
+#[inline]
+fn digit(b: u8) -> Option<u32> {
+    let d = b.wrapping_sub(b'0');
+    if d <= 9 {
+        Some(d as u32)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn ascii_u32_2(b: &[u8], at: usize) -> Option<u32> {
+    Some(digit(b[at])? * 10 + digit(b[at + 1])?)
+}
+
+#[inline]
+fn ascii_u32_4(b: &[u8], at: usize) -> Option<u32> {
+    Some(
+        digit(b[at])? * 1000 + digit(b[at + 1])? * 100 + digit(b[at + 2])? * 10 + digit(b[at + 3])?,
+    )
+}
+
+/// Recognises only `YYYY-MM-DDTHH:MM:SS.fff` (23 bytes, `T` separator,
+/// 3-digit fraction). Returns `None` for any other length or layout — the
+/// caller falls through to the chrono cascade.
+fn parse_fast(s: &str) -> Option<NaiveDateTime> {
+    let b = s.as_bytes();
+    if b.len() != 23
+        || b[4] != b'-'
+        || b[7] != b'-'
+        || b[10] != b'T'
+        || b[13] != b':'
+        || b[16] != b':'
+        || b[19] != b'.'
+    {
+        return None;
+    }
+
+    let year = ascii_u32_4(b, 0)? as i32;
+    let month = ascii_u32_2(b, 5)?;
+    let day = ascii_u32_2(b, 8)?;
+    let hour = ascii_u32_2(b, 11)?;
+    let minute = ascii_u32_2(b, 14)?;
+    let second = ascii_u32_2(b, 17)?;
+    let frac_millis = digit(b[20])? * 100 + digit(b[21])? * 10 + digit(b[22])?;
+
+    NaiveDate::from_ymd_opt(year, month, day)?.and_hms_nano_opt(
+        hour,
+        minute,
+        second,
+        frac_millis * 1_000_000,
+    )
+}
+
+fn parse_with_chrono(s: &str) -> chrono::ParseResult<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f"))
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S"))
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.fZ"))
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f UTC"))
+        .or_else(|_| {
+            NaiveDate::parse_from_str(s, "%Y-%m-%d").map(|date| date.and_hms_opt(0, 0, 0).unwrap())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ymd_hmsn(y: i32, m: u32, d: u32, h: u32, mi: u32, s: u32, n: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(y, m, d)
+            .unwrap()
+            .and_hms_nano_opt(h, mi, s, n)
+            .unwrap()
+    }
+
+    #[test]
+    fn fast_path_accepts_canonical_shape() {
+        let cases: &[(&str, NaiveDateTime)] = &[
+            ("2022-01-01T00:00:00.000", ymd_hmsn(2022, 1, 1, 0, 0, 0, 0)),
+            (
+                "2024-06-15T13:45:07.123",
+                ymd_hmsn(2024, 6, 15, 13, 45, 7, 123_000_000),
+            ),
+            (
+                "9999-12-31T23:59:59.999",
+                ymd_hmsn(9999, 12, 31, 23, 59, 59, 999_000_000),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(parse_fast(input), Some(*expected), "fast path: {}", input);
+            assert_eq!(
+                parse_date_str(input).unwrap(),
+                *expected,
+                "wrapper: {}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn fast_path_rejects_non_canonical() {
+        // Wrong length / shape — must not be fast-parsed.
+        let rejects = [
+            "2022",
+            "2022-01-01",
+            "2022-01-01 00:00:00",
+            "2022-01-01T00:00:00",
+            "2022-01-01T00:00:00.000Z",
+            "2022-01-01 00:00:00.000",
+            "2022-01-01T00:00:00.123456",
+            "2022-13-01T00:00:00.000",
+            "2022-01-32T00:00:00.000",
+            "2022/01/01T00:00:00.000",
+            "2022-01-01x00:00:00.000",
+            "2022-01-01T25:00:00.000",
+            "2022-01-01T00:60:00.000",
+            "2022-01-01T00:00:60.000",
+        ];
+        for s in rejects {
+            assert!(parse_fast(s).is_none(), "unexpectedly fast-parsed: {:?}", s);
+        }
+    }
+
+    #[test]
+    fn wrapper_handles_other_shapes_via_chrono_fallback() {
+        let cases: &[(&str, NaiveDateTime)] = &[
+            ("2022-01-01", ymd_hmsn(2022, 1, 1, 0, 0, 0, 0)),
+            ("2022-01-01 00:00:00", ymd_hmsn(2022, 1, 1, 0, 0, 0, 0)),
+            ("2022-01-01T00:00:00", ymd_hmsn(2022, 1, 1, 0, 0, 0, 0)),
+            ("2022-01-01T00:00:00.000Z", ymd_hmsn(2022, 1, 1, 0, 0, 0, 0)),
+            (
+                "2022-01-01 00:00:00.000 UTC",
+                ymd_hmsn(2022, 1, 1, 0, 0, 0, 0),
+            ),
+            (
+                "2024-06-15T13:45:07.123456789",
+                ymd_hmsn(2024, 6, 15, 13, 45, 7, 123_456_789),
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert!(
+                parse_fast(input).is_none(),
+                "fast path should reject: {}",
+                input
+            );
+            assert_eq!(
+                parse_date_str(input).unwrap(),
+                *expected,
+                "wrapper: {}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_propagate_through_wrapper() {
+        for s in ["", "2022/01/01", "2022-01-01T00:00:00+02:00"] {
+            assert!(parse_date_str(s).is_err(), "should error: {:?}", s);
+        }
+    }
 }

--- a/rust/cubesql/cubesql/src/compile/date_parser.rs
+++ b/rust/cubesql/cubesql/src/compile/date_parser.rs
@@ -36,9 +36,7 @@ fn ascii_u32_4(b: &[u8], at: usize) -> Option<u32> {
     )
 }
 
-/// Recognises only `YYYY-MM-DDTHH:MM:SS.fff` (23 bytes, `T` separator,
-/// 3-digit fraction). Returns `None` for any other length or layout — the
-/// caller falls through to the chrono cascade.
+/// Recognizes only `YYYY-MM-DDTHH:MM:SS.fff` (23 bytes, `T` separator, 3-digit fraction).
 fn parse_fast(s: &str) -> Option<NaiveDateTime> {
     let b = s.as_bytes();
     if b.len() != 23
@@ -158,11 +156,6 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            assert!(
-                parse_fast(input).is_none(),
-                "fast path should reject: {}",
-                input
-            );
             assert_eq!(
                 parse_date_str(input).unwrap(),
                 *expected,

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -1358,7 +1358,9 @@ mod tests {
     use cubeclient::models::V1LoadResponse;
     use datafusion::{
         arrow::{
-            array::{BooleanArray, Float64Array, StringArray, TimestampNanosecondArray},
+            array::{
+                BooleanArray, Date32Array, Float64Array, StringArray, TimestampNanosecondArray,
+            },
             datatypes::{Field, Schema},
         },
         execution::{
@@ -1424,11 +1426,11 @@ mod tests {
                             "timeDimensions": []
                         },
                         "data": [
-                            {"KibanaSampleDataEcommerce.count": null, "KibanaSampleDataEcommerce.maxPrice": null, "KibanaSampleDataEcommerce.isBool": null, "KibanaSampleDataEcommerce.orderDate": null, "KibanaSampleDataEcommerce.city": "City 1"},
-                            {"KibanaSampleDataEcommerce.count": 5, "KibanaSampleDataEcommerce.maxPrice": 5.05, "KibanaSampleDataEcommerce.isBool": true, "KibanaSampleDataEcommerce.orderDate": "2022-01-01 00:00:00.000", "KibanaSampleDataEcommerce.city": "City 2"},
-                            {"KibanaSampleDataEcommerce.count": "5", "KibanaSampleDataEcommerce.maxPrice": "5.05", "KibanaSampleDataEcommerce.isBool": false, "KibanaSampleDataEcommerce.orderDate": "2023-01-01 00:00:00.000", "KibanaSampleDataEcommerce.city": "City 3"},
-                            {"KibanaSampleDataEcommerce.count": null, "KibanaSampleDataEcommerce.maxPrice": null, "KibanaSampleDataEcommerce.isBool": "true", "KibanaSampleDataEcommerce.orderDate": "9999-12-31 00:00:00.000", "KibanaSampleDataEcommerce.city": "City 4"},
-                            {"KibanaSampleDataEcommerce.count": null, "KibanaSampleDataEcommerce.maxPrice": null, "KibanaSampleDataEcommerce.isBool": "false", "KibanaSampleDataEcommerce.orderDate": null, "KibanaSampleDataEcommerce.city": null}
+                            {"KibanaSampleDataEcommerce.count": null, "KibanaSampleDataEcommerce.maxPrice": null, "KibanaSampleDataEcommerce.isBool": null, "KibanaSampleDataEcommerce.orderTimestamp": null, "KibanaSampleDataEcommerce.orderDate": null, "KibanaSampleDataEcommerce.city": "City 1"},
+                            {"KibanaSampleDataEcommerce.count": 5, "KibanaSampleDataEcommerce.maxPrice": 5.05, "KibanaSampleDataEcommerce.isBool": true, "KibanaSampleDataEcommerce.orderTimestamp": "2022-01-01 00:00:00.000", "KibanaSampleDataEcommerce.orderDate": "2022-01-01", "KibanaSampleDataEcommerce.city": "City 2"},
+                            {"KibanaSampleDataEcommerce.count": "5", "KibanaSampleDataEcommerce.maxPrice": "5.05", "KibanaSampleDataEcommerce.isBool": false, "KibanaSampleDataEcommerce.orderTimestamp": "2023-01-01 00:00:00.000", "KibanaSampleDataEcommerce.orderDate": "2023-01-01", "KibanaSampleDataEcommerce.city": "City 3"},
+                            {"KibanaSampleDataEcommerce.count": null, "KibanaSampleDataEcommerce.maxPrice": null, "KibanaSampleDataEcommerce.isBool": "true", "KibanaSampleDataEcommerce.orderTimestamp": "9999-12-31 00:00:00.000", "KibanaSampleDataEcommerce.orderDate": "9999-12-31", "KibanaSampleDataEcommerce.city": "City 4"},
+                            {"KibanaSampleDataEcommerce.count": null, "KibanaSampleDataEcommerce.maxPrice": null, "KibanaSampleDataEcommerce.isBool": "false", "KibanaSampleDataEcommerce.orderTimestamp": null, "KibanaSampleDataEcommerce.orderDate": null, "KibanaSampleDataEcommerce.city": null}
                         ]
                     }]
                 }
@@ -1481,7 +1483,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_df_cube_scan_execute() {
+    async fn test_df_cube_scan_execute() -> Result<(), CubeError> {
         assert_eq!(std::mem::size_of::<FieldValue>(), 24);
 
         let schema = Arc::new(Schema::new(vec![
@@ -1493,7 +1495,7 @@ mod tests {
                 false,
             ),
             Field::new(
-                "KibanaSampleDataEcommerce.orderDate",
+                "KibanaSampleDataEcommerce.orderTimestamp",
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
                 false,
             ),
@@ -1504,6 +1506,11 @@ mod tests {
                 false,
             ),
             Field::new("KibanaSampleDataEcommerce.city", DataType::Utf8, false),
+            Field::new(
+                "KibanaSampleDataEcommerce.orderDate",
+                DataType::Date32,
+                false,
+            ),
         ]));
 
         let scan_node = CubeScanExecutionPlan {
@@ -1526,6 +1533,7 @@ mod tests {
                 ]),
                 dimensions: Some(vec![
                     "KibanaSampleDataEcommerce.isBool".to_string(),
+                    "KibanaSampleDataEcommerce.orderTimestamp".to_string(),
                     "KibanaSampleDataEcommerce.orderDate".to_string(),
                     "KibanaSampleDataEcommerce.city".to_string(),
                 ]),
@@ -1548,9 +1556,7 @@ mod tests {
             config_obj: crate::config::Config::test().config_obj(),
         };
 
-        let runtime = Arc::new(
-            RuntimeEnv::new(RuntimeConfig::new()).expect("Unable to create RuntimeEnv for testing"),
-        );
+        let runtime = Arc::new(RuntimeEnv::new(RuntimeConfig::new())?);
         let task = Arc::new(TaskContext::new(
             "test".to_string(),
             "session".to_string(),
@@ -1559,8 +1565,8 @@ mod tests {
             HashMap::new(),
             runtime,
         ));
-        let stream = scan_node.execute(0, task).await.unwrap();
-        let batches = common::collect(stream).await.unwrap();
+        let stream = scan_node.execute(0, task).await?;
+        let batches = common::collect(stream).await?;
 
         assert_eq!(
             batches[0],
@@ -1610,9 +1616,17 @@ mod tests {
                         Some("City 4"),
                         None
                     ])) as ArrayRef,
+                    Arc::new(Date32Array::from(vec![
+                        None,
+                        Some(18993),
+                        Some(19358),
+                        Some(2_932_896),
+                        None,
+                    ])) as ArrayRef,
                 ],
-            )
-            .unwrap()
-        )
+            )?
+        );
+
+        Ok(())
     }
 }

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -1086,14 +1086,12 @@ macro_rules! transform_response_body {
                             (FieldValue::String(s), builder) => {
                                 let timestamp = parse_date_str(s.as_ref())?;
                                 // TODO switch parsing to microseconds
-                                if timestamp.and_utc().timestamp_millis() > (((1i64) << 62) / 1_000_000) {
-                                    builder.append_null()?;
-                                } else if let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() {
+                                if let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() {
                                     builder.append_value(nanos)?;
                                 } else {
                                     log::error!(
                                         "Unable to cast timestamp value to nanoseconds: {}",
-                                        timestamp.to_string()
+                                        timestamp
                                     );
                                     builder.append_null()?;
                                 }
@@ -1114,12 +1112,7 @@ macro_rules! transform_response_body {
                         {
                             (FieldValue::String(s), builder) => {
                                 let timestamp = parse_date_str(s.as_ref())?;
-                                // TODO switch parsing to microseconds
-                                if timestamp.and_utc().timestamp_millis() > (((1 as i64) << 62) / 1_000_000) {
-                                    builder.append_null()?;
-                                } else {
-                                    builder.append_value(timestamp.and_utc().timestamp_millis())?;
-                                }
+                                builder.append_value(timestamp.and_utc().timestamp_millis())?;
                             },
                         },
                         {
@@ -1136,28 +1129,18 @@ macro_rules! transform_response_body {
                         field_name,
                         {
                             (FieldValue::String(s), builder) => {
-                                let date = NaiveDate::parse_from_str(s.as_ref(), "%Y-%m-%d")
-                                    // FIXME: temporary solution for cases when expected type is Date32
-                                    // but underlying data is a Timestamp
-                                    .or_else(|_| NaiveDate::parse_from_str(s.as_ref(), "%Y-%m-%dT00:00:00.000"))
-                                    .map_err(|e| {
-                                        DataFusionError::Execution(format!(
-                                            "Can't parse date: '{}': {}",
-                                            s, e
-                                        ))
-                                    });
-                                match date {
-                                    Ok(date) => {
+                                match parse_date_str(s.as_ref()) {
+                                    Ok(timestamp) => {
                                         let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                                        let days_since_epoch = date.num_days_from_ce()  - epoch.num_days_from_ce();
+                                        let days_since_epoch = timestamp.date().num_days_from_ce()
+                                            - epoch.num_days_from_ce();
                                         builder.append_value(days_since_epoch)?;
                                     }
                                     Err(error) => {
                                         log::error!(
                                             "Unable to parse value as Date32: {}",
-                                            error.to_string()
+                                            error
                                         );
-
                                         builder.append_null()?
                                     }
                                 }


### PR DESCRIPTION
`parse_date_str` previously walked a 7-format `chrono::NaiveDateTime::parse_from_str` cascade. Cube's canonical wire shape is `%Y-%m-%dT%H:%M:%S%.3f` — `YYYY-MM-DDTHH:MM:SS.fff`, exactly 23 bytes — and was the 5th attempt in that cascade, so most rows reparsed the prefix 4 times before matching.

Benchmark on Apple M3 Max (`cargo bench --bench transform_response`, 10k rows, master vs. this commit):

| Shape (10k rows)          | Before    | After     | Δ      |
| ------------------------- | --------- | --------- | ------ |
| row      / cols=8  / td=1 | 22.48 ms  | 15.84 ms  | -29.5% |
| columnar / cols=8  / td=1 | 7.76 ms   | 3.08 ms   | -60.3% |
| row      / cols=16 / td=2 | ~43 ms    | 36.19 ms  | -15.8% |
| columnar / cols=16 / td=2 | ~16 ms    | 6.11 ms   | -61.8% |
| columnar / cols=16 / td=0 | unchanged | unchanged | noise  |