### PR TITLE
docs: Rename billing segments to on-demand and contract customers

### DIFF
--- a/.cursor/rules/namings-rule.mdc
+++ b/.cursor/rules/namings-rule.mdc
@@ -51,6 +51,20 @@ Available on the [Enterprise plan](https://cube.dev/pricing).
 
 Place the callout immediately after the section heading it applies to.
 
+# Cube Cloud billing customer segments
+
+When describing how a Cube Cloud account is sold and billed (for example on
+billing settings, pricing, and support pages):
+
+- **On-demand customers** — subscribe on the on-demand payment plan
+  (recurring billing, typically by credit card). Legacy: "self-serve customers".
+- **Contract customers** — annual commit under a signed commercial agreement
+  (commit payment plan). Legacy: "order form customers".
+
+**Self-serve** remains the right term for analytics and product UX meaning
+(end users exploring data without filing tickets) — for example "self-serve
+analytics". That usage is unrelated to the billing segment above.
+
 # Infrastructure Naming
 
 Infrastructure options are a separate, orthogonal concept from deployment types.

--- a/.cursor/rules/namings-rule.mdc
+++ b/.cursor/rules/namings-rule.mdc
@@ -51,20 +51,6 @@ Available on the [Enterprise plan](https://cube.dev/pricing).
 
 Place the callout immediately after the section heading it applies to.
 
-# Cube Cloud billing customer segments
-
-When describing how a Cube Cloud account is sold and billed (for example on
-billing settings, pricing, and support pages):
-
-- **On-demand customers** — subscribe on the on-demand payment plan
-  (recurring billing, typically by credit card). Legacy: "self-serve customers".
-- **Contract customers** — annual commit under a signed commercial agreement
-  (commit payment plan). Legacy: "order form customers".
-
-**Self-serve** remains the right term for analytics and product UX meaning
-(end users exploring data without filing tickets) — for example "self-serve
-analytics". That usage is unrelated to the billing segment above.
-
 # Infrastructure Naming
 
 Infrastructure options are a separate, orthogonal concept from deployment types.
@@ -102,7 +88,7 @@ Guidance:
   infrastructure.
 
 # Product Taxonomy
-Make sure to use correct terms.
+Make sure to use correct terms. On billing, pricing, and support pages, use **on-demand customers** for the on-demand payment plan (legacy billing copy: "self-serve customers") and **contract customers** for the commit payment plan (legacy: "order form customers"). Elsewhere, **self-serve** (e.g. self-serve analytics) describes end-user exploration, not the billing segment.
 
 - **Account**
   - **Deployment**

--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -12,10 +12,10 @@ Cube's [AI-powered features][ref-ai-overview] consume tokens based on the
 resources required to complete each request. Token allocation differs by
 customer type:
 
-- **Self-serve customers** receive [per-seat token grants](#per-seat-token-grants)
+- **On-demand customers** receive [per-seat token grants](#per-seat-token-grants)
   equal to half of their seat price, with optional
   [on-demand consumption](#on-demand-consumption) beyond that
-- **Order form customers** can purchase [pooled token packages](#token-packages)
+- **Contract customers** can purchase [pooled token packages](#token-packages)
 
 ## Token consumption
 
@@ -36,7 +36,7 @@ is subject to change as the product evolves.
 
 ## Per-seat token grants
 
-Self-serve customers on paid plans receive **per-seat token grants** equal to
+On-demand customers on paid plans receive **per-seat token grants** equal to
 **half of the seat price**. Each user is awarded an individual monthly token
 allocation based on their role.
 
@@ -48,7 +48,7 @@ Per-seat grants:
 
 ### On-demand consumption
 
-When a self-serve user exceeds their monthly per-seat grant, usage
+When a user on an on-demand plan exceeds their monthly per-seat grant, usage
 automatically continues as **on-demand consumption**. On-demand usage is billed
 through the credit card on file.
 
@@ -58,7 +58,7 @@ for each billing cycle.
 
 ## Token packages
 
-Order form customers can purchase **pooled add-on token packages**. Token
+Contract customers can purchase **pooled add-on token packages**. Token
 packages are added to a shared pool accessible by all users in the account.
 
 - Each package is valid for the duration of the contract or until fully

--- a/docs-mintlify/admin/account-billing/billing-faq.mdx
+++ b/docs-mintlify/admin/account-billing/billing-faq.mdx
@@ -8,9 +8,9 @@ description: Frequently asked questions about Cube billing, pricing, payments, a
 
 ### How does the billing structure work?
 
-#### Self-serve customers
+#### On-demand customers
 
-Self-serve customers are billed monthly. The credit card on file is automatically
+On-demand customers are billed monthly. The credit card on file is automatically
 charged through Stripe upon invoice generation.
 
 - Invoices bill active seats in advance for the upcoming period
@@ -18,38 +18,38 @@ charged through Stripe upon invoice generation.
   arrears on a prorated basis on the next invoice, as well as billed in advance
   on all subsequent invoices until the customer makes further adjustments
 
-#### Order form customers
+#### Contract customers
 
-**Order form customers** are billed annually and upfront according to the terms
-in their signed order form.
+**Contract customers** are billed annually and upfront according to the terms
+in their contract.
 
 - Committed seats are billed annually
 - Overages for uncommitted seats and usage are billed in arrears separately on a
-  basis specified in the signed order form
+  basis specified in the contract
 - Standard payment terms are **Net 30**, unless otherwise specified in the agreement
 
 ### What payment methods does Cube accept?
 
-#### Self-serve customers
+#### On-demand customers
 
-Self-serve subscriptions must be paid by credit card via Stripe. Your card is
+On-demand subscriptions must be paid by credit card via Stripe. Your card is
 automatically charged on a recurring subscription basis at the start of each
 billing cycle.
 
 <Info>
-Cube does **not** support ACH or wire transfer payments for self-serve plans.
+Cube does **not** support ACH or wire transfer payments for on-demand payment plans.
 </Info>
 
-#### Order form customers
+#### Contract customers
 
-Order form customers can pay via:
+Contract customers can pay via:
 
 - **Invoice billing** (e.g., Net 30 terms) — Payment terms are defined in your
-  executed order form and reflected on your invoice.
+  contract and reflected on your invoice.
 - **ACH / wire transfer** — Bank details (Stripe-managed virtual accounts) are
   listed directly on the invoice. Please reach out to
   [support@cube.dev](mailto:support@cube.dev) if you require validation.
-- **Credit card** (via Stripe) — Order form customers may also pay by credit card.
+- **Credit card** (via Stripe) — Contract customers may also pay by credit card.
 
 ### How can I update my payment information?
 

--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -30,7 +30,7 @@ subscription:
 card, and start using Cube Cloud right away. [Starter](#starter) and [Premium](#premium)
 product tiers are available on the on-demand payment plan.
 * _Commit payment plan_ allows you to have a contract with a CCU amount specified
-in an order form. [Premium](#premium) and [Enterprise](#enterprise) product tiers are available on the
+in that contract. [Premium](#premium) and [Enterprise](#enterprise) product tiers are available on the
 commit payment plan. [Contact us][link-contact-us] to learn more.
 
 ## Product tiers

--- a/docs-mintlify/admin/account-billing/support.mdx
+++ b/docs-mintlify/admin/account-billing/support.mdx
@@ -29,8 +29,8 @@ with **2 support tickets per month** through the in-product chat feature.
 * [Premium product tier][ref-premium-tier] includes support via **online resources** such as
 [documentation][ref-docs-intro], [webinars][cube-webinars], and [community
 Slack][cube-slack].
-* It also includes **either 4 support tickets per month** (self-serve customers)
-or **unlimited support tickets** (customers with an annual commit) for our support engineers during
+* It also includes **either 4 support tickets per month** (on-demand customers)
+or **unlimited support tickets** (contract customers) for our support engineers during
 [support hours](#support-hours) through our in-product chat.
 
 | Priority | Response time during support hours |

--- a/docs/content/product/administration/deployment/support.mdx
+++ b/docs/content/product/administration/deployment/support.mdx
@@ -25,8 +25,8 @@ with **2 support tickets per month** through the in-product chat feature.
 * [Premium product tier][ref-premium-tier] includes support via **online resources** such as
 [documentation][ref-docs-intro], [webinars][cube-webinars], and [community
 Slack][cube-slack].
-* It also includes **either 4 support tickets per month** (self-serve customers)
-or **unlimited support tickets** (customers with an annual commit) for our support engineers during
+* It also includes **either 4 support tickets per month** (on-demand customers)
+or **unlimited support tickets** (contract customers) for our support engineers during
 [support hours](#support-hours) through our in-product chat.
 
 | Priority | Response time during support hours |

--- a/docs/content/product/administration/pricing.mdx
+++ b/docs/content/product/administration/pricing.mdx
@@ -28,7 +28,7 @@ subscription:
 card, and start using Cube Cloud right away. [Starter](#starter) and [Premium](#premium)
 product tiers are available on the on-demand payment plan.
 * _Commit payment plan_ allows you to have a contract with a CCU amount specified
-in an order form. [Premium](#premium), [Enterprise](#enterprise), and
+in that contract. [Premium](#premium), [Enterprise](#enterprise), and
 [Enterprise Premier](#enterprise-premier) product tiers are available on the
 commit payment plan. [Contact us][link-contact-us] to learn more.
 


### PR DESCRIPTION
Align account-billing docs with on-demand vs contract customer terminology, document the terms in naming conventions, and mirror the support/pricing wording in legacy product docs.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
