### PR TITLE
perf(cubeorchestrator): Hand-written Deserialize for DBResponsePrimit…

### DIFF
--- a/rust/cube/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cube/cubeorchestrator/src/query_result_transform.rs
@@ -9,7 +9,10 @@ use anyhow::{bail, Context, Result};
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use indexmap::IndexMap;
 use itertools::multizip;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{self, MapAccess, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
 use serde_json::Value;
 use std::{
     collections::{HashMap, HashSet},
@@ -961,7 +964,7 @@ pub struct RequestResultArray {
     pub results: Vec<RequestResultData>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum DBResponsePrimitive {
     Null,
@@ -969,6 +972,93 @@ pub enum DBResponsePrimitive {
     Number(f64),
     String(String),
     Uncommon(Value),
+}
+
+// Hand-written `Deserialize` that avoids serde's untagged-enum buffering.
+impl<'de> Deserialize<'de> for DBResponsePrimitive {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DBResponsePrimitiveVisitor;
+
+        impl<'de> Visitor<'de> for DBResponsePrimitiveVisitor {
+            type Value = DBResponsePrimitive;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a JSON primitive (null, bool, number, string) or container")
+            }
+
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Boolean(v))
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Number(v as f64))
+            }
+
+            fn visit_i128<E: de::Error>(self, v: i128) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Number(v as f64))
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Number(v as f64))
+            }
+
+            fn visit_u128<E: de::Error>(self, v: u128) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Number(v as f64))
+            }
+
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Number(v))
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::String(v.to_owned()))
+            }
+
+            fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::String(v.to_owned()))
+            }
+
+            fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::String(v))
+            }
+
+            fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Null)
+            }
+
+            fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+                Ok(DBResponsePrimitive::Null)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let value = Value::deserialize(de::value::SeqAccessDeserializer::new(seq))?;
+                Ok(DBResponsePrimitive::Uncommon(value))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let value = Value::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                Ok(DBResponsePrimitive::Uncommon(value))
+            }
+        }
+
+        deserializer.deserialize_any(DBResponsePrimitiveVisitor)
+    }
 }
 
 impl Display for DBResponsePrimitive {


### PR DESCRIPTION
…ive (-95%, ~20x parse)

The derived `#[serde(untagged)]` impl funnels every value through `serde::__private::de::Content`, materializing an intermediate tree per element. For wire payloads dominated by strings/numbers/null (the common CubeStore row shape) that buffering is the bottleneck. A direct `Visitor` dispatches on the JSON token in one pass; only the rare seq/map branches pay the `Value`-materialization cost via `Uncommon`.

Measured on `QueryResult::from_js_raw_data` bench (criterion, 100 samples for c16; --quick elsewhere):

| Bench                          | Before     | After     | Difference  | Speedup | Faster by |
| ------------------------------ | ---------- | --------- | ----------- | ------- | --------- |
| parse_only / c08_r10000        |   39.80 ms |   1.96 ms |   -37.84 ms |  ~20x   |   -95.1%  |
| parse_plus_build / c08_r10000  |   39.99 ms |   2.25 ms |   -37.74 ms |  ~18x   |   -94.4%  |
| parse_only / c16_r10000        |   82.39 ms |   4.03 ms |   -78.36 ms |  20.4x  |   -95.1%  |
| parse_plus_build / c16_r10000  |   79.94 ms |   4.79 ms |   -75.15 ms |  16.7x  |   -94.0%  |
| parse_only / c16_r100000       |  836.81 ms |  40.25 ms |  -796.56 ms |  20.8x  |   -95.2%  |
| parse_plus_build / c16_r100000 |  832.44 ms |  55.58 ms |  -776.86 ms |  15.0x  |   -93.3%  |
| parse_only / c32_r100000       | 1662.60 ms |  81.66 ms | -1580.94 ms |  ~20x   |   -95.1%  |
| parse_plus_build / c32_r100000 | 1677.50 ms | 114.22 ms | -1563.28 ms |  ~15x   |   -93.2%  |

Throughput on pure parse jumps from ~2 Melem/s to ~40 Melem/s. `parse_plus_build` gains less because the transpose into `QueryResult` now dominates once parsing is cheap.