### PR TITLE
docs: document userProfile field on Generate Session API

### DIFF
--- a/docs-mintlify/reference/embed-apis/generate-session.mdx
+++ b/docs-mintlify/reference/embed-apis/generate-session.mdx
@@ -23,30 +23,31 @@ POST https://{accountName}.cubecloud.dev/api/v1/embed/generate-session
 
 ### Request Headers
 
-| Header | Value | Required |
-|--------|-------|----------|
-| `Content-Type` | `application/json` | Yes |
-| `Authorization` | `Api-Key YOUR_API_KEY` | Yes |
+| Header          | Value                  | Required |
+| --------------- | ---------------------- | -------- |
+| `Content-Type`  | `application/json`     | Yes      |
+| `Authorization` | `Api-Key YOUR_API_KEY` | Yes      |
 
 ### Request Body
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `deploymentId` | number | Yes | ID of the deployment the session should grant access to. |
-| `externalId` | string | Conditional | Stable identifier for the external user. Provide either `externalId` or `internalId` (not both). Must be lowercase and trimmed. |
-| `internalId` | string | Conditional | Username of an existing internal Cube Cloud user. Provide either `externalId` or `internalId` (not both). The user must already exist. |
-| `email` | string | No | Email to attach to the provisioned external user. Used only with `externalId`. |
-| `embedTenantName` | string | No | Embed tenant to scope content to. Lowercase, 5–36 chars, must start with a letter and end with a letter or digit, only `a-z`, `0-9`, `-`. Defaults to the current tenant. |
-| `creatorMode` | boolean | No | When `true`, mints a [creator-mode][ref-creator-mode] session and resolves groups/attributes against the embed tenant's scoped tables. Requires the `useCreatorMode` tenant flag. |
-| `userAttributes` | array | No | Attribute values for row-level security. See [User attributes](#user-attributes). Not allowed with `internalId`. |
-| `groups` | string[] | No | Group memberships for the user. See [Groups](#groups). Not allowed with `internalId`. |
-| `userAttributeDefinitions` | array | No | Idempotently upsert attribute definitions before applying values. Requires `creatorMode: true`. See [Creator mode bootstrap](#creator-mode-bootstrapping-groups-and-user-attributes). |
-| `groupDefinitions` | array | No | Idempotently upsert group definitions before assigning memberships. Requires `creatorMode: true`. See [Creator mode bootstrap](#creator-mode-bootstrapping-groups-and-user-attributes). |
-| `securityContext` | object | No | Custom security context object passed to Cube queries. Not allowed with `internalId`. |
+| Field                      | Type     | Required    | Description                                                                                                                                                                             |
+| -------------------------- | -------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deploymentId`             | number   | Yes         | ID of the deployment the session should grant access to.                                                                                                                                |
+| `externalId`               | string   | Conditional | Stable identifier for the external user. Provide either `externalId` or `internalId` (not both). Must be lowercase and trimmed.                                                         |
+| `internalId`               | string   | Conditional | Username of an existing internal Cube Cloud user. Provide either `externalId` or `internalId` (not both). The user must already exist.                                                  |
+| `email`                    | string   | No          | Email to attach to the provisioned external user. Used only with `externalId`.                                                                                                          |
+| `userProfile`              | object   | No          | Display name and profile picture to attach to the external user. See [User profile](#user-profile). Not allowed with `internalId`.                                                      |
+| `embedTenantName`          | string   | No          | Embed tenant to scope content to. Lowercase, 5–36 chars, must start with a letter and end with a letter or digit, only `a-z`, `0-9`, `-`. Defaults to the current tenant.               |
+| `creatorMode`              | boolean  | No          | When `true`, mints a [creator-mode][ref-creator-mode] session and resolves groups/attributes against the embed tenant's scoped tables. Requires the `useCreatorMode` tenant flag.       |
+| `userAttributes`           | array    | No          | Attribute values for row-level security. See [User attributes](#user-attributes). Not allowed with `internalId`.                                                                        |
+| `groups`                   | string[] | No          | Group memberships for the user. See [Groups](#groups). Not allowed with `internalId`.                                                                                                   |
+| `userAttributeDefinitions` | array    | No          | Idempotently upsert attribute definitions before applying values. Requires `creatorMode: true`. See [Creator mode bootstrap](#creator-mode-bootstrapping-groups-and-user-attributes).   |
+| `groupDefinitions`         | array    | No          | Idempotently upsert group definitions before assigning memberships. Requires `creatorMode: true`. See [Creator mode bootstrap](#creator-mode-bootstrapping-groups-and-user-attributes). |
+| `securityContext`          | object   | No          | Custom security context object passed to Cube queries. Not allowed with `internalId`.                                                                                                   |
 
 <Info>
 
-When using `internalId`, the user must already exist in Cube Cloud. You cannot specify `groups`, `userAttributes`, `groupDefinitions`, `userAttributeDefinitions`, or `securityContext` with `internalId` — the internal user's existing permissions are used instead.
+When using `internalId`, the user must already exist in Cube Cloud. You cannot specify `groups`, `userAttributes`, `groupDefinitions`, `userAttributeDefinitions`, `securityContext`, or `userProfile` with `internalId` — the internal user's existing permissions are used instead.
 
 </Info>
 
@@ -55,6 +56,43 @@ When using `internalId`, the user must already exist in Cube Cloud. You cannot s
 Accounts are limited to 10,000 external users. To increase this limit, please contact support.
 
 </Warning>
+
+## User profile
+
+`userProfile` lets you attach a human-readable display name and avatar to an external user so they render with a recognizable identity inside embedded surfaces (workbook owners, dashboard headers, etc.) instead of the raw `externalId`.
+
+```json
+{
+  "userProfile": {
+    "displayName": "Jane Query",
+    "picture": "https://example.com/avatars/jq.png"
+  }
+}
+```
+
+| Property      | Type   | Required | Notes                                                                                                   |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------- |
+| `displayName` | string | No       | Human-readable name shown next to the user's avatar.                                                    |
+| `picture`     | string | No       | Publicly accessible URL of the user's profile picture. Must be an absolute `http://` or `https://` URL. |
+
+**Behavior**:
+
+- Both fields are persisted on the external user (keyed by `externalId`).
+- Sending `userProfile` on subsequent `generate-session` calls overwrites the previously-saved values.
+- Omitting `userProfile` (or omitting a property inside it) preserves whatever was saved before.
+
+### Picture format
+
+The `picture` URL must be reachable by the end-user's browser — it's loaded directly via an `<img>` tag in the embedded UI, not proxied through Cube Cloud. The server validates only that the value is a syntactically valid `http(s)://` URL; it does not download or sniff the content.
+
+Use a URL that returns one of the common web image formats: **PNG, JPEG, GIF, WebP, or SVG**. Other content types (videos, PDFs, HTML pages) will fail to render and the avatar will fall back to the user's initials.
+
+Practical guidance:
+
+- Prefer HTTPS URLs — mixed-content rules will block `http://` images on HTTPS embed pages.
+- Keep the image under ~1 MB and ideally square (e.g. 96×96 or 256×256). Avatars are displayed in small containers, so anything larger is wasted bandwidth.
+- The URL must be publicly reachable — signed URLs that expire or assets behind auth headers will not load.
+- If the URL fails to load for any reason (404, wrong content type, CORS, network error), the UI gracefully falls back to an initials avatar derived from `displayName`. No error is returned to the caller.
 
 ## User attributes
 
@@ -71,10 +109,10 @@ Accounts are limited to 10,000 external users. To increase this limit, please co
 }
 ```
 
-| Property | Type | Notes |
-|----------|------|-------|
-| `name` | string | Must reference an existing attribute definition (see lookup rules below). |
-| `value` | `string` \| `number` \| `string[]` \| `number[]` \| `null` | The value type must match the definition's `type`. `null` clears the value. |
+| Property | Type                                                       | Notes                                                                       |
+| -------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `name`   | string                                                     | Must reference an existing attribute definition (see lookup rules below).   |
+| `value`  | `string` \| `number` \| `string[]` \| `number[]` \| `null` | The value type must match the definition's `type`. `null` clears the value. |
 
 **Attribute definition lookup**:
 
@@ -96,11 +134,11 @@ Accounts are limited to 10,000 external users. To increase this limit, please co
 
 **Behavior**:
 
-| Value | Effect |
-|-------|--------|
-| Field omitted (`undefined`) | Existing memberships are preserved. |
-| `[]` (empty array) | All memberships are cleared. |
-| Populated array | Memberships are replaced with exactly the supplied names. |
+| Value                       | Effect                                                    |
+| --------------------------- | --------------------------------------------------------- |
+| Field omitted (`undefined`) | Existing memberships are preserved.                       |
+| `[]` (empty array)          | All memberships are cleared.                              |
+| Populated array             | Memberships are replaced with exactly the supplied names. |
 
 **Group definition lookup**:
 
@@ -132,10 +170,10 @@ Both fields:
 }
 ```
 
-| Property | Type | Required | Notes |
-|----------|------|----------|-------|
-| `name` | string | Yes | Group name. Existing groups with this name are reused. |
-| `description` | string | No | Updated when supplied and different from the stored value. Never cleared. |
+| Property      | Type   | Required | Notes                                                                     |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------- |
+| `name`        | string | Yes      | Group name. Existing groups with this name are reused.                    |
+| `description` | string | No       | Updated when supplied and different from the stored value. Never cleared. |
 
 Duplicate `name` entries within the same request are rejected.
 
@@ -155,13 +193,13 @@ Duplicate `name` entries within the same request are rejected.
 }
 ```
 
-| Property | Type | Required | Notes |
-|----------|------|----------|-------|
-| `name` | string | Yes | Attribute name. Existing attributes with this name are reused. |
-| `type` | enum | Yes | One of `string`, `number`, `string_array`, `number_array`. **Immutable** — see below. |
-| `displayName` | string | No | Updated when supplied and different from the stored value. |
-| `defaultValue` | string | No | Updated when supplied and different from the stored value. |
-| `description` | string | No | Updated when supplied and different from the stored value. |
+| Property       | Type   | Required | Notes                                                                                 |
+| -------------- | ------ | -------- | ------------------------------------------------------------------------------------- |
+| `name`         | string | Yes      | Attribute name. Existing attributes with this name are reused.                        |
+| `type`         | enum   | Yes      | One of `string`, `number`, `string_array`, `number_array`. **Immutable** — see below. |
+| `displayName`  | string | No       | Updated when supplied and different from the stored value.                            |
+| `defaultValue` | string | No       | Updated when supplied and different from the stored value.                            |
+| `description`  | string | No       | Updated when supplied and different from the stored value.                            |
 
 **`type` is immutable.** If a definition with the supplied `name` already exists with a different `type`, the request fails with `cannot change type` and nothing is upserted. This protects every value already stored against that attribute from silently becoming invalid. To change the type, delete the attribute via the [embed-tenant admin API](#embed-tenant-admin-api) and recreate it.
 
@@ -175,30 +213,30 @@ Define a group and an attribute, assign the user to both, and mint a session —
 const session = await fetch(
   `https://${ACCOUNT_NAME}.cubecloud.dev/api/v1/embed/generate-session`,
   {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       Authorization: `Api-Key ${API_KEY}`,
     },
     body: JSON.stringify({
       deploymentId: DEPLOYMENT_ID,
-      externalId: 'user-123',
-      embedTenantName: 'acme-corp',
+      externalId: "user-123",
+      embedTenantName: "acme-corp",
       creatorMode: true,
 
       // Upserted before validation runs
       groupDefinitions: [
-        { name: 'analysts', description: 'Read-only viewers' },
+        { name: "analysts", description: "Read-only viewers" },
       ],
       userAttributeDefinitions: [
-        { name: 'department', type: 'string', displayName: 'Department' },
+        { name: "department", type: "string", displayName: "Department" },
       ],
 
       // Reference the names we just defined
-      groups: ['analysts'],
-      userAttributes: [{ name: 'department', value: 'Sales' }],
+      groups: ["analysts"],
+      userAttributes: [{ name: "department", value: "Sales" }],
     }),
-  },
+  }
 );
 ```
 
@@ -227,8 +265,8 @@ The API returns a session object:
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field       | Type   | Description                                            |
+| ----------- | ------ | ------------------------------------------------------ |
 | `sessionId` | string | Unique session identifier to use for embedding content |
 
 Use the `sessionId` directly in your embed URL to authenticate and load content securely.
@@ -264,26 +302,24 @@ session_id = response.json()['sessionId']
 ```
 
 ```javascript title="JavaScript" JavaScript
-const API_KEY = 'YOUR_API_KEY';
-const ACCOUNT_NAME = 'your-account';
+const API_KEY = "YOUR_API_KEY";
+const ACCOUNT_NAME = "your-account";
 
 // Generate a session on your server
 const response = await fetch(
   `https://${ACCOUNT_NAME}.cubecloud.dev/api/v1/embed/generate-session`,
   {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Api-Key ${API_KEY}`
+      "Content-Type": "application/json",
+      Authorization: `Api-Key ${API_KEY}`,
     },
     body: JSON.stringify({
       deploymentId: 32,
-      externalId: 'user@example.com',
-      userAttributes: [
-        { name: 'department', value: 'Sales' }
-      ],
-      groups: ['analysts']
-    })
+      externalId: "user@example.com",
+      userAttributes: [{ name: "department", value: "Sales" }],
+      groups: ["analysts"],
+    }),
   }
 );
 


### PR DESCRIPTION
Adds a User profile section to the Generate Session reference documenting the new userProfile.displayName and userProfile.picture fields, including supported image formats and graceful fallback behavior when the picture URL fails to load.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
