### PR TITLE
docs(data-modeling): add Model Configuration page

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -170,6 +170,7 @@
                   "docs/data-modeling/dynamic/schema-execution-environment"
                 ]
               },
+              "docs/data-modeling/configuration",
               {
                 "group": "Developing Model",
                 "pages": [

--- a/docs-mintlify/docs/data-modeling/configuration.mdx
+++ b/docs-mintlify/docs/data-modeling/configuration.mdx
@@ -1,0 +1,100 @@
+---
+title: Configuration
+description: Configure model-level query defaults for a Cube deployment — query time zone, row limits, and query timeout.
+---
+
+The **Model Configuration** section in deployment settings is where you set
+model-level defaults that every query in a [deployment][ref-deployment-types]
+inherits unless it overrides them explicitly: the query time zone, default
+and maximum row limits, and the per-query timeout.
+
+<Frame>
+  <img
+    src="https://static.cube.dev/docs/data-modeling/configuration/configuration-page-v2.png"
+    alt="Model Configuration section in deployment settings"
+  />
+</Frame>
+
+To open it, go to **Settings** → **Configuration** in the deployment
+sidebar.
+
+<Note>
+
+Model Configuration is a curated, typed UI for the most common
+model-level environment variables. Anything set here can also be set
+through the [Environment Variables][ref-env-vars] page directly.
+
+</Note>
+
+## Default time zone
+
+The time zone used to interpret and return time dimensions when a query
+doesn't specify one. Accepts any TZ database name, such as
+`America/Los_Angeles` or `Europe/Berlin`. Defaults to `UTC`.
+
+Backed by the
+[`CUBEJS_DEFAULT_TIMEZONE`](/reference/configuration/environment-variables#cubejs_default_timezone)
+environment variable. See [time zone][ref-time-zone] in the queries
+reference for how Cube applies it to time dimensions and date ranges.
+
+## Default row limit
+
+The [row limit][ref-row-limit] applied to a query when it doesn't include
+an explicit `LIMIT`. Defaults to `10,000`.
+
+Lower this if most of your dashboards aggregate to a small number of rows
+and you want to catch run-away "select everything" queries earlier. Raise
+it if you're frequently truncating legitimate result sets.
+
+Backed by
+[`CUBEJS_DB_QUERY_DEFAULT_LIMIT`](/reference/configuration/environment-variables#cubejs_db_query_default_limit).
+
+## Maximum row limit
+
+The hard cap on row count for any query. Any explicit `LIMIT` is reduced
+to this value, regardless of what the client requested. Defaults to
+`50,000`.
+
+This is the guardrail that protects the deployment from out-of-memory
+crashes and accidental full-table extracts.
+
+<Warning>
+
+Raising the maximum row limit can cause out-of-memory crashes and makes
+the deployment more vulnerable to denial-of-service attacks if the APIs
+are exposed to untrusted clients. Increase it only when you have a
+specific use case that requires it.
+
+</Warning>
+
+Backed by
+[`CUBEJS_DB_QUERY_LIMIT`](/reference/configuration/environment-variables#cubejs_db_query_limit).
+[SQL API][ref-sql-api] queries running in streaming mode can exceed this
+cap by design.
+
+## Query timeout
+
+The per-query timeout applied to the upstream data source. Accepts a
+duration string (`10m`, `30s`, `2h`) or a plain number of seconds.
+Defaults to `10m`.
+
+If a query exceeds this timeout, Cube cancels it and returns an error to
+the client. Tune this based on the slowest legitimate query you expect to
+run against the data source.
+
+Backed by
+[`CUBEJS_DB_QUERY_TIMEOUT`](/reference/configuration/environment-variables#cubejs_db_query_timeout).
+
+## Applying changes
+
+Saving Model Configuration restarts the deployment's development-mode
+worker so the new values take effect immediately for the
+[development environment][ref-environments-dev]. Production environments
+pick up the changes on the next build or deploy.
+
+[ref-deployment-types]: /admin/deployment/deployment-types
+[ref-env-vars]: /reference/configuration/environment-variables
+[ref-time-zone]: /reference/core-data-apis/queries#time-zone
+[ref-row-limit]: /reference/core-data-apis/queries#row-limit
+[ref-sql-api]: /reference/core-data-apis/sql-api
+[ref-environments-dev]: /admin/deployment/environments#development-environments

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -21,7 +21,28 @@ Note that chart tables are different from results tables. You can configure pivo
 
 ## Limiting
 
-By default, queries are limited to 5,000 rows of data, but the limit can be adjusted up to 50,000.
+Every query in a workbook returns at most a fixed number of rows. By
+default, queries are limited to **5,000 rows**, and you can adjust the
+limit up to **50,000 rows** from the query controls.
+
+The default and maximum values available in the workbook are governed by
+the deployment's [Model Configuration][ref-configuration]:
+
+- **Default row limit** is applied when a query doesn't specify one
+  explicitly.
+- **Maximum row limit** is the upper bound — any value you pick in the
+  workbook is capped at this number.
+
+Updating those settings at the deployment level changes what every
+workbook in the deployment can request.
+
+<Warning>
+
+Large result sets can slow down chart rendering and may hit browser
+memory limits, especially for tables. When possible, aggregate in the
+semantic layer instead of pulling raw rows into the workbook.
+
+</Warning>
 
 ## Sorting
 
@@ -92,4 +113,5 @@ Currently, advanced semantic queries can be placed on dashboards, but dashboard 
 [ref-core-data-apis]: /reference/core-data-apis
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-graphql-api]: /reference/core-data-apis/graphql-api
+[ref-configuration]: /docs/data-modeling/configuration
 


### PR DESCRIPTION
Document the Model Configuration section of deployment settings — default time zone, default row limit, maximum row limit, and query timeout — and slot it into the Data Modeling group right before Developing Model.

Also expand the Limiting section in the workbook Querying data doc to reference the new page and call out browser-side limits.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

<!--

Please uncomment and fill the sections below if applicable. This will help the reviewer to get the context quicker.

**Issue Reference this PR resolves**

[For example #12]

**Description of Changes Made (if issue reference is not provided)**

[Description goes here]
-->
