### PR TITLE
fix(cubesql): Correctly escape/unescape LIKE patterns

### DIFF
--- a/packages/cubejs-dremio-driver/driver/DremioQuery.js
+++ b/packages/cubejs-dremio-driver/driver/DremioQuery.js
@@ -165,6 +165,8 @@ class DremioQuery extends BaseQuery {
     templates.functions.DATEDIFF = 'DATE_DIFF(DATE, DATE_TRUNC(\'{{ date_part }}\', {{ args[1] }}), DATE_TRUNC(\'{{ date_part }}\', {{ args[2] }}))';
     templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.expressions.interval_single_date_part = 'CAST({{ num }} as INTERVAL {{ date_part }})';
+    templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
+    delete templates.expressions.ilike;
     templates.quotes.identifiers = '"';
     return templates;
   }

--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -64,6 +64,8 @@ export class DuckDBQuery extends BaseQuery {
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
     templates.functions.STRING_AGG = 'STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}, COALESCE({{ args[1] }}, \'\'))';
+    templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
+    templates.expressions.ilike = '{{ expr }} {% if negated %}NOT {% endif %}ILIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     return templates;
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/BaseFilter.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseFilter.ts
@@ -114,7 +114,15 @@ export class BaseFilter extends BaseDimension {
   }
 
   public isWildcardOperator() {
-    return this.camelizeOperator === 'contains' || this.camelizeOperator === 'notContains';
+    // All LIKE-based operators need wildcard chars escaped in user values
+    return (
+      this.camelizeOperator === 'contains' ||
+      this.camelizeOperator === 'notContains' ||
+      this.camelizeOperator === 'startsWith' ||
+      this.camelizeOperator === 'notStartsWith' ||
+      this.camelizeOperator === 'endsWith' ||
+      this.camelizeOperator === 'notEndsWith'
+    );
   }
 
   public filterParams() {

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -274,6 +274,7 @@ export class MssqlQuery extends BaseQuery {
     delete templates.functions.STRING_AGG;
     // PERCENTILE_CONT works but requires PARTITION BY
     delete templates.functions.PERCENTILECONT;
+    templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     delete templates.expressions.ilike;
     // MSSQL uses + for string concatenation instead of ||
     templates.expressions.concat_strings = '{{ strings | join(\' + \' ) }}';

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -161,6 +161,7 @@ export class PrestodbQuery extends BaseQuery {
     templates.expressions.binary = '{% if op == \'||\' %}' +
       '(CAST({{ left }} AS VARCHAR) || CAST({{ right }} AS VARCHAR))' +
       '{% else %}({{ left }} {{ op }} {{ right }}){% endif %}';
+    templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     delete templates.expressions.ilike;
     templates.types.string = 'VARCHAR';
     templates.types.float = 'REAL';

--- a/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
@@ -116,6 +116,8 @@ export class SnowflakeQuery extends BaseQuery {
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
     templates.expressions.interval = 'INTERVAL \'{{ interval }}\'';
     templates.expressions.timestamp_literal = '\'{{ value }}\'::timestamp_tz';
+    templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\\\'{% endif %}';
+    templates.expressions.ilike = '{{ expr }} {% if negated %}NOT {% endif %}ILIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\\\'{% endif %}';
     templates.operators.is_not_distinct_from = 'IS NOT DISTINCT FROM';
     templates.join_types.full = 'FULL';
     delete templates.types.interval;

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -28,7 +28,7 @@ use datafusion::{
     error::{DataFusionError, Result},
     logical_plan::{
         plan::Extension, replace_col, Column, DFSchema, DFSchemaRef, Expr, GroupingSet, JoinType,
-        LogicalPlan, UserDefinedLogicalNode,
+        LogicalPlan, Operator, UserDefinedLogicalNode,
     },
     physical_plan::{aggregates::AggregateFunction, functions::BuiltinScalarFunction},
     scalar::ScalarValue,
@@ -1859,15 +1859,42 @@ impl WrappedSelectNode {
                     subqueries,
                 )
                 .await?;
-                let resulting_sql = sql_generator
-                    .get_sql_templates()
-                    .binary_expr(left, op.to_string(), right)
-                    .map_err(|e| {
-                        DataFusionError::Internal(format!(
-                            "Can't generate SQL for binary expr: {}",
-                            e
-                        ))
-                    })?;
+                let resulting_sql = match op {
+                    Operator::Like => sql_generator.get_sql_templates().like_expr(
+                        LikeType::Like,
+                        left,
+                        false,
+                        right,
+                        None,
+                    ),
+                    Operator::NotLike => sql_generator.get_sql_templates().like_expr(
+                        LikeType::Like,
+                        left,
+                        true,
+                        right,
+                        None,
+                    ),
+                    Operator::ILike => sql_generator.get_sql_templates().like_expr(
+                        LikeType::ILike,
+                        left,
+                        false,
+                        right,
+                        None,
+                    ),
+                    Operator::NotILike => sql_generator.get_sql_templates().like_expr(
+                        LikeType::ILike,
+                        left,
+                        true,
+                        right,
+                        None,
+                    ),
+                    _ => sql_generator
+                        .get_sql_templates()
+                        .binary_expr(left, op.to_string(), right),
+                }
+                .map_err(|e| {
+                    DataFusionError::Internal(format!("Can't generate SQL for binary expr: {}", e))
+                })?;
                 Ok((resulting_sql, sql_query))
             }
             // Expr::AnyExpr { .. } => {}

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -3389,6 +3389,43 @@ limit
                 }]),
                 None,
             ),
+            // LIKE with `\` as escape character: `\_` and `\%` must be
+            // resolved to literal characters, not preserved in the filter
+            // value, and the resulting filter must use `equals` since the
+            // unescaped pattern contains no wildcards.
+            (
+                r"customer_gender LIKE 'fem\_ale'".to_string(),
+                Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("equals".to_string()),
+                    values: Some(vec!["fem_ale".to_string()]),
+                    or: None,
+                    and: None,
+                }]),
+                None,
+            ),
+            (
+                r"customer_gender LIKE 'fem\%ale%'".to_string(),
+                Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("startsWith".to_string()),
+                    values: Some(vec!["fem%ale".to_string()]),
+                    or: None,
+                    and: None,
+                }]),
+                None,
+            ),
+            (
+                r"customer_gender NOT LIKE '%fem\_ale'".to_string(),
+                Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("notEndsWith".to_string()),
+                    values: Some(vec!["fem_ale".to_string()]),
+                    or: None,
+                    and: None,
+                }]),
+                None,
+            ),
             // Segment
             (
                 "is_male = true".to_string(),
@@ -11395,6 +11432,75 @@ ORDER BY "source"."str0" ASC
                 ..Default::default()
             }
         )
