### PR TITLE
Add percentile aggregation types (p25-p99)

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3803,6 +3803,8 @@ export class BaseQuery {
           funDef = `PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY ${evaluateSql})`;
         } else if (symbol.type === 'p95') {
           funDef = `PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+        } else if (symbol.type === 'p99') {
+          funDef = `PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ${evaluateSql})`;
         } else if (CubeSymbols.isCalculatedMeasureType(symbol.type)) {
           // TODO calculated measure type will be ungrouped
           // if (this.multiStageDimensions.length !== this.dimensions.length) {
@@ -3833,6 +3835,8 @@ export class BaseQuery {
       return `PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY ${evaluateSql})`;
     } else if (symbol.type === 'p95') {
       return `PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+    } else if (symbol.type === 'p99') {
+      return `PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY ${evaluateSql})`;
     }
     if (multiplied) {
       if (symbol.type === 'number' && evaluateSql === 'count(*)') {

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3793,6 +3793,16 @@ export class BaseQuery {
           funDef = this.countDistinctApprox(evaluateSql);
         } else if (symbol.type === 'countDistinct' || symbol.type === 'count' && !symbol.sql && multiplied) {
           funDef = `count(distinct ${evaluateSql})`;
+        } else if (symbol.type === 'p25') {
+          funDef = `PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+        } else if (symbol.type === 'p50') {
+          funDef = `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+        } else if (symbol.type === 'p75') {
+          funDef = `PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+        } else if (symbol.type === 'p90') {
+          funDef = `PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+        } else if (symbol.type === 'p95') {
+          funDef = `PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ${evaluateSql})`;
         } else if (CubeSymbols.isCalculatedMeasureType(symbol.type)) {
           // TODO calculated measure type will be ungrouped
           // if (this.multiStageDimensions.length !== this.dimensions.length) {
@@ -3813,6 +3823,16 @@ export class BaseQuery {
       return `count(distinct ${evaluateSql})`;
     } else if (symbol.type === 'runningTotal') {
       return `sum(${evaluateSql})`; // TODO
+    } else if (symbol.type === 'p25') {
+      return `PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+    } else if (symbol.type === 'p50') {
+      return `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+    } else if (symbol.type === 'p75') {
+      return `PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+    } else if (symbol.type === 'p90') {
+      return `PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY ${evaluateSql})`;
+    } else if (symbol.type === 'p95') {
+      return `PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ${evaluateSql})`;
     }
     if (multiplied) {
       if (symbol.type === 'number' && evaluateSql === 'count(*)') {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -784,16 +784,18 @@ const CubeRefreshKeySchema = condition(
 );
 
 const measureType = Joi.string().valid(
-  'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox'
+  'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox',
+  'p25', 'p50', 'p75', 'p90', 'p95'
 );
 
 const measureTypeWithCount = Joi.string().valid(
-  'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox'
+  'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox',
+  'p25', 'p50', 'p75', 'p90', 'p95'
 );
 
 const multiStageMeasureType = Joi.string().valid(
   'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox', 'numberAgg',
-  'rank'
+  'rank', 'p25', 'p50', 'p75', 'p90', 'p95'
 );
 
 const timeShiftItemRequired = Joi.object({

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -785,17 +785,17 @@ const CubeRefreshKeySchema = condition(
 
 const measureType = Joi.string().valid(
   'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox',
-  'p25', 'p50', 'p75', 'p90', 'p95'
+  'p25', 'p50', 'p75', 'p90', 'p95', 'p99'
 );
 
 const measureTypeWithCount = Joi.string().valid(
   'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox',
-  'p25', 'p50', 'p75', 'p90', 'p95'
+  'p25', 'p50', 'p75', 'p90', 'p95', 'p99'
 );
 
 const multiStageMeasureType = Joi.string().valid(
   'count', 'number', 'string', 'boolean', 'time', 'sum', 'avg', 'min', 'max', 'countDistinct', 'runningTotal', 'countDistinctApprox', 'numberAgg',
-  'rank', 'p25', 'p50', 'p75', 'p90', 'p95'
+  'rank', 'p25', 'p50', 'p75', 'p90', 'p95', 'p99'
 );
 
 const timeShiftItemRequired = Joi.object({


### PR DESCRIPTION
## Summary

- Adds percentile aggregation types: p25, p50, p75, p90, p95, p99
- Uses `PERCENTILE_CONT` SQL function for multi-stage measures
- Enables benchmarking use cases (e.g., "how does my org compare to the median?")

## Changes

- `CubeValidator.ts`: Added percentile types to measure type validators
- `BaseQuery.js`: Added SQL generation for `PERCENTILE_CONT(x) WITHIN GROUP (ORDER BY ...)`

## Test plan

- [x] Verified percentile measures work with `add_group_by` for multi-stage aggregations
- [x] Tested with reports_benchmark cube in cube-internal

🤖 Generated with [Claude Code](https://claude.ai/code)