### PR TITLE
fix(backend-native): unguarded .unwrap() in js_stream_push_chunk

### DIFF
--- a/packages/cubejs-backend-native/src/stream.rs
+++ b/packages/cubejs-backend-native/src/stream.rs
@@ -320,12 +320,9 @@ fn js_stream_push_chunk(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         cx,
         handle: chunk_array,
     };
-    // Handle transform errors via `reject()` rather than `.unwrap()` — a
-    // panic here bubbles up as an unhandled rejection on Node's tick queue
-    // and crashes the process. We signal both ends of the FFI bridge: the
-    // Rust downstream via `reject()` (so the wire layer can emit a Postgres
-    // `ErrorResponse`) and the JS callback via the same async wrapper used
-    // on the success path (avoids mixing sync/async stream-callback timing).
+    // Don't unwrap: a panic across the FFI boundary crashes the process.
+    // Signal the error on both sides of the bridge — reject() for the Rust
+    // downstream, the chunk callback for JS.
     let value =
         match transform_response(&mut value_object, this.schema.clone(), &this.member_fields) {
             Ok(v) => v,

--- a/packages/cubejs-backend-native/src/stream.rs
+++ b/packages/cubejs-backend-native/src/stream.rs
@@ -320,8 +320,30 @@ fn js_stream_push_chunk(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         cx,
         handle: chunk_array,
     };
+    // Handle transform errors via `reject()` rather than `.unwrap()` — a
+    // panic here bubbles up as an unhandled rejection on Node's tick queue
+    // and crashes the process. We signal both ends of the FFI bridge: the
+    // Rust downstream via `reject()` (so the wire layer can emit a Postgres
+    // `ErrorResponse`) and the JS callback via the same async wrapper used
+    // on the success path (avoids mixing sync/async stream-callback timing).
     let value =
-        transform_response(&mut value_object, this.schema.clone(), &this.member_fields).unwrap();
+        match transform_response(&mut value_object, this.schema.clone(), &this.member_fields) {
+            Ok(v) => v,
+            Err(e) => {
+                let err_msg = e.message.to_string();
+                this.reject(err_msg.clone());
+
+                let err_future = async move { Err(CubeError::internal(err_msg)) };
+                wait_for_future_and_execute_callback(
+                    this.tokio_handle.clone(),
+                    value_object.cx.channel(),
+                    callback,
+                    err_future,
+                );
+
+                return Ok(value_object.cx.undefined());
+            }
+        };
     let future = this.push_chunk(value);
     wait_for_future_and_execute_callback(
         this.tokio_handle.clone(),

--- a/packages/cubejs-backend-native/test/response-fake.ts
+++ b/packages/cubejs-backend-native/test/response-fake.ts
@@ -112,3 +112,40 @@ export class FakeRowStream extends stream.Readable {
     }
   }
 }
+
+// Pushes rows whose field values are unsupported types (nested arrays) for the
+// native bridge's JsValueObject::get. Used to trigger a deterministic
+// `transform_response` failure on the Rust side without depending on a
+// specific backing database's error path.
+//
+// Each pushed row has the shape `{ <dimension>: [<nested>, <array>] }` — the
+// bridge's primitive-type extractor rejects JsArray values and returns
+// `Err(...)`. The error must flow through `JsWriteStream::reject` rather than
+// panicking; see cube-js/cube#10875.
+export class FakeMalformedRowStream extends stream.Readable {
+  protected readonly fieldNames: string[];
+
+  public constructor(query: any) {
+    super({
+      objectMode: true,
+      highWaterMark: 1024,
+    });
+    this.fieldNames = [
+      ...(query.dimensions || []),
+      ...(query.measures || []),
+    ];
+    if (this.fieldNames.length === 0) {
+      throw new Error('FakeMalformedRowStream requires at least one dimension or measure');
+    }
+    this.setMaxListeners(10);
+  }
+
+  public _read(_size: number) {
+    const row: Record<string, unknown> = {};
+    for (const field of this.fieldNames) {
+      row[field] = [1, 2, 3];
+    }
+    this.push(row);
+    this.push(null);
+  }
+}

--- a/packages/cubejs-backend-native/test/response-fake.ts
+++ b/packages/cubejs-backend-native/test/response-fake.ts
@@ -113,15 +113,9 @@ export class FakeRowStream extends stream.Readable {
   }
 }
 
