### PR TITLE
docs: add Access Policies viewer page and clean up modeling docs

### DIFF
--- a/docs-mintlify/admin/deployment/environments.mdx
+++ b/docs-mintlify/admin/deployment/environments.mdx
@@ -9,12 +9,6 @@ Every Cube Cloud deployment provides a number of environments:
 - Multiple [staging environments](#staging-environments).
 - Per-user [development environments](#development-environments).
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 ## Production environment
 
 This is the main environment. It runs the data model from the _main branch_.

--- a/docs-mintlify/admin/deployment/infrastructure.mdx
+++ b/docs-mintlify/admin/deployment/infrastructure.mdx
@@ -26,12 +26,6 @@ scaling, and monitoring your Cube Deployments, as well as managing Cube Store
 and persisting pre-aggregated data. This option requires the least effort to
 set up.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 Please note that some Enterprise features, such as VPC peering or PrivateLink are
 not available on the multi-tenant infrastructure. There's also a possibility of
 resource contention ("noisy neighbor") problem.

--- a/docs-mintlify/admin/monitoring/pre-aggregations.mdx
+++ b/docs-mintlify/admin/monitoring/pre-aggregations.mdx
@@ -9,12 +9,6 @@ can see which pre-aggregations are accelerating queries, if they are [being
 refreshed][ref-caching-using-preaggs-refresh], along with the last 24 hours of
 build history.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 <Frame>
   <img src="https://ucarecdn.com/eb10de99-4ff6-4a9f-abd5-736971497583/" />
 </Frame>

--- a/docs-mintlify/admin/monitoring/query-history.mdx
+++ b/docs-mintlify/admin/monitoring/query-history.mdx
@@ -10,8 +10,8 @@ failed.
 
 <Note>
 
-Available on [all plans](https://cube.dev/pricing).
-You can also choose a [Query History tier](/admin/account-billing/pricing#query-history-tiers).
+You can choose a [Query History tier](/admin/account-billing/pricing#query-history-tiers)
+to fit your retention and throughput needs.
 
 </Note>
 

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -175,7 +175,8 @@
                 "pages": [
                   "docs/data-modeling/visual-modeler",
                   "docs/data-modeling/data-model-ide",
-                  "docs/data-modeling/dev-mode"
+                  "docs/data-modeling/dev-mode",
+                  "docs/data-modeling/access-policies-viewer"
                 ]
               }
             ]

--- a/docs-mintlify/docs/data-modeling/access-control/context.mdx
+++ b/docs-mintlify/docs/data-modeling/access-control/context.mdx
@@ -300,12 +300,6 @@ enrich the security context with additional attributes.
 When using Cube Cloud, you can enrich the security context with information about
 an authenticated user, obtained during their authentication.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 You can enable the authentication integration by navigating to the **Settings → Configuration**
 of your Cube Cloud deployment and using the **Enable Cloud Auth Integration** toggle.
 

--- a/docs-mintlify/docs/data-modeling/access-policies-viewer.mdx
+++ b/docs-mintlify/docs/data-modeling/access-policies-viewer.mdx
@@ -1,0 +1,85 @@
+---
+title: Access Policies viewer
+description: Audit row-level, member-level, and member-masking access policies that govern your data model from the Cube Cloud UI, grouped by user group.
+---
+
+The Access Policies viewer surfaces, in one place, every [access policy][ref-access-policies]
+defined in your [data model][ref-data-modeling] — row-level filters, member-level
+restrictions, and member masking — broken down by the user [groups][ref-user-groups]
+they apply to.
+
+Use it to audit who can see which cubes and views, and how each policy is composed,
+without grepping through `cube` files or running test queries.
+
+<Info>
+
+The viewer is read-only. Access policies themselves are authored in the
+[data model][ref-access-policies] using `access_policy` blocks; this page
+visualizes the resolved rules so you can review and debug them.
+
+</Info>
+
+## Opening the viewer
+
+In Cube Cloud, navigate to the **Model** module and click **Access Policies** in
+the sub-sidebar. The viewer reflects whichever branch and build you are currently
+viewing, so policies you are editing in [development mode][ref-dev-mode] appear
+alongside what is live in production.
+
+You need the `PlaygroundRead` permission to open the viewer.
+
+## List view
+
+The list view shows one row per group declared anywhere in the data model:
+
+<Frame>
+  <img src="https://static.cube.dev/docs/data-modeling/access-policies-viewer/list-view.png" alt="Access Policies list view, with one row per user group" />
+</Frame>
+
+
+| Column | What it shows |
+| --- | --- |
+| **Group** | Name of the group. The wildcard entry `*` is rendered as **All Groups** — this is the catch-all default policy applied when no other policy matches. |
+| **Policies** | Number of cubes and views with an explicit policy for this group. Hover the cell to see the full list of cube and view names. |
+| **Default Policy** | Number of cubes and views this group can access without an explicit policy — the union of cubes covered by the wildcard `*` policy and any cubes that have no policy at all. |
+
+Cubes and views with no `access_policy` block defined are considered fully open;
+they appear under **Default Policy** for every group.
+
+Click a row to drill into the per-cube breakdown for that group.
+
+## Per-policy detail view
+
+The detail view shows one row per cube or view that the selected group can
+access, with the resolved policy expanded across four columns:
+
+| Column | What it shows |
+| --- | --- |
+| **Cube / View** | Name of the cube or view, with an icon distinguishing the two. |
+| **Condition** | The number of [`condition`][ref-policy-condition] expressions on the policy, or `—` if the policy applies unconditionally. Conditions are arbitrary expressions defined in the model. |
+| **Member-level Access** | One of three states: **Allow All** (no member-level restrictions), **Deny All** (member access is fully denied), or **Allow:** followed by the resolved set of allowed dimensions, segments, and measures. |
+| **Member Masking** | `—` if no [member masking][ref-mls-masking] applies, otherwise the list of masked dimensions. |
+| **Row-level Access** | Either **Allow All**, or **Filters on:** followed by the dimensions referenced by the row-level filter. |
+
+Member names are shortened to the last path segment for readability — for
+example, `orders.user.email` is shown as `email`.
+
+## What the viewer does not do
+
+The viewer is intentionally scoped to inspecting policies that are already
+defined in the model. It does not:
+
+- Create, edit, or delete access policies. Edit `access_policy` blocks in your
+  data model and commit through your normal Git workflow.
+- Show which individual users belong to a given group. See
+  [User groups][ref-user-groups] for membership management.
+- Run preview queries against a policy. To verify behavior end-to-end, switch
+  the security context and issue queries against your development API.
+
+
+[ref-data-modeling]: /docs/data-modeling/overview
+[ref-access-policies]: /docs/data-modeling/data-access-policies
+[ref-policy-condition]: /reference/data-modeling/data-access-policies#conditions
+[ref-mls-masking]: /docs/data-modeling/data-access-policies#data-masking
+[ref-dev-mode]: /docs/data-modeling/dev-mode
+[ref-user-groups]: /admin/users-and-permissions/user-groups

--- a/docs-mintlify/docs/data-modeling/data-model-ide.mdx
+++ b/docs-mintlify/docs/data-modeling/data-model-ide.mdx
@@ -9,12 +9,6 @@ Data model editor provides the code-first experience for building and enhancing 
 Unlike the [Visual Modeler][ref-visual-model] editor, it provides the freedom to use all
 available data modeling features at the expense of a code-centric experience.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 Cube Cloud can create branch-based development API instances to quickly test
 changes in the data model in your frontend applications before pushing them into
 production.

--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -6,12 +6,6 @@ description: Outlines development mode in Cube Cloud—branch-scoped APIs, save 
 Development mode allows to test and debug the data model in an isolated
 [development environment][ref-environments-dev] before releasing any changes to production.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 When you enter the development mode, you'll have access to your personal API endpoints
 that will track the branch you're on and will be updated automatically when you make
 changes to the data model.

--- a/docs-mintlify/docs/data-modeling/sql-runner.mdx
+++ b/docs-mintlify/docs/data-modeling/sql-runner.mdx
@@ -8,12 +8,6 @@ on your data source or Cube Store. It can be used to inform the development of
 the data model, for ad-hoc querying as well as debugging SQL queries generated
 by Cube to execute against the data source.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 <video width="100%" controls>
   <source
     src="https://ucarecdn.com/8cbdd639-e86b-4190-bbaa-37122c39bc01/video.mp4"

--- a/docs-mintlify/docs/data-modeling/visual-modeler.mdx
+++ b/docs-mintlify/docs/data-modeling/visual-modeler.mdx
@@ -23,10 +23,6 @@ feature.
 
 </Info>
 
-<Frame>
-  <img src="https://ucarecdn.com/8c6c183c-6cf5-4ee1-ab67-36e37b62a12f/" />
-</Frame>
-
 ## Prerequisites
 
 Visual Modeler integrates with the [development mode][ref-dev-mode],

--- a/docs-mintlify/embedding/authentication/security-context.mdx
+++ b/docs-mintlify/embedding/authentication/security-context.mdx
@@ -300,12 +300,6 @@ enrich the security context with additional attributes.
 When using Cube Cloud, you can enrich the security context with information about
 an authenticated user, obtained during their authentication.
 
-<Note>
-
-Available on [all plans](https://cube.dev/pricing).
-
-</Note>
-
 You can enable the authentication integration by navigating to the **Settings → Configuration**
 of your Cube Cloud deployment and using the **Enable Cloud Auth Integration** toggle.
 


### PR DESCRIPTION
- Add a new page under Data Modeling → Developing Model that documents the Access Policies viewer in Cube Cloud, including the list view (with screenshot) and the per-policy detail view.
- Remove the broken hero image from the Visual Modeler page.
- Drop the redundant "Available on all plans" callout from nine pages; the convention is to use a plan-availability <Note> only when the feature is actually plan-gated.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
