### PR TITLE
docs: stop indexing pages outside the docs.json navigation

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -691,7 +691,7 @@
     }
   },
   "seo": {
-    "indexing": "all",
+    "indexing": "navigable",
     "metatags": {
       "og:type": "website",
       "og:site_name": "Cube Documentation"


### PR DESCRIPTION
Switch seo.indexing from "all" to "navigable" so pages we removed from the sidebar (e.g. the legacy visualization-tools entries like Sigma) no longer appear in site search, the sitemap, or AI assistant context.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