-// Pushes rows whose field values are unsupported types (nested arrays) for the
-// native bridge's JsValueObject::get. Used to trigger a deterministic
-// `transform_response` failure on the Rust side without depending on a
-// specific backing database's error path.
-//
-// Each pushed row has the shape `{ <dimension>: [<nested>, <array>] }` — the
-// bridge's primitive-type extractor rejects JsArray values and returns
-// `Err(...)`. The error must flow through `JsWriteStream::reject` rather than
-// panicking; see cube-js/cube#10875.
+// Pushes rows with nested-array field values, which the native bridge can't
+// convert to primitives — triggers a deterministic transform_response failure
+// without needing a real database error (see #10875).
 export class FakeMalformedRowStream extends stream.Readable {
   protected readonly fieldNames: string[];
 

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -4,7 +4,7 @@ import { Writable } from 'stream';
 
 import * as native from '../js';
 import metaFixture from './meta';
-import { FakeRowStream } from './response-fake';
+import { FakeRowStream, FakeMalformedRowStream } from './response-fake';
 
 const _logger = jest.fn(({ event }) => {
   if (
@@ -567,5 +567,80 @@ describe('SQLInterface', () => {
     } finally {
       await native.shutdownInterface(instance, 'fast');
     }
+  });
+
+  // Regression test for #10875: a chunk that fails to decode in the native
+  // bridge's transform_response must surface as a stream error, not a panic
+  // that kills the process.
+  it('does not crash node when a stream chunk fails to transform', async () => {
+    if (process.env.CUBESQL_STREAM_MODE !== 'true') {
+      expect(process.env.CUBESQL_STREAM_MODE).toBeFalsy();
+      return;
+    }
+
+    const baseMethods = interfaceMethods();
+    const instance = await native.registerInterface({
+      pgPort: 5556,
+      ...baseMethods,
+      sqlApiLoad: jest.fn(async ({ query, streaming }) => {
+        if (streaming) {
+          return { stream: new FakeMalformedRowStream(query) };
+        }
+        return { error: 'non-streaming path not exercised by this test' };
+      }),
+      stream: jest.fn(async ({ query }) => ({
+        stream: new FakeMalformedRowStream(query),
+      })),
+      canSwitchUserForSession: (_payload) => true,
+    });
+
+    let buf = '';
+    const errors: string[] = [];
+
+    const write = jest.fn((chunk, _, callback) => {
+      const lines = (buf + chunk.toString('utf-8')).split('\n');
+      buf = lines.pop() || '';
+
+      for (const line of lines.filter((it) => it.trim().length)) {
+        const json = JSON.parse(line);
+        if (json.error) {
+          errors.push(json.error);
+        }
+      }
+
+      callback();
+    });
+
+    const cubeSqlStream = new Writable({ write });
+
+    try {
+      // LIMIT above non_streaming_query_max_row_limit (50000) forces the
+      // streaming path
+      await native.execSql(
+        instance,
+        'SELECT order_date FROM KibanaSampleDataEcommerce ORDER BY order_date DESC LIMIT 100000;',
+        cubeSqlStream
+      );
+    } catch (_e) {
+      // execSql may resolve or reject here — we only assert no crash below
+    }
+
+    if (buf.length > 0) {
+      const json = JSON.parse(buf);
+      if (json.error) {
+        errors.push(json.error);
+      }
+    }
+
+    expect(errors.length).toBeGreaterThan(0);
+
+    // A panic caught by Neon also puts the message on the wire, prefixed
+    // with "internal error in Neon module" — its absence is what
+    // distinguishes clean reject() propagation from the old panic.
+    const errorBlob = errors.join('\n');
+    expect(errorBlob).toContain('Expected primitive value');
+    expect(errorBlob).not.toContain('internal error in Neon module');
+
+    await native.shutdownInterface(instance, 'fast');
   });
 });


### PR DESCRIPTION
Found while investigating #10875 (the trigger fix for that is #10877).

## Problem

`js_stream_push_chunk` unwraps the result of `transform_response`. If a driver pushes a chunk whose values don't match the declared schema (e.g. an array where a primitive is expected), the panic crosses the Neon FFI boundary and surfaces as `internal error in Neon module: called Result::unwrap()...`, hiding the real error. Well-behaved drivers don't currently hit this, but the FFI boundary shouldn't be able to panic at all.

## Fix

Replace the `.unwrap()` with an error arm that signals both sides of the bridge: `reject()` so the Rust wire layer surfaces the error to the client, and the per-chunk JS callback so the Node side doesn't hang.

## Testing

A new test pushes chunks with nested-array values through a fake stream (`FakeMalformedRowStream`), forcing `transform_response` to fail, and asserts the real error reaches the wire without the Neon panic prefix.
