### PR TITLE
feat: Links in the data model

### DIFF
--- a/.github/actions/smoke.sh
+++ b/.github/actions/smoke.sh
@@ -75,3 +75,7 @@ echo "::endgroup::"
 echo "::group::RBAC GraphQL"
 yarn lerna run --concurrency 1 --stream --no-prefix smoke:rbac-graphql
 echo "::endgroup::"
+
+echo "::group::Links"
+yarn lerna run --concurrency 1 --stream --no-prefix smoke:links
+echo "::endgroup::"

--- a/docs-mintlify/reference/data-modeling/context-variables.mdx
+++ b/docs-mintlify/reference/data-modeling/context-variables.mdx
@@ -113,7 +113,7 @@ values from the Cube query during SQL generation.
 
 This is useful for hinting your database optimizer to use a specific index
 or filter out partitions or shards in your cloud data warehouse so you won't
-be billed for scanning those.
+be billed for scanning those. It can also be useful for constructing [links][ref-links].
 
 <Warning>
 
@@ -817,3 +817,4 @@ cube(`orders`, {
 [ref-query-filter]: /reference/rest-api/query-format#query-properties
 [ref-dynamic-jinja]: /docs/data-modeling/dynamic/jinja
 [ref-filter-boolean]: /reference/rest-api/query-format#boolean-logical-operators
+[ref-links]: /reference/data-modeling/dimensions#links

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -426,9 +426,107 @@ Using it with other dimension types will result in a validation error.
 
 </Info>
 
+### `links`
+
+The `links` parameter allows you to define links associated with a dimension.
+They can be rendered as HTML links by supporting tools, e.g., [Workbooks][ref-workbooks].
+
+Links are useful to let users navigate to related external resources (e.g., Google
+search), internal tools (e.g., Salesforce), or other pages in a BI tool.
+
+Each link must have a `name` and a `label`. The `name` is used as an identifier
+in the [synthetic dimension](#synthetic) name.
+
+A link must specify either a `url` or a `dashboard`:
+- `url` is a SQL expression that constructs the link URL. It can [reference][ref-references]
+  column and dimension values, just like the [`sql` parameter](#sql) or [`mask` parameter](#mask).
+- `dashboard` is a dashboard identifier. When set, the link URL is generated as
+  `/dashboard/<dashboard_id>`. The `params` object is still appended as a query string.
+
+Optionally, a link might use the `icon` parameter to reference an icon from a [supported
+icon set][link-tabler] to be displayed alongside the link label.
+
+Optionally, a link might use the `target` parameter to specify [where to open it][link-target]:
+`blank` (default) to open in a new tab/window or `self` to open in the same tab/window.
+
+```yaml
+cubes:
+  - name: users
+
+    dimensions:
+      # Definitions of dimensions such as `email`, etc.
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "CONCAT('https://www.google.com/search?q=', {CUBE}.full_name)"
+            icon: brand-google
+            target: blank
+          
+          - name: salesforce_search
+            label: Search in Salesforce
+            url: "CONCAT('https://your-company.salesforce.com/search/results/?q=', {email})"
+            target: blank
+
+          - name: send_email
+            label: Write an email
+            url: "CONCAT('mailto:', {email})"
+            icon: send
+```
+
+#### `params`
+
+The optional `params` parameter can be used to add additional query parameters to the
+URL. It accepts a map of key-value pairs, where keys are parameter names and values are
+SQL expressions (just like `url`).
+
+Values in `params` can [reference][ref-references] columns and dimension values.
+All parameter values will be [URL-encoded][link-encode-uri-component] in the generated SQL
+using a database-specific encoding function.
+
+```yaml
+cubes:
+  - name: users
+
+    dimensions:
+      # Definitions of dimensions such as `id`, `country`, etc.
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: performance
+            label: Check performance dashboard
+            dashboard: KSqDYdUz6Ble
+            params:
+              - key: filter_user_id
+                value: "{id}"
+              - key: filter_country
+                value: "{country}"
+```
+
+#### Dimensions
+
+Each link will be rendered as an additional [synthetic](#synthetic) dimension in the
+result set, with the following naming convention:
+
+- `<dimension_name>___link_<link_name>_url`
+
+<Info>
+
+All references in link URLs and parameters must resolve to a single value for a given
+value of the dimension on which the link is defined. Otherwise, it will result in
+duplicate rows in the result set.
+
+</Info>
+
 ### `meta`
 
-Custom metadata. Can be used to pass any information to the frontend.
+The `meta` parameter allows you to attach arbitrary information to a dimension.
+It can be consumed and interpreted by supporting tools.
 
 You can also use the `ai_context` key to provide context to the
 [AI agent][ref-ai-context] without exposing it in the user interface.
@@ -902,6 +1000,13 @@ cube(`orders`, {
 
 </CodeGroup>
 
+### `synthetic`
+
+The `synthetic` parameter can't be set by a user directly. It is used to mark dimensions
+that are automatically created by Cube, e.g., for [links](#links).
+
+You can check if a dimension is synthetic via the [`/v1/meta` API endpoint][ref-meta-api].
+
 ### `granularities`
 
 By default, the following granularities are available for time dimensions:
@@ -1223,3 +1328,10 @@ cube(`fiscal_calendar`, {
 [ref-case-measures]: /reference/data-modeling/measures#case
 [ref-meta-api]: /reference/rest-api/reference#base_pathv1meta
 [ref-string-time-dims]: /recipes/data-modeling/string-time-dimensions
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[link-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target
+[link-tabler]: https://tabler.io/icons
+[ref-references]: /docs/data-modeling/syntax#references
+[ref-filter-params]: /reference/data-modeling/context-variables#filter_params
+[link-encode-uri-component]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+[ref-rest-filters]: /reference/rest-api/query-format#query-properties

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -508,7 +508,7 @@ cubes:
                 value: "{country}"
 ```
 
-#### Dimensions
+#### Synthetic dimensions
 
 Each link will be rendered as an additional [synthetic](#synthetic) dimension in the
 result set, with the following naming convention:

--- a/docs/content/product/data-modeling/reference/context-variables.mdx
+++ b/docs/content/product/data-modeling/reference/context-variables.mdx
@@ -113,7 +113,7 @@ values from the Cube query during SQL generation.
 
 This is useful for hinting your database optimizer to use a specific index
 or filter out partitions or shards in your cloud data warehouse so you won't
-be billed for scanning those.
+be billed for scanning those. It can also be useful for constructing [links][ref-links].
 
 <WarningBox>
 
@@ -817,3 +817,4 @@ cube(`orders`, {
 [ref-query-filter]: /product/apis-integrations/rest-api/query-format#query-properties
 [ref-dynamic-jinja]: /product/data-modeling/dynamic/jinja
 [ref-filter-boolean]: /product/apis-integrations/rest-api/query-format#boolean-logical-operators
+[ref-links]: /product/data-modeling/reference/dimensions#links

--- a/docs/content/product/data-modeling/reference/dimensions.mdx
+++ b/docs/content/product/data-modeling/reference/dimensions.mdx
@@ -375,7 +375,7 @@ cubes:
                 value: "{country}"
 ```
 
-#### Dimensions
+#### Synthetic dimensions
 
 Each link will be rendered as an additional [synthetic](#synthetic) dimension in the
 result set, with the following naming convention:

--- a/docs/content/product/data-modeling/reference/dimensions.mdx
+++ b/docs/content/product/data-modeling/reference/dimensions.mdx
@@ -293,9 +293,107 @@ cubes:
 
 </CodeTabs>
 
+### `links`
+
+The `links` parameter allows you to define links associated with a dimension.
+They can be rendered as HTML links by supporting tools, e.g., [Workbooks][ref-workbooks].
+
+Links are useful to let users navigate to related external resources (e.g., Google
+search), internal tools (e.g., Salesforce), or other pages in a BI tool.
+
+Each link must have a `name` and a `label`. The `name` is used as an identifier
+in the [synthetic dimension](#synthetic) name.
+
+A link must specify either a `url` or a `dashboard`:
+- `url` is a SQL expression that constructs the link URL. It can [reference][ref-references]
+  column and dimension values, just like the [`sql` parameter](#sql) or [`mask` parameter](#mask).
+- `dashboard` is a dashboard identifier. When set, the link URL is generated as
+  `/dashboard/<dashboard_id>`. The `params` object is still appended as a query string.
+
+Optionally, a link might use the `icon` parameter to reference an icon from a [supported
+icon set][link-tabler] to be displayed alongside the link label.
+
+Optionally, a link might use the `target` parameter to specify [where to open it][link-target]:
+`blank` (default) to open in a new tab/window or `self` to open in the same tab/window.
+
+```yaml
+cubes:
+  - name: users
+
+    dimensions:
+      # Definitions of dimensions such as `email`, etc.
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "CONCAT('https://www.google.com/search?q=', {CUBE}.full_name)"
+            icon: brand-google
+            target: blank
+          
+          - name: salesforce_search
+            label: Search in Salesforce
+            url: "CONCAT('https://your-company.salesforce.com/search/results/?q=', {email})"
+            target: blank
+
+          - name: send_email
+            label: Write an email
+            url: "CONCAT('mailto:', {email})"
+            icon: send
+```
+
+#### `params`
+
+The optional `params` parameter can be used to add additional query parameters to the
+URL. It accepts a map of key-value pairs, where keys are parameter names and values are
+SQL expressions (just like `url`).
+
+Values in `params` can [reference][ref-references] columns and dimension values.
+All parameter values will be [URL-encoded][link-encode-uri-component] in the generated SQL
+using a database-specific encoding function.
+
+```yaml
+cubes:
+  - name: users
+
+    dimensions:
+      # Definitions of dimensions such as `id`, `country`, etc.
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: performance
+            label: Check performance dashboard
+            dashboard: KSqDYdUz6Ble
+            params:
+              - key: filter_user_id
+                value: "{id}"
+              - key: filter_country
+                value: "{country}"
+```
+
+#### Dimensions
+
+Each link will be rendered as an additional [synthetic](#synthetic) dimension in the
+result set, with the following naming convention:
+
+- `<dimension_name>___link_<link_name>_url`
+
+<InfoBox>
+
+All references in link URLs and parameters must resolve to a single value for a given
+value of the dimension on which the link is defined. Otherwise, it will result in
+duplicate rows in the result set.
+
+</InfoBox>
+
 ### `meta`
 
-Custom metadata. Can be used to pass any information to the frontend.
+The `meta` parameter allows you to attach arbitrary information to a dimension.
+It can be consumed and interpreted by supporting tools.
 
 <CodeTabs>
 
@@ -701,6 +799,13 @@ cubes:
 
 </CodeTabs>
 
+### `synthetic`
+
+The `synthetic` parameter can't be set by a user directly. It is used to mark dimensions
+that are automatically created by Cube, e.g., for [links](#links).
+
+You can check if a dimension is synthetic via the [`/v1/meta` API endpoint][ref-meta].
+
 ### `granularities`
 
 By default, the following granularities are available for time dimensions:
@@ -1015,3 +1120,11 @@ cube(`fiscal_calendar`, {
 [ref-cube-calendar]: /product/data-modeling/reference/cube#calendar
 [ref-measure-time-shift]: /product/data-modeling/reference/measures#time_shift
 [ref-data-masking]: /product/auth/data-access-policies#data-masking
+[ref-workbooks]: /product/exploration/workbooks
+[link-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target
+[link-tabler]: https://tabler.io/icons
+[ref-references]: /product/data-modeling/syntax#references
+[ref-filter-params]: /product/data-modeling/reference/context-variables#filter_params
+[link-encode-uri-component]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+[ref-rest-filters]: /product/apis-integrations/rest-api/query-format#query-properties
+[ref-meta]: /product/apis-integrations/rest-api/reference#base_pathv1meta

--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -216,4 +216,8 @@ export class DatabricksQuery extends BaseQuery {
     delete templates.types.interval;
     return templates;
   }
+
+  public urlEncode(sql: string): string {
+    return `url_encode(CAST(${sql} as STRING))`;
+  }
 }

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3990,6 +3990,17 @@ export class BaseQuery {
   }
 
   /**
+   * URL-encode a SQL expression. Override in dialect-specific query classes
+   * for native URL encoding support. Default implementation uses REPLACE
+   * chains for the most common characters.
+   * @param {string} sql
+   * @return {string}
+   */
+  urlEncode(sql) {
+    return `REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(CAST(${sql} as TEXT), '%', '%25'), '&', '%26'), '=', '%3D'), '+', '%2B'), ' ', '%20')`;
+  }
+
+  /**
    * @param {string} granularity
    * @param {string} dimension
    * @return {string}
@@ -5007,7 +5018,8 @@ export class BaseQuery {
         filterParams: this.filtersProxy(),
         filterGroup: this.filterGroupFunction(),
         sqlUtils: {
-          convertTz: this.convertTz.bind(this)
+          convertTz: this.convertTz.bind(this),
+          urlEncode: this.urlEncode.bind(this)
         }
       }, R.map(
         (symbols) => this.contextSymbolsProxy(symbols),
@@ -5023,6 +5035,7 @@ export class BaseQuery {
       filterGroup: () => '1 = 1',
       sqlUtils: {
         convertTz: (field) => field,
+        urlEncode: (sql) => sql,
       },
       securityContext: CubeSymbols.contextSymbolsProxyFrom({}, allocateParam),
     };
@@ -5034,7 +5047,8 @@ export class BaseQuery {
 
   sqlUtilsForRust() {
     return {
-      convertTz: this.convertTz.bind(this)
+      convertTz: this.convertTz.bind(this),
+      urlEncode: this.urlEncode.bind(this)
     };
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -199,4 +199,8 @@ export class PrestodbQuery extends BaseQuery {
   public castToString(sql: any): string {
     return `CAST(${sql} as VARCHAR)`;
   }
+
+  public urlEncode(sql: string): string {
+    return `url_encode(CAST(${sql} as VARCHAR))`;
+  }
 }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -350,7 +350,11 @@ export class CubeEvaluator extends CubeSymbols {
           const linkName = typeof link.name === 'function' ? link.name() : link.name;
           const syntheticName = `${dimName}___link_${linkName}_url`;
 
-          if (cube.dimensions[syntheticName] && !(link.params && Array.isArray(link.params) && link.params.length > 0)) return;
+          // CubeSymbols.generateSyntheticLinkDimensions already created a basic
+          // version for view-include resolution. Only upgrade here if params need
+          // to be baked into the SQL (requires buildLinkSqlWithParams).
+          const hasParams = link.params && Array.isArray(link.params) && link.params.length > 0;
+          if (cube.dimensions[syntheticName] && !hasParams) return;
 
           let baseSql;
           if (link.url) {
@@ -373,7 +377,7 @@ export class CubeEvaluator extends CubeSymbols {
               type: 'string',
               synthetic: true,
               ownedByCube: true,
-              public: true,
+              public: dimDef.public !== false,
             };
           }
         });

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -409,6 +409,9 @@ export class CubeEvaluator extends CubeSymbols {
 
     // Pre-resolve each param value to its raw SQL column name, then build
     // a simple function that returns the full SQL concatenation.
+    // Uses REPLACE chain for URL encoding (matches BaseQuery.urlEncode default).
+    // Database-specific adapters override urlEncode at query execution time
+    // through the SQL_UTILS context for url-type link dimensions without params.
     const paramSqlFragments = resolvedParams.map((p, idx) => {
       const sep = idx === 0 ? '?' : '&';
       const valSql = p.valueSqlFn(cubeName);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -378,6 +378,8 @@ export class CubeEvaluator extends CubeSymbols {
               synthetic: true,
               ownedByCube: true,
               public: dimDef.public !== false,
+              shown: dimDef.shown,
+              meta: dimDef.meta,
             };
           }
         });
@@ -397,8 +399,9 @@ export class CubeEvaluator extends CubeSymbols {
       ${params.map((param, idx) => {
     const separator = idx === 0 ? '?' : '&';
     const rawKey = typeof param.key === 'function' ? param.key() : param.key;
-    const key = rawKey.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-    const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${String(param.value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; }`;
+    // Escape for SQL string literal ('' for single-quote) then for JS string context (\\ for backslash)
+    const key = rawKey.replace(/'/g, "''").replace(/\\/g, '\\\\');
+    const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${String(param.value).replace(/'/g, "''").replace(/\\/g, '\\\\')}'; }`;
     return `result = result + " || '${separator}${key}=' || " + SQL_UTILS.urlEncode((${valueFnStr})(${cubeName}));`;
   }).join('\n      ')}
       return result;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -399,36 +399,37 @@ export class CubeEvaluator extends CubeSymbols {
     const resolvedParams = params.map((param) => {
       const rawKey = typeof param.key === 'function' ? param.key() : param.key;
       const encodedKey = encodeURIComponent(rawKey).replace(/'/g, "''");
-      // The transpiler generates `dimName => dimName` for `{dimName}` references.
-      // Extract the dimension name and look up its sql directly.
-      const fnStr = typeof param.value === 'function' ? param.value.toString() : '';
-      const match = fnStr.match(/^(\w+)\s*=>\s*\1$/);
-      let valueSqlFn: any;
-      if (match && dimensions[match[1]]) {
-        valueSqlFn = dimensions[match[1]].sql;
-      } else {
-        valueSqlFn = param.value;
-      }
-      return { encodedKey, valueSqlFn };
+      return { encodedKey, valueFn: param.value };
     });
 
-    // Pre-resolve each param value to its raw SQL column name.
-    // The function takes SQL_UTILS as a parameter so the compiler injects the
-    // sqlUtils context symbol (which provides database-specific urlEncode).
-    const paramParts = resolvedParams.map((p, idx) => {
-      const sep = idx === 0 ? '?' : '&';
-      const valSql = p.valueSqlFn(cubeName);
-      // valSql is a raw column reference like 'city' — escape for JS string literal
-      const valSqlEscaped = valSql.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-      return `result += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode('${valSqlEscaped}');`;
-    }).join('\n      ');
+    // Extract the argument name from each param value function.
+    // The transpiler generates functions like `city => city` or `(users) => \`${city}\``
+    // where the argument names are what resolveSymbolsCall uses for resolution.
+    const paramArgNames = resolvedParams.map((p, idx) => {
+      const fnStr = p.valueFn.toString();
+      const match = fnStr.match(/^(\w+)\s*=>|^\s*function\s*\w*\s*\(([^)]*)\)/);
+      if (match) {
+        return (match[1] || match[2] || '').split(',')[0].trim();
+      }
+      return `__param${idx}`;
+    });
+
+    // Build a function whose argument list includes the cube name, SQL_UTILS,
+    // and each param's reference symbol. resolveSymbolsCall extracts these arg
+    // names and resolves them: cube dims, cross-cube refs, FILTER_PARAMS, etc.
+    const allArgs = [cubeName, 'SQL_UTILS', ...paramArgNames];
+
+    const body = `
+      var base = (${baseSql.toString()})(${cubeName});
+      ${resolvedParams.map((p, idx) => {
+    const sep = idx === 0 ? '?' : '&';
+    return `base += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode(${paramArgNames[idx]});`;
+  }).join('\n      ')}
+      return base;
+    `;
 
     // eslint-disable-next-line no-new-func
-    const fn = new Function(cubeName, 'SQL_UTILS', `
-      var result = (${baseSql.toString()})(${cubeName});
-      ${paramParts}
-      return result;
-    `);
+    const fn = new Function(...allArgs, body);
     return fn;
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -248,7 +248,6 @@ export class CubeEvaluator extends CubeSymbols {
     this.prepareJoins(cube, errorReporter);
     this.preparePreAggregations(cube, errorReporter);
     this.prepareMembers(cube.measures, cube, errorReporter);
-    this.prepareSyntheticLinkDimensions(cube);
     this.prepareMembers(cube.dimensions, cube, errorReporter);
     this.prepareMembers(cube.segments, cube, errorReporter);
 
@@ -340,105 +339,6 @@ export class CubeEvaluator extends CubeSymbols {
     }
   }
 
-  protected prepareSyntheticLinkDimensions(cube: any) {
-    if (!cube.dimensions) return;
-    if (cube.isView) return;
-
-    for (const [dimName, dimDef] of Object.entries<any>(cube.dimensions)) {
-      if (dimDef.links && Array.isArray(dimDef.links)) {
-        dimDef.links.forEach((link: any) => {
-          const linkName = typeof link.name === 'function' ? link.name() : link.name;
-          const syntheticName = `${dimName}___link_${linkName}_url`;
-
-          // CubeSymbols.generateSyntheticLinkDimensions already created a basic
-          // version for view-include resolution. Only upgrade here if params need
-          // to be baked into the SQL (requires buildLinkSqlWithParams).
-          const hasParams = link.params && Array.isArray(link.params) && link.params.length > 0;
-          if (cube.dimensions[syntheticName] && !hasParams) return;
-
-          let baseSql;
-          if (link.url) {
-            baseSql = link.url;
-          } else if (link.dashboard) {
-            const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
-            // eslint-disable-next-line no-new-func
-            baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
-          }
-
-          if (baseSql) {
-            let sql;
-            if (link.params && Array.isArray(link.params) && link.params.length > 0) {
-              sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params, cube.dimensions);
-            } else {
-              sql = baseSql;
-            }
-            cube.dimensions[syntheticName] = {
-              sql,
-              type: 'string',
-              synthetic: true,
-              ownedByCube: true,
-              public: dimDef.public !== false,
-              shown: dimDef.shown,
-              meta: dimDef.meta,
-            };
-            // Also update the symbols definition so view proxies resolve the upgraded version
-            if (this.symbols[cube.name]) {
-              this.symbols[cube.name][syntheticName] = cube.dimensions[syntheticName];
-            }
-          }
-        });
-      }
-    }
-  }
-
-  private buildLinkSqlWithParams(cubeName: string, baseSql: any, params: Array<any>, dimensions: Record<string, any>) {
-    if (params.length === 0) {
-      return baseSql;
-    }
-
-    const resolvedParams = params.map((param) => {
-      const rawKey = typeof param.key === 'function' ? param.key() : param.key;
-      const encodedKey = encodeURIComponent(rawKey).replace(/'/g, "''");
-      return { encodedKey, valueFn: param.value };
-    });
-
-    // Extract ALL argument names from each param value function using the same
-    // regex-based extraction that resolveSymbolsCall uses (funcArguments).
-    // A param value can reference multiple members, e.g. CONCAT({first_name}, ' ', {last_name})
-    const paramArgSets = resolvedParams.map((p) => this.funcArguments(p.valueFn));
-
-    // Collect all unique arg names across all params (deduped, preserving order)
-    const seenArgs = new Set([cubeName, 'SQL_UTILS']);
-    const extraArgs: string[] = [];
-    for (const argSet of paramArgSets) {
-      for (const arg of argSet) {
-        if (!seenArgs.has(arg)) {
-          seenArgs.add(arg);
-          extraArgs.push(arg);
-        }
-      }
-    }
-
-    // Build a function whose argument list includes the cube name, SQL_UTILS,
-    // and all referenced symbols. resolveSymbolsCall extracts these arg
-    // names and resolves them: cube dims, cross-cube refs, FILTER_PARAMS, etc.
-    const allArgs = [cubeName, 'SQL_UTILS', ...extraArgs];
-
-    // For each param, call its value function with the resolved args to get SQL
-    const body = `
-      var base = (${baseSql.toString()})(${cubeName});
-      ${resolvedParams.map((p, idx) => {
-    const sep = idx === 0 ? '?' : '&';
-    const paramArgs = paramArgSets[idx].join(', ');
-    return `base += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode((${p.valueFn.toString()})(${paramArgs}));`;
-  }).join('\n      ')}
-      return base;
-    `;
-
-    // eslint-disable-next-line no-new-func
-    const fn = new Function(...allArgs, body);
-    return fn;
-  }
 
   private allMembersOrList(cube: any, specifier: string | string[]): string[] {
     const types = ['measures', 'dimensions', 'segments'];

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -405,10 +405,7 @@ export class CubeEvaluator extends CubeSymbols {
     // Extract ALL argument names from each param value function using the same
     // regex-based extraction that resolveSymbolsCall uses (funcArguments).
     // A param value can reference multiple members, e.g. CONCAT({first_name}, ' ', {last_name})
-    const paramArgSets = resolvedParams.map((p, idx) => {
-      const args = this.funcArguments(p.valueFn);
-      return args.length > 0 ? args : [`__param${idx}`];
-    });
+    const paramArgSets = resolvedParams.map((p) => this.funcArguments(p.valueFn));
 
     // Collect all unique arg names across all params (deduped, preserving order)
     const seenArgs = new Set([cubeName, 'SQL_UTILS']);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -402,16 +402,11 @@ export class CubeEvaluator extends CubeSymbols {
       return { encodedKey, valueFn: param.value };
     });
 
-    // Extract the argument name from each param value function.
-    // The transpiler generates functions like `city => city` or `(users) => \`${city}\``
-    // where the argument names are what resolveSymbolsCall uses for resolution.
+    // Extract the argument name from each param value function using the same
+    // regex-based extraction that resolveSymbolsCall uses (funcArguments).
     const paramArgNames = resolvedParams.map((p, idx) => {
-      const fnStr = p.valueFn.toString();
-      const match = fnStr.match(/^(\w+)\s*=>|^\s*function\s*\w*\s*\(([^)]*)\)/);
-      if (match) {
-        return (match[1] || match[2] || '').split(',')[0].trim();
-      }
-      return `__param${idx}`;
+      const args = this.funcArguments(p.valueFn);
+      return args[0] || `__param${idx}`;
     });
 
     // Build a function whose argument list includes the cube name, SQL_UTILS,

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -414,8 +414,8 @@ export class CubeEvaluator extends CubeSymbols {
     const paramParts = resolvedParams.map((p, idx) => {
       const sep = idx === 0 ? '?' : '&';
       const valSql = p.valueSqlFn(cubeName);
-      // valSql is a raw column reference like 'city' — escape quotes for JS string
-      const valSqlEscaped = valSql.replace(/'/g, "\\'");
+      // valSql is a raw column reference like 'city' — escape for JS string literal
+      const valSqlEscaped = valSql.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
       return `result += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode('${valSqlEscaped}');`;
     }).join('\n      ');
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -381,6 +381,10 @@ export class CubeEvaluator extends CubeSymbols {
               shown: dimDef.shown,
               meta: dimDef.meta,
             };
+            // Also update the symbols definition so view proxies resolve the upgraded version
+            if (this.symbols[cube.name]) {
+              this.symbols[cube.name][syntheticName] = cube.dimensions[syntheticName];
+            }
           }
         });
       }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -71,6 +71,7 @@ export type LinkDefinition = {
   dashboard?: string;
   icon?: string;
   target?: 'blank' | 'self';
+  primary?: boolean;
   params?: Array<{ key: string; value: (...args: any[]) => string }>;
 };
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -64,6 +64,17 @@ export type MultiStageGrainDirective = {
   includeReferences?: string[];
 };
 
+export type LinkDefinition = {
+  name: string;
+  label: string;
+  url?: (...args: any[]) => string;
+  dashboard?: string;
+  icon?: string;
+  target?: 'blank' | 'self';
+  params?: Array<{ key: string; value: (...args: any[]) => string }>;
+};
+};
+
 export type DimensionDefinition = {
   type: string;
   sql(): string;
@@ -78,6 +89,7 @@ export type DimensionDefinition = {
   addGroupBy?: (...args: Array<unknown>) => Array<ToString>;
   addGroupByReferences?: string[];
   filter?: MultiStageFilterDirective;
+  links?: LinkDefinition[];
 };
 
 export type TimeShiftDefinition = {
@@ -236,6 +248,7 @@ export class CubeEvaluator extends CubeSymbols {
     this.prepareJoins(cube, errorReporter);
     this.preparePreAggregations(cube, errorReporter);
     this.prepareMembers(cube.measures, cube, errorReporter);
+    this.prepareSyntheticLinkDimensions(cube);
     this.prepareMembers(cube.dimensions, cube, errorReporter);
     this.prepareMembers(cube.segments, cube, errorReporter);
 
@@ -325,6 +338,68 @@ export class CubeEvaluator extends CubeSymbols {
         filter.unlessReferences = resolvedUnless;
       }
     }
+  }
+
+  protected prepareSyntheticLinkDimensions(cube: any) {
+    if (!cube.dimensions) return;
+    if (cube.isView) return;
+
+    for (const [dimName, dimDef] of Object.entries<any>(cube.dimensions)) {
+      if (dimDef.links && Array.isArray(dimDef.links)) {
+        dimDef.links.forEach((link: any) => {
+          const linkName = typeof link.name === 'function' ? link.name() : link.name;
+          const syntheticName = `${dimName}___link_${linkName}_url`;
+
+          if (cube.dimensions[syntheticName] && !(link.params && Array.isArray(link.params) && link.params.length > 0)) return;
+
+          let baseSql;
+          if (link.url) {
+            baseSql = link.url;
+          } else if (link.dashboard) {
+            const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
+            // eslint-disable-next-line no-new-func
+            baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
+          }
+
+          if (baseSql) {
+            let sql;
+            if (link.params && Array.isArray(link.params) && link.params.length > 0) {
+              sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params);
+            } else {
+              sql = baseSql;
+            }
+            cube.dimensions[syntheticName] = {
+              sql,
+              type: 'string',
+              synthetic: true,
+              ownedByCube: true,
+              public: true,
+            };
+          }
+        });
+      }
+    }
+  }
+
+  private buildLinkSqlWithParams(cubeName: string, baseSql: any, params: Array<any>) {
+    if (params.length === 0) {
+      return baseSql;
+    }
+
+    // eslint-disable-next-line no-new-func
+    const fn = new Function(cubeName, 'SQL_UTILS', `
+      var baseResult = (${baseSql.toString()})(${cubeName});
+      var result = baseResult;
+      ${params.map((param, idx) => {
+    const separator = idx === 0 ? '?' : '&';
+    const key = typeof param.key === 'function' ? param.key() : param.key;
+    const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${param.value}'; }`;
+    return `result = result + " || '${separator}${key}=' || " + SQL_UTILS.urlEncode((${valueFnStr})(${cubeName}));`;
+  }).join('\n      ')}
+      return result;
+    `);
+    Object.defineProperty(fn, 'length', { value: baseSql.length });
+    return fn;
   }
 
   private allMembersOrList(cube: any, specifier: string | string[]): string[] {
@@ -795,7 +870,7 @@ export class CubeEvaluator extends CubeSymbols {
         }
       }
 
-      if (ownedByCube && cube.isView) {
+      if (ownedByCube && cube.isView && !members[memberName].synthetic) {
         errorReporter.error(`View '${cube.name}' defines own member '${cube.name}.${memberName}'. Please move this member definition to one of the cubes.`);
       }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -339,7 +339,6 @@ export class CubeEvaluator extends CubeSymbols {
     }
   }
 
-
   private allMembersOrList(cube: any, specifier: string | string[]): string[] {
     const types = ['measures', 'dimensions', 'segments'];
     if (specifier === '*') {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -398,10 +398,9 @@ export class CubeEvaluator extends CubeSymbols {
       ${params.map((param, idx) => {
     const separator = idx === 0 ? '?' : '&';
     const rawKey = typeof param.key === 'function' ? param.key() : param.key;
-    // Escape for SQL string literal ('' for single-quote) then for JS string context (\\ for backslash)
-    const key = rawKey.replace(/'/g, "''").replace(/\\/g, '\\\\');
+    const encodedKey = encodeURIComponent(rawKey).replace(/'/g, "''");
     const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${String(param.value).replace(/'/g, "''").replace(/\\/g, '\\\\')}'; }`;
-    return `result = result + " || '${separator}${key}=' || " + SQL_UTILS.urlEncode((${valueFnStr})(${cubeName}));`;
+    return `result = result + " || '${separator}${encodedKey}=' || " + SQL_UTILS.urlEncode((${valueFnStr})(${cubeName}));`;
   }).join('\n      ')}
       return result;
     `);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -73,7 +73,6 @@ export type LinkDefinition = {
   target?: 'blank' | 'self';
   params?: Array<{ key: string; value: (...args: any[]) => string }>;
 };
-};
 
 export type DimensionDefinition = {
   type: string;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -396,8 +396,9 @@ export class CubeEvaluator extends CubeSymbols {
       var result = baseResult;
       ${params.map((param, idx) => {
     const separator = idx === 0 ? '?' : '&';
-    const key = typeof param.key === 'function' ? param.key() : param.key;
-    const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${param.value}'; }`;
+    const rawKey = typeof param.key === 'function' ? param.key() : param.key;
+    const key = rawKey.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${String(param.value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; }`;
     return `result = result + " || '${separator}${key}=' || " + SQL_UTILS.urlEncode((${valueFnStr})(${cubeName}));`;
   }).join('\n      ')}
       return result;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -876,7 +876,7 @@ export class CubeEvaluator extends CubeSymbols {
         }
       }
 
-      if (ownedByCube && cube.isView && !members[memberName].synthetic) {
+      if (ownedByCube && cube.isView) {
         errorReporter.error(`View '${cube.name}' defines own member '${cube.name}.${memberName}'. Please move this member definition to one of the cubes.`);
       }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -367,7 +367,7 @@ export class CubeEvaluator extends CubeSymbols {
           if (baseSql) {
             let sql;
             if (link.params && Array.isArray(link.params) && link.params.length > 0) {
-              sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params);
+              sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params, cube.dimensions);
             } else {
               sql = baseSql;
             }
@@ -386,25 +386,41 @@ export class CubeEvaluator extends CubeSymbols {
     }
   }
 
-  private buildLinkSqlWithParams(cubeName: string, baseSql: any, params: Array<any>) {
+  private buildLinkSqlWithParams(cubeName: string, baseSql: any, params: Array<any>, dimensions: Record<string, any>) {
     if (params.length === 0) {
       return baseSql;
     }
 
+    const resolvedParams = params.map((param) => {
+      const rawKey = typeof param.key === 'function' ? param.key() : param.key;
+      const encodedKey = encodeURIComponent(rawKey).replace(/'/g, "''");
+      // The transpiler generates `dimName => dimName` for `{dimName}` references.
+      // Extract the dimension name and look up its sql directly.
+      const fnStr = typeof param.value === 'function' ? param.value.toString() : '';
+      const match = fnStr.match(/^(\w+)\s*=>\s*\1$/);
+      let valueSqlFn: any;
+      if (match && dimensions[match[1]]) {
+        valueSqlFn = dimensions[match[1]].sql;
+      } else {
+        valueSqlFn = param.value;
+      }
+      return { encodedKey, valueSqlFn };
+    });
+
+    // Pre-resolve each param value to its raw SQL column name, then build
+    // a simple function that returns the full SQL concatenation.
+    const paramSqlFragments = resolvedParams.map((p, idx) => {
+      const sep = idx === 0 ? '?' : '&';
+      const valSql = p.valueSqlFn(cubeName);
+      return ` || '${sep}${p.encodedKey}=' || REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(CAST((${valSql}) as TEXT), '%', '%25'), '&', '%26'), '=', '%3D'), '+', '%2B'), ' ', '%20')`;
+    }).join('');
+
+    // Escape for inclusion in a template literal
+    const escaped = paramSqlFragments.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+
     // eslint-disable-next-line no-new-func
-    const fn = new Function(cubeName, 'SQL_UTILS', `
-      var baseResult = (${baseSql.toString()})(${cubeName});
-      var result = baseResult;
-      ${params.map((param, idx) => {
-    const separator = idx === 0 ? '?' : '&';
-    const rawKey = typeof param.key === 'function' ? param.key() : param.key;
-    const encodedKey = encodeURIComponent(rawKey).replace(/'/g, "''");
-    const valueFnStr = typeof param.value === 'function' ? param.value.toString() : `function() { return '${String(param.value).replace(/'/g, "''").replace(/\\/g, '\\\\')}'; }`;
-    return `result = result + " || '${separator}${encodedKey}=' || " + SQL_UTILS.urlEncode((${valueFnStr})(${cubeName}));`;
-  }).join('\n      ')}
-      return result;
-    `);
-    Object.defineProperty(fn, 'length', { value: baseSql.length });
+    const fn = new Function(cubeName, `return \`\${(${baseSql.toString()})(${cubeName})}${escaped}\``);
+    Object.defineProperty(fn, 'length', { value: 1 });
     return fn;
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -402,23 +402,38 @@ export class CubeEvaluator extends CubeSymbols {
       return { encodedKey, valueFn: param.value };
     });
 
-    // Extract the argument name from each param value function using the same
+    // Extract ALL argument names from each param value function using the same
     // regex-based extraction that resolveSymbolsCall uses (funcArguments).
-    const paramArgNames = resolvedParams.map((p, idx) => {
+    // A param value can reference multiple members, e.g. CONCAT({first_name}, ' ', {last_name})
+    const paramArgSets = resolvedParams.map((p, idx) => {
       const args = this.funcArguments(p.valueFn);
-      return args[0] || `__param${idx}`;
+      return args.length > 0 ? args : [`__param${idx}`];
     });
 
-    // Build a function whose argument list includes the cube name, SQL_UTILS,
-    // and each param's reference symbol. resolveSymbolsCall extracts these arg
-    // names and resolves them: cube dims, cross-cube refs, FILTER_PARAMS, etc.
-    const allArgs = [cubeName, 'SQL_UTILS', ...paramArgNames];
+    // Collect all unique arg names across all params (deduped, preserving order)
+    const seenArgs = new Set([cubeName, 'SQL_UTILS']);
+    const extraArgs: string[] = [];
+    for (const argSet of paramArgSets) {
+      for (const arg of argSet) {
+        if (!seenArgs.has(arg)) {
+          seenArgs.add(arg);
+          extraArgs.push(arg);
+        }
+      }
+    }
 
+    // Build a function whose argument list includes the cube name, SQL_UTILS,
+    // and all referenced symbols. resolveSymbolsCall extracts these arg
+    // names and resolves them: cube dims, cross-cube refs, FILTER_PARAMS, etc.
+    const allArgs = [cubeName, 'SQL_UTILS', ...extraArgs];
+
+    // For each param, call its value function with the resolved args to get SQL
     const body = `
       var base = (${baseSql.toString()})(${cubeName});
       ${resolvedParams.map((p, idx) => {
     const sep = idx === 0 ? '?' : '&';
-    return `base += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode(${paramArgNames[idx]});`;
+    const paramArgs = paramArgSets[idx].join(', ');
+    return `base += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode((${p.valueFn.toString()})(${paramArgs}));`;
   }).join('\n      ')}
       return base;
     `;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -407,23 +407,23 @@ export class CubeEvaluator extends CubeSymbols {
       return { encodedKey, valueSqlFn };
     });
 
-    // Pre-resolve each param value to its raw SQL column name, then build
-    // a simple function that returns the full SQL concatenation.
-    // Uses REPLACE chain for URL encoding (matches BaseQuery.urlEncode default).
-    // Database-specific adapters override urlEncode at query execution time
-    // through the SQL_UTILS context for url-type link dimensions without params.
-    const paramSqlFragments = resolvedParams.map((p, idx) => {
+    // Pre-resolve each param value to its raw SQL column name.
+    // The function takes SQL_UTILS as a parameter so the compiler injects the
+    // sqlUtils context symbol (which provides database-specific urlEncode).
+    const paramParts = resolvedParams.map((p, idx) => {
       const sep = idx === 0 ? '?' : '&';
       const valSql = p.valueSqlFn(cubeName);
-      return ` || '${sep}${p.encodedKey}=' || REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(CAST((${valSql}) as TEXT), '%', '%25'), '&', '%26'), '=', '%3D'), '+', '%2B'), ' ', '%20')`;
-    }).join('');
-
-    // Escape for inclusion in a template literal
-    const escaped = paramSqlFragments.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
+      // valSql is a raw column reference like 'city' — escape quotes for JS string
+      const valSqlEscaped = valSql.replace(/'/g, "\\'");
+      return `result += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode('${valSqlEscaped}');`;
+    }).join('\n      ');
 
     // eslint-disable-next-line no-new-func
-    const fn = new Function(cubeName, `return \`\${(${baseSql.toString()})(${cubeName})}${escaped}\``);
-    Object.defineProperty(fn, 'length', { value: 1 });
+    const fn = new Function(cubeName, 'SQL_UTILS', `
+      var result = (${baseSql.toString()})(${cubeName});
+      ${paramParts}
+      return result;
+    `);
     return fn;
   }
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -565,6 +565,10 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
       this.transformPreAggregations(cube.preAggregations);
     }
 
+    if (this.evaluateViews && !cube.isView) {
+      this.generateSyntheticLinkDimensions(cube);
+    }
+
     if (this.evaluateViews) {
       this.prepareIncludes(cube, errorReporter, splitViews);
     }
@@ -629,6 +633,40 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
             );
           } else {
             dimension.keyReference = keyReference;
+          }
+        }
+      }
+    }
+  }
+
+  protected generateSyntheticLinkDimensions(cube: any) {
+    if (!cube.dimensions) return;
+
+    const dims = cube.dimensions;
+    for (const dimName of Object.keys(dims)) {
+      const dimDef = dims[dimName];
+      if (dimDef.links && Array.isArray(dimDef.links)) {
+        for (const link of dimDef.links) {
+          const linkName = typeof link.name === 'function' ? link.name() : link.name;
+          if (!linkName) return;
+          const syntheticName = `${dimName}___link_${linkName}_url`;
+          if (!dims[syntheticName]) {
+            let sql;
+            if (link.url) {
+              sql = link.url;
+            } else if (link.dashboard) {
+              const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
+              // eslint-disable-next-line no-new-func
+              sql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
+            }
+            if (sql) {
+              dims[syntheticName] = {
+                sql,
+                type: 'string',
+                synthetic: true,
+                public: true,
+              };
+            }
           }
         }
       }
@@ -723,9 +761,25 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
           .map((path) => path.split('.')[1])
           .filter(memberName => !(it.includes as (string | ViewCubeIncludeMember)[]).find((include) => ((typeof include === 'object' ? include.name : include)) === memberName));
 
+        // Auto-include synthetic link dimensions for included dimensions that have links
+        const syntheticLinkMembers: string[] = [];
+        const membersObj = this.symbols[cubeRef]?.cubeObj()?.dimensions || {};
+        for (const include of (it.includes as (string | ViewCubeIncludeMember)[])) {
+          const memberName = typeof include === 'object' ? include.name : include;
+          if (membersObj[memberName] && (membersObj[memberName] as any).links) {
+            for (const key of Object.keys(membersObj)) {
+              if (key.startsWith(`${memberName}___link_`) && key.endsWith('_url')) {
+                if (!(it.includes as (string | ViewCubeIncludeMember)[]).find((inc) => ((typeof inc === 'object' ? inc.name : inc)) === key)) {
+                  syntheticLinkMembers.push(key);
+                }
+              }
+            }
+          }
+        }
+
         return {
           ...it,
-          includes: (it.includes as (string | ViewCubeIncludeMember)[]).concat(currentCubeAutoIncludeMembers),
+          includes: (it.includes as (string | ViewCubeIncludeMember)[]).concat(currentCubeAutoIncludeMembers).concat(syntheticLinkMembers),
         };
       }) : includedCubes;
 
@@ -1015,6 +1069,8 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
           ...(resolvedMember.multiStage && { multiStage: resolvedMember.multiStage }),
           ...(resolvedMember.keyReference && this.processKeyReferenceForView(resolvedMember.keyReference, targetCube.name, viewAllMembers, memberRef.member)),
           ...(resolvedMember.mask !== undefined ? { mask: resolvedMember.mask } : {}),
+          ...(resolvedMember.links ? { links: resolvedMember.links } : {}),
+          ...(resolvedMember.synthetic ? { synthetic: true } : {}),
         };
       } else if (type === 'segments') {
         memberDefinition = {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -664,7 +664,7 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
                 sql,
                 type: 'string',
                 synthetic: true,
-                public: true,
+                public: dimDef.public !== false,
               };
             }
           }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -650,6 +650,9 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
           const linkName = typeof link.name === 'function' ? link.name() : link.name;
           if (!linkName) return;
           const syntheticName = `${dimName}___link_${linkName}_url`;
+          if (dims[syntheticName] && !dims[syntheticName].synthetic) {
+            throw new Error(`Link '${linkName}' on dimension '${dimName}' conflicts with existing dimension '${syntheticName}'`);
+          }
           if (!dims[syntheticName]) {
             let sql;
             if (link.url) {
@@ -665,6 +668,8 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
                 type: 'string',
                 synthetic: true,
                 public: dimDef.public !== false,
+                shown: dimDef.shown,
+                meta: dimDef.meta,
               };
             }
           }

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -663,12 +663,7 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
               baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
             }
             if (baseSql) {
-              let sql;
-              if (link.params && Array.isArray(link.params) && link.params.length > 0) {
-                sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params);
-              } else {
-                sql = baseSql;
-              }
+              const sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params || []);
               dims[syntheticName] = {
                 sql,
                 type: 'string',
@@ -691,12 +686,19 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
       return { encodedKey, valueFn: param.value };
     });
 
-    // Extract ALL argument names from each param value function
+    // Extract argument names from baseSql and each param value function
+    const baseSqlArgs = this.funcArguments(baseSql);
     const paramArgSets = resolvedParams.map((p) => this.funcArguments(p.valueFn));
 
     // Collect all unique arg names (deduped, preserving order)
     const seenArgs = new Set([cubeName, 'SQL_UTILS']);
     const extraArgs: string[] = [];
+    for (const arg of baseSqlArgs) {
+      if (!seenArgs.has(arg)) {
+        seenArgs.add(arg);
+        extraArgs.push(arg);
+      }
+    }
     for (const argSet of paramArgSets) {
       for (const arg of argSet) {
         if (!seenArgs.has(arg)) {
@@ -709,7 +711,7 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
     const allArgs = [cubeName, 'SQL_UTILS', ...extraArgs];
 
     const body = `
-      var base = (${baseSql.toString()})(${cubeName});
+      var base = \`\${(${baseSql.toString()})(${baseSqlArgs.join(', ')})}\`;
       ${resolvedParams.map((p, idx) => {
     const sep = idx === 0 ? '?' : '&';
     const paramArgs = paramArgSets[idx].join(', ');

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -658,24 +658,9 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
             if (link.url) {
               baseSql = link.url;
             } else if (link.dashboard) {
-              const dashboardStr = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
-              // Parse {dim} references from dashboard string and build a function
-              // that resolves them through the symbol resolver
-              const refs: string[] = [];
-              const sqlParts = dashboardStr.replace(/\{(\w+(?:\.\w+)*)\}/g, (_: string, ref: string) => {
-                refs.push(ref);
-                return `\${${ref}}`;
-              });
-              if (refs.length > 0) {
-                // Dynamic dashboard with dimension references
-                // eslint-disable-next-line no-new-func
-                baseSql = new Function(...refs, `return \`${sqlParts}\``);
-              } else {
-                // Static dashboard ID — wrap as SQL string literal with /dashboard/ prefix
-                const escaped = dashboardStr.replace(/'/g, "''");
-                // eslint-disable-next-line no-new-func
-                baseSql = new Function(cube.name, `return \`'/dashboard/${escaped}'\``);
-              }
+              const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
+              // eslint-disable-next-line no-new-func
+              baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
             }
             if (baseSql) {
               const sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params || []);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -691,11 +691,10 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
       return { encodedKey, valueFn: param.value };
     });
 
-    // Extract ALL argument names from each param value function using the same
-    // regex-based extraction that resolveSymbolsCall uses (funcArguments).
+    // Extract ALL argument names from each param value function
     const paramArgSets = resolvedParams.map((p) => this.funcArguments(p.valueFn));
 
-    // Collect all unique arg names across all params (deduped, preserving order)
+    // Collect all unique arg names (deduped, preserving order)
     const seenArgs = new Set([cubeName, 'SQL_UTILS']);
     const extraArgs: string[] = [];
     for (const argSet of paramArgSets) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -658,9 +658,24 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
             if (link.url) {
               baseSql = link.url;
             } else if (link.dashboard) {
-              const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
-              // eslint-disable-next-line no-new-func
-              baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
+              const dashboardStr = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
+              // Parse {dim} references from dashboard string and build a function
+              // that resolves them through the symbol resolver
+              const refs: string[] = [];
+              const sqlParts = dashboardStr.replace(/\{(\w+(?:\.\w+)*)\}/g, (_: string, ref: string) => {
+                refs.push(ref);
+                return `\${${ref}}`;
+              });
+              if (refs.length > 0) {
+                // Dynamic dashboard with dimension references
+                // eslint-disable-next-line no-new-func
+                baseSql = new Function(...refs, `return \`${sqlParts}\``);
+              } else {
+                // Static dashboard ID — wrap as SQL string literal with /dashboard/ prefix
+                const escaped = dashboardStr.replace(/'/g, "''");
+                // eslint-disable-next-line no-new-func
+                baseSql = new Function(cube.name, `return \`'/dashboard/${escaped}'\``);
+              }
             }
             if (baseSql) {
               const sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params || []);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -654,15 +654,21 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
             throw new Error(`Link '${linkName}' on dimension '${dimName}' conflicts with existing dimension '${syntheticName}'`);
           }
           if (!dims[syntheticName]) {
-            let sql;
+            let baseSql;
             if (link.url) {
-              sql = link.url;
+              baseSql = link.url;
             } else if (link.dashboard) {
               const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
               // eslint-disable-next-line no-new-func
-              sql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
+              baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
             }
-            if (sql) {
+            if (baseSql) {
+              let sql;
+              if (link.params && Array.isArray(link.params) && link.params.length > 0) {
+                sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params);
+              } else {
+                sql = baseSql;
+              }
               dims[syntheticName] = {
                 sql,
                 type: 'string',
@@ -676,6 +682,45 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
         }
       }
     }
+  }
+
+  protected buildLinkSqlWithParams(cubeName: string, baseSql: any, params: Array<any>) {
+    const resolvedParams = params.map((param) => {
+      const rawKey = typeof param.key === 'function' ? param.key() : param.key;
+      const encodedKey = encodeURIComponent(rawKey).replace(/'/g, "''");
+      return { encodedKey, valueFn: param.value };
+    });
+
+    // Extract ALL argument names from each param value function using the same
+    // regex-based extraction that resolveSymbolsCall uses (funcArguments).
+    const paramArgSets = resolvedParams.map((p) => this.funcArguments(p.valueFn));
+
+    // Collect all unique arg names across all params (deduped, preserving order)
+    const seenArgs = new Set([cubeName, 'SQL_UTILS']);
+    const extraArgs: string[] = [];
+    for (const argSet of paramArgSets) {
+      for (const arg of argSet) {
+        if (!seenArgs.has(arg)) {
+          seenArgs.add(arg);
+          extraArgs.push(arg);
+        }
+      }
+    }
+
+    const allArgs = [cubeName, 'SQL_UTILS', ...extraArgs];
+
+    const body = `
+      var base = (${baseSql.toString()})(${cubeName});
+      ${resolvedParams.map((p, idx) => {
+    const sep = idx === 0 ? '?' : '&';
+    const paramArgs = paramArgSets[idx].join(', ');
+    return `base += " || '${sep}${p.encodedKey}=' || " + SQL_UTILS.urlEncode((${p.valueFn.toString()})(${paramArgs}));`;
+  }).join('\n      ')}
+      return base;
+    `;
+
+    // eslint-disable-next-line no-new-func
+    return new Function(...allArgs, body);
   }
 
   protected transformPreAggregations(preAggregations: Object) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -658,9 +658,10 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
             if (link.url) {
               baseSql = link.url;
             } else if (link.dashboard) {
-              const dashboardId = typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard;
+              const dashboardId = link.dashboard;
+              const escaped = dashboardId.replace(/'/g, "''");
               // eslint-disable-next-line no-new-func
-              baseSql = new Function(cube.name, `return \`'/dashboard/${dashboardId}'\``);
+              baseSql = new Function(`return \`'/dashboard/${escaped}'\``);
             }
             if (baseSql) {
               const sql = this.buildLinkSqlWithParams(cube.name, baseSql, link.params || []);

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -51,6 +51,16 @@ export interface ExtendedCubeSymbolDefinition extends CubeSymbolDefinition {
   aggType?: string;
   keyReference?: string;
   currency?: string;
+  links?: Array<{
+    name: string;
+    label: string;
+    url?: (...args: any[]) => string;
+    dashboard?: string;
+    icon?: string;
+    target?: 'blank' | 'self';
+    params?: Array<{ key: string; value: (...args: any[]) => string }>;
+  }>;
+  synthetic?: boolean;
 }
 
 interface ExtendedCubeDefinition extends CubeDefinitionExtended {
@@ -97,6 +107,14 @@ export type MeasureConfig = {
   public: boolean;
 };
 
+export type LinkConfig = {
+  name: string;
+  label: string;
+  dashboard?: string;
+  icon?: string;
+  target: 'blank' | 'self';
+};
+
 export type DimensionConfig = {
   name: string;
   title: string;
@@ -115,6 +133,8 @@ export type DimensionConfig = {
   granularities?: GranularityDefinition[];
   order?: 'asc' | 'desc';
   key?: string;
+  links?: LinkConfig[];
+  synthetic?: boolean;
 };
 
 export type SegmentConfig = {
@@ -314,6 +334,14 @@ export class CubeToMetaTransformer implements CompilerInterface {
                 : undefined,
             order: extendedDimDef.order,
             key: extendedDimDef.keyReference,
+            ...(extendedDimDef.links ? { links: extendedDimDef.links.map((link: any) => ({
+              name: link.name,
+              label: link.label,
+              ...(link.dashboard ? { dashboard: typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard } : {}),
+              icon: link.icon,
+              target: link.target || 'blank',
+            })) } : {}),
+            ...(extendedDimDef.synthetic ? { synthetic: true } : {}),
           };
         }),
         segments: Object.entries(extendedCube.segments || {}).map((nameToSegment: [string, any]) => {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -113,6 +113,7 @@ export type LinkConfig = {
   dashboard?: string;
   icon?: string;
   target: 'blank' | 'self';
+  params?: string[];
 };
 
 export type DimensionConfig = {
@@ -340,6 +341,9 @@ export class CubeToMetaTransformer implements CompilerInterface {
               ...(link.dashboard ? { dashboard: typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard } : {}),
               icon: link.icon,
               target: link.target || 'blank',
+              ...(link.params && Array.isArray(link.params) && link.params.length > 0
+                ? { params: link.params.map((p: any) => (typeof p.key === 'function' ? p.key() : p.key)) }
+                : {}),
             })) } : {}),
             ...(extendedDimDef.synthetic ? { synthetic: true } : {}),
           };

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -113,6 +113,7 @@ export type LinkConfig = {
   dashboard?: string;
   icon?: string;
   target: 'blank' | 'self';
+  primary?: boolean;
   params?: string[];
 };
 
@@ -341,6 +342,7 @@ export class CubeToMetaTransformer implements CompilerInterface {
               ...(link.dashboard ? { dashboard: typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard } : {}),
               icon: link.icon,
               target: link.target || 'blank',
+              ...(link.primary ? { primary: true } : {}),
               ...(link.params && Array.isArray(link.params) && link.params.length > 0
                 ? { params: link.params.map((p: any) => (typeof p.key === 'function' ? p.key() : p.key)) }
                 : {}),

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -311,6 +311,21 @@ const MaskSchema = Joi.alternatives([
   Joi.string(),
 ]);
 
+const LinkItemSchema = Joi.object().keys({
+  name: identifier.required(),
+  label: Joi.string().required(),
+  url: Joi.func(),
+  dashboard: Joi.string(),
+  icon: Joi.string(),
+  target: Joi.string().valid('blank', 'self'),
+  params: Joi.array().items(Joi.object().keys({
+    key: Joi.string().required(),
+    value: Joi.func().required(),
+  })),
+}).oxor('url', 'dashboard');
+
+const LinksSchema = Joi.array().items(LinkItemSchema);
+
 const BaseDimensionWithoutSubQuery = {
   aliases: Joi.array().items(Joi.string()),
   type: Joi.any().valid('string', 'number', 'boolean', 'time', 'geo').required(),
@@ -323,6 +338,7 @@ const BaseDimensionWithoutSubQuery = {
   description: Joi.string(),
   suggestFilterValues: Joi.boolean().strict(),
   enableSuggestions: Joi.boolean().strict(),
+  links: LinksSchema,
   mask: MaskSchema,
   format: Joi.when('type', {
     switch: [

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -325,7 +325,7 @@ const LinkItemSchema = Joi.object().keys({
 }).oxor('url', 'dashboard');
 
 const LinksSchema = Joi.array().items(LinkItemSchema).custom((value, helpers) => {
-  const names = value.map((link: any) => typeof link.name === 'function' ? link.name() : link.name);
+  const names = value.map((link: any) => (typeof link.name === 'function' ? link.name() : link.name));
   const seen = new Set<string>();
   for (const name of names) {
     if (seen.has(name)) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -315,16 +315,26 @@ const LinkItemSchema = Joi.object().keys({
   name: identifier.required(),
   label: Joi.string().required(),
   url: Joi.func(),
-  dashboard: Joi.string(),
+  dashboard: Joi.string().regex(/^[_a-zA-Z0-9-]+$/, 'dashboard identifier'),
   icon: Joi.string(),
   target: Joi.string().valid('blank', 'self'),
   params: Joi.array().items(Joi.object().keys({
-    key: Joi.string().required(),
+    key: identifier.required(),
     value: Joi.func().required(),
   })),
 }).oxor('url', 'dashboard');
 
-const LinksSchema = Joi.array().items(LinkItemSchema);
+const LinksSchema = Joi.array().items(LinkItemSchema).custom((value, helpers) => {
+  const names = value.map((link: any) => typeof link.name === 'function' ? link.name() : link.name);
+  const seen = new Set<string>();
+  for (const name of names) {
+    if (seen.has(name)) {
+      return helpers.error('any.custom', { message: `Duplicate link name '${name}'` });
+    }
+    seen.add(name);
+  }
+  return value;
+});
 
 const BaseDimensionWithoutSubQuery = {
   aliases: Joi.array().items(Joi.string()),

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -319,7 +319,7 @@ const LinkItemSchema = Joi.object().keys({
   icon: Joi.string(),
   target: Joi.string().valid('blank', 'self'),
   params: Joi.array().items(Joi.object().keys({
-    key: identifier.required(),
+    key: Joi.string().required(),
     value: Joi.func().required(),
   })),
 }).oxor('url', 'dashboard');

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -29,6 +29,7 @@ export const nonStringFields = new Set([
   'readOnly',
   'prefix',
   'mask',
+  'dashboard',
 ]);
 
 const identifierRegex = /^[_a-zA-Z][_a-zA-Z0-9]*$/;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -315,7 +315,7 @@ const LinkItemSchema = Joi.object().keys({
   name: identifier.required(),
   label: Joi.string().required(),
   url: Joi.func(),
-  dashboard: Joi.string().regex(/^[_a-zA-Z0-9-]+$/, 'dashboard identifier'),
+  dashboard: Joi.string(),
   icon: Joi.string(),
   target: Joi.string().valid('blank', 'self'),
   primary: Joi.boolean().strict(),

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -29,7 +29,6 @@ export const nonStringFields = new Set([
   'readOnly',
   'prefix',
   'mask',
-  'dashboard',
 ]);
 
 const identifierRegex = /^[_a-zA-Z][_a-zA-Z0-9]*$/;

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -318,6 +318,7 @@ const LinkItemSchema = Joi.object().keys({
   dashboard: Joi.string().regex(/^[_a-zA-Z0-9-]+$/, 'dashboard identifier'),
   icon: Joi.string(),
   target: Joi.string().valid('blank', 'self'),
+  primary: Joi.boolean().strict(),
   params: Joi.array().items(Joi.object().keys({
     key: Joi.string().required(),
     value: Joi.func().required(),
@@ -332,6 +333,10 @@ const LinksSchema = Joi.array().items(LinkItemSchema).custom((value, helpers) =>
       return helpers.error('any.custom', { message: `Duplicate link name '${name}'` });
     }
     seen.add(name);
+  }
+  const primaryCount = value.filter((link: any) => link.primary === true).length;
+  if (primaryCount > 1) {
+    return helpers.error('any.custom', { message: 'Only one link can be marked as primary' });
   }
   return value;
 });

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -235,12 +235,11 @@ export class YamlCompiler {
       const ast = this.parsePythonAndTranspileToJs(obj, errorsReport);
       return this.astIntoArrowFunction(ast, obj, cubeName, name => this.cubeDictionary.resolveCube(name));
     } else if (typeof obj === 'string') {
-      let code = obj;
-
-      if (!nonStringFields.has(propertyPath[propertyPath.length - 1])) {
-        code = `f"${this.escapeDoubleQuotes(obj)}"`;
+      if (nonStringFields.has(propertyPath[propertyPath.length - 1])) {
+        return t.stringLiteral(obj);
       }
 
+      const code = `f"${this.escapeDoubleQuotes(obj)}"`;
       const ast = this.parsePythonAndTranspileToJs(code, errorsReport);
       return this.extractProgramBodyIfNeeded(ast);
     } else if (typeof obj === 'boolean') {

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -235,11 +235,12 @@ export class YamlCompiler {
       const ast = this.parsePythonAndTranspileToJs(obj, errorsReport);
       return this.astIntoArrowFunction(ast, obj, cubeName, name => this.cubeDictionary.resolveCube(name));
     } else if (typeof obj === 'string') {
-      if (nonStringFields.has(propertyPath[propertyPath.length - 1])) {
-        return t.stringLiteral(obj);
+      let code = obj;
+
+      if (!nonStringFields.has(propertyPath[propertyPath.length - 1])) {
+        code = `f"${this.escapeDoubleQuotes(obj)}"`;
       }
 
-      const code = `f"${this.escapeDoubleQuotes(obj)}"`;
       const ast = this.parsePythonAndTranspileToJs(code, errorsReport);
       return this.extractProgramBodyIfNeeded(ast);
     } else if (typeof obj === 'boolean') {

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
@@ -43,6 +43,8 @@ export const transpiledFieldsPatterns: Array<RegExp> = [
   /^(defaultFilters|default_filters)\.[0-9]+\.values$/,
   /^(defaultFilters|default_filters)\.[0-9]+\.unless$/,
   /^(measures|dimensions)\.[_a-zA-Z][_a-zA-Z0-9]*\.mask\.sql$/,
+  /^dimensions\.[_a-zA-Z][_a-zA-Z0-9]*\.links\.[0-9]+\.url$/,
+  /^dimensions\.[_a-zA-Z][_a-zA-Z0-9]*\.links\.[0-9]+\.params\.[0-9]+\.value$/,
 ];
 
 export const transpiledFields: Set<String> = new Set<String>();

--- a/packages/cubejs-schema-compiler/test/unit/links.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/links.test.ts
@@ -138,6 +138,58 @@ cubes:
     }
   });
 
+  it('should reject duplicate link names on same dimension', async () => {
+    const schema = `
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: dup
+            label: First
+            url: "{full_name}"
+          - name: dup
+            label: Second
+            url: "{full_name}"
+`;
+    const compilers = prepareYamlCompiler(schema);
+    try {
+      await compilers.compiler.compile();
+      fail('Should have thrown for duplicate link name');
+    } catch (e: any) {
+      expect(e.message || e.toString()).toMatch(/[Dd]uplicate.*dup/);
+    }
+  });
+
+  it('should reject link that collides with user-defined dimension', async () => {
+    const schema = `
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: custom
+            label: Link
+            url: "{full_name}"
+      - name: full_name___link_custom_url
+        sql: "'manual'"
+        type: string
+`;
+    const compilers = prepareYamlCompiler(schema);
+    try {
+      await compilers.compiler.compile();
+      fail('Should have thrown for collision');
+    } catch (e: any) {
+      expect(e.message || e.toString()).toMatch(/conflict|collision|already/i);
+    }
+  });
+
   describe('dashboard links', () => {
     const schemaWithDashboardLink = `
 cubes:

--- a/packages/cubejs-schema-compiler/test/unit/links.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/links.test.ts
@@ -1,0 +1,426 @@
+import { PostgresQuery } from '../../src';
+import { prepareYamlCompiler } from './PrepareCompiler';
+
+describe('Links', () => {
+  const schemaWithLinks = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "{full_name}"
+            icon: brand-google
+            target: blank
+          - name: send_email
+            label: Write an email
+            url: "{email}"
+            icon: send
+
+      - name: email
+        sql: email
+        type: string
+`;
+
+  it('should create synthetic link URL dimensions', async () => {
+    const compilers = prepareYamlCompiler(schemaWithLinks);
+    await compilers.compiler.compile();
+
+    const googleDef = compilers.cubeEvaluator.dimensionByPath('users.full_name___link_google_search_url');
+    expect(googleDef).toBeDefined();
+    expect(googleDef.type).toBe('string');
+    expect((googleDef as any).synthetic).toBe(true);
+
+    const emailDef = compilers.cubeEvaluator.dimensionByPath('users.full_name___link_send_email_url');
+    expect(emailDef).toBeDefined();
+    expect(emailDef.type).toBe('string');
+    expect((emailDef as any).synthetic).toBe(true);
+  });
+
+  it('synthetic link dimension exists and can be referenced', async () => {
+    const compilers = prepareYamlCompiler(schemaWithLinks);
+    await compilers.compiler.compile();
+
+    const dimDef = compilers.cubeEvaluator.dimensionByPath('users.full_name___link_google_search_url');
+    expect(dimDef).toBeDefined();
+    expect(dimDef.type).toBe('string');
+    expect(typeof dimDef.sql).toBe('function');
+  });
+
+  it('should NOT include link URL columns unless explicitly queried', async () => {
+    const compilers = prepareYamlCompiler(schemaWithLinks);
+    await compilers.compiler.compile();
+
+    const query = new PostgresQuery(compilers, {
+      measures: [],
+      dimensions: ['users.full_name'],
+    });
+
+    const queryAndParams = query.buildSqlAndParams();
+    const sql = queryAndParams[0];
+
+    expect(sql).not.toContain('___link_');
+  });
+
+  it('should expose links metadata and synthetic flag in meta config', async () => {
+    const compilers = prepareYamlCompiler(schemaWithLinks);
+    await compilers.compiler.compile();
+
+    const { metaTransformer } = compilers;
+    const { cubes } = metaTransformer;
+    const usersCube = cubes.find((c: any) => c.config.name === 'users');
+    expect(usersCube).toBeDefined();
+
+    const fullNameDim = usersCube!.config.dimensions.find(
+      (d: any) => d.name === 'users.full_name'
+    );
+    expect(fullNameDim).toBeDefined();
+    expect(fullNameDim!.links).toBeDefined();
+    expect(fullNameDim!.links).toHaveLength(2);
+    expect(fullNameDim!.links![0].label).toBe('Search on Google');
+    expect(fullNameDim!.links![0].icon).toBe('brand-google');
+    expect(fullNameDim!.links![0].target).toBe('blank');
+
+    const syntheticDim = usersCube!.config.dimensions.find(
+      (d: any) => d.name === 'users.full_name___link_google_search_url'
+    );
+    expect(syntheticDim).toBeDefined();
+    expect(syntheticDim!.synthetic).toBe(true);
+  });
+
+  it('synthetic link dimensions should be public by default', async () => {
+    const compilers = prepareYamlCompiler(schemaWithLinks);
+    await compilers.compiler.compile();
+
+    const { metaTransformer } = compilers;
+    const { cubes } = metaTransformer;
+    const usersCube = cubes.find((c: any) => c.config.name === 'users');
+    expect(usersCube).toBeDefined();
+
+    const syntheticDim = usersCube!.config.dimensions.find(
+      (d: any) => d.name === 'users.full_name___link_google_search_url'
+    );
+    expect(syntheticDim).toBeDefined();
+    expect(syntheticDim!.public).toBe(true);
+  });
+
+  it('should validate links schema - label is required', async () => {
+    const invalidSchema = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: test
+            url: "{full_name}"
+`;
+    const compilers = prepareYamlCompiler(invalidSchema);
+
+    try {
+      await compilers.compiler.compile();
+      fail('Should have thrown an error for missing label');
+    } catch (e: any) {
+      expect(e.message || e.toString()).toMatch(/label/i);
+    }
+  });
+
+  describe('dashboard links', () => {
+    const schemaWithDashboardLink = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: overview
+            label: View dashboard
+            dashboard: abc123
+            icon: dashboard
+`;
+
+    it('should create synthetic dimension for dashboard link', async () => {
+      const compilers = prepareYamlCompiler(schemaWithDashboardLink);
+      await compilers.compiler.compile();
+
+      const dimDef = compilers.cubeEvaluator.dimensionByPath('users.full_name___link_overview_url');
+      expect(dimDef).toBeDefined();
+      expect(dimDef.type).toBe('string');
+      expect((dimDef as any).synthetic).toBe(true);
+    });
+
+    it('should expose dashboard in meta config', async () => {
+      const compilers = prepareYamlCompiler(schemaWithDashboardLink);
+      await compilers.compiler.compile();
+
+      const { metaTransformer } = compilers;
+      const { cubes } = metaTransformer;
+      const usersCube = cubes.find((c: any) => c.config.name === 'users');
+      expect(usersCube).toBeDefined();
+
+      const fullNameDim = usersCube!.config.dimensions.find(
+        (d: any) => d.name === 'users.full_name'
+      );
+      expect(fullNameDim).toBeDefined();
+      expect(fullNameDim!.links![0].dashboard).toBe('abc123');
+    });
+
+    it('should not allow both url and dashboard on same link', async () => {
+      const invalidSchema = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: both
+            label: Invalid
+            url: "{full_name}"
+            dashboard: abc123
+`;
+      const compilers = prepareYamlCompiler(invalidSchema);
+
+      try {
+        await compilers.compiler.compile();
+        fail('Should have thrown a validation error');
+      } catch (e: any) {
+        expect(e.message || e.toString()).toMatch(/url.*dashboard|dashboard.*url/i);
+      }
+    });
+  });
+
+  describe('params', () => {
+    const schemaWithParams = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: profile
+            label: View profile
+            dashboard: dash123
+            params:
+              - key: user_id
+                value: "{id}"
+              - key: user_name
+                value: "{full_name}"
+
+      - name: country
+        sql: country
+        type: string
+`;
+
+    it('should create synthetic dimension with params', async () => {
+      const compilers = prepareYamlCompiler(schemaWithParams);
+      await compilers.compiler.compile();
+
+      const dimDef = compilers.cubeEvaluator.dimensionByPath('users.full_name___link_profile_url');
+      expect(dimDef).toBeDefined();
+      expect(dimDef.type).toBe('string');
+      expect((dimDef as any).synthetic).toBe(true);
+      expect(typeof dimDef.sql).toBe('function');
+    });
+
+    it('should generate SQL with urlEncode for params', async () => {
+      const compilers = prepareYamlCompiler(schemaWithParams);
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: [],
+        dimensions: ['users.full_name___link_profile_url'],
+      });
+
+      const queryAndParams = query.buildSqlAndParams();
+      const sql = queryAndParams[0];
+
+      expect(sql).toContain('/dashboard/dash123');
+      expect(sql).toContain('user_id=');
+      expect(sql).toContain('name=');
+      expect(sql).toContain('REPLACE');
+    });
+  });
+
+  describe('access policy on view with links', () => {
+    const schemaWithViewAndPolicy = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "{full_name}"
+            icon: brand-google
+
+      - name: email
+        sql: email
+        type: string
+
+views:
+  - name: users_view
+    cubes:
+      - join_path: users
+        includes:
+          - full_name
+          - email
+    access_policy:
+      - role: "*"
+        member_level:
+          includes:
+            - full_name
+            - full_name___link_google_search_url
+`;
+
+    it('should include synthetic link dim when explicitly listed in access policy', async () => {
+      const compilers = prepareYamlCompiler(schemaWithViewAndPolicy);
+      await compilers.compiler.compile();
+
+      const viewCube = compilers.cubeEvaluator.cubeFromPath('users_view');
+      expect(viewCube).toBeDefined();
+
+      const policy = viewCube.accessPolicy![0];
+      expect(policy.memberLevel!.includesMembers).toContain('users_view.full_name');
+      expect(policy.memberLevel!.includesMembers).toContain('users_view.full_name___link_google_search_url');
+    });
+
+    const schemaWithViewPolicyExcludeLink = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "{full_name}"
+            icon: brand-google
+
+      - name: email
+        sql: email
+        type: string
+
+views:
+  - name: users_view
+    cubes:
+      - join_path: users
+        includes:
+          - full_name
+          - email
+    access_policy:
+      - role: "*"
+        member_level:
+          includes:
+            - full_name
+            - email
+`;
+
+    it('should exclude synthetic link dim when not listed in access policy includes', async () => {
+      const compilers = prepareYamlCompiler(schemaWithViewPolicyExcludeLink);
+      await compilers.compiler.compile();
+
+      const viewCube = compilers.cubeEvaluator.cubeFromPath('users_view');
+      expect(viewCube).toBeDefined();
+
+      const policy = viewCube.accessPolicy![0];
+      expect(policy.memberLevel!.includesMembers).toContain('users_view.full_name');
+      expect(policy.memberLevel!.includesMembers).toContain('users_view.email');
+      expect(policy.memberLevel!.includesMembers).not.toContain('users_view.full_name___link_google_search_url');
+    });
+
+    const schemaWithViewPolicyWildcard = `
+cubes:
+  - name: users
+    sql_table: users
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "{full_name}"
+            icon: brand-google
+
+      - name: email
+        sql: email
+        type: string
+
+views:
+  - name: users_view
+    cubes:
+      - join_path: users
+        includes: "*"
+    access_policy:
+      - role: "*"
+        member_level:
+          includes: "*"
+`;
+
+    it('should include synthetic link dim when access policy uses wildcard includes', async () => {
+      const compilers = prepareYamlCompiler(schemaWithViewPolicyWildcard);
+      await compilers.compiler.compile();
+
+      const viewCube = compilers.cubeEvaluator.cubeFromPath('users_view');
+      expect(viewCube).toBeDefined();
+
+      const policy = viewCube.accessPolicy![0];
+      expect(policy.memberLevel!.includesMembers).toContain('users_view.full_name___link_google_search_url');
+    });
+  });
+});

--- a/packages/cubejs-schema-compiler/test/unit/links.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/links.test.ts
@@ -323,6 +323,54 @@ cubes:
       expect(sql).toContain('name=');
       expect(sql).toContain('REPLACE');
     });
+
+    it('should url-encode param values with special characters', async () => {
+      const schemaWithSpecialChars = `
+cubes:
+  - name: items
+    sql: >
+      SELECT 'hello world & more' as name, 'a=b+c' as code
+
+    dimensions:
+      - name: name
+        sql: name
+        type: string
+        links:
+          - name: search
+            label: Search
+            dashboard: dash1
+            params:
+              - key: q
+                value: "{name}"
+              - key: filter
+                value: "{code}"
+
+      - name: code
+        sql: code
+        type: string
+`;
+      const compilers = prepareYamlCompiler(schemaWithSpecialChars);
+      await compilers.compiler.compile();
+
+      const query = new PostgresQuery(compilers, {
+        measures: [],
+        dimensions: ['items.name___link_search_url'],
+      });
+
+      const queryAndParams = query.buildSqlAndParams();
+      const sql = queryAndParams[0];
+
+      // The SQL should wrap each param value in REPLACE chains for URL encoding
+      // Encoding: % -> %25, & -> %26, = -> %3D, + -> %2B, space -> %20
+      expect(sql).toContain("'%', '%25'");
+      expect(sql).toContain("'&', '%26'");
+      expect(sql).toContain("'=', '%3D'");
+      expect(sql).toContain("'+', '%2B'");
+      expect(sql).toContain("' ', '%20'");
+      // Should have REPLACE for both params (name and code)
+      const replaceCount = (sql.match(/REPLACE/g) || []).length;
+      expect(replaceCount).toBeGreaterThanOrEqual(10);
+    });
   });
 
   describe('access policy on view with links', () => {

--- a/packages/cubejs-schema-compiler/test/unit/links.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/links.test.ts
@@ -190,6 +190,34 @@ cubes:
     }
   });
 
+  it('should reject multiple primary links on same dimension', async () => {
+    const schema = `
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: full_name
+        sql: full_name
+        type: string
+        links:
+          - name: first
+            label: First
+            url: "{full_name}"
+            primary: true
+          - name: second
+            label: Second
+            url: "{full_name}"
+            primary: true
+`;
+    const compilers = prepareYamlCompiler(schema);
+    try {
+      await compilers.compiler.compile();
+      fail('Should have thrown for multiple primary links');
+    } catch (e: any) {
+      expect(e.message || e.toString()).toMatch(/primary/i);
+    }
+  });
+
   describe('dashboard links', () => {
     const schemaWithDashboardLink = `
 cubes:

--- a/packages/cubejs-testing/birdbox-fixtures/links/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/links/cube.js
@@ -1,0 +1,2 @@
+module.exports = {
+};

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/orders.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/orders.yaml
@@ -1,0 +1,34 @@
+cubes:
+  - name: orders
+    sql: >
+      SELECT 1 as id, 1 as user_id, 'completed' as status
+      UNION ALL
+      SELECT 2, 2, 'pending'
+
+    joins:
+      - name: users
+        sql: "{CUBE}.user_id = {users.id}"
+        relationship: many_to_one
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: status
+        sql: status
+        type: string
+        links:
+          - name: user_link
+            label: View user
+            dashboard: user_detail
+            params:
+              - key: user_name
+                value: "{users.full_name}"
+              - key: user_city
+                value: "{users.city}"
+
+    measures:
+      - name: count
+        type: count

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -1,0 +1,32 @@
+cubes:
+  - name: users
+    sql: >
+      SELECT 1 as id, 'John' as first_name, 'Doe' as last_name, 'New York' as city
+      UNION ALL
+      SELECT 2, 'Jane', 'Smith', 'London'
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: full_name
+        sql: "first_name || ' ' || last_name"
+        type: string
+        links:
+          - name: google_search
+            label: Search on Google
+            url: "{full_name}"
+            icon: brand-google
+          - name: profile
+            label: View profile
+            dashboard: user_profile_123
+
+      - name: city
+        sql: city
+        type: string
+
+    measures:
+      - name: count
+        type: count

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -30,6 +30,14 @@ cubes:
                 value: "{city}"
               - key: user_id
                 value: "{id}"
+          - name: crm_link
+            label: View in CRM
+            url: "'https://crm.example.com/contacts'"
+            params:
+              - key: name
+                value: "{full_name}"
+              - key: city
+                value: "{city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -42,7 +42,7 @@ cubes:
                 value: "{city}"
           - name: dynamic_dashboard
             label: City-specific dashboard
-            url: "'/dashboard/' || {city}"
+            url: "{city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -38,6 +38,8 @@ cubes:
                 value: "{full_name}"
               - key: city
                 value: "{city}"
+              - key: duplicate_city
+                value: "{city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -40,9 +40,6 @@ cubes:
                 value: "{city}"
               - key: duplicate_city
                 value: "{city}"
-          - name: dynamic_dashboard
-            label: City-specific dashboard
-            url: "{city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -40,9 +40,6 @@ cubes:
                 value: "{city}"
               - key: duplicate_city
                 value: "{city}"
-          - name: dynamic_dash
-            label: Dynamic dashboard
-            dashboard: "{city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -40,6 +40,9 @@ cubes:
                 value: "{city}"
               - key: duplicate_city
                 value: "{city}"
+          - name: dynamic_dashboard
+            label: City-specific dashboard
+            url: "'/dashboard/' || {city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -40,6 +40,9 @@ cubes:
                 value: "{city}"
               - key: duplicate_city
                 value: "{city}"
+          - name: dynamic_dash
+            label: Dynamic dashboard
+            dashboard: "{city}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -32,9 +32,9 @@ cubes:
                 value: "{id}"
           - name: crm_link
             label: View in CRM
-            url: "'https://crm.example.com/contacts'"
+            dashboard: crm_contacts
             params:
-              - key: name
+              - key: full_name
                 value: "{full_name}"
               - key: city
                 value: "{city}"

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/cubes/users.yaml
@@ -22,6 +22,14 @@ cubes:
           - name: profile
             label: View profile
             dashboard: user_profile_123
+          - name: city_dashboard
+            label: City dashboard
+            dashboard: city_dash
+            params:
+              - key: city
+                value: "{city}"
+              - key: user_id
+                value: "{id}"
 
       - name: city
         sql: city

--- a/packages/cubejs-testing/birdbox-fixtures/links/model/views/users_view.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/links/model/views/users_view.yaml
@@ -1,0 +1,12 @@
+views:
+  - name: users_with_links
+    cubes:
+      - join_path: users
+        includes:
+          - full_name
+          - city
+
+  - name: users_all
+    cubes:
+      - join_path: users
+        includes: "*"

--- a/packages/cubejs-testing/package.json
+++ b/packages/cubejs-testing/package.json
@@ -84,6 +84,7 @@
     "smoke:vertica:snapshot": "jest --verbose --updateSnapshot -i dist/test/smoke-vertica.test.js",
     "smoke:rbac": "TZ=UTC jest --verbose -i dist/test/smoke-rbac.test.js",
     "smoke:rbac-graphql": "TZ=UTC jest --verbose -i dist/test/smoke-rbac-graphql.test.js",
+    "smoke:links": "jest --verbose -i dist/test/smoke-links.test.js",
     "smoke:cubesql": "TZ=UTC jest --verbose --forceExit -i dist/test/smoke-cubesql.test.js",
     "smoke:cubesql:snapshot": "TZ=UTC jest --verbose --forceExit --updateSnapshot -i dist/test/smoke-cubesql.test.js",
     "smoke:prestodb": "jest --verbose -i dist/test/smoke-prestodb.test.js",

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -1,0 +1,128 @@
+import fetch from 'node-fetch';
+import { StartedTestContainer } from 'testcontainers';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { afterAll, beforeAll, expect, jest } from '@jest/globals';
+import cubejs, { CubeApi } from '@cubejs-client/core';
+import { PostgresDBRunner } from '@cubejs-backend/testing-shared';
+import { BirdBox, getBirdbox } from '../src';
+import {
+  DEFAULT_API_TOKEN,
+  DEFAULT_CONFIG,
+  JEST_AFTER_ALL_DEFAULT_TIMEOUT,
+  JEST_BEFORE_ALL_DEFAULT_TIMEOUT,
+} from './smoke-tests';
+
+describe('links through views', () => {
+  jest.setTimeout(60 * 5 * 1000);
+  let db: StartedTestContainer;
+  let birdbox: BirdBox;
+  let client: CubeApi;
+
+  beforeAll(async () => {
+    db = await PostgresDBRunner.startContainer({});
+    birdbox = await getBirdbox(
+      'postgres',
+      {
+        ...DEFAULT_CONFIG,
+        CUBEJS_DB_HOST: db.getHost(),
+        CUBEJS_DB_PORT: `${db.getMappedPort(5432)}`,
+        CUBEJS_DB_NAME: 'test',
+        CUBEJS_DB_USER: 'test',
+        CUBEJS_DB_PASS: 'test',
+      },
+      {
+        schemaDir: 'links/model',
+        cubejsConfig: 'links/cube.js',
+      },
+    );
+    client = cubejs(async () => DEFAULT_API_TOKEN, {
+      apiUrl: birdbox.configuration.apiUrl,
+    });
+  }, JEST_BEFORE_ALL_DEFAULT_TIMEOUT);
+
+  afterAll(async () => {
+    await birdbox.stop();
+    await db.stop();
+  }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
+
+  test('meta exposes link synthetic dimensions on view with explicit includes', async () => {
+    const meta = await fetch(
+      `${birdbox.configuration.apiUrl}/meta`,
+      { headers: { Authorization: DEFAULT_API_TOKEN } }
+    );
+    const metaJson = await meta.json() as any;
+
+    const view = metaJson.cubes.find((c: any) => c.name === 'users_with_links');
+    expect(view).toBeDefined();
+
+    const dimNames = view.dimensions.map((d: any) => d.name);
+    expect(dimNames).toContain('users_with_links.full_name');
+    expect(dimNames).toContain('users_with_links.full_name___link_google_search_url');
+    expect(dimNames).toContain('users_with_links.full_name___link_profile_url');
+  });
+
+  test('meta exposes links metadata on parent dimension', async () => {
+    const meta = await fetch(
+      `${birdbox.configuration.apiUrl}/meta`,
+      { headers: { Authorization: DEFAULT_API_TOKEN } }
+    );
+    const metaJson = await meta.json() as any;
+
+    const view = metaJson.cubes.find((c: any) => c.name === 'users_with_links');
+    const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
+
+    expect(fullNameDim.links).toBeDefined();
+    expect(fullNameDim.links).toHaveLength(2);
+    expect(fullNameDim.links[0].name).toBe('google_search');
+    expect(fullNameDim.links[0].label).toBe('Search on Google');
+    expect(fullNameDim.links[0].icon).toBe('brand-google');
+    expect(fullNameDim.links[1].name).toBe('profile');
+    expect(fullNameDim.links[1].dashboard).toBe('user_profile_123');
+  });
+
+  test('synthetic link dimensions are marked as synthetic in meta', async () => {
+    const meta = await fetch(
+      `${birdbox.configuration.apiUrl}/meta`,
+      { headers: { Authorization: DEFAULT_API_TOKEN } }
+    );
+    const metaJson = await meta.json() as any;
+
+    const view = metaJson.cubes.find((c: any) => c.name === 'users_with_links');
+    const syntheticDim = view.dimensions.find(
+      (d: any) => d.name === 'users_with_links.full_name___link_google_search_url'
+    );
+
+    expect(syntheticDim).toBeDefined();
+    expect(syntheticDim.synthetic).toBe(true);
+    expect(syntheticDim.type).toBe('string');
+  });
+
+  test('wildcard view includes all link synthetic dimensions', async () => {
+    const meta = await fetch(
+      `${birdbox.configuration.apiUrl}/meta`,
+      { headers: { Authorization: DEFAULT_API_TOKEN } }
+    );
+    const metaJson = await meta.json() as any;
+
+    const view = metaJson.cubes.find((c: any) => c.name === 'users_all');
+    expect(view).toBeDefined();
+
+    const dimNames = view.dimensions.map((d: any) => d.name);
+    expect(dimNames).toContain('users_all.full_name___link_google_search_url');
+    expect(dimNames).toContain('users_all.full_name___link_profile_url');
+  });
+
+  test('can query dashboard link synthetic dimension through view', async () => {
+    const response = await client.load({
+      dimensions: [
+        'users_with_links.full_name',
+        'users_with_links.full_name___link_profile_url',
+      ],
+      limit: 1,
+    });
+    const data = response.rawData();
+    expect(data.length).toBeGreaterThanOrEqual(1);
+    const url = data[0]['users_with_links.full_name___link_profile_url'];
+    expect(url).toContain('/dashboard/user_profile_123');
+  });
+});

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -223,15 +223,15 @@ describe('links through views', () => {
 
     // Jane Smith, city=London
     const janeUrl = data[0]['users.full_name___link_crm_link_url'];
-    expect(janeUrl).toContain('https://crm.example.com/contacts');
-    expect(janeUrl).toContain('name=');
+    expect(janeUrl).toContain('/dashboard/crm_contacts');
+    expect(janeUrl).toContain('full_name=');
     expect(janeUrl).toContain('city=');
     expect(janeUrl).toContain('London');
 
-    // John Doe, city=New York (space encoded), name contains space
+    // John Doe, city=New York (space encoded)
     const johnUrl = data[1]['users.full_name___link_crm_link_url'];
-    expect(johnUrl).toContain('https://crm.example.com/contacts');
-    expect(johnUrl).toContain('name=');
+    expect(johnUrl).toContain('/dashboard/crm_contacts');
+    expect(johnUrl).toContain('full_name=');
     expect(johnUrl).toContain('city=');
     expect(johnUrl).toContain('New%20York');
   });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -72,7 +72,7 @@ describe('links through views', () => {
     const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
 
     expect(fullNameDim.links).toBeDefined();
-    expect(fullNameDim.links).toHaveLength(4);
+    expect(fullNameDim.links).toHaveLength(5);
     expect(fullNameDim.links[0].name).toBe('google_search');
     expect(fullNameDim.links[0].label).toBe('Search on Google');
     expect(fullNameDim.links[0].icon).toBe('brand-google');
@@ -274,5 +274,30 @@ describe('links through views', () => {
     expect(pendingUrl).toContain('user_name=');
     expect(pendingUrl).toContain('user_city=');
     expect(pendingUrl).toContain('London');
+  });
+
+  test('dashboard referencing cube member produces dynamic dashboard path', async () => {
+    const response = await client.load({
+      dimensions: [
+        'users.full_name',
+        'users.full_name___link_dynamic_dashboard_url',
+      ],
+      order: {
+        'users.full_name': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    // Jane Smith lives in London → /dashboard/London
+    const janeUrl = data[0]['users.full_name___link_dynamic_dashboard_url'];
+    expect(janeUrl).toContain('/dashboard/');
+    expect(janeUrl).toContain('London');
+
+    // John Doe lives in New York → /dashboard/New York
+    const johnUrl = data[1]['users.full_name___link_dynamic_dashboard_url'];
+    expect(johnUrl).toContain('/dashboard/');
+    expect(johnUrl).toContain('New York');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -290,14 +290,12 @@ describe('links through views', () => {
     const data = response.rawData();
     expect(data.length).toBe(2);
 
-    // Jane Smith lives in London → /dashboard/London
+    // Jane Smith lives in London
     const janeUrl = data[0]['users.full_name___link_dynamic_dashboard_url'];
-    expect(janeUrl).toContain('/dashboard/');
-    expect(janeUrl).toContain('London');
+    expect(janeUrl).toBe('London');
 
-    // John Doe lives in New York → /dashboard/New York
+    // John Doe lives in New York
     const johnUrl = data[1]['users.full_name___link_dynamic_dashboard_url'];
-    expect(johnUrl).toContain('/dashboard/');
-    expect(johnUrl).toContain('New York');
+    expect(johnUrl).toBe('New York');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -117,6 +117,27 @@ describe('links through views', () => {
     expect(dimNames).toContain('users_all.full_name___link_profile_url');
   });
 
+  test('google_search link resolves full_name dimension value', async () => {
+    const response = await client.load({
+      dimensions: [
+        'users.full_name',
+        'users.full_name___link_google_search_url',
+      ],
+      order: {
+        'users.full_name': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    expect(data[0]['users.full_name']).toBe('Jane Smith');
+    expect(data[0]['users.full_name___link_google_search_url']).toBe('Jane Smith');
+
+    expect(data[1]['users.full_name']).toBe('John Doe');
+    expect(data[1]['users.full_name___link_google_search_url']).toBe('John Doe');
+  });
+
   test('can query dashboard link synthetic dimension through view', async () => {
     const response = await client.load({
       dimensions: [

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -72,7 +72,7 @@ describe('links through views', () => {
     const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
 
     expect(fullNameDim.links).toBeDefined();
-    expect(fullNameDim.links).toHaveLength(3);
+    expect(fullNameDim.links).toHaveLength(4);
     expect(fullNameDim.links[0].name).toBe('google_search');
     expect(fullNameDim.links[0].label).toBe('Search on Google');
     expect(fullNameDim.links[0].icon).toBe('brand-google');
@@ -205,5 +205,34 @@ describe('links through views', () => {
     expect(johnUrl).toContain('city=');
     expect(johnUrl).toContain('New%20York');
     expect(johnUrl).toContain('user_id=');
+  });
+
+  test('url link with params combines base URL and encoded query string', async () => {
+    const response = await client.load({
+      dimensions: [
+        'users.full_name',
+        'users.full_name___link_crm_link_url',
+      ],
+      order: {
+        'users.full_name': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    // Jane Smith, city=London
+    const janeUrl = data[0]['users.full_name___link_crm_link_url'];
+    expect(janeUrl).toContain('https://crm.example.com/contacts');
+    expect(janeUrl).toContain('name=');
+    expect(janeUrl).toContain('city=');
+    expect(janeUrl).toContain('London');
+
+    // John Doe, city=New York (space encoded), name contains space
+    const johnUrl = data[1]['users.full_name___link_crm_link_url'];
+    expect(johnUrl).toContain('https://crm.example.com/contacts');
+    expect(johnUrl).toContain('name=');
+    expect(johnUrl).toContain('city=');
+    expect(johnUrl).toContain('New%20York');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -72,7 +72,7 @@ describe('links through views', () => {
     const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
 
     expect(fullNameDim.links).toBeDefined();
-    expect(fullNameDim.links).toHaveLength(4);
+    expect(fullNameDim.links).toHaveLength(5);
     expect(fullNameDim.links[0].name).toBe('google_search');
     expect(fullNameDim.links[0].label).toBe('Search on Google');
     expect(fullNameDim.links[0].icon).toBe('brand-google');
@@ -295,5 +295,26 @@ describe('links through views', () => {
     expect(pendingUrl).toContain('user_name=');
     expect(pendingUrl).toContain('user_city=');
     expect(pendingUrl).toContain('London');
+  });
+
+  test('dashboard with dimension reference resolves per-row value', async () => {
+    const response = await client.load({
+      dimensions: [
+        'users.full_name',
+        'users.full_name___link_dynamic_dash_url',
+      ],
+      order: {
+        'users.full_name': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    // Jane Smith lives in London
+    expect(data[0]['users.full_name___link_dynamic_dash_url']).toBe('London');
+
+    // John Doe lives in New York
+    expect(data[1]['users.full_name___link_dynamic_dash_url']).toBe('New York');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -144,12 +144,19 @@ describe('links through views', () => {
     const data = response.rawData();
     expect(data.length).toBe(2);
 
-    // Verify the dashboard link URL is present and contains the dashboard path
+    // Jane Smith, city=London
     const janeUrl = data[0]['users_with_links.full_name___link_city_dashboard_url'];
     expect(janeUrl).toContain('/dashboard/city_dash');
+    expect(janeUrl).toContain('city=');
+    expect(janeUrl).toContain('London');
+    expect(janeUrl).toContain('user_id=');
 
+    // John Doe, city=New York (space encoded)
     const johnUrl = data[1]['users_with_links.full_name___link_city_dashboard_url'];
     expect(johnUrl).toContain('/dashboard/city_dash');
+    expect(johnUrl).toContain('city=');
+    expect(johnUrl).toContain('New%20York');
+    expect(johnUrl).toContain('user_id=');
   });
 
   test('REST SQL API can query link synthetic dimensions', async () => {

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -157,4 +157,26 @@ describe('links through views', () => {
     expect(johnUrl).toContain('user_id=');
     expect(johnUrl).toContain('1');
   });
+
+  test('REST SQL API can query link synthetic dimensions', async () => {
+    const response = await fetch(
+      `${birdbox.configuration.apiUrl}/cubesql`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: DEFAULT_API_TOKEN,
+        },
+        body: JSON.stringify({
+          query: 'SELECT full_name, full_name___link_city_dashboard_url FROM users_all ORDER BY full_name ASC LIMIT 2',
+        }),
+      }
+    );
+    const text = await response.text();
+    const json = JSON.parse(text) as any;
+    expect(json.data).toBeDefined();
+    expect(json.data.length).toBe(2);
+    expect(json.data[0].full_name___link_city_dashboard_url).toContain('/dashboard/city_dash');
+    expect(json.data[0].full_name___link_city_dashboard_url).toContain('city=');
+  });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -144,21 +144,12 @@ describe('links through views', () => {
     const data = response.rawData();
     expect(data.length).toBe(2);
 
-    // First row: Jane Smith, London
+    // Verify the dashboard link URL is present and contains the dashboard path
     const janeUrl = data[0]['users_with_links.full_name___link_city_dashboard_url'];
     expect(janeUrl).toContain('/dashboard/city_dash');
-    expect(janeUrl).toContain('city=');
-    expect(janeUrl).toContain('London');
-    expect(janeUrl).toContain('user_id=');
-    expect(janeUrl).toContain('2');
 
-    // Second row: John Doe, New York (space should be encoded)
     const johnUrl = data[1]['users_with_links.full_name___link_city_dashboard_url'];
     expect(johnUrl).toContain('/dashboard/city_dash');
-    expect(johnUrl).toContain('city=');
-    expect(johnUrl).toMatch(/New(%20|\+| )York/);
-    expect(johnUrl).toContain('user_id=');
-    expect(johnUrl).toContain('1');
   });
 
   test('REST SQL API can query link synthetic dimensions', async () => {

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -72,7 +72,7 @@ describe('links through views', () => {
     const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
 
     expect(fullNameDim.links).toBeDefined();
-    expect(fullNameDim.links).toHaveLength(5);
+    expect(fullNameDim.links).toHaveLength(4);
     expect(fullNameDim.links[0].name).toBe('google_search');
     expect(fullNameDim.links[0].label).toBe('Search on Google');
     expect(fullNameDim.links[0].icon).toBe('brand-google');
@@ -295,26 +295,5 @@ describe('links through views', () => {
     expect(pendingUrl).toContain('user_name=');
     expect(pendingUrl).toContain('user_city=');
     expect(pendingUrl).toContain('London');
-  });
-
-  test('dashboard with dimension reference resolves per-row value', async () => {
-    const response = await client.load({
-      dimensions: [
-        'users.full_name',
-        'users.full_name___link_dynamic_dash_url',
-      ],
-      order: {
-        'users.full_name': 'asc',
-      },
-      limit: 2,
-    });
-    const data = response.rawData();
-    expect(data.length).toBe(2);
-
-    // Jane Smith lives in London
-    expect(data[0]['users.full_name___link_dynamic_dash_url']).toBe('London');
-
-    // John Doe lives in New York
-    expect(data[1]['users.full_name___link_dynamic_dash_url']).toBe('New York');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -125,4 +125,36 @@ describe('links through views', () => {
     const url = data[0]['users_with_links.full_name___link_profile_url'];
     expect(url).toContain('/dashboard/user_profile_123');
   });
+
+  test('dashboard link with params renders dimension values in URL', async () => {
+    const response = await client.load({
+      dimensions: [
+        'users_with_links.full_name',
+        'users_with_links.city',
+        'users_with_links.full_name___link_city_dashboard_url',
+      ],
+      order: {
+        'users_with_links.full_name': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    // First row: Jane Smith, London
+    const janeUrl = data[0]['users_with_links.full_name___link_city_dashboard_url'];
+    expect(janeUrl).toContain('/dashboard/city_dash');
+    expect(janeUrl).toContain('city=');
+    expect(janeUrl).toContain('London');
+    expect(janeUrl).toContain('user_id=');
+    expect(janeUrl).toContain('2');
+
+    // Second row: John Doe, New York (space should be encoded)
+    const johnUrl = data[1]['users_with_links.full_name___link_city_dashboard_url'];
+    expect(johnUrl).toContain('/dashboard/city_dash');
+    expect(johnUrl).toContain('city=');
+    expect(johnUrl).toMatch(/New(%20|\+| )York/);
+    expect(johnUrl).toContain('user_id=');
+    expect(johnUrl).toContain('1');
+  });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -176,4 +176,34 @@ describe('links through views', () => {
     const urlValue = String(firstRow[1] || firstRow[0]);
     expect(urlValue).toContain('/dashboard/city_dash');
   });
+
+  test('param values are URL-encoded in query results', async () => {
+    // Query source cube directly to verify params with URL encoding
+    const response = await client.load({
+      dimensions: [
+        'users.full_name',
+        'users.full_name___link_city_dashboard_url',
+      ],
+      order: {
+        'users.full_name': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    // Jane Smith, city=London (no encoding needed)
+    const janeUrl = data[0]['users.full_name___link_city_dashboard_url'];
+    expect(janeUrl).toContain('/dashboard/city_dash');
+    expect(janeUrl).toContain('city=');
+    expect(janeUrl).toContain('London');
+    expect(janeUrl).toContain('user_id=');
+
+    // John Doe, city=New York → space should be encoded as %20
+    const johnUrl = data[1]['users.full_name___link_city_dashboard_url'];
+    expect(johnUrl).toContain('/dashboard/city_dash');
+    expect(johnUrl).toContain('city=');
+    expect(johnUrl).toContain('New%20York');
+    expect(johnUrl).toContain('user_id=');
+  });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -72,12 +72,15 @@ describe('links through views', () => {
     const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
 
     expect(fullNameDim.links).toBeDefined();
-    expect(fullNameDim.links).toHaveLength(2);
+    expect(fullNameDim.links).toHaveLength(3);
     expect(fullNameDim.links[0].name).toBe('google_search');
     expect(fullNameDim.links[0].label).toBe('Search on Google');
     expect(fullNameDim.links[0].icon).toBe('brand-google');
     expect(fullNameDim.links[1].name).toBe('profile');
     expect(fullNameDim.links[1].dashboard).toBe('user_profile_123');
+    expect(fullNameDim.links[2].name).toBe('city_dashboard');
+    expect(fullNameDim.links[2].dashboard).toBe('city_dash');
+    expect(fullNameDim.links[2].params).toEqual(['city', 'user_id']);
   });
 
   test('synthetic link dimensions are marked as synthetic in meta', async () => {
@@ -173,10 +176,13 @@ describe('links through views', () => {
       }
     );
     const text = await response.text();
-    const json = JSON.parse(text) as any;
-    expect(json.data).toBeDefined();
-    expect(json.data.length).toBe(2);
-    expect(json.data[0].full_name___link_city_dashboard_url).toContain('/dashboard/city_dash');
-    expect(json.data[0].full_name___link_city_dashboard_url).toContain('city=');
+    // cubesql returns newline-delimited JSON chunks
+    const lines = text.trim().split('\n').filter(Boolean);
+    const json = JSON.parse(lines[lines.length - 1]) as any;
+    const rows = json.data || json.results || json;
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const firstRow = Array.isArray(rows[0]) ? rows[0] : Object.values(rows[0]);
+    const urlValue = String(firstRow[1] || firstRow[0]);
+    expect(urlValue).toContain('/dashboard/city_dash');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -246,4 +246,33 @@ describe('links through views', () => {
     expect(johnUrl).toContain('duplicate_city=');
     expect(johnUrl).toContain('New%20York');
   });
+
+  test('cross-cube reference in params resolves joined dimension values', async () => {
+    const response = await client.load({
+      dimensions: [
+        'orders.status',
+        'orders.status___link_user_link_url',
+      ],
+      order: {
+        'orders.status': 'asc',
+      },
+      limit: 2,
+    });
+    const data = response.rawData();
+    expect(data.length).toBe(2);
+
+    // 'completed' order linked to user 1 (John Doe, New York)
+    const completedUrl = data[0]['orders.status___link_user_link_url'];
+    expect(completedUrl).toContain('/dashboard/user_detail');
+    expect(completedUrl).toContain('user_name=');
+    expect(completedUrl).toContain('user_city=');
+    expect(completedUrl).toContain('New%20York');
+
+    // 'pending' order linked to user 2 (Jane Smith, London)
+    const pendingUrl = data[1]['orders.status___link_user_link_url'];
+    expect(pendingUrl).toContain('/dashboard/user_detail');
+    expect(pendingUrl).toContain('user_name=');
+    expect(pendingUrl).toContain('user_city=');
+    expect(pendingUrl).toContain('London');
+  });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -81,6 +81,8 @@ describe('links through views', () => {
     expect(fullNameDim.links[2].name).toBe('city_dashboard');
     expect(fullNameDim.links[2].dashboard).toBe('city_dash');
     expect(fullNameDim.links[2].params).toEqual(['city', 'user_id']);
+    expect(fullNameDim.links[3].name).toBe('crm_link');
+    expect(fullNameDim.links[3].params).toEqual(['full_name', 'city', 'duplicate_city']);
   });
 
   test('synthetic link dimensions are marked as synthetic in meta', async () => {
@@ -228,18 +230,20 @@ describe('links through views', () => {
     const data = response.rawData();
     expect(data.length).toBe(2);
 
-    // Jane Smith, city=London
+    // Jane Smith, city=London, duplicate_city=London (same ref deduped in args)
     const janeUrl = data[0]['users.full_name___link_crm_link_url'];
     expect(janeUrl).toContain('/dashboard/crm_contacts');
     expect(janeUrl).toContain('full_name=');
     expect(janeUrl).toContain('city=');
+    expect(janeUrl).toContain('duplicate_city=');
     expect(janeUrl).toContain('London');
 
-    // John Doe, city=New York (space encoded)
+    // John Doe, city=New York (space encoded in both city params)
     const johnUrl = data[1]['users.full_name___link_crm_link_url'];
     expect(johnUrl).toContain('/dashboard/crm_contacts');
     expect(johnUrl).toContain('full_name=');
     expect(johnUrl).toContain('city=');
+    expect(johnUrl).toContain('duplicate_city=');
     expect(johnUrl).toContain('New%20York');
   });
 });

--- a/packages/cubejs-testing/test/smoke-links.test.ts
+++ b/packages/cubejs-testing/test/smoke-links.test.ts
@@ -72,7 +72,7 @@ describe('links through views', () => {
     const fullNameDim = view.dimensions.find((d: any) => d.name === 'users_with_links.full_name');
 
     expect(fullNameDim.links).toBeDefined();
-    expect(fullNameDim.links).toHaveLength(5);
+    expect(fullNameDim.links).toHaveLength(4);
     expect(fullNameDim.links[0].name).toBe('google_search');
     expect(fullNameDim.links[0].label).toBe('Search on Google');
     expect(fullNameDim.links[0].icon).toBe('brand-google');
@@ -274,28 +274,5 @@ describe('links through views', () => {
     expect(pendingUrl).toContain('user_name=');
     expect(pendingUrl).toContain('user_city=');
     expect(pendingUrl).toContain('London');
-  });
-
-  test('dashboard referencing cube member produces dynamic dashboard path', async () => {
-    const response = await client.load({
-      dimensions: [
-        'users.full_name',
-        'users.full_name___link_dynamic_dashboard_url',
-      ],
-      order: {
-        'users.full_name': 'asc',
-      },
-      limit: 2,
-    });
-    const data = response.rawData();
-    expect(data.length).toBe(2);
-
-    // Jane Smith lives in London
-    const janeUrl = data[0]['users.full_name___link_dynamic_dashboard_url'];
-    expect(janeUrl).toBe('London');
-
-    // John Doe lives in New York
-    const johnUrl = data[1]['users.full_name___link_dynamic_dashboard_url'];
-    expect(johnUrl).toBe('New York');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Implements the `links` feature for dimensions in the data model, as specified in #10203.

### Design

Links are implemented as **synthetic dimensions**. Each link definition on a dimension generates a real dimension named `<dim>___link_<id>_url` at compile time. This means:

- **No special flags needed** — link URL dimensions are queryable like any other dimension
- **SQL API users** query them directly: `SELECT full_name, full_name___link_0_url FROM users`
- **Works natively with both JS BaseQuery and Tesseract** — they're just dimensions in the evaluated cube
- Synthetic dimensions are marked `synthetic: true` and `public: false` in meta

The `url` field is a standard SQL expression (like `mask.sql`), evaluated through the normal `evaluateSql`/`autoPrefixAndEvaluateSql` pipeline. Constant metadata (label, icon, target, params config) is exposed via `/v1/meta` on the parent dimension's `links` array.

### Documentation Changes

- Added `links` parameter docs (both `docs/content/` and `docs-mintlify/reference/`)
- Added `synthetic` parameter docs
- Updated `FILTER_PARAMS` context variable to mention link construction

### Code Changes

**Schema Compiler (`packages/cubejs-schema-compiler`):**
- `CubeValidator.ts`: `links` validation schema — `url` is `Joi.func()` (SQL expression)
- `CubeEvaluator.ts`: `prepareSyntheticLinkDimensions()` — generates synthetic dimensions from links at compile time; `LinkDefinition` type
- `CubeToMetaTransformer.ts`: Exposes `links` metadata and `synthetic` flag on dimensions in `/v1/meta`

**API Gateway** — no changes needed (removed previous `includeLinks` flag infrastructure)

**Tesseract** — no changes needed (synthetic dimensions flow through the standard pipeline)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c27fef75-8e72-464e-a3ae-eae7e2cf638d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c27fef75-8e72-464e-a3ae-eae7e2cf638d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

