### PR TITLE
fix(schema-compiler): resolve multi_stage order_by in owning cube context for view-exposed measures

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3360,7 +3360,11 @@ export class BaseQuery {
           }
         }
         const primaryKeys = this.cubeEvaluator.primaryKeys[cubeName];
-        const orderBySql = (symbol.orderBy || []).map(o => ({ sql: this.evaluateSql(cubeName, o.sql), dir: o.dir }));
+        // order_by templates reference members by bare name in the cube that
+        // authored them — for view-exposed measures resolve through
+        // aliasMember (as memberMaskSql does), not the view's context, see #10856
+        const orderByCubeName = symbol.aliasMember ? symbol.aliasMember.split('.')[0] : cubeName;
+        const orderBySql = (symbol.orderBy || []).map(o => ({ sql: this.evaluateSql(orderByCubeName, o.sql), dir: o.dir }));
         let sql;
         let patchedSymbol = symbol;
         if (symbol.type !== 'rank') {
@@ -3647,6 +3651,12 @@ export class BaseQuery {
           cubeName,
           name
         );
+      if (!resolvedSymbol) {
+        throw new UserError(
+          `Symbol '${name}' could not be resolved on cube '${cubeName}'. ` +
+          'Check that the referenced member exists and is accessible from this context.'
+        );
+      }
       // eslint-disable-next-line no-underscore-dangle
       if (resolvedSymbol._objectWithResolvedProperties) {
         return resolvedSymbol;

--- a/packages/cubejs-schema-compiler/test/unit/multi-stage-orderby-view-alias.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/multi-stage-orderby-view-alias.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-restricted-syntax */
+import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { prepareJsCompiler } from './PrepareCompiler';
+
+describe('Multi-stage rank order_by template resolution through a view (issue #10856)', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+    cube(\`orders\`, {
+      sql: \`SELECT 1 as id, 5 as parcels, '2024-01-01'::timestamp as created_at\`,
+
+      dimensions: {
+        id: {
+          sql: \`id\`,
+          type: \`number\`,
+          primary_key: true,
+          public: true
+        },
+
+        created_at: {
+          sql: \`created_at\`,
+          type: \`time\`
+        }
+      },
+
+      measures: {
+        num_parcels: {
+          type: \`sum\`,
+          sql: \`parcels\`
+        },
+
+        volume_by_day_rank: {
+          multi_stage: true,
+          type: \`rank\`,
+          order_by: [{
+            sql: \`\${num_parcels}\`,
+            dir: 'desc'
+          }],
+          reduce_by: [created_at]
+        }
+      }
+    });
+
+    view(\`orders_view\`, {
+      cubes: [{
+        join_path: orders,
+        includes: [\`created_at\`, \`volume_by_day_rank\`]
+      }]
+    });
+
+    view(\`orders_aliased_view\`, {
+      cubes: [{
+        join_path: orders,
+        includes: [
+          \`created_at\`,
+          { name: \`volume_by_day_rank\`, alias: \`day_rank\` }
+        ]
+      }]
+    });
+
+    view(\`orders_full_view\`, {
+      cubes: [{
+        join_path: orders,
+        includes: [\`created_at\`, \`num_parcels\`, \`volume_by_day_rank\`]
+      }]
+    });
+  `);
+
+  function buildSql(measures: string[]) {
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures,
+      timeDimensions: [{
+        dimension: `${measures[0].split('.')[0]}.created_at`,
+        granularity: 'day',
+      }],
+      timezone: 'UTC',
+    });
+    return query.buildSqlAndParams()[0];
+  }
+
+  beforeAll(async () => {
+    await compiler.compile();
+  });
+
+  // Before the fix this crashed with TypeError reading
+  // '_objectWithResolvedProperties': the rank's order_by template
+  // `${num_parcels}` was resolved against the view's symbol table, which
+  // doesn't expose num_parcels.
+  it('resolves rank order_by against the owning cube when the view does not expose the referenced measure', () => {
+    const sql = buildSql(['orders_view.volume_by_day_rank']);
+    expect(sql).toMatch(/ORDER BY[^)]*parcels/i);
+  });
+
+  it('resolves rank order_by when the rank itself is included under an alias', () => {
+    const sql = buildSql(['orders_aliased_view.day_rank']);
+    expect(sql).toMatch(/ORDER BY[^)]*parcels/i);
+  });
+
+  it('resolves rank order_by against the owning cube even when the view exposes the referenced measure', () => {
+    const sql = buildSql(['orders_full_view.volume_by_day_rank']);
+    expect(sql).toMatch(/ORDER BY[^)]*parcels/i);
+  });
+
+  it('keeps direct cube access unchanged', () => {
+    const sql = buildSql(['orders.volume_by_day_rank']);
+    expect(sql).toMatch(/ORDER BY[^)]*parcels/i);
+  });
+});

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
@@ -578,13 +578,6 @@ impl SymbolFactory for MeasureSymbolFactory {
             }
         }
 
