### PR TITLE
docs: clean up Monitoring Integrations section

### DIFF
--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -96,7 +96,7 @@ of deployments within a Cube Cloud account. The consumption is measured in 5-min
 | Cube Store Worker | <nobr>1..2</nobr> | Depends on a [chosen tier](#cube-store-worker-tiers) |
 | [Semantic Catalog][ref-semantic-catalog] | <nobr>2..4</nobr> | Depends on a [chosen tier](#semantic-catalog-tiers) |
 | [Query History][ref-query-history] | <nobr>0..20</nobr> | Depends on a [chosen tier](#query-history-tiers) |
-| [Monitoring Integrations][ref-monitoring-integrations] | <nobr>1..4</nobr> | Depends on a [chosen tier](#monitoring-integrations-tiers) |
+| [Monitoring Integrations][ref-monitoring-integrations] | — | Available as an [add-on](#monitoring-integrations) on the Enterprise plan |
 
 The following resource types incur CCU consumption and apply to the _whole Cube Cloud
 account_:
@@ -169,18 +169,11 @@ features analyze and visualize the data available under the following tiers:
 You can upgrade to a chosen tier in the
 **Settings** of your deployment.
 
-### Monitoring Integrations tiers
+### Monitoring Integrations
 
-[Monitoring Integrations][ref-monitoring-integrations] feature has the following tiers:
-
-| Tier | CCUs per hour | Exported data  | Dependent features |
-| ---- | :-----------: | -------------- | --- |
-| XS   | 1             | Up to 10 GB/mo | — |
-| S    | 2             | Up to 25 GB/mo | — |
-| M    | 4             | Up to 50 GB/mo | [Query History export][ref-query-history-export] |
-
-You can [upgrade][ref-monitoring-integrations-config] to a chosen tier in the
-**Settings** of your deployment.
+[Monitoring Integrations][ref-monitoring-integrations], including [Query History
+export][ref-query-history-export], are available as an add-on on the Enterprise
+plan. [Contact us][cube-contact-us] for pricing.
 
 ### Audit Log tiers
 
@@ -330,7 +323,6 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 [ref-cloud-deployment-prod-cluster]: /docs/deployment/cloud/deployment-types#dedicated
 [ref-cloud-limits]: /docs/deployment/cloud/limits
 [ref-monitoring-integrations]: /docs/monitoring/integrations
-[ref-monitoring-integrations-config]: /admin/deployment/monitoring-integrations#configuration
 [ref-cloud-acl]: /admin/users-and-permissions/custom-roles
 [ref-cloud-deployment-prod-multicluster]: /docs/deployment/cloud/deployment-types#multi-cluster
 [ref-cloud-custom-domains]: /docs/deployment/cloud/custom-domains

--- a/docs-mintlify/admin/deployment/limits.mdx
+++ b/docs-mintlify/admin/deployment/limits.mdx
@@ -35,7 +35,7 @@ types][ref-deployment-types] and [product tiers][ref-pricing]:
 | [Query History][ref-query-history] — queries processed per day for each deployment  |   1,000   | Depends on the [tier][ref-query-history-tiers] | Depends on the [tier][ref-query-history-tiers] | Depends on the [tier][ref-query-history-tiers] |
 | [Audit Log][ref-audit-log] — retention period                                       |     —     |     —     |     —     | 30 days    |
 | [Audit Log][ref-audit-log] — events collected                                       |     —     |     —     |     —     | 10,000     |
-| [Monitoring Integrations][ref-monitoring-integrations] — exported data              |     —     | Depends on the [tier][ref-monitoring-integrations-tiers] | Depends on the [tier][ref-monitoring-integrations-tiers] | Depends on the [tier][ref-monitoring-integrations-tiers] |
+| [Monitoring Integrations][ref-monitoring-integrations] — exported data              |     —     |     —     |     —     | Available as an [add-on][ref-monitoring-integrations] |
 
 ### Number of deployments
 
@@ -82,8 +82,8 @@ support][cube-contact-us] for further assistance.
 
 ### Data exported via Monitoring Integrations
 
-This is a hard limit. Consider upgrading to the next [Monitoring Integrations tier][ref-monitoring-integrations-tiers].
-Usage is calculated per Cube Cloud deployment.
+This is a hard limit. Usage is calculated per Cube Cloud deployment. [Contact
+support][cube-contact-us] for higher quotas.
 
 ## Quotas
 
@@ -106,4 +106,3 @@ response.
 [cube-contact-us]: https://cube.dev/contact
 [ref-query-history-tiers]: /admin/account-billing/pricing#query-history-tiers
 [ref-audit-log]: /admin/monitoring/audit-log
-[ref-monitoring-integrations-tiers]: /admin/account-billing/pricing#monitoring-integrations-tiers

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -1,9 +1,7 @@
 ---
-title: Strategy, credentials, etc.
+title: Overview
 description: Export Cube Cloud logs and metrics to external monitoring tools like Datadog, Grafana Cloud, and New Relic.
 ---
-
- Monitoring Integrations
 
 Cube Cloud allows exporting logs and metrics to external monitoring tools so you
 can leverage your existing monitoring stack and retain logs and metrics for the
@@ -11,8 +9,7 @@ long term.
 
 <Note>
 
-Available on [Enterprise plan](https://cube.dev/pricing).
-You can also choose a [Monitoring Integrations tier](/admin/account-billing/pricing#monitoring-integrations-tiers).
+Available as an add-on on the [Enterprise plan](https://cube.dev/pricing).
 
 </Note>
 
@@ -47,16 +44,21 @@ destinations][vector-docs-sinks], also known as _sinks_.
 Monitoring integrations work with various popular monitoring tools. Check the
 following guides and configuration examples to get tool-specific instructions:
 
-<CardGroup cols={2}>
-  <Card title="Amazon CloudWatch" img="https://static.cube.dev/icons/aws.svg" href="/admin/monitoring/monitoring-integrations/cloudwatch">
+<CardGroup cols={3}>
+  <Card title="Amazon CloudWatch" href="/admin/monitoring/monitoring-integrations/cloudwatch">
+    Export logs and metrics to Amazon CloudWatch.
   </Card>
-  <Card title="Amazon S3" img="https://static.cube.dev/icons/aws.svg" href="/admin/monitoring/monitoring-integrations/s3">
+  <Card title="Amazon S3" href="/admin/monitoring/monitoring-integrations/s3">
+    Archive logs to an Amazon S3 bucket.
   </Card>
-  <Card title="Datadog" img="https://static.cube.dev/icons/datadog.svg" href="/admin/monitoring/monitoring-integrations/datadog">
+  <Card title="Datadog" href="/admin/monitoring/monitoring-integrations/datadog">
+    Export logs and metrics to Datadog.
   </Card>
-  <Card title="Grafana Cloud" img="https://static.cube.dev/icons/grafana.svg" href="/admin/monitoring/monitoring-integrations/grafana-cloud">
+  <Card title="Grafana Cloud" href="/admin/monitoring/monitoring-integrations/grafana-cloud">
+    Export logs and metrics to Grafana Cloud.
   </Card>
-  <Card title="New Relic" img="https://static.cube.dev/icons/new-relic.svg" href="/admin/monitoring/monitoring-integrations/new-relic">
+  <Card title="New Relic" href="/admin/monitoring/monitoring-integrations/new-relic">
+    Export logs and metrics to New Relic.
   </Card>
 </CardGroup>
 
@@ -64,8 +66,7 @@ following guides and configuration examples to get tool-specific instructions:
 
 To enable monitoring integrations, navigate to **Settings → Monitoring
 Integrations** and click **Enable Vector** to add a Vector agent to
-your deployment. You can use the dropdown to select a [Monitoring Integrations
-tier](/admin/account-billing/pricing#monitoring-integrations-tiers).
+your deployment.
 
 <Frame>
   <img src="https://ucarecdn.com/bf05182f-bbb0-4c20-a95e-ca7aeb03829e/" />
@@ -283,12 +284,12 @@ external monitoring solution for further analysis, for example:
 * Set up alerts for queries that exceed a certain duration.
 * Attribute usage to specific users and implement chargebacks.
 
-<Info>
+<Note>
 
-Requires the [M tier](/admin/account-billing/pricing#monitoring-integrations-tiers)
-of Monitoring Integrations.
+Query History export is part of the Monitoring Integrations add-on,
+available on the [Enterprise plan](https://cube.dev/pricing).
 
-</Info>
+</Note>
 
 <iframe
   width="100%"

--- a/docs-mintlify/admin/monitoring/query-history-export.mdx
+++ b/docs-mintlify/admin/monitoring/query-history-export.mdx
@@ -1,5 +1,6 @@
 ---
 title: Analyzing data from Query History export
+sidebarTitle: Query History export
 description: Walk through exporting Query History to Amazon S3 with Vector and analyzing the files with DuckDB inside Cube.
 ---
 


### PR DESCRIPTION
- Reposition Monitoring Integrations as an Enterprise add-on (no tiers) on the index page, limits page, and pricing page.
- Replace large vendor-logo cards with title + description cards in a 3-column grid.
- Rename the index page title from "Strategy, credentials, etc." to "Overview" and drop the orphan migration-leftover heading.
- Make the Query History export callout state explicitly that it is part of the Monitoring Integrations add-on.
- Use a shorter sidebar label for the Query History export recipe.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
