### PR TITLE
style(docs): make legacy-docs banner taller and more prominent

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -253,6 +253,13 @@ header.nextra-navbar nav > div.x\:max-md\:hidden:has(button) {
   }
 }
 
+/* Legacy-docs Banner - taller bar so the "visit new docs" link is more prominent */
+.nextra-banner > div {
+  padding-top: 32px !important;
+  padding-bottom: 32px !important;
+  font-size: 1.125rem !important;
+}
+
 /* Purple Banner wrapper - animated reveal */
 .pb-wrapper {
   --purple-banner-font: var(--font-cera-pro), system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
Bumps the Nextra banner padding and font-size so the "Visit the new docs" notice on the old documentation site is harder to miss.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