-        let mut measure_order_by = vec![];
-        if let Some(group_by) = definition.order_by()? {
-            for item in group_by.iter() {
-                let node = compiler.compile_sql_call(path.cube_name(), item.sql()?)?;
-                measure_order_by.push(MeasureOrderBy::new(node, item.dir()?));
-            }
-        }
         let sql = if let Some(sql) = sql {
             Some(compiler.compile_sql_call(path.cube_name(), sql)?)
         } else {
@@ -593,21 +586,26 @@ impl SymbolFactory for MeasureSymbolFactory {
 
         let is_sql_is_direct_ref = sql.as_ref().is_some_and(|s| s.is_direct_reference());
 
-        // mask.sql references are written in the context of the cube that
-        // owns the measure. When a measure is exposed through a view, the
-        // measure's sql is a direct reference to the underlying cube member;
-        // compile mask.sql against that referenced member's cube so CUBE /
-        // cross-cube references inside the mask resolve the same way as on
-        // the owning cube — and as they do on the legacy BaseQuery path,
-        // which routes mask compilation through aliasMember for the same
-        // reason.
-        let mask_sql_cube_name = sql
+        // order_by and mask.sql references are written in the context of the
+        // cube that owns the measure. For a view-exposed measure the sql is a
+        // direct reference to the underlying cube member — compile both
+        // against that cube, as the legacy BaseQuery path does via aliasMember.
+        let owning_cube_name = sql
             .as_ref()
             .and_then(|s| s.resolve_direct_reference())
             .map(|dep| dep.cube_name())
             .unwrap_or_else(|| path.cube_name().clone());
+
+        let mut measure_order_by = vec![];
+        if let Some(group_by) = definition.order_by()? {
+            for item in group_by.iter() {
+                let node = compiler.compile_sql_call(&owning_cube_name, item.sql()?)?;
+                measure_order_by.push(MeasureOrderBy::new(node, item.dir()?));
+            }
+        }
+
         let mask_sql = if let Some(mask_sql) = mask_sql {
-            Some(compiler.compile_sql_call(&mask_sql_cube_name, mask_sql)?)
+            Some(compiler.compile_sql_call(&owning_cube_name, mask_sql)?)
         } else {
             None
         };

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -533,3 +533,12 @@ views:
                 - total_amount
                 - amount_prev_month
                 - mom_growth
+
+    # Exposes a rank measure WITHOUT the measure its order_by references
+    # (total_amount) — regression model for cube-js/cube#10856.
+    - name: orders_rank_view
+      cubes:
+          - join_path: orders
+            includes:
+                - status
+                - amount_rank_by_status

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_rank_order_by_referencing_unexposed_measure.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_rank_order_by_referencing_unexposed_measure.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_rank_view__status | orders_rank_view__amount_rank_by_status
+-------------------------+----------------------------------------
+cancelled                | 3                                      
+pending                  | 2                                      
+completed                | 1

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
@@ -80,3 +80,25 @@ async fn test_view_with_filter() {
         insta::assert_snapshot!(result);
     }
 }
+
+// Regression test for cube-js/cube#10856: the rank's order_by references
+// total_amount, which orders_rank_view does not expose. order_by must compile
+// in the owning cube's context, not the view's — before the fix this failed
+// to plan at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_rank_order_by_referencing_unexposed_measure() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders_rank_view.amount_rank_by_status
+        dimensions:
+          - orders_rank_view.status
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}


### PR DESCRIPTION
Fixes #10856. A `multi_stage` rank measure exposed through a view fails when its `order_by` template references a measure the view doesn't expose — the legacy path crashes with `TypeError: Cannot read properties of undefined (reading '_objectWithResolvedProperties')`, and Tesseract fails planning on the same model.

## Problem

An `order_by` template references members by bare name (e.g. `${num_parcels}`) in the cube that authored it. When the measure is included in a view, the copied template was evaluated in the **view's** context on both engines: the JS path resolved it against the view's symbol table, and the Rust planner compiled it against `path.cube_name()` (the view). Any referenced member not exposed on the view breaks the query, even though it's an internal implementation detail of the rank that shouldn't need exposing.

## Fix

Resolve the template in the owning cube's context, the way `mask` is already handled on both engines:

- **JS**: `BaseQuery` derives the owning cube from `symbol.aliasMember` (the same mechanism `memberMaskSql` uses) and falls back to the queried cube for direct access. Also replaces the unguarded `_objectWithResolvedProperties` access with a clear `UserError` when a symbol can't be resolved.
- **Tesseract**: `measure_symbol.rs` compiles `order_by` against the cube derived from the measure's direct SQL reference, sharing the derivation the file already uses for `mask`.

One deliberate behaviour note: when a view *does* expose the referenced member, resolution now consistently binds to the owning cube's member on both engines (previously the JS path bound to the view's copy).

## Testing

- JS unit tests cover four shapes: view not exposing the referenced measure (the crash), the rank included under an alias, a view that does expose the referenced measure, and direct cube access.
- New Tesseract integration test (`test_view_rank_order_by_referencing_unexposed_measure`) with a fixture view exposing a rank but not its order_by referent: fails to plan without the Rust fix, and with it returns ranks matching the seed data (completed=1, pending=2, cancelled=3 by total amount).

## Related gap, not addressed here

While verifying this fix we found an adjacent bug with the same user-facing shape: `reduce_by`/`group_by` references are dropped entirely when a multi_stage measure is queried through a view on the legacy JS path (view definitions never receive `reduceByReferences`, and the partition pruning in `BaseQuery` compares cube-qualified paths against view-qualified members). The window partitions by dimensions it should reduce away — rank() returns 1 on every row, silently. Tesseract is NOT affected (verified by the integration test above — it resolves the alias chain to the cube symbol before planning). Details in a comment on #10856.
