### PR TITLE
chore(tesseract): rename view `filters` to `default_filters`

### DIFF
--- a/packages/cubejs-backend-native/src/bridge_test_exports.rs
+++ b/packages/cubejs-backend-native/src/bridge_test_exports.rs
@@ -722,7 +722,7 @@ fn invoke_cube_definition<IT: InnerTypes>(b: &NativeCubeDefinition<IT>) -> Invok
     let mut r = InvokeResult::new();
     r.record("sql_table", b.sql_table());
     r.record("sql", b.sql());
-    r.record("filters", b.filters());
+    r.record("default_filters", b.default_filters());
     r
 }
 

--- a/packages/cubejs-backend-native/test/bridge/bridge-fixtures.ts
+++ b/packages/cubejs-backend-native/test/bridge/bridge-fixtures.ts
@@ -144,7 +144,7 @@ export const cubeDefinitionFixture = (): unknown => ({
   name: 'Orders',
   // sqlAlias, isView, isCalendar, joinMap optional
   // sql_table, sql optional getters
-  filters: [viewFilterDefinitionFixture()],
+  defaultFilters: [viewFilterDefinitionFixture()],
 });
 
 export const dimensionDefinitionFixture = (): unknown => ({

--- a/packages/cubejs-backend-native/test/bridge/object-bridges-coverage.test.ts
+++ b/packages/cubejs-backend-native/test/bridge/object-bridges-coverage.test.ts
@@ -88,7 +88,7 @@ const BRIDGES: BridgeSpec[] = [
   {
     name: 'cubeDefinition',
     expected: [
-      'filters',
+      'default_filters',
       'is_calendar',
       'is_view',
       'join_map',

--- a/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeEvaluator.ts
@@ -148,7 +148,7 @@ export type EvaluatedCube = {
   accessPolicy?: AccessPolicyDefinition[];
   isView?: boolean;
   includedMembers?: ViewIncludedMember[];
-  filters?: ViewDefaultValueFilter[];
+  defaultFilters?: ViewDefaultValueFilter[];
 };
 
 export class CubeEvaluator extends CubeSymbols {
@@ -215,7 +215,7 @@ export class CubeEvaluator extends CubeSymbols {
   }
 
   private prepareViewFilters(cube: any, errorReporter: ErrorReporter) {
-    if (!cube.filters) {
+    if (!cube.defaultFilters) {
       return;
     }
 
@@ -250,7 +250,7 @@ export class CubeEvaluator extends CubeSymbols {
       return `${cube.name}.${match.name}`;
     };
 
-    for (const filter of cube.filters as ViewDefaultValueFilter[]) {
+    for (const filter of cube.defaultFilters as ViewDefaultValueFilter[]) {
       const rawMember = this.evaluateReferences(cube.name, filter.member);
       const resolved = resolveViewMember('member', rawMember);
       if (resolved !== null) {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -226,7 +226,7 @@ export interface CubeDefinition {
   isView?: boolean;
   viewGroup?: string | ((...args: any[]) => any);
   viewGroups?: string[] | ((...args: any[]) => any);
-  filters?: ViewDefaultValueFilter[];
+  defaultFilters?: ViewDefaultValueFilter[];
   calendar?: boolean;
   isSplitView?: boolean;
   includedMembers?: ViewIncludedMember[];

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -1130,7 +1130,7 @@ const folderSchema = Joi.object().keys({
   ]).required(),
 }).id('folderSchema');
 
-const ViewFilterSchema = Joi.object().keys({
+const ViewDefaultFilterSchema = Joi.object().keys({
   member: Joi.func().required(),
   operator: Joi.any().valid(
     'equals',
@@ -1195,7 +1195,7 @@ const viewSchema = inherit(baseSchema, {
     })
   ),
   folders: Joi.array().items(folderSchema),
-  filters: Joi.array().items(ViewFilterSchema),
+  defaultFilters: Joi.array().items(ViewDefaultFilterSchema),
 });
 
 function formatErrorMessageFromDetails(explain, d) {

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -193,8 +193,8 @@ export class YamlCompiler {
           // `includedMembers` are not resolvable at transpile time, so
           // running them through the Python parser would treat the name
           // as an undefined identifier.
-          const isViewFilterMember = /^filters\.\d+\.member$/.test(fullPath);
-          const isViewFilterUnless = /^filters\.\d+\.unless$/.test(fullPath);
+          const isViewFilterMember = /^defaultFilters\.\d+\.member$/.test(fullPath);
+          const isViewFilterUnless = /^defaultFilters\.\d+\.unless$/.test(fullPath);
           if (typeof obj === 'string' && ['sql', 'sqlTable'].includes(propertyPath[propertyPath.length - 1])) {
             return this.parsePythonIntoArrowFunction(`f"${this.escapeDoubleQuotes(obj)}"`, cubeName, obj, errorsReport);
           } else if (typeof obj === 'string' && isViewFilterMember) {

--- a/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/transpilers/CubePropContextTranspiler.ts
@@ -37,9 +37,9 @@ export const transpiledFieldsPatterns: Array<RegExp> = [
   /^(accessPolicy|access_policy)\.[0-9]+\.(rowLevel|row_level)\.filters\.[0-9]+.*\.member$/,
   /^(accessPolicy|access_policy)\.[0-9]+\.(rowLevel|row_level)\.filters\.[0-9]+.*\.values$/,
   /^(accessPolicy|access_policy)\.[0-9]+\.conditions.[0-9]+\.if$/,
-  /^filters\.[0-9]+\.member$/,
-  /^filters\.[0-9]+\.values$/,
-  /^filters\.[0-9]+\.unless$/,
+  /^(defaultFilters|default_filters)\.[0-9]+\.member$/,
+  /^(defaultFilters|default_filters)\.[0-9]+\.values$/,
+  /^(defaultFilters|default_filters)\.[0-9]+\.unless$/,
   /^(measures|dimensions)\.[_a-zA-Z][_a-zA-Z0-9]*\.mask\.sql$/,
 ];
 

--- a/packages/cubejs-schema-compiler/test/integration/postgres/view-default-value-filters.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/view-default-value-filters.test.ts
@@ -53,7 +53,7 @@ views:
     cubes:
       - join_path: orders
         includes: "*"
-    filters:
+    default_filters:
       - member: country
         operator: equals
         values:
@@ -63,7 +63,7 @@ views:
     cubes:
       - join_path: orders
         includes: "*"
-    filters:
+    default_filters:
       - member: country
         operator: equals
         values:
@@ -75,7 +75,7 @@ views:
     cubes:
       - join_path: orders
         includes: "*"
-    filters:
+    default_filters:
       - member: currency
         operator: equals
         values:
@@ -85,7 +85,7 @@ views:
     cubes:
       - join_path: orders
         includes: "*"
-    filters:
+    default_filters:
       - member: currency
         operator: equals
         values:

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -219,7 +219,7 @@ describe('Cube Validation', () => {
         name: 'orders_view',
         isView: true,
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             member: () => 'currency',
             operator: 'equals',
@@ -239,7 +239,7 @@ describe('Cube Validation', () => {
         name: 'orders_view',
         isView: true,
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             member: () => 'currency',
             operator: 'equals',
@@ -260,7 +260,7 @@ describe('Cube Validation', () => {
         name: 'orders_view',
         isView: true,
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             member: () => 'currency',
             operator: 'set',
@@ -279,7 +279,7 @@ describe('Cube Validation', () => {
         name: 'orders_view',
         isView: true,
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             member: () => 'currency',
             operator: 'equals',
@@ -298,7 +298,7 @@ describe('Cube Validation', () => {
         name: 'orders_view',
         isView: true,
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             operator: 'equals',
             values: () => ['USD'],
@@ -317,7 +317,7 @@ describe('Cube Validation', () => {
         name: 'orders_view',
         isView: true,
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             member: () => 'currency',
             operator: 'someInvalidOperator',
@@ -337,7 +337,7 @@ describe('Cube Validation', () => {
         name: 'orders',
         sql: () => 'SELECT * FROM orders',
         fileName: 'fileName',
-        filters: [
+        defaultFilters: [
           {
             member: () => 'currency',
             operator: 'equals',

--- a/packages/cubejs-schema-compiler/test/unit/schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/schema.test.ts
@@ -571,7 +571,7 @@ describe('Schema Testing', () => {
       compiler.throwIfAnyErrors();
 
       const view = cubeEvaluator.evaluatedCubes.orders_view;
-      const filters = view.filters!;
+      const filters = view.defaultFilters!;
       expect(filters).toHaveLength(3);
 
       expect(filters[0].operator).toBe('equals');
@@ -606,7 +606,7 @@ describe('Schema Testing', () => {
 
         view(\`orders_view\`, {
           cubes: [{ join_path: orders, includes: '*' }],
-          filters: [
+          defaultFilters: [
             { member: \`currency\`, operator: 'set' },
             { member: \`orders.currency\`, operator: 'set' },
             { member: \`orders_view.currency\`, operator: 'set' },
@@ -617,7 +617,7 @@ describe('Schema Testing', () => {
       await compiler.compile();
       compiler.throwIfAnyErrors();
 
-      const filters = cubeEvaluator.evaluatedCubes.orders_view.filters!;
+      const filters = cubeEvaluator.evaluatedCubes.orders_view.defaultFilters!;
       expect(filters.map(f => f.memberReference)).toEqual([
         'orders_view.currency',
         'orders_view.currency',
@@ -644,7 +644,7 @@ describe('Schema Testing', () => {
             join_path: orders,
             includes: ['id', 'currency'],
           }],
-          filters: [
+          defaultFilters: [
             { member: \`country\`, operator: 'set' },
           ],
         })
@@ -681,7 +681,7 @@ describe('Schema Testing', () => {
             join_path: orders,
             includes: ['id', 'currency'],
           }],
-          filters: [
+          defaultFilters: [
             { member: \`currency\`, operator: 'set', unless: [\`country\`] },
           ],
         })
@@ -712,7 +712,7 @@ describe('Schema Testing', () => {
 
         view(\`orders_view\`, {
           cubes: [{ join_path: orders, includes: '*' }],
-          filters: [
+          defaultFilters: [
             { member: \`other.currency\`, operator: 'set' },
           ],
         })

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -409,7 +409,7 @@ export function createViewSchemaWithDefaultValueFilter(): string {
         join_path: orders,
         includes: '*',
       }],
-      filters: [
+      defaultFilters: [
         {
           member: \`currency\`,
           operator: 'equals',

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/cube_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/cube_definition.rs
@@ -41,5 +41,5 @@ pub trait CubeDefinition {
     #[nbridge(field, optional)]
     fn sql(&self) -> Result<Option<Rc<dyn MemberSql>>, CubeError>;
     #[nbridge(field, optional, vec)]
-    fn filters(&self) -> Result<Option<Vec<Rc<dyn ViewFilterDefinition>>>, CubeError>;
+    fn default_filters(&self) -> Result<Option<Vec<Rc<dyn ViewFilterDefinition>>>, CubeError>;
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties_compiler.rs
@@ -450,7 +450,7 @@ impl QueryPropertiesCompiler {
             if !cube_def.static_data().is_view.unwrap_or(false) {
                 continue;
             }
-            if let Some(view_filters) = cube_def.filters()? {
+            if let Some(view_filters) = cube_def.default_filters()? {
                 pending_view_filters.extend(view_filters);
             }
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_cube_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_cube_definition.rs
@@ -32,7 +32,7 @@ pub struct MockCubeDefinition {
     joins: HashMap<String, MockJoinItemDefinition>,
 
     #[builder(default)]
-    filters: Vec<MockViewFilterDefinition>,
+    default_filters: Vec<MockViewFilterDefinition>,
 }
 
 impl_static_data!(
@@ -70,16 +70,16 @@ impl CubeDefinition for MockCubeDefinition {
         }
     }
 
-    fn has_filters(&self) -> Result<bool, CubeError> {
-        Ok(!self.filters.is_empty())
+    fn has_default_filters(&self) -> Result<bool, CubeError> {
+        Ok(!self.default_filters.is_empty())
     }
 
-    fn filters(&self) -> Result<Option<Vec<Rc<dyn ViewFilterDefinition>>>, CubeError> {
-        if self.filters.is_empty() {
+    fn default_filters(&self) -> Result<Option<Vec<Rc<dyn ViewFilterDefinition>>>, CubeError> {
+        if self.default_filters.is_empty() {
             Ok(None)
         } else {
             Ok(Some(
-                self.filters
+                self.default_filters
                     .iter()
                     .map(|f| Rc::new(f.clone()) as Rc<dyn ViewFilterDefinition>)
                     .collect(),
@@ -308,8 +308,8 @@ mod tests {
             .sql("SELECT * FROM orders".to_string())
             .build();
 
-        assert!(!view.has_filters().unwrap());
-        assert!(view.filters().unwrap().is_none());
+        assert!(!view.has_default_filters().unwrap());
+        assert!(view.default_filters().unwrap().is_none());
     }
 
     #[test]
@@ -318,7 +318,7 @@ mod tests {
             .name("orders_view".to_string())
             .is_view(Some(true))
             .sql("SELECT * FROM orders".to_string())
-            .filters(vec![
+            .default_filters(vec![
                 MockViewFilterDefinition::builder()
                     .operator("equals".to_string())
                     .member_reference("orders.currency".to_string())
@@ -332,8 +332,8 @@ mod tests {
             ])
             .build();
 
-        assert!(view.has_filters().unwrap());
-        let filters = view.filters().unwrap().unwrap();
+        assert!(view.has_default_filters().unwrap());
+        let filters = view.default_filters().unwrap().unwrap();
         assert_eq!(filters.len(), 2);
 
         let first = filters[0].static_data();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
@@ -641,7 +641,7 @@ impl MockViewBuilder {
         let view_def = MockCubeDefinition::builder()
             .name(self.view_name.clone())
             .is_view(Some(true))
-            .filters(self.default_filters)
+            .default_filters(self.default_filters)
             .build();
 
         let view_cube = MockCube {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/schema.rs
@@ -79,11 +79,11 @@ struct YamlView {
     name: String,
     cubes: Vec<YamlViewCube>,
     #[serde(default)]
-    filters: Vec<YamlViewFilter>,
+    default_filters: Vec<YamlViewDefaultFilter>,
 }
 
 #[derive(Debug, Deserialize)]
-struct YamlViewFilter {
+struct YamlViewDefaultFilter {
     member: String,
     operator: String,
     #[serde(default)]
@@ -185,7 +185,7 @@ impl YamlSchema {
                     view_builder.include_cube_with_prefix(view_cube.join_path, includes, prefix);
             }
 
-            for filter in view.filters {
+            for filter in view.default_filters {
                 let mock_filter = MockViewFilterDefinition::builder()
                     .operator(filter.operator)
                     .member_reference(filter.member)

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/view_default_filters.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/view_default_filters.yaml
@@ -46,7 +46,7 @@ views:
       cubes:
           - join_path: orders
             includes: "*"
-      filters:
+      default_filters:
           - member: orders_view.currency
             operator: equals
             values:
@@ -56,7 +56,7 @@ views:
       cubes:
           - join_path: orders
             includes: "*"
-      filters:
+      default_filters:
           - member: orders_view_with_unless.currency
             operator: equals
             values:


### PR DESCRIPTION
## Summary

Renames the view-level default-value filter key introduced in #10892 from `filters` to `default_filters` (camelCase `defaultFilters` in JS) so the data-model surface reflects that these are *default* filters, distinct from the per-query `filters` option.

