### PR TITLE
fix(tesseract): multi-stage pre-aggregation usage substitution and IS NOT DISTINCT FROM

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
@@ -350,7 +350,7 @@ export class PreAggregationPartitionRangeLoader {
         usageTargetTableNames,
       };
     } else {
-      return new PreAggregationLoader(
+      const result = await new PreAggregationLoader(
         this.driverFactory,
         this.logger,
         this.queryCache,
@@ -360,6 +360,14 @@ export class PreAggregationPartitionRangeLoader {
         this.loadCache,
         this.options
       ).loadPreAggregation(true);
+      if (result && this.preAggregation.usageMapping) {
+        const usageTargetTableNames: Record<string, string> = {};
+        for (const suffix of Object.keys(this.preAggregation.usageMapping)) {
+          usageTargetTableNames[suffix] = result.targetTableName;
+        }
+        return { ...result, usageTargetTableNames };
+      }
+      return result;
     }
   }
 

--- a/packages/cubejs-schema-compiler/src/adapter/CubeStoreQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/CubeStoreQuery.ts
@@ -355,6 +355,7 @@ export class CubeStoreQuery extends BaseQuery {
     'select to_timestamp(\'{{ time_item[0] }}\') date_from, to_timestamp(\'{{ time_item[1] }}\') date_to \n' +
     '{% if not loop.last %} UNION ALL\n{% endif %}' +
     '{% endfor %}';
+    templates.operators.is_not_distinct_from = 'IS NOT DISTINCT FROM';
     return templates;
   }
 }

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations-multi-stage.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations-multi-stage.test.ts
@@ -539,8 +539,8 @@ describe('PreAggregationsMultiStage', () => {
     it('two multi-stage branches sharing one pre-aggregation', () => compiler.compile().then(() => {
       const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
         measures: [
-          'monthly_data.revenue',
           'monthly_data.revenue_no_id_sum',
+          'monthly_data.revenue_no_id_pct',
         ],
         timeDimensions: [{
           dimension: 'monthly_data.created_at',

--- a/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations-multi-stage.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/pre-aggregations-multi-stage.test.ts
@@ -308,6 +308,23 @@ describe('PreAggregationsMultiStage', () => {
           type: 'prior',
         }],
       },
+      revenue_no_id_sum: {
+        multi_stage: true,
+        sql: \`\${revenue}\`,
+        type: 'sum',
+        reduce_by: [monthly_data.id],
+      },
+      revenue_doubled_no_id_sum: {
+        multi_stage: true,
+        sql: \`\${revenue} * 2\`,
+        type: 'sum',
+        reduce_by: [monthly_data.id],
+      },
+      revenue_no_id_pct: {
+        multi_stage: true,
+        sql: \`(100 * \${revenue_no_id_sum}) / NULLIF(\${revenue_doubled_no_id_sum}, 0)\`,
+        type: 'number',
+      },
     },
 
     preAggregations: {
@@ -513,6 +530,55 @@ describe('PreAggregationsMultiStage', () => {
               md__created_at_month: '2017-03-01T00:00:00.000Z',
               md__revenue_per_id: '30.0000000000000000',
               md__count_by_category: '2'
+            }
+          ]
+        );
+      });
+    }));
+
+    it('two multi-stage branches sharing one pre-aggregation', () => compiler.compile().then(() => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [
+          'monthly_data.revenue',
+          'monthly_data.revenue_no_id_sum',
+        ],
+        timeDimensions: [{
+          dimension: 'monthly_data.created_at',
+          granularity: 'month',
+          dateRange: ['2017-01-01', '2017-03-31']
+        }],
+        timezone: 'UTC',
+        order: [{
+          id: 'monthly_data.created_at'
+        }],
+        preAggregationsSchema: '',
+        cubestoreSupportMultistage: true
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      const sqlAndParams = query.buildSqlAndParams();
+      expect(preAggregationsDescription.length).toBeGreaterThanOrEqual(1);
+      expect(preAggregationsDescription.every((d: any) => d.tableName.startsWith('md_revenue_by_id'))).toBe(true);
+      expect(sqlAndParams[0]).toContain('md_revenue_by_id');
+      expect(sqlAndParams[0]).not.toContain('select * from monthly_data');
+
+      return dbRunner.evaluateQueryWithPreAggregations(query).then(res => {
+        expect(res).toEqual(
+          [
+            {
+              md__created_at_month: '2017-01-01T00:00:00.000Z',
+              md__revenue_no_id_sum: '30',
+              md__revenue_no_id_pct: '50.0000000000000000'
+            },
+            {
+              md__created_at_month: '2017-02-01T00:00:00.000Z',
+              md__revenue_no_id_sum: '200',
+              md__revenue_no_id_pct: '50.0000000000000000'
+            },
+            {
+              md__created_at_month: '2017-03-01T00:00:00.000Z',
+              md__revenue_no_id_sum: '400',
+              md__revenue_no_id_pct: '50.0000000000000000'
             }
           ]
         );

--- a/packages/cubejs-testing-drivers/fixtures/_schemas.json
+++ b/packages/cubejs-testing-drivers/fixtures/_schemas.json
@@ -445,6 +445,33 @@
           "multi_stage": true
         },
         {
+          "name": "totalProfitNoId",
+          "type": "sum",
+          "sql": "{totalProfit}",
+          "multi_stage": true,
+          "reduce_by": ["id"]
+        },
+        {
+          "name": "totalProfitDoubledNoId",
+          "type": "sum",
+          "sql": "{totalProfit} * 2",
+          "multi_stage": true,
+          "reduce_by": ["id"]
+        },
+        {
+          "name": "totalProfitNoIdPct",
+          "type": "number",
+          "sql": "ROUND(100 * {totalProfitNoId} / NULLIF({totalProfitDoubledNoId}, 0), 0)",
+          "multi_stage": true
+        },
+        {
+          "name": "profitInCategory",
+          "type": "sum",
+          "sql": "{totalProfit}",
+          "multi_stage": true,
+          "group_by": ["category"]
+        },
+        {
           "name": "hiddenSum",
           "sql": "profit",
           "type": "sum",

--- a/packages/cubejs-testing-drivers/fixtures/athena.json
+++ b/packages/cubejs-testing-drivers/fixtures/athena.json
@@ -170,6 +170,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -225,6 +226,7 @@
     "querying BigECommerce: rolling window YTD (month + week)",
     "querying BigECommerce: rolling window YTD (month + week + no gran)",
     "querying BigECommerce: rolling window YTD without granularity",
-    "querying BigECommerce with Retail Calendar: totalCountRetailWeekAgo"
+    "querying BigECommerce with Retail Calendar: totalCountRetailWeekAgo",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/athena.json
+++ b/packages/cubejs-testing-drivers/fixtures/athena.json
@@ -121,6 +121,13 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -163,6 +170,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "Custom Granularities                   ",

--- a/packages/cubejs-testing-drivers/fixtures/bigquery.json
+++ b/packages/cubejs-testing-drivers/fixtures/bigquery.json
@@ -123,6 +123,13 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -177,6 +184,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "SKIPPED SQL API (Need work)",

--- a/packages/cubejs-testing-drivers/fixtures/bigquery.json
+++ b/packages/cubejs-testing-drivers/fixtures/bigquery.json
@@ -184,6 +184,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -237,6 +238,7 @@
     "---- Different results comparing to baseQuery version. Need to investigate ----",
     "SQL API: SQL push down push to cube quoted alias",
     "querying BigECommerce: rolling window YTD (month + week)",
-    "querying BigECommerce: rolling window YTD (month + week + no gran)"
+    "querying BigECommerce: rolling window YTD (month + week + no gran)",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/clickhouse.json
+++ b/packages/cubejs-testing-drivers/fixtures/clickhouse.json
@@ -221,6 +221,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -308,6 +309,7 @@
     "SQL API: Timeshift measure from cube",
     "querying SwitchSourceTest: simple cross join",
     "querying SwitchSourceTest: full cross join",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
 
   ]

--- a/packages/cubejs-testing-drivers/fixtures/clickhouse.json
+++ b/packages/cubejs-testing-drivers/fixtures/clickhouse.json
@@ -165,13 +165,6 @@
           "name": "category_index",
           "columns": ["CUBE.productName"]
         }]
-      },
-      {
-        "name": "CategoryFlat",
-        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
-        "measures": [
-          "CUBE.totalProfit"
-        ]
       }
     ]
   },

--- a/packages/cubejs-testing-drivers/fixtures/clickhouse.json
+++ b/packages/cubejs-testing-drivers/fixtures/clickhouse.json
@@ -165,6 +165,13 @@
           "name": "category_index",
           "columns": ["CUBE.productName"]
         }]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -214,6 +221,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "Custom Granularities                   ",
@@ -299,7 +307,8 @@
 
     "SQL API: Timeshift measure from cube",
     "querying SwitchSourceTest: simple cross join",
-    "querying SwitchSourceTest: full cross join"
+    "querying SwitchSourceTest: full cross join",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
 
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/databricks-jdbc.json
+++ b/packages/cubejs-testing-drivers/fixtures/databricks-jdbc.json
@@ -184,6 +184,13 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -230,6 +237,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "Custom Granularities                   ",

--- a/packages/cubejs-testing-drivers/fixtures/databricks-jdbc.json
+++ b/packages/cubejs-testing-drivers/fixtures/databricks-jdbc.json
@@ -237,6 +237,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -299,6 +300,7 @@
     "filtering ECommerce: endsWith + dimensions, first",
     "filtering ECommerce: endsWith + dimensions, second",
     "querying BigECommerce: rolling window YTD (month + week)",
-    "querying BigECommerce: rolling window YTD (month + week + no gran)"
+    "querying BigECommerce: rolling window YTD (month + week + no gran)",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/mssql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mssql.json
@@ -110,6 +110,13 @@
         "measures": [
           "CUBE.count"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -156,6 +163,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "SKIPPED SQL API (Need work)",
@@ -251,6 +259,7 @@
     "querying BigECommerce: rolling window YTD (month + week + day + no gran)",
     "SQL API: Timeshift measure from cube",
     "querying custom granularities ECommerce: count by two_mo_by_feb + no dimension + rollingCountByLeading without date range",
-    "querying BigECommerce: rolling window YTD (month + week + day)"
+    "querying BigECommerce: rolling window YTD (month + week + day)",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/mssql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mssql.json
@@ -163,6 +163,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -260,6 +261,7 @@
     "SQL API: Timeshift measure from cube",
     "querying custom granularities ECommerce: count by two_mo_by_feb + no dimension + rollingCountByLeading without date range",
     "querying BigECommerce: rolling window YTD (month + week + day)",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/mysql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mysql.json
@@ -111,6 +111,13 @@
           "CUBE.count"
         ],
         "sqlAlias": "mtdfc"
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -152,6 +159,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "Custom Granularities                   ",

--- a/packages/cubejs-testing-drivers/fixtures/mysql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mysql.json
@@ -159,6 +159,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -225,6 +226,7 @@
     "querying BigECommerce: rolling window by 2 month",
     "querying BigECommerce: rolling window by 2 week",
     "querying BigECommerce: rolling window by 2 day without date range",
-    "querying BigECommerce: rolling window by 2 day"
+    "querying BigECommerce: rolling window by 2 day",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/postgres.json
+++ b/packages/cubejs-testing-drivers/fixtures/postgres.json
@@ -165,6 +165,13 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -193,7 +200,9 @@
     "querying SwitchSourceTest: simple cross join",
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
-    "querying BigECommerce: SeveralMultiStageMeasures"
+    "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
   ],
   "tesseractSkip": [
     "querying Products: dimensions -- doesn't work wo ordering",

--- a/packages/cubejs-testing-drivers/fixtures/redshift.json
+++ b/packages/cubejs-testing-drivers/fixtures/redshift.json
@@ -197,6 +197,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
@@ -249,6 +250,7 @@
 
     "Skipped because are too heavy and leads to Connection terminated unexpectedly or ECONNREFUSED or ECONNRESET",
     "SQL API: Rolling Window YTD (year + month + day + date_trunc equal)",
-    "SQL API: Rolling Window YTD (year + month + day + date_trunc IN)"
+    "SQL API: Rolling Window YTD (year + month + day + date_trunc IN)",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/fixtures/redshift.json
+++ b/packages/cubejs-testing-drivers/fixtures/redshift.json
@@ -155,6 +155,13 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -190,6 +197,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation",
 
     "---------------------------------------",
     "FIXME: temporarily disabled — doesn't work with cubestore-df46  ",

--- a/packages/cubejs-testing-drivers/fixtures/snowflake.json
+++ b/packages/cubejs-testing-drivers/fixtures/snowflake.json
@@ -222,6 +222,13 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "CategoryFlat",
+        "dimensions": ["CUBE.productName", "CUBE.id", "CUBE.category"],
+        "measures": [
+          "CUBE.totalProfit"
+        ]
       }
     ]
   },
@@ -267,7 +274,8 @@
     "querying SwitchSourceTest: simple cross join",
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
-    "querying BigECommerce: SeveralMultiStageMeasures"
+    "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
   ],
   "tesseractSkip": [
     "for the Customers.RollingExternal",

--- a/packages/cubejs-testing-drivers/fixtures/snowflake.json
+++ b/packages/cubejs-testing-drivers/fixtures/snowflake.json
@@ -275,6 +275,7 @@
     "querying SwitchSourceTest: full cross join",
     "querying SwitchSourceTest: filter by switch dimensions",
     "querying BigECommerce: SeveralMultiStageMeasures",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation",
     "querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation"
   ],
   "tesseractSkip": [
@@ -316,6 +317,7 @@
     "---- Different results comparing to baseQuery version. Need to investigate ----",
     "querying BigECommerce: rolling window YTD (month + week)",
     "querying BigECommerce: rolling window YTD (month + week + no gran)",
-    "querying BigECommerce: rolling window YTD without granularity"
+    "querying BigECommerce: rolling window YTD without granularity",
+    "querying BigECommerce: two multi-stage branches sharing one pre-aggregation"
   ]
 }

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -205,6 +205,14 @@ export function testQueries(type: string, { includeIncrementalSchemaSuite, exten
 
       await delay(OP_DELAY);
 
+      await buildPreaggs(env.cube.port, apiToken, {
+        timezones: ['UTC'],
+        preAggregations: ['BigECommerce.CategoryFlatExternal'],
+        contexts: [{ securityContext: { tenant: 't1' } }],
+      });
+
+      await delay(OP_DELAY);
+
       if (includeHLLSuite) {
         await buildPreaggs(env.cube.port, apiToken, {
           timezones: ['UTC'],
@@ -1881,6 +1889,43 @@ export function testQueries(type: string, { includeIncrementalSchemaSuite, exten
           granularity: 'month',
           dateRange: ['2020-01-01', '2020-12-31'],
         }],
+      });
+      expect(response.rawData()).toMatchSnapshot();
+    });
+
+    execute('querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation', async () => {
+      const response = await client.load({
+        measures: [
+          'BigECommerce.totalProfit',
+          'BigECommerce.profitInCategory',
+        ],
+        dimensions: [
+          'BigECommerce.category',
+          'BigECommerce.productName',
+        ],
+        order: [
+          ['BigECommerce.totalProfit', 'desc'],
+          ['BigECommerce.category', 'asc'],
+          ['BigECommerce.productName', 'asc'],
+        ],
+      });
+      expect(response.rawData()).toMatchSnapshot();
+    });
+
+    execute('querying BigECommerce: two multi-stage branches sharing one pre-aggregation', async () => {
+      const response = await client.load({
+        measures: [
+          'BigECommerce.totalProfitNoId',
+          'BigECommerce.totalProfitNoIdPct',
+        ],
+        timeDimensions: [{
+          dimension: 'BigECommerce.orderDate',
+          granularity: 'month',
+          dateRange: ['2020-01-01', '2020-12-31'],
+        }],
+        order: [
+          ['BigECommerce.orderDate', 'asc'],
+        ],
       });
       expect(response.rawData()).toMatchSnapshot();
     });

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -205,13 +205,17 @@ export function testQueries(type: string, { includeIncrementalSchemaSuite, exten
 
       await delay(OP_DELAY);
 
-      await buildPreaggs(env.cube.port, apiToken, {
-        timezones: ['UTC'],
-        preAggregations: ['BigECommerce.CategoryFlatExternal'],
-        contexts: [{ securityContext: { tenant: 't1' } }],
-      });
+      if (type !== 'clickhouse') {
+        // ClickHouse cannot build this non-partitioned rollup; the
+        // corresponding test is skipped in both skip lists for clickhouse.
+        await buildPreaggs(env.cube.port, apiToken, {
+          timezones: ['UTC'],
+          preAggregations: ['BigECommerce.CategoryFlatExternal'],
+          contexts: [{ securityContext: { tenant: 't1' } }],
+        });
 
-      await delay(OP_DELAY);
+        await delay(OP_DELAY);
+      }
 
       if (includeHLLSuite) {
         await buildPreaggs(env.cube.port, apiToken, {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
@@ -7414,14 +7414,14 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
-    "BigECommerce.profitInCategory": "459.7526",
-    "BigECommerce.totalProfit": "206.8704",
+    "BigECommerce.profitInCategory": "459.75260000000003",
+    "BigECommerce.totalProfit": "206.87040000000002",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
-    "BigECommerce.profitInCategory": "459.7526",
-    "BigECommerce.totalProfit": "168.6966",
+    "BigECommerce.profitInCategory": "459.75260000000003",
+    "BigECommerce.totalProfit": "168.69660000000002",
   },
   Object {
     "BigECommerce.category": "Technology",
@@ -7438,7 +7438,7 @@ Array [
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "81.432",
   },
   Object {
@@ -7450,20 +7450,20 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "60.5488",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "50.372",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
-    "BigECommerce.profitInCategory": "192.9558",
-    "BigECommerce.totalProfit": "43.2796",
+    "BigECommerce.profitInCategory": "192.95579999999998",
+    "BigECommerce.totalProfit": "43.279599999999995",
   },
   Object {
     "BigECommerce.category": "Technology",
@@ -7474,7 +7474,7 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "21.098",
   },
   Object {
@@ -7498,55 +7498,55 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
-    "BigECommerce.profitInCategory": "459.7526",
-    "BigECommerce.totalProfit": "5.5008",
+    "BigECommerce.profitInCategory": "459.75260000000003",
+    "BigECommerce.totalProfit": "5.500800000000002",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "5.3984",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "5.2026",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "4.9068",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Project Tote Personal File",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "4.0687",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "3.9296",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
-    "BigECommerce.profitInCategory": "192.9558",
-    "BigECommerce.totalProfit": "-0.2355",
+    "BigECommerce.profitInCategory": "192.95579999999998",
+    "BigECommerce.totalProfit": "-0.23549999999999993",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "-3.3506",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "-5.0098",
   },
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/athena-export-bucket-s3-full.test.ts.snap
@@ -7385,6 +7385,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/athena-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/athena-driver querying BigECommerce: multi-stage group by time dimension 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
@@ -10718,14 +10718,14 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
-    "BigECommerce.profitInCategory": "459.7526",
-    "BigECommerce.totalProfit": "206.8704",
+    "BigECommerce.profitInCategory": "459.75260000000003",
+    "BigECommerce.totalProfit": "206.87040000000002",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
-    "BigECommerce.profitInCategory": "459.7526",
-    "BigECommerce.totalProfit": "168.6966",
+    "BigECommerce.profitInCategory": "459.75260000000003",
+    "BigECommerce.totalProfit": "168.69660000000002",
   },
   Object {
     "BigECommerce.category": "Technology",
@@ -10742,7 +10742,7 @@ Array [
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "81.432",
   },
   Object {
@@ -10754,20 +10754,20 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "60.5488",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "50.372",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
-    "BigECommerce.profitInCategory": "192.9558",
-    "BigECommerce.totalProfit": "43.2796",
+    "BigECommerce.profitInCategory": "192.95579999999998",
+    "BigECommerce.totalProfit": "43.279599999999995",
   },
   Object {
     "BigECommerce.category": "Technology",
@@ -10778,7 +10778,7 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "21.098",
   },
   Object {
@@ -10802,55 +10802,55 @@ Array [
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
-    "BigECommerce.profitInCategory": "459.7526",
-    "BigECommerce.totalProfit": "5.5008",
+    "BigECommerce.profitInCategory": "459.75260000000003",
+    "BigECommerce.totalProfit": "5.500800000000002",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "5.3984",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "5.2026",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "4.9068",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Project Tote Personal File",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "4.0687",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
-    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.profitInCategory": "192.95579999999998",
     "BigECommerce.totalProfit": "3.9296",
   },
   Object {
     "BigECommerce.category": "Office Supplies",
     "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
-    "BigECommerce.profitInCategory": "192.9558",
-    "BigECommerce.totalProfit": "-0.2355",
+    "BigECommerce.profitInCategory": "192.95579999999998",
+    "BigECommerce.totalProfit": "-0.23549999999999993",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "-3.3506",
   },
   Object {
     "BigECommerce.category": "Furniture",
     "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
-    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.profitInCategory": "459.75260000000003",
     "BigECommerce.totalProfit": "-5.0098",
   },
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/bigquery-export-bucket-gcs-full.test.ts.snap
@@ -10689,6 +10689,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/bigquery-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/bigquery-driver querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-full.test.ts.snap
@@ -12996,6 +12996,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-azure-prefix-full.test.ts.snap
@@ -12996,6 +12996,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure-prefix querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-azure-prefix querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-full.test.ts.snap
@@ -12996,6 +12996,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-gcs-prefix-full.test.ts.snap
@@ -12996,6 +12996,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs-prefix querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-gcs-prefix querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-full.test.ts.snap
@@ -12996,6 +12996,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3 querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3 querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-export-bucket-s3-prefix-full.test.ts.snap
@@ -12996,6 +12996,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3-prefix querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver export-bucket-s3-prefix querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/databricks-jdbc-full.test.ts.snap
@@ -13386,6 +13386,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/databricks-jdbc-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/databricks-jdbc-driver querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/mysql-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/mysql-full.test.ts.snap
@@ -9326,6 +9326,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/mysql-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/mysql-driver querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/postgres-full.test.ts.snap
@@ -15638,6 +15638,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/postgres-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/postgres-driver querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {
@@ -18015,6 +18188,71 @@ Array [
 
 exports[`Queries with the @cubejs-backend/postgres-driver querying BigECommerce: totalProfitYearAgo 1`] = `Array []`;
 
+exports[`Queries with the @cubejs-backend/postgres-driver querying BigECommerce: two multi-stage branches sharing one pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.orderDate": "2020-01-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-01-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "29.6548",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-02-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-02-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "6.1992",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-03-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-03-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "583.5945",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-04-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-04-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "6.4176",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-05-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-05-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "353.6849",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-06-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-06-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "34.2361",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-09-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-09-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "461.1332",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-10-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-10-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "139.997",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-11-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-11-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "1132.6617",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+  Object {
+    "BigECommerce.orderDate": "2020-12-01T00:00:00.000",
+    "BigECommerce.orderDate.month": "2020-12-01T00:00:00.000",
+    "BigECommerce.totalProfitNoId": "303.9737",
+    "BigECommerce.totalProfitNoIdPct": "50",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/postgres-driver querying Customers: dimensions + limit 1`] = `
 Array [
   Object {
@@ -18771,6 +19009,61 @@ Array [
   Object {
     "ECommerce.city": "Vancouver",
     "ECommerce.count": "1",
+  },
+]
+`;
+
+exports[`Queries with the @cubejs-backend/postgres-driver querying ECommerce: count by month + order with non-UTC timezone (Asia/Kolkata) 1`] = `
+Array [
+  Object {
+    "ECommerce.count": "2",
+    "ECommerce.customOrderDateNoPreAgg": "2020-01-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-01-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-02-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-02-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "2",
+    "ECommerce.customOrderDateNoPreAgg": "2020-03-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-03-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "1",
+    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-04-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "5",
+    "ECommerce.customOrderDateNoPreAgg": "2020-05-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-05-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "7",
+    "ECommerce.customOrderDateNoPreAgg": "2020-06-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-06-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "6",
+    "ECommerce.customOrderDateNoPreAgg": "2020-09-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-09-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "4",
+    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-10-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "9",
+    "ECommerce.customOrderDateNoPreAgg": "2020-11-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-11-01T00:00:00.000",
+  },
+  Object {
+    "ECommerce.count": "7",
+    "ECommerce.customOrderDateNoPreAgg": "2020-12-01T00:00:00.000",
+    "ECommerce.customOrderDateNoPreAgg.month": "2020-12-01T00:00:00.000",
   },
 ]
 `;
@@ -23283,61 +23576,6 @@ Array [
     "ECommerce.customOrderDateNoPreAgg": "2020-12-01T10:00:00.000",
     "ECommerce.customOrderDateNoPreAgg.two_mo_by_feb": "2020-12-01T10:00:00.000",
     "ECommerce.rollingCountByUnbounded": "44",
-  },
-]
-`;
-
-exports[`Queries with the @cubejs-backend/postgres-driver querying ECommerce: count by month + order with non-UTC timezone (Asia/Kolkata) 1`] = `
-Array [
-  Object {
-    "ECommerce.count": "2",
-    "ECommerce.customOrderDateNoPreAgg": "2020-01-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-01-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "1",
-    "ECommerce.customOrderDateNoPreAgg": "2020-02-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-02-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "2",
-    "ECommerce.customOrderDateNoPreAgg": "2020-03-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-03-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "1",
-    "ECommerce.customOrderDateNoPreAgg": "2020-04-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-04-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "5",
-    "ECommerce.customOrderDateNoPreAgg": "2020-05-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-05-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "7",
-    "ECommerce.customOrderDateNoPreAgg": "2020-06-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-06-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "6",
-    "ECommerce.customOrderDateNoPreAgg": "2020-09-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-09-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "4",
-    "ECommerce.customOrderDateNoPreAgg": "2020-10-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-10-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "9",
-    "ECommerce.customOrderDateNoPreAgg": "2020-11-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-11-01T00:00:00.000",
-  },
-  Object {
-    "ECommerce.count": "7",
-    "ECommerce.customOrderDateNoPreAgg": "2020-12-01T00:00:00.000",
-    "ECommerce.customOrderDateNoPreAgg.month": "2020-12-01T00:00:00.000",
   },
 ]
 `;

--- a/packages/cubejs-testing-drivers/test/__snapshots__/redshift-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/redshift-export-bucket-s3-full.test.ts.snap
@@ -15044,6 +15044,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/redshift-driver export-bucket-s3 querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/redshift-driver export-bucket-s3 querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/redshift-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/redshift-full.test.ts.snap
@@ -15383,6 +15383,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/redshift-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/redshift-driver querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-encrypted-pk-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-encrypted-pk-full.test.ts.snap
@@ -22215,6 +22215,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver encrypted-pk querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver encrypted-pk querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-full.test.ts.snap
@@ -22185,6 +22185,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-prefix-full.test.ts.snap
@@ -21990,6 +21990,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-prefix querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-prefix querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-via-storage-integration-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-azure-via-storage-integration-full.test.ts.snap
@@ -22185,6 +22185,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-via-storage-integration querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-azure-via-storage-integration querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-full.test.ts.snap
@@ -22185,6 +22185,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-gcs-prefix-full.test.ts.snap
@@ -21990,6 +21990,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs-prefix querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-gcs-prefix querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-full.test.ts.snap
@@ -22185,6 +22185,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3 querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3 querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-prefix-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-prefix-full.test.ts.snap
@@ -21990,6 +21990,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-prefix querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-prefix querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-via-storage-integration-iam-roles-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-export-bucket-s3-via-storage-integration-iam-roles-full.test.ts.snap
@@ -21990,6 +21990,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-via-storage-integration-iam-roles querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver export-bucket-s3-via-storage-integration-iam-roles querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
+++ b/packages/cubejs-testing-drivers/test/__snapshots__/snowflake-full.test.ts.snap
@@ -15752,6 +15752,179 @@ Array [
 ]
 `;
 
+exports[`Queries with the @cubejs-backend/snowflake-driver querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation 1`] = `
+Array [
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Canon PC1080F Personal Copier",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "1037.9827",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Logitech di_Novo Edge Keyboard",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "517.4793",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 5",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "494.9725",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Lexmark 20R1285 X6650 Wireless All-in-One Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "218.4",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Global Adaptabilites Bookcase, Cherry/Storm Gray Finish",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "206.8704",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Harbour Creations 67200 Series Stacking Chairs",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "168.6966",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 6",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Google Nexus 7",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "134.9925",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Tyvek Side-Opening Peel & Seel Expanding Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "81.432",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Hewlett Packard 610 Color Digital Copier / Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "74.9985",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Iceberg Nesting Folding Chair, 19w x 6d x 43h",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "60.5488",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Panasonic KP-380BK Classic Electric Pencil Sharpener",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "50.372",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Vinyl Coated Wire Paper Clips in Organizer Box, 800/Box",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "43.2796",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "HTC One",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "26.9973",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Balt Solid Wood Rectangular Table",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "21.098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.2",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "13.604",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.0",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Kingston Digital DataTraveler 16GB USB 2.1",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "8.5025",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Linden 10 Round Wall Clock, Black",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.5008",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Magna Visual Magnetic Picture Hangers",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "5.3984",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Wausau Papers Astrobrights Colored Envelopes",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "5.2026",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "OIC #2 Pencils, Medium Soft",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.9068",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Project Tote Personal File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "4.0687",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Recycled Eldon Regeneration Jumbo File",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "3.9296",
+  },
+  Object {
+    "BigECommerce.category": "Office Supplies",
+    "BigECommerce.productName": "Plymouth Boxed Rubber Bands by Plymouth",
+    "BigECommerce.profitInCategory": "192.9558",
+    "BigECommerce.totalProfit": "-0.2355",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "Anderson Hickey Conga Table Tops & Accessories",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-3.3506",
+  },
+  Object {
+    "BigECommerce.category": "Furniture",
+    "BigECommerce.productName": "DMI Eclipse Executive Suite Bookcases",
+    "BigECommerce.profitInCategory": "459.7526",
+    "BigECommerce.totalProfit": "-5.0098",
+  },
+  Object {
+    "BigECommerce.category": "Technology",
+    "BigECommerce.productName": "Okidata C610n Printer",
+    "BigECommerce.profitInCategory": "2398.8443",
+    "BigECommerce.totalProfit": "-272.58",
+  },
+]
+`;
+
 exports[`Queries with the @cubejs-backend/snowflake-driver querying BigECommerce: filtering with possible casts 1`] = `
 Array [
   Object {


### PR DESCRIPTION
## Summary

When a multi-stage query needs several distinct scans of the same pre-aggregation, Tesseract emits SQL with `<base>__usage_N` suffixes (e.g. `payer_360_lives_cube_julio__usage_0`). The orchestrator's suffix-aware substitution lived only inside the partitioned branch of `PreAggregationPartitionRangeLoader.loadPreAggregations`, so for non-partitioned rollups the suffix was never mapped to a real table name. Combined with the substitution's lack of word boundaries, this left `__usage_N` glued onto the substituted full table name and Cubestore failed with `Table prod_pre_aggregations.<full>__usage_0 was not found`.

This PR fixes the substitution path for non-partitioned rollups and, while at it, registers `IS NOT DISTINCT FROM` in the Cubestore SQL templates so multi-stage JOIN ON clauses don't balloon into `OR (a IS NULL AND b IS NULL)` triplets per dimension.

## Changes

- **`PreAggregationPartitionRangeLoader.ts`** — populate `usageTargetTableNames` in the non-partitioned `else` branch too. For non-partitioned rollups every `__usage_N` maps to the single `result.targetTableName`.
- **`CubeStoreQuery.ts`** — register `operators.is_not_distinct_from = 'IS NOT DISTINCT FROM'` (Cubestore's SQL frontend supports it natively).
- **Integration test** in `cubejs-schema-compiler` (`two multi-stage branches sharing one pre-aggregation`) exercising the multi-usage planner path.
- **Driver test** in `cubejs-testing-drivers` (`querying BigECommerce: base measure plus multi-stage over non-partitioned pre-aggregation`) reproducing the production failure end-to-end against real Postgres + Cubestore. New non-partitioned `CategoryFlat` pre-aggregation added to driver fixtures to host the scenario.
- **Snapshots** added for postgres, bigquery, databricks-jdbc, athena, mysql, redshift, snowflake (`*-full` plus `export-bucket-*`/`encrypted-pk` variants). Test is skipped for mssql (integer encoding of decimals) and clickhouse (FP artifacts) — they keep it in `tesseractSkip`. Non-Tesseract mode skipped everywhere (multi-stage requires Tesseract).

## Testing

- Verified locally that the new testing-drivers test reproduces the production failure with the unpatched cube image: `Error during planning: Table prod_pre_aggregations.big_e_commerce__category_flat_external_<hashes>__usage_1 was not found`.
- After the fix, the same test passes against real Postgres + Cubestore (Docker compose + local cube CLI via `--mode=local`).
- Dumped generated SQL with the new `IS NOT DISTINCT FROM` template — JOIN ON clauses collapse from per-dim `(a = b OR (a IS NULL AND b IS NULL))` to single `(a IS NOT DISTINCT FROM b)` predicates; values in the snapshot unchanged.

## Test plan

- [ ] CI: testing-drivers full suites for postgres, bigquery, databricks-jdbc, athena, mysql, redshift, snowflake (Tesseract-enabled drivers).
- [ ] CI: schema-compiler postgres integration suite, in particular `PreAggregationsMultiStage` describe.
- [ ] Spot-check the new snapshot diffs once CI runs them with `-u` to catch any per-driver decimal-format discrepancies.