### PR TITLE
docs: fix broken links to Update channels page and broken HEIC image

### DIFF
--- a/docs-mintlify/admin/account-billing/distribution.mdx
+++ b/docs-mintlify/admin/account-billing/distribution.mdx
@@ -124,4 +124,4 @@ open http://localhost:3000
 [ref-infrastructure]: /admin/deployment/infrastructure
 [ref-workspace]: /admin/workspace
 [ref-deployment]: /admin/deployment
-[ref-update-channels]: /admin/deployment/deployments#update-channels
+[ref-update-channels]: /admin/deployment/index#update-channels

--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -124,4 +124,4 @@ response times to be significantly longer than usual.
 [self-effects]: #effects-on-experience
 [ref-refresh-worker]: /cube-core/architecture#refresh-worker
 [ref-sls]: /docs/integrations/semantic-layer-sync#on-schedule
-[ref-cube-version]: /admin/deployment/deployments#cube-version
+[ref-cube-version]: /admin/deployment/index#cube-version

--- a/docs-mintlify/admin/deployment/environments.mdx
+++ b/docs-mintlify/admin/deployment/environments.mdx
@@ -120,5 +120,5 @@ credentials**][ref-credentials].
 [ref-suspend]: /docs/deployment/cloud/auto-suspension
 [ref-overview]: /docs/workspace/integrations#review-integrations
 [ref-credentials]: /docs/workspace/integrations#view-api-credentials
-[ref-version]: /docs/deployment/cloud/deployments#cube-version
-[ref-version-channel]: /docs/deployment/cloud/deployments#update-channels
+[ref-version]: /admin/deployment/index#cube-version
+[ref-version-channel]: /admin/deployment/index#update-channels

--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -147,7 +147,7 @@ You can view or change the update channel by navigating to **Settings →
 General → Cube version**:
 
 <Frame>
-  <img src="https://ucarecdn.com/3ef5fa36-4b27-437c-aa70-dbc0aa01255d/" />
+  <img src="https://ucarecdn.com/3ef5fa36-4b27-437c-aa70-dbc0aa01255d/-/format/auto/" />
 </Frame>
 
 You can select a specific version in the drop-down. Only versions that have been used by

--- a/docs-mintlify/reference/control-plane-api.mdx
+++ b/docs-mintlify/reference/control-plane-api.mdx
@@ -260,7 +260,7 @@ curl \
 [ref-core-data-apis]: /reference/core-data-apis
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-metadata-api]: /reference/core-data-apis/rest-api/reference#metadata-api
-[ref-deployments]: /admin/deployment/deployments
+[ref-deployments]: /admin/deployment/index
 [ref-environments]: /admin/workspace/environments
 [ref-api-keys]: /admin/account-billing/api-keys
 [ref-security-context]: /docs/data-modeling/access-control/context

--- a/docs/content/product/administration/deployment/deployments.mdx
+++ b/docs/content/product/administration/deployment/deployments.mdx
@@ -123,7 +123,7 @@ You can view or change the update channel by navigating to <Btn>Settings →
 General → Cube version</Btn>:
 
 <Screenshot
-  src="https://ucarecdn.com/3ef5fa36-4b27-437c-aa70-dbc0aa01255d/"
+  src="https://ucarecdn.com/3ef5fa36-4b27-437c-aa70-dbc0aa01255d/-/format/auto/"
   highlight="inset(36% 41% 34% 21% round 10px)"
 />
 

--- a/docs/content/product/administration/deployment/environments.mdx
+++ b/docs/content/product/administration/deployment/environments.mdx
@@ -112,5 +112,5 @@ credentials</Btn>][ref-credentials].
 [ref-suspend]: /product/deployment/cloud/auto-suspension
 [ref-overview]: /product/workspace/integrations#review-integrations
 [ref-credentials]: /product/workspace/integrations#view-api-credentials
-[ref-version]: /product/deployment/cloud/deployments#cube-version
-[ref-version-channel]: /product/deployment/cloud/deployments#update-channels
+[ref-version]: /product/administration/deployment/deployments#cube-version
+[ref-version-channel]: /product/administration/deployment/deployments#update-channels


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

CUB-2581

**Description of Changes Made**

Fixes broken links and a broken image on the Update channels documentation page.

### 1. Broken links to non-existent `deployments.mdx` page (Mintlify docs)

In the Mintlify docs, there is no `admin/deployment/deployments.mdx` — the content lives in `admin/deployment/index.mdx`. Fixed all references:

- `docs-mintlify/admin/account-billing/distribution.mdx` — `[ref-update-channels]` pointed to `/admin/deployment/deployments#update-channels` → `/admin/deployment/index#update-channels`
- `docs-mintlify/admin/deployment/environments.mdx` — `[ref-version]` and `[ref-version-channel]` pointed to `/docs/deployment/cloud/deployments#...` → `/admin/deployment/index#...`
- `docs-mintlify/admin/deployment/auto-suspension.mdx` — `[ref-cube-version]` pointed to `/admin/deployment/deployments#cube-version` → `/admin/deployment/index#cube-version`
- `docs-mintlify/reference/control-plane-api.mdx` — `[ref-deployments]` pointed to `/admin/deployment/deployments` → `/admin/deployment/index`

### 2. Broken links in old docs

- `docs/content/product/administration/deployment/environments.mdx` — `[ref-version]` and `[ref-version-channel]` used wrong path prefix `/product/deployment/cloud/deployments` → `/product/administration/deployment/deployments`

### 3. Broken image on Update channels section

The screenshot (`ucarecdn.com/3ef5fa36-...`) is stored in HEIC format, which browsers cannot render. Appended ucarecdn's `-/format/auto/` processing suffix so the CDN converts it to a browser-compatible format. Fixed in both:

- `docs-mintlify/admin/deployment/index.mdx`
- `docs/content/product/administration/deployment/deployments.mdx`

### Note

The "Learn more" link in the Cube cloud platform Settings UI under "Update channel" also points to the broken URL (`/admin/deployment/deployments#update-channels`). That link lives in the `@cubejs-enterprise/console-ui` package (enterprise repo) and needs to be updated separately to `/admin/deployment/index#update-channels`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CUB-2581](https://linear.app/cube-d3/issue/CUB-2581/fix-broken-docs-links-and-image-on-update-channels-page)

<div><a href="https://cursor.com/agents/bc-03b09831-81df-4907-9c72-853d4594f6a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b09831-81df-4907-9c72-853d4594f6a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