+    }
+
+    #[tokio::test]
+    async fn test_cube_scan_like_escaped_chars_filter() {
+        init_testing_logger();
+
+        let logical_plan = convert_select_to_query_plan(
+            r#"
+            SELECT customer_gender
+            FROM "public"."KibanaSampleDataEcommerce"
+            WHERE customer_gender LIKE '%fem\_ale%'
+            GROUP BY 1
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await
+        .as_logical_plan();
+
+        assert_eq!(
+            logical_plan.find_cube_scan().request,
+            V1LoadRequestQuery {
+                measures: Some(vec![]),
+                dimensions: Some(vec!["KibanaSampleDataEcommerce.customer_gender".to_string()]),
+                segments: Some(vec![]),
+                order: Some(vec![]),
+                filters: Some(vec![V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("contains".to_string()),
+                    values: Some(vec!["fem_ale".to_string()]),
+                    or: None,
+                    and: None,
+                }]),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sql_push_down_like_with_escape() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan_customized(
+            r#"
+            SELECT customer_gender
+            FROM "public"."KibanaSampleDataEcommerce"
+            WHERE
+                LOWER(customer_gender) <> 'a'
+                AND customer_gender LIKE 'foo\%bar'
+            GROUP BY 1
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+            vec![(
+                "expressions/like".to_string(),
+                "{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}\
+                 {% if default_escape %} ESCAPE '\\\\'{% endif %}"
+                    .to_string(),
+            )],
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        assert!(sql.contains(" LIKE "));
+        assert!(sql.contains(" ESCAPE "));
     }
 
     #[tokio::test]

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -64,6 +64,87 @@ pub struct FilterRules {
     eval_stable_functions: bool,
 }
 
+/// Shape of a SQL LIKE pattern once escape sequences have been resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LikePatternShape {
+    /// No wildcards: matches the literal exactly.
+    Equals,
+    /// Trailing `%` wildcard only.
+    StartsWith,
+    /// Leading `%` wildcard only.
+    EndsWith,
+    /// Both leading and trailing `%` wildcards.
+    Contains,
+}
+
+/// Parse a SQL LIKE pattern using `escape_char` as the escape character.
+///
+/// Returns the pattern shape and its unescaped literal portion (with `\%`,
+/// `\_`, `\\` resolved to `%`, `_`, `\`), or `None` if the pattern contains
+/// an internal wildcard — i.e. an unescaped `_`, or an unescaped `%` that is
+/// not the very first or very last token — since such patterns cannot be
+/// represented by Cube's equals/contains/startsWith/endsWith filter operators.
+fn parse_like_pattern(pattern: &str, escape_char: char) -> Option<(LikePatternShape, String)> {
+    enum Token {
+        Literal(char),
+        Percent,
+        Underscore,
+    }
+
+    let mut tokens: Vec<Token> = Vec::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == escape_char {
+            match chars.peek().copied() {
+                Some(next) if next == '%' || next == '_' || next == escape_char => {
+                    chars.next();
+                    tokens.push(Token::Literal(next));
+                }
+                _ => {
+                    // Escape char with no following %/_/escape — keep the
+                    // escape char itself as a literal so input semantics are
+                    // preserved rather than silently dropped.
+                    tokens.push(Token::Literal(c));
+                }
+            }
+            continue;
+        }
+        match c {
+            '%' => tokens.push(Token::Percent),
+            '_' => tokens.push(Token::Underscore),
+            _ => tokens.push(Token::Literal(c)),
+        }
+    }
+
+    let starts_with_percent = matches!(tokens.first(), Some(Token::Percent));
+    let ends_with_percent = matches!(tokens.last(), Some(Token::Percent));
+
+    let start = if starts_with_percent { 1 } else { 0 };
+    let end = if ends_with_percent {
+        tokens.len() - 1
+    } else {
+        tokens.len()
+    };
+
+    let mut literal = String::new();
+    if end > start {
+        for tok in &tokens[start..end] {
+            match tok {
+                Token::Literal(c) => literal.push(*c),
+                Token::Percent | Token::Underscore => return None,
+            }
+        }
+    }
+
+    let shape = match (starts_with_percent, ends_with_percent) {
+        (false, false) => LikePatternShape::Equals,
+        (false, true) => LikePatternShape::StartsWith,
+        (true, false) => LikePatternShape::EndsWith,
+        (true, true) => LikePatternShape::Contains,
+    };
+    Some((shape, literal))
+}
+
 impl FilterRules {
     fn inlist_expr_list(&self, exprs: Vec<impl Display>) -> String {
         inlist_expr_list(exprs, self.config_obj.push_down_pull_up_split())
@@ -3660,73 +3741,60 @@ impl FilterRules {
                                         },
                                     };
 
-                                    let op = match literal {
-                                        ScalarValue::Utf8(Some(value)) => match op {
-                                            "contains" => {
-                                                let starts_with_pcnt = value.starts_with("%");
-                                                let ends_with_pcnt = value.ends_with("%");
-                                                match (starts_with_pcnt, ends_with_pcnt) {
-                                                    (false, false) => "equals",
-                                                    (false, true) => "startsWith",
-                                                    (true, false) => "endsWith",
-                                                    (true, true) => "contains",
-                                                }
-                                            }
-                                            "notContains" => {
-                                                let starts_with_pcnt = value.starts_with("%");
-                                                let ends_with_pcnt = value.ends_with("%");
-                                                match (starts_with_pcnt, ends_with_pcnt) {
-                                                    (false, false) => "notEquals",
-                                                    (false, true) => "notStartsWith",
-                                                    (true, false) => "notEndsWith",
-                                                    (true, true) => "notContains",
-                                                }
-                                            }
-                                            _ => op,
-                                        },
-                                        _ => op,
+                                    // LIKE-family operators are handled
+                                    // separately so that `\%`, `\_`, `\\`
+                                    // escape sequences in the pattern are
+                                    // resolved before the literal is placed
+                                    // into the CubeScan filter value, and so
+                                    // that patterns with internal wildcards
+                                    // are not silently misrepresented as
+                                    // equals/contains/startsWith/endsWith.
+                                    let is_like_op = matches!(
+                                        expr_op,
+                                        Operator::Like
+                                            | Operator::ILike
+                                            | Operator::NotLike
+                                            | Operator::NotILike,
+                                    );
+
+                                    let (op, like_value): (&str, Option<String>) = if is_like_op {
+                                        let value = match literal {
+                                            ScalarValue::Utf8(Some(value)) => value,
+                                            _ => continue,
+                                        };
+                                        let Some((shape, unescaped)) =
+                                            parse_like_pattern(value, '\\')
+                                        else {
+                                            continue;
+                                        };
+                                        let negated = matches!(
+                                            expr_op,
+                                            Operator::NotLike | Operator::NotILike,
+                                        );
+                                        let op = match (shape, negated) {
+                                            (LikePatternShape::Equals, false) => "equals",
+                                            (LikePatternShape::StartsWith, false) => "startsWith",
+                                            (LikePatternShape::EndsWith, false) => "endsWith",
+                                            (LikePatternShape::Contains, false) => "contains",
+                                            (LikePatternShape::Equals, true) => "notEquals",
+                                            (LikePatternShape::StartsWith, true) => "notStartsWith",
+                                            (LikePatternShape::EndsWith, true) => "notEndsWith",
+                                            (LikePatternShape::Contains, true) => "notContains",
+                                        };
+                                        (op, Some(unescaped))
+                                    } else {
+                                        (op, None)
                                     };
 
                                     let values = match literal {
                                         ScalarValue::Utf8(Some(value)) => vec![{
-                                            if op == "startsWith"
+                                            if let Some(like_value) = like_value {
+                                                like_value
+                                            } else if op == "startsWith"
                                                 && value.starts_with("^^")
                                                 && value.ends_with(".*$")
                                             {
                                                 value[2..value.len() - 3].to_string()
-                                            } else if op == "contains" || op == "notContains" {
-                                                if value.starts_with("%") && value.ends_with("%") {
-                                                    let without_wildcard =
-                                                        value[1..value.len() - 1].to_string();
-                                                    if without_wildcard.contains("%") {
-                                                        continue;
-                                                    }
-                                                    without_wildcard
-                                                } else {
-                                                    value.to_string()
-                                                }
-                                            } else if op == "startsWith" || op == "notStartsWith" {
-                                                if value.ends_with("%") {
-                                                    let without_wildcard =
-                                                        value[..value.len() - 1].to_string();
-                                                    if without_wildcard.contains("%") {
-                                                        continue;
-                                                    }
-                                                    without_wildcard
-                                                } else {
-                                                    value.to_string()
-                                                }
-                                            } else if op == "endsWith" || op == "notEndsWith" {
-                                                if let Some(without_wildcard) =
-                                                    value.strip_prefix("%")
-                                                {
-                                                    if without_wildcard.contains("%") {
-                                                        continue;
-                                                    }
-                                                    without_wildcard.to_string()
-                                                } else {
-                                                    value.to_string()
-                                                }
                                             } else {
                                                 value.to_string()
                                             }

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -912,7 +912,12 @@ impl SqlTemplates {
 
         let rendered_like = self.render_template(
             &format!("expressions/{}", expression_name),
-            context! { expr => expr, negated => negated, pattern => pattern },
+            context! {
+                expr => expr,
+                negated => negated,
+                pattern => pattern,
+                default_escape => escape_char.is_none(),
+            },
         )?;
 
         let Some(escape_char) = escape_char else {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes an issue with special characters in `LIKE` pattern generating incorrect SQL by fixes two issues in CubeSQL and one in BaseQuery:
- Fixed CubeSQL passing LIKE filters to CubeScan by unescaping the escape sequences
- Fixed an issue where BaseQuery would not autoescape query params when using `startsWith`/`endsWith` filter operators
- Fixed CubeSQL push down not generating an implicit `ESCAPE` clause for `LIKE` for data warehouses that have no default escape

Related tests are included.
