### PR TITLE
fix(schema-compiler): Throw error for duplicate cube and view names in JS models

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeDictionary.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeDictionary.ts
@@ -14,9 +14,19 @@ export class CubeDictionary implements TranspilerCubeResolver, CompilerInterface
     this.byId = new Map<string, Cube>();
   }
 
-  public compile(cubes: Cube[], _errorReporter?: ErrorReporter): void {
+  public compile(cubes: Cube[], errorReporter?: ErrorReporter): void {
     this.byId = new Map<string, Cube>();
     for (const cube of cubes) {
+      if (errorReporter && this.byId.has(cube.name)) {
+        const existing = this.byId.get(cube.name)!;
+        const existingType = existing.isView ? 'view' : 'cube';
+        const newType = cube.isView ? 'view' : 'cube';
+        if (existingType === newType) {
+          errorReporter.error(`Found duplicate ${newType} name '${cube.name}'.`);
+        } else {
+          errorReporter.error(`Found conflicting cube and view name '${cube.name}'.`);
+        }
+      }
       this.byId.set(cube.name, cube);
     }
   }

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -1365,4 +1365,134 @@ describe('Schema Testing', () => {
       });
     });
   });
+
+  describe('Duplicate cube and view name detection in JS models', () => {
+    it('detects duplicate cube names in a single JS file', async () => {
+      const content = `
+        cube('orders', {
+          sql_table: 'orders',
+          dimensions: {
+            id: { sql: 'id', type: 'number', primary_key: true }
+          }
+        });
+        cube('orders', {
+          sql_table: 'orders_v2',
+          dimensions: {
+            id: { sql: 'id', type: 'number', primary_key: true }
+          }
+        });
+      `;
+
+      const { compiler } = prepareCompiler([{ content, fileName: 'main.js' }]);
+
+      try {
+        await compiler.compile();
+        throw new Error('compile must return an error');
+      } catch (e: any) {
+        expect(e.message).toContain("Found duplicate cube name 'orders'");
+      }
+    });
+
+    it('detects duplicate cube names across JS files', async () => {
+      const { compiler } = prepareCompiler([
+        {
+          content: `cube('orders', {
+            sql_table: 'orders',
+            dimensions: { id: { sql: 'id', type: 'number', primary_key: true } }
+          });`,
+          fileName: 'orders1.js',
+        },
+        {
+          content: `cube('orders', {
+            sql_table: 'orders_v2',
+            dimensions: { id: { sql: 'id', type: 'number', primary_key: true } }
+          });`,
+          fileName: 'orders2.js',
+        },
+      ]);
+
+      try {
+        await compiler.compile();
+        throw new Error('compile must return an error');
+      } catch (e: any) {
+        expect(e.message).toContain("Found duplicate cube name 'orders'");
+      }
+    });
+
+    it('detects duplicate view names in a single JS file', async () => {
+      const content = `
+        cube('orders', {
+          sql_table: 'orders',
+          dimensions: {
+            id: { sql: 'id', type: 'number', primary_key: true },
+            status: { sql: 'status', type: 'string' }
+          }
+        });
+        view('orders_view', {
+          cubes: [{ join_path: orders, includes: ['id'] }]
+        });
+        view('orders_view', {
+          cubes: [{ join_path: orders, includes: ['status'] }]
+        });
+      `;
+
+      const { compiler } = prepareCompiler([{ content, fileName: 'main.js' }]);
+
+      try {
+        await compiler.compile();
+        throw new Error('compile must return an error');
+      } catch (e: any) {
+        expect(e.message).toContain("Found duplicate view name 'orders_view'");
+      }
+    });
+
+    it('detects conflicting cube and view with the same name', async () => {
+      const content = `
+        cube('orders', {
+          sql_table: 'orders',
+          dimensions: {
+            id: { sql: 'id', type: 'number', primary_key: true },
+            status: { sql: 'status', type: 'string' }
+          }
+        });
+        view('orders', {
+          cubes: [{ join_path: orders, includes: ['id'] }]
+        });
+      `;
+
+      const { compiler } = prepareCompiler([{ content, fileName: 'main.js' }]);
+
+      try {
+        await compiler.compile();
+        throw new Error('compile must return an error');
+      } catch (e: any) {
+        expect(e.message).toContain("Found conflicting cube and view name 'orders'");
+      }
+    });
+
+    it('detects conflicting cube and view names across files', async () => {
+      const { compiler } = prepareCompiler([
+        {
+          content: `cube('orders', {
+            sql_table: 'orders',
+            dimensions: { id: { sql: 'id', type: 'number', primary_key: true } }
+          });`,
+          fileName: 'orders_cube.js',
+        },
+        {
+          content: `view('orders', {
+            cubes: [{ join_path: orders, includes: ['id'] }]
+          });`,
+          fileName: 'orders_view.js',
+        },
+      ]);
+
+      try {
+        await compiler.compile();
+        throw new Error('compile must return an error');
+      } catch (e: any) {
+        expect(e.message).toContain("Found conflicting cube and view name 'orders'");
+      }
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Previously, when two cubes or views shared the same name in JS data model files, the later definition would silently overwrite the earlier one. This was already fixed for YAML models (in `YamlCompiler.ts`) but not for JS models.

This PR adds duplicate name detection in `CubeDictionary.compile()` which runs during stage 0 of compilation (the first phase that processes all collected cube/view definitions). It catches:

- **Duplicate cube names** — same name used twice for cubes (within same file or across files)
- **Duplicate view names** — same name used twice for views (within same file or across files)
- **Conflicting cube and view names** — a cube and a view sharing the same name

The detection is placed in `CubeDictionary` because it's the first compiler to receive the complete list of cubes/views regardless of source format (JS or YAML). This provides a unified safety net for all model types.

**Error messages:**
- `Found duplicate cube name '<name>'.`
- `Found duplicate view name '<name>'.`
- `Found conflicting cube and view name '<name>'.`

**Tests added:** 5 new test cases covering single-file duplicates, cross-file duplicates, and cube/view name conflicts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e6303b0-8611-4e04-8e91-c5458938d5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e6303b0-8611-4e04-8e91-c5458938d5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

