### PR TITLE
docs: fix broken /docs/deployment/cloud/* links

### DIFF
--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -326,13 +326,13 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 
 [cube-pricing]: https://cube.dev/pricing
 [link-contact-us]: https://cube.dev/contact
-[ref-cloud-deployment-dev-instance]: /docs/deployment/cloud/deployment-types#shared
-[ref-cloud-deployment-prod-cluster]: /docs/deployment/cloud/deployment-types#dedicated
-[ref-cloud-limits]: /docs/deployment/cloud/limits
+[ref-cloud-deployment-dev-instance]: /admin/deployment/deployment-types#shared
+[ref-cloud-deployment-prod-cluster]: /admin/deployment/deployment-types#dedicated
+[ref-cloud-limits]: /admin/deployment/limits
 [ref-monitoring-integrations]: /docs/monitoring/integrations
 [ref-monitoring-integrations-config]: /admin/deployment/monitoring-integrations#configuration
 [ref-cloud-acl]: /admin/users-and-permissions/custom-roles
-[ref-cloud-deployment-prod-multicluster]: /docs/deployment/cloud/deployment-types#multi-cluster
+[ref-cloud-deployment-prod-multicluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-cloud-custom-domains]: /docs/deployment/cloud/custom-domains
 [ref-cloud-vpc-peering]: /docs/deployment/cloud/vpc
 [ref-sls]: /docs/integrations/semantic-layer-sync
@@ -346,8 +346,8 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 [ref-audit-log]: /admin/monitoring/audit-log
 [ref-dedicated-infra]: /docs/deployment/cloud/infrastructure#dedicated-infrastructure
 [ref-sso]: /docs/workspace/sso
-[ref-production-cluster]: /docs/deployment/cloud/deployment-types#dedicated
-[ref-development-instance]: /docs/deployment/cloud/deployment-types#shared
+[ref-production-cluster]: /admin/deployment/deployment-types#dedicated
+[ref-development-instance]: /admin/deployment/deployment-types#shared
 [ref-apis]: /reference
 [ref-mdx-api]: /reference/mdx-api
 [ref-dax-api]: /reference/dax-api

--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -114,9 +114,9 @@ longer in certain situations depending on two major factors:
 Complex data models take more time to compile, and complex queries can cause
 response times to be significantly longer than usual.
 
-[ref-deployment-dev-instance]: /docs/deployment/cloud/deployment-types#shared
-[ref-deployment-prod-cluster]: /docs/deployment/cloud/deployment-types#dedicated
-[ref-prod-multi-cluster]: /docs/deployment/cloud/deployment-types#multi-cluster
+[ref-deployment-dev-instance]: /admin/deployment/deployment-types#shared
+[ref-deployment-prod-cluster]: /admin/deployment/deployment-types#dedicated
+[ref-prod-multi-cluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-deployment-pricing]: /admin/account-billing/pricing
 [ref-monitoring]: /admin/deployment/monitoring-integrations
 [ref-data-model]: /docs/data-modeling/overview

--- a/docs-mintlify/admin/deployment/deployment-types.mdx
+++ b/docs-mintlify/admin/deployment/deployment-types.mdx
@@ -158,9 +158,9 @@ To switch a deployment's type, go to the deployment's **Settings** screen
 and select from the available options.
 
 [ref-ctx-to-app-id]: /reference/configuration/config#context_to_app_id
-[ref-limits]: /docs/deployment/cloud/limits#resources
-[ref-scalability]: /docs/deployment/cloud/scalability
+[ref-limits]: /admin/deployment/limits#resources
+[ref-scalability]: /admin/deployment/scalability
 [ref-multitenancy]: /embedding/multitenancy
-[ref-auto-sus]: /docs/deployment/cloud/auto-suspension
+[ref-auto-sus]: /admin/deployment/auto-suspension
 [ref-refresh-worker]: /cube-core/architecture#refresh-worker
 [ref-dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure

--- a/docs-mintlify/admin/deployment/environments.mdx
+++ b/docs-mintlify/admin/deployment/environments.mdx
@@ -108,10 +108,10 @@ credentials**][ref-credentials].
 
 
 [ref-dev-mode]: /docs/data-modeling/dev-mode
-[ref-deployment-types]: /docs/deployment/cloud/deployment-types
-[ref-api-instance-scalability]: /docs/deployment/cloud/scalability#auto-scaling-of-api-instances
+[ref-deployment-types]: /admin/deployment/deployment-types
+[ref-api-instance-scalability]: /admin/deployment/scalability#auto-scaling-of-api-instances
 [ref-pricing-deployment-tiers]: /admin/account-billing/pricing
-[ref-suspend]: /docs/deployment/cloud/auto-suspension
+[ref-suspend]: /admin/deployment/auto-suspension
 [ref-overview]: /docs/workspace/integrations#review-integrations
 [ref-credentials]: /docs/workspace/integrations#view-api-credentials
 [ref-version]: /admin/deployment/index#cube-version

--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -185,9 +185,9 @@ resource consumption in different scenarios.
 
 
 [cube-cloud-signup]: https://cubecloud.dev/auth/signup
-[ref-deployment-types]: /docs/deployment/cloud/deployment-types
+[ref-deployment-types]: /admin/deployment/deployment-types
 [ref-dev-mode]: /docs/data-modeling/dev-mode
-[ref-auto-sus]: /docs/deployment/cloud/auto-suspension
+[ref-auto-sus]: /admin/deployment/auto-suspension
 [ref-total-cost]: /admin/account-billing/pricing#total-cost-examples
 [ref-data-source]: /admin/connect-to-data/data-sources
 [ref-duckdb]: /admin/connect-to-data/data-sources/duckdb

--- a/docs-mintlify/admin/deployment/limits.mdx
+++ b/docs-mintlify/admin/deployment/limits.mdx
@@ -97,12 +97,12 @@ response.
 
 [ref-rest-api]: /reference/rest-api
 [ref-gql-api]: /reference/graphql-api
-[ref-deployment-types]: /docs/deployment/cloud/deployment-types
+[ref-deployment-types]: /admin/deployment/deployment-types
 [ref-pricing]: /admin/account-billing/pricing
 [ref-query-history]: /admin/monitoring/query-history
 [ref-monitoring-integrations]: /admin/deployment/monitoring-integrations
-[ref-dev-instance]: /docs/deployment/cloud/deployment-types#shared
-[ref-prod-cluster]: /docs/deployment/cloud/deployment-types#dedicated
+[ref-dev-instance]: /admin/deployment/deployment-types#shared
+[ref-prod-cluster]: /admin/deployment/deployment-types#dedicated
 [cube-contact-us]: https://cube.dev/contact
 [ref-query-history-tiers]: /admin/account-billing/pricing#query-history-tiers
 [ref-audit-log]: /admin/monitoring/audit-log

--- a/docs-mintlify/admin/deployment/scalability.mdx
+++ b/docs-mintlify/admin/deployment/scalability.mdx
@@ -53,4 +53,4 @@ dropdown:
 </Frame>
 
 
-[ref-limits]: /docs/deployment/cloud/limits#resources
+[ref-limits]: /admin/deployment/limits#resources

--- a/docs-mintlify/admin/deployment/warm-up.mdx
+++ b/docs-mintlify/admin/deployment/warm-up.mdx
@@ -90,8 +90,8 @@ and enable **Warm-up pre-aggregations before deploying API**:
 </Frame>
 
 
-[ref-prod-cluster]: /docs/deployment/cloud/deployment-types#dedicated
-[ref-prod-multi-cluster]: /docs/deployment/cloud/deployment-types#multi-cluster
+[ref-prod-cluster]: /admin/deployment/deployment-types#dedicated
+[ref-prod-multi-cluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-data-model]: /docs/data-modeling/overview
 [ref-dynamic-data-model]: /docs/data-modeling/dynamic
 [ref-multitenancy]: /embedding/multitenancy

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -340,7 +340,7 @@ Query History export.
 </Note>
 
 
-[ref-autosuspend]: /docs/deployment/cloud/auto-suspension#effects-on-experience
+[ref-autosuspend]: /admin/deployment/auto-suspension#effects-on-experience
 [self-sinks-for-metrics]: #configuration-sinks-for-metrics
 [vector]: https://vector.dev/
 [vector-docs-config]: https://vector.dev/docs/reference/configuration/

--- a/docs-mintlify/admin/monitoring/performance.mdx
+++ b/docs-mintlify/admin/monitoring/performance.mdx
@@ -173,12 +173,12 @@ increase it until you see that there's no saturation and no wait time
 for queries and jobs.
 
 
-[ref-scalability-api]: /docs/deployment/cloud/scalability#auto-scaling-of-api-instances
-[ref-scalability-cube-store]: /docs/deployment/cloud/scalability#sizing-cube-store-workers
-[ref-auto-sus]: /docs/deployment/cloud/auto-suspension
-[ref-dev-instance]: /docs/deployment/cloud/deployment-types#shared
-[ref-prod-cluster]: /docs/deployment/cloud/deployment-types#dedicated
-[ref-multi-cluster]: /docs/deployment/cloud/deployment-types#multi-cluster
+[ref-scalability-api]: /admin/deployment/scalability#auto-scaling-of-api-instances
+[ref-scalability-cube-store]: /admin/deployment/scalability#sizing-cube-store-workers
+[ref-auto-sus]: /admin/deployment/auto-suspension
+[ref-dev-instance]: /admin/deployment/deployment-types#shared
+[ref-prod-cluster]: /admin/deployment/deployment-types#dedicated
+[ref-multi-cluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-pre-aggregations]: /docs/pre-aggregations/using-pre-aggregations
 [ref-multitenancy]: /embedding/multitenancy
 [ref-context-to-app-id]: /reference/configuration/config#context_to_app_id

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -814,6 +814,22 @@
     {
       "source": "/admin/deployment/vpc/gcp/byoc",
       "destination": "/admin/deployment/dedicated/gcp/byoc"
+    },
+    {
+      "source": "/docs/deployment/cloud/deployment-types",
+      "destination": "/admin/deployment/deployment-types"
+    },
+    {
+      "source": "/docs/deployment/cloud/auto-suspension",
+      "destination": "/admin/deployment/auto-suspension"
+    },
+    {
+      "source": "/docs/deployment/cloud/limits",
+      "destination": "/admin/deployment/limits"
+    },
+    {
+      "source": "/docs/deployment/cloud/scalability",
+      "destination": "/admin/deployment/scalability"
     }
   ]
 }

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
@@ -370,4 +370,4 @@ on, i.e., your development mode branch, shared branch, or main branch.
 [ref-config-contexts]: /reference/configuration/config#scheduledrefreshcontexts
 [ref-config-schemaversion]: /reference/configuration/config#schema_version
 [ref-dev-mode]: /docs/data-modeling/dev-mode
-[ref-auto-sus]: /docs/deployment/cloud/auto-suspension
+[ref-auto-sus]: /admin/deployment/auto-suspension

--- a/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
@@ -48,4 +48,4 @@ that would automatically do this for you.
 
 [ref-multitenancy]: /embedding/multitenancy
 [ref-preaggs]: /docs/pre-aggregations/using-pre-aggregations
-[ref-production-multi-cluster]: /docs/deployment/cloud/deployment-types#multi-cluster
+[ref-production-multi-cluster]: /admin/deployment/deployment-types#multi-cluster


### PR DESCRIPTION
## Summary

A customer reported that https://docs.cube.dev/admin/deployment/deployment-types#deployment-types is broken. While investigating, I found:

- The page itself is live and the customer-reported URL returns 200. The `#deployment-types` fragment in their URL doesn't match any heading on the page (section anchors are `#shared`, `#dedicated`, `#multi-cluster`, `#switching-between-deployment-types`), so the page just lands at the top instead of scrolling. Nothing in our codebase generates that exact fragment.
- The **actual** broken-link problem is much bigger: the legacy paths `/docs/deployment/cloud/{deployment-types,auto-suspension,limits,scalability}` now 404 on the live docs, but were still used as `[ref-...]` link references in 12 of our own MDX files. So every "learn more about deployment types / auto-suspension / limits / scalability" link from those pages was silently 404'ing.

This PR:

- Adds four redirects in `docs-mintlify/docs.json` mapping `/docs/deployment/cloud/{deployment-types,auto-suspension,limits,scalability}` → `/admin/deployment/<same>`, so any external/cached/customer-saved link keeps working.
- Rewrites internal `[ref-...]` references in 12 MDX files to use the canonical `/admin/deployment/*` paths directly, so internal links no longer route through the redirect.

Verified live status before/after of each path:

```
deployment-types: legacy=404 new=200
auto-suspension:  legacy=404 new=200
limits:           legacy=404 new=200
scalability:      legacy=404 new=200
```

## Test plan

- [ ] `mintlify dev --no-open` boots without compile errors.
- [ ] `mintlify broken-links` reports no new broken anchors.
- [ ] Spot-check rendered pages: pricing, auto-suspension, limits, scalability, deployment-types, environments, warm-up, performance, monitoring-integrations, semantic-layer-sync, refreshing-pre-aggregations — all `[ref-...]` links resolve to live pages.
- [ ] After deploy, `curl -sI https://docs.cube.dev/docs/deployment/cloud/deployment-types` returns a redirect to `/admin/deployment/deployment-types`.

Made with [Cursor](https://cursor.com)