### PR TITLE
chore(tesseract): Split member symbol business model and SQL rendering

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/mod.rs
@@ -9,6 +9,7 @@ pub mod order;
 pub mod query_plan;
 pub mod schema;
 pub mod select;
+pub mod symbols;
 pub mod time_series;
 pub mod union;
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/case_dimension.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/case_dimension.rs
@@ -1,0 +1,16 @@
+use super::super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::symbols::dimension_kinds::CaseDimension;
+use cubenativeutils::CubeError;
+
+impl ToSql for CaseDimension {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        if let Some(member_sql) = self.member_sql() {
+            ctx.eval_sql_call(member_sql)
+        } else {
+            Err(CubeError::internal(format!(
+                "Dimension {} hasn't sql evaluator",
+                ctx.full_name
+            )))
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/case_dimension.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/case_dimension.rs
@@ -8,7 +8,7 @@ impl ToSql for CaseDimension {
             ctx.eval_sql_call(member_sql)
         } else {
             Err(CubeError::internal(format!(
-                "Dimension {} hasn't sql evaluator",
+                "Dimension {} has no sql evaluator",
                 ctx.full_name
             )))
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/mod.rs
@@ -1,0 +1,21 @@
+pub mod case_dimension;
+pub mod regular;
+pub mod switch;
+
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::DimensionKind;
+use cubenativeutils::CubeError;
+
+impl ToSql for DimensionKind {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self {
+            Self::Regular(r) => r.to_sql(ctx),
+            Self::Geo(_) => Err(CubeError::internal(format!(
+                "Geo dimension {} doesn't support evaluate_sql directly",
+                ctx.full_name
+            ))),
+            Self::Switch(s) => s.to_sql(ctx),
+            Self::Case(c) => c.to_sql(ctx),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/regular.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/regular.rs
@@ -1,0 +1,9 @@
+use super::super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::symbols::dimension_kinds::RegularDimension;
+use cubenativeutils::CubeError;
+
+impl ToSql for RegularDimension {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        ctx.eval_sql_call(self.member_sql())
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/switch.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_kinds/switch.rs
@@ -1,0 +1,13 @@
+use super::super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::symbols::dimension_kinds::SwitchDimension;
+use cubenativeutils::CubeError;
+
+impl ToSql for SwitchDimension {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        if let Some(member_sql) = self.member_sql() {
+            ctx.eval_sql_call(member_sql)
+        } else {
+            ctx.templates.quote_identifier(ctx.name)
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/dimension_symbol.rs
@@ -1,0 +1,9 @@
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::DimensionSymbol;
+use cubenativeutils::CubeError;
+
+impl ToSql for DimensionSymbol {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        self.kind().to_sql(ctx)
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/aggregated.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/aggregated.rs
@@ -1,0 +1,14 @@
+use super::super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::symbols::measure_kinds::AggregatedMeasure;
+use cubenativeutils::CubeError;
+
+impl ToSql for AggregatedMeasure {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self.member_sql() {
+            Some(sql) => ctx.eval_sql_call(sql),
+            None => Err(CubeError::internal(
+                "Aggregated measure without sql cannot be evaluated directly".to_string(),
+            )),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/calculated.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/calculated.rs
@@ -1,0 +1,14 @@
+use super::super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::symbols::measure_kinds::CalculatedMeasure;
+use cubenativeutils::CubeError;
+
+impl ToSql for CalculatedMeasure {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self.member_sql() {
+            Some(sql) => ctx.eval_sql_call(sql),
+            None => Err(CubeError::internal(
+                "Calculated measure without sql cannot be evaluated directly".to_string(),
+            )),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/count.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/count.rs
@@ -1,0 +1,27 @@
+use super::super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::symbols::measure_kinds::{CountMeasure, CountSql};
+use cubenativeutils::CubeError;
+
+impl ToSql for CountMeasure {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self.sql() {
+            CountSql::Explicit(sql) => ctx.eval_sql_call(sql),
+            CountSql::Auto(pk_sqls) => {
+                if pk_sqls.len() > 1 {
+                    let pk_strings = pk_sqls
+                        .iter()
+                        .map(|pk| -> Result<_, CubeError> {
+                            let res = ctx.eval_sql_call(pk)?;
+                            ctx.templates.cast_to_string(&res)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    ctx.templates.concat_strings(&pk_strings)
+                } else if let Some(pk_sql) = pk_sqls.first() {
+                    ctx.eval_sql_call(pk_sql)
+                } else {
+                    Ok("*".to_string())
+                }
+            }
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_kinds/mod.rs
@@ -1,0 +1,21 @@
+pub mod aggregated;
+pub mod calculated;
+pub mod count;
+
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::MeasureKind;
+use cubenativeutils::CubeError;
+
+impl ToSql for MeasureKind {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self {
+            Self::Count(c) => c.to_sql(ctx),
+            Self::Aggregated(a) => a.to_sql(ctx),
+            Self::Calculated(c) => c.to_sql(ctx),
+            Self::Rank => Err(CubeError::internal(format!(
+                "Rank measure doesn't support direct evaluation for {}",
+                ctx.full_name
+            ))),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/measure_symbol.rs
@@ -1,0 +1,9 @@
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::MeasureSymbol;
+use cubenativeutils::CubeError;
+
+impl ToSql for MeasureSymbol {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        self.kind().to_sql(ctx)
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/member_expression_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/member_expression_symbol.rs
@@ -1,0 +1,20 @@
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::{MemberExpressionExpression, MemberExpressionSymbol};
+use cubenativeutils::CubeError;
+
+impl ToSql for MemberExpressionSymbol {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        let sql = match self.expression() {
+            MemberExpressionExpression::SqlCall(sql_call) => ctx.eval_sql_call(sql_call)?,
+            MemberExpressionExpression::PatchedSymbol(symbol) => {
+                ctx.visitor
+                    .apply(symbol, ctx.node_processor.clone(), ctx.templates)?
+            }
+        };
+        if self.is_parenthesized() {
+            Ok(format!("({})", sql))
+        } else {
+            Ok(sql)
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/member_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/member_symbol.rs
@@ -1,0 +1,14 @@
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::MemberSymbol;
+use cubenativeutils::CubeError;
+
+impl ToSql for MemberSymbol {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        match self {
+            Self::Dimension(d) => d.to_sql(ctx),
+            Self::TimeDimension(t) => t.to_sql(ctx),
+            Self::Measure(m) => m.to_sql(ctx),
+            Self::MemberExpression(e) => e.to_sql(ctx),
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/mod.rs
@@ -1,0 +1,10 @@
+pub mod dimension_kinds;
+pub mod dimension_symbol;
+pub mod measure_kinds;
+pub mod measure_symbol;
+pub mod member_expression_symbol;
+pub mod member_symbol;
+pub mod time_dimension_symbol;
+pub mod to_sql;
+
+pub use to_sql::{MemberSqlContext, ToSql};

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/time_dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/time_dimension_symbol.rs
@@ -1,0 +1,14 @@
+use super::{MemberSqlContext, ToSql};
+use crate::planner::sql_evaluator::TimeDimensionSymbol;
+use cubenativeutils::CubeError;
+
+impl ToSql for TimeDimensionSymbol {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
+        let visitor = ctx.visitor.with_ignore_tz_convert();
+        visitor.apply(
+            &self.base_symbol(),
+            ctx.node_processor.clone(),
+            ctx.templates,
+        )
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/to_sql.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/plan/symbols/to_sql.rs
@@ -1,0 +1,30 @@
+use crate::planner::query_tools::QueryTools;
+use crate::planner::sql_evaluator::sql_nodes::SqlNode;
+use crate::planner::sql_evaluator::{SqlCall, SqlEvaluatorVisitor};
+use crate::planner::sql_templates::PlanSqlTemplates;
+use cubenativeutils::CubeError;
+use std::rc::Rc;
+
+pub struct MemberSqlContext<'a> {
+    pub visitor: &'a SqlEvaluatorVisitor,
+    pub node_processor: &'a Rc<dyn SqlNode>,
+    pub query_tools: &'a Rc<QueryTools>,
+    pub templates: &'a PlanSqlTemplates,
+    pub name: &'a str,
+    pub full_name: &'a str,
+}
+
+impl<'a> MemberSqlContext<'a> {
+    pub fn eval_sql_call(&self, sql_call: &Rc<SqlCall>) -> Result<String, CubeError> {
+        sql_call.eval(
+            self.visitor,
+            self.node_processor.clone(),
+            self.query_tools.clone(),
+            self.templates,
+        )
+    }
+}
+
+pub trait ToSql {
+    fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError>;
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/evaluate_sql.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/evaluate_sql.rs
@@ -25,15 +25,14 @@ impl SqlNode for EvaluateSqlNode {
         node_processor: Rc<dyn SqlNode>,
         templates: &PlanSqlTemplates,
     ) -> Result<String, CubeError> {
-        let name = node.name();
-        let full_name = node.full_name();
+        let path = node.compiled_path();
         let ctx = MemberSqlContext {
             visitor,
             node_processor: &node_processor,
             query_tools: &query_tools,
             templates,
-            name: &name,
-            full_name: &full_name,
+            name: path.name(),
+            full_name: path.full_name(),
         };
         node.as_ref().to_sql(&ctx)
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/evaluate_sql.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/sql_nodes/evaluate_sql.rs
@@ -1,4 +1,5 @@
 use super::SqlNode;
+use crate::plan::symbols::{MemberSqlContext, ToSql};
 use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_evaluator::MemberSymbol;
 use crate::planner::sql_evaluator::SqlEvaluatorVisitor;
@@ -24,38 +25,17 @@ impl SqlNode for EvaluateSqlNode {
         node_processor: Rc<dyn SqlNode>,
         templates: &PlanSqlTemplates,
     ) -> Result<String, CubeError> {
-        let res = match node.as_ref() {
-            MemberSymbol::Dimension(ev) => {
-                let res = ev.evaluate_sql(
-                    visitor,
-                    node_processor.clone(),
-                    query_tools.clone(),
-                    templates,
-                )?;
-                Ok(res)
-            }
-            MemberSymbol::TimeDimension(ev) => {
-                let visitor = visitor.with_ignore_tz_convert();
-                let res = visitor.apply(&ev.base_symbol(), node_processor.clone(), templates)?;
-                Ok(res)
-            }
-            MemberSymbol::Measure(ev) => ev.evaluate_sql(
-                visitor,
-                node_processor.clone(),
-                query_tools.clone(),
-                templates,
-            ),
-            MemberSymbol::MemberExpression(e) => {
-                let res = e.evaluate_sql(
-                    visitor,
-                    node_processor.clone(),
-                    query_tools.clone(),
-                    templates,
-                )?;
-                Ok(res)
-            }
-        }?;
-        Ok(res)
+        let name = node.name();
+        let full_name = node.full_name();
+        let ctx = MemberSqlContext {
+            visitor,
+            node_processor: &node_processor,
+            query_tools: &query_tools,
+            templates,
+            name: &name,
+            full_name: &full_name,
+        };
+        node.as_ref().to_sql(&ctx)
     }
 
     fn as_any(self: Rc<Self>) -> Rc<dyn Any> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/case_dimension.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/case_dimension.rs
@@ -1,8 +1,6 @@
 use super::super::common::{Case, DimensionType};
 use super::super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -39,24 +37,6 @@ impl CaseDimension {
             dimension_type: self.dimension_type,
             case: new_case,
             member_sql: self.member_sql.clone(),
-        }
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        full_name: &str,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        if let Some(member_sql) = &self.member_sql {
-            member_sql.eval(visitor, node_processor, query_tools, templates)
-        } else {
-            Err(CubeError::internal(format!(
-                "Dimension {} hasn't sql evaluator",
-                full_name
-            )))
         }
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/mod.rs
@@ -10,9 +10,7 @@ pub use switch::*;
 
 use super::common::DimensionType;
 use super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -25,30 +23,6 @@ pub enum DimensionKind {
 }
 
 impl DimensionKind {
-    pub fn evaluate_sql(
-        &self,
-        name: &str,
-        full_name: &str,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        match self {
-            Self::Regular(r) => r.evaluate_sql(visitor, node_processor, query_tools, templates),
-            Self::Geo(_) => Err(CubeError::internal(format!(
-                "Geo dimension {} doesn't support evaluate_sql directly",
-                full_name
-            ))),
-            Self::Switch(s) => {
-                s.evaluate_sql(name, visitor, node_processor, query_tools, templates)
-            }
-            Self::Case(c) => {
-                c.evaluate_sql(full_name, visitor, node_processor, query_tools, templates)
-            }
-        }
-    }
-
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
         match self {
             Self::Regular(r) => r.get_dependencies(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/regular.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/regular.rs
@@ -1,8 +1,6 @@
 use super::super::common::DimensionType;
 use super::super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -26,17 +24,6 @@ impl RegularDimension {
 
     pub fn member_sql(&self) -> &Rc<SqlCall> {
         &self.member_sql
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        self.member_sql
-            .eval(visitor, node_processor, query_tools, templates)
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/switch.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_kinds/switch.rs
@@ -1,7 +1,5 @@
 use super::super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -26,21 +24,6 @@ impl SwitchDimension {
 
     pub fn is_calc_group(&self) -> bool {
         self.member_sql.is_none()
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        name: &str,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        if let Some(member_sql) = &self.member_sql {
-            member_sql.eval(visitor, node_processor, query_tools, templates)
-        } else {
-            Ok(templates.quote_identifier(name)?)
-        }
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/dimension_symbol.rs
@@ -8,11 +8,8 @@ use super::{DimensionType, MemberSymbol, SymbolFactory};
 use crate::cube_bridge::dimension_definition::DimensionDefinition;
 use crate::cube_bridge::evaluator::CubeEvaluator;
 use crate::cube_bridge::member_sql::MemberSql;
-use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_evaluator::TimeDimensionSymbol;
-use crate::planner::sql_evaluator::{
-    sql_nodes::SqlNode, Compiler, CubeRef, SqlCall, SqlEvaluatorVisitor,
-};
+use crate::planner::sql_evaluator::{Compiler, CubeRef, SqlCall};
 use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::planner::GranularityHelper;
 use crate::planner::SqlInterval;
@@ -71,23 +68,6 @@ impl DimensionSymbol {
             propagate_filters_to_sub_query,
             mask_sql,
         })
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        self.kind.evaluate_sql(
-            self.compiled_path.name(),
-            self.compiled_path.full_name(),
-            visitor,
-            node_processor,
-            query_tools,
-            templates,
-        )
     }
 
     pub fn is_calc_group(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/aggregated.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/aggregated.rs
@@ -1,8 +1,6 @@
 use super::super::super::MemberSymbol;
 use super::super::common::AggregationType;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -33,21 +31,6 @@ impl AggregatedMeasure {
 
     pub fn member_sql(&self) -> Option<&Rc<SqlCall>> {
         self.member_sql.as_ref()
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        match &self.member_sql {
-            Some(sql) => sql.eval(visitor, node_processor, query_tools, templates),
-            None => Err(CubeError::internal(
-                "Aggregated measure without sql cannot be evaluated directly".to_string(),
-            )),
-        }
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/calculated.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/calculated.rs
@@ -1,7 +1,5 @@
 use super::super::super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -61,21 +59,6 @@ impl CalculatedMeasure {
 
     pub fn member_sql(&self) -> Option<&Rc<SqlCall>> {
         self.member_sql.as_ref()
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        match &self.member_sql {
-            Some(sql) => sql.eval(visitor, node_processor, query_tools, templates),
-            None => Err(CubeError::internal(
-                "Calculated measure without sql cannot be evaluated directly".to_string(),
-            )),
-        }
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/count.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/count.rs
@@ -1,7 +1,5 @@
 use super::super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -23,40 +21,6 @@ impl CountMeasure {
 
     pub fn sql(&self) -> &CountSql {
         &self.sql
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        match &self.sql {
-            CountSql::Explicit(sql) => sql.eval(visitor, node_processor, query_tools, templates),
-            CountSql::Auto(pk_sqls) => {
-                if pk_sqls.len() > 1 {
-                    let pk_strings = pk_sqls
-                        .iter()
-                        .map(|pk| -> Result<_, CubeError> {
-                            let res = pk.eval(
-                                visitor,
-                                node_processor.clone(),
-                                query_tools.clone(),
-                                templates,
-                            )?;
-                            templates.cast_to_string(&res)
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
-                    templates.concat_strings(&pk_strings)
-                } else if pk_sqls.len() == 1 {
-                    let pk_sql = pk_sqls.first().unwrap();
-                    pk_sql.eval(visitor, node_processor, query_tools, templates)
-                } else {
-                    Ok("*".to_string())
-                }
-            }
-        }
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_kinds/mod.rs
@@ -8,9 +8,7 @@ pub use count::*;
 
 use super::common::AggregationType;
 use super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
-use crate::planner::sql_evaluator::{sql_nodes::SqlNode, CubeRef, SqlCall, SqlEvaluatorVisitor};
-use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::sql_evaluator::{CubeRef, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -59,25 +57,6 @@ impl MeasureKind {
                 "Unknown measure type: '{}'",
                 measure_type
             )))
-        }
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        full_name: &str,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        match self {
-            Self::Count(c) => c.evaluate_sql(visitor, node_processor, query_tools, templates),
-            Self::Aggregated(a) => a.evaluate_sql(visitor, node_processor, query_tools, templates),
-            Self::Calculated(c) => c.evaluate_sql(visitor, node_processor, query_tools, templates),
-            Self::Rank => Err(CubeError::internal(format!(
-                "Rank measure doesn't support direct evaluation for {}",
-                full_name
-            ))),
         }
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/measure_symbol.rs
@@ -5,11 +5,8 @@ use super::{MemberSymbol, SymbolFactory};
 use crate::cube_bridge::evaluator::CubeEvaluator;
 use crate::cube_bridge::measure_definition::{MeasureDefinition, RollingWindow};
 use crate::cube_bridge::member_sql::MemberSql;
-use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_evaluator::collectors::find_owned_by_cube_child;
-use crate::planner::sql_evaluator::{
-    sql_nodes::SqlNode, Compiler, CubeRef, SqlCall, SqlEvaluatorVisitor,
-};
+use crate::planner::sql_evaluator::{Compiler, CubeRef, SqlCall};
 use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::planner::SqlInterval;
 use cubenativeutils::CubeError;
@@ -264,22 +261,6 @@ impl MeasureSymbol {
         } else {
             self.kind.is_additive()
         }
-    }
-
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        self.kind.evaluate_sql(
-            &self.full_name(),
-            visitor,
-            node_processor,
-            query_tools,
-            templates,
-        )
     }
 
     pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/member_expression_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_evaluator/symbols/member_expression_symbol.rs
@@ -1,10 +1,7 @@
 use super::common::CompiledMemberPath;
 use super::MemberSymbol;
-use crate::planner::query_tools::QueryTools;
 use crate::planner::sql_evaluator::collectors::member_childs;
-use crate::planner::sql_evaluator::{
-    sql_nodes::SqlNode, CubeRef, CubeTableSymbol, SqlCall, SqlEvaluatorVisitor,
-};
+use crate::planner::sql_evaluator::{CubeRef, CubeTableSymbol, SqlCall};
 use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::utils::debug::DebugSql;
 use cubenativeutils::CubeError;
@@ -52,32 +49,18 @@ impl MemberExpressionSymbol {
         }))
     }
 
-    pub fn evaluate_sql(
-        &self,
-        visitor: &SqlEvaluatorVisitor,
-        node_processor: Rc<dyn SqlNode>,
-        query_tools: Rc<QueryTools>,
-        templates: &PlanSqlTemplates,
-    ) -> Result<String, CubeError> {
-        let sql = match &self.expression {
-            MemberExpressionExpression::SqlCall(sql_call) => {
-                sql_call.eval(visitor, node_processor, query_tools, templates)?
-            }
-            MemberExpressionExpression::PatchedSymbol(symbol) => {
-                visitor.apply(symbol, node_processor, templates)?
-            }
-        };
-        if self.parenthesized {
-            Ok(format!("({})", sql))
-        } else {
-            Ok(sql)
-        }
-    }
-
     pub fn with_parenthesized(self: &Rc<Self>) -> Rc<Self> {
         let mut result = self.as_ref().clone();
         result.parenthesized = true;
         Rc::new(result)
+    }
+
+    pub fn expression(&self) -> &MemberExpressionExpression {
+        &self.expression
+    }
+
+    pub fn is_parenthesized(&self) -> bool {
+        self.parenthesized
     }
 
     pub fn compiled_path(&self) -> &CompiledMemberPath {


### PR DESCRIPTION
## Summary

Extracts SQL rendering out of `MemberSymbol` and its constituents into a dedicated `ToSql` trait in `plan/symbols/`, mirroring the prior Filter refactor (#10828). Business types under `planner/sql_evaluator/symbols/` no longer carry SQL emission knowledge — `planner/` is now closer to a pure logical-model layer, `plan/` owns SQL rendering.

## Changes

- New `plan/symbols/` module with `ToSql` trait + `MemberSqlContext` (helper carrying visitor, node_processor, query_tools, templates, name, full_name; exposes `eval_sql_call`).
- `impl ToSql` for every level of the member dispatch ladder:
  - top: `MemberSymbol`
  - per-variant: `DimensionSymbol`, `MeasureSymbol`, `MemberExpressionSymbol`, `TimeDimensionSymbol` (the latter does the `with_ignore_tz_convert` recursion)
  - kinds: `DimensionKind` (Geo → error), `MeasureKind` (Rank → error)
  - concrete: `RegularDimension`, `CaseDimension`, `SwitchDimension`, `CountMeasure`, `AggregatedMeasure`, `CalculatedMeasure`
- `EvaluateSqlNode::to_sql` collapses to building a `MemberSqlContext` and dispatching through the trait.
- All `evaluate_sql` methods removed from `planner/sql_evaluator/symbols/` (4 layers) along with the now-unused `QueryTools`/`SqlEvaluatorVisitor`/`SqlNode`/`PlanSqlTemplates` imports.
- Added `expression()` / `is_parenthesized()` accessors on `MemberExpressionSymbol` so the impl can live outside.
