### PR TITLE
docs(schema-compiler): note Jinja template filter is mirrored downstream

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/DataSchemaCompiler.ts
@@ -266,6 +266,10 @@ export class DataSchemaCompiler {
       : files).forEach(file => {
       if (file.fileName.endsWith('.js')) {
         originalJsFiles.push(file);
+      // Downstream Cube products mirror this filter to populate the Jinja template
+      // store before rendering a single file (e.g. preview endpoints). Keep them in
+      // sync — narrowing this filter without updating those callers will cause
+      // imports of files that fall outside the narrower set to fail at render time.
       } else if (file.fileName.endsWith('.jinja') ||
       (file.fileName.endsWith('.yml') || file.fileName.endsWith('.yaml')) && file.content.match(JINJA_SYNTAX)) {
         jinjaTemplatedFiles.push(file);


### PR DESCRIPTION
## Summary

- The filter at `DataSchemaCompiler.ts` that selects Jinja template files (`.jinja` plus `.yml`/`.yaml` with Jinja syntax) is duplicated in downstream Cube products that need to populate the in-memory minijinja template store before rendering a single file (e.g. a preview endpoint).
- Adds a comment so anyone narrowing this filter is reminded to update those callers. Narrowing it without updating the mirror causes `{% import %}` of files outside the narrower set to fail at render time with "template not found".

No behavior change — comment-only.

## Test plan

- [x] No code paths touched; nothing to test directly. CI ensures the surrounding code still compiles and existing schema-compiler tests pass.