### PR TITLE
Fix broken links in 'Next Steps' section of Data Modeling Overview docs

### DIFF
--- a/docs-mintlify/docs/data-modeling/overview.mdx
+++ b/docs-mintlify/docs/data-modeling/overview.mdx
@@ -338,5 +338,5 @@ model.
 [ref-apis]: /reference
 [ref-calculated-measures]: /docs/data-modeling/measures#calculated-measures
 [ref-views]: /reference/data-modeling/view
-[ref-explore]: /analytics/explore
-[ref-workbooks]: /analytics/workbooks
+[ref-explore]: /docs/explore-analyze/explore
+[ref-workbooks]: /docs/explore-analyze/workbooks/index


### PR DESCRIPTION
## What
This PR fixes broken or outdated links in the "Next Steps" section of the Data Modeling Overview page.

## Changes
- Updated `/analytics/explore` → `/docs/explore-analyze/explore`
- Updated `/analytics/workbooks` → `/docs/explore-analyze/workbooks/index`

## Why
The previous links pointed to deprecated routes and resulted in 404 pages. These updates ensure users are directed to the correct Explore & Workbooks documentation sections.

## Impact
- Improves navigation from Data Modeling Overview
- Eliminates broken links in documentation flow
- Aligns with current docs routing structure