### PR TITLE
docs: drop description from view group example

### DIFF
--- a/docs-mintlify/docs/data-modeling/view-groups.mdx
+++ b/docs-mintlify/docs/data-modeling/view-groups.mdx
@@ -19,8 +19,8 @@ parameters and configuration options.
 ## Defining a view group
 
 A view group is a top-level entity, defined alongside views. At minimum it
-needs a `name`; `title` and `description` make it easier to navigate in
-downstream tools.
+needs a `name`; adding a `title` makes it easier to navigate in downstream
+tools.
 
 <CodeGroup>
 
@@ -28,13 +28,11 @@ downstream tools.
 view_groups:
   - name: sales
     title: Sales
-    description: Revenue and order views for the sales team
 ```
 
 ```javascript title="JavaScript"
 view_group(`sales`, {
-  title: `Sales`,
-  description: `Revenue and order views for the sales team`
+  title: `Sales`
 })
 ```
 


### PR DESCRIPTION
## Summary

Removes `description` from the view group example on the `View groups` data-modeling page. `description` is not part of the documented view group parameter set, so showing it in the example was misleading. The example now uses only `name` and `title`, and the surrounding prose is updated to match.

## Test plan

- [ ] `mintlify dev --no-open` boots without compile errors.
- [ ] Rendered `docs/data-modeling/view-groups` page shows only `name` and `title` in the example for both YAML and JavaScript code groups.

Made with [Cursor](https://cursor.com)