### PR TITLE
docs: make legacy-docs banner non-dismissible and sticky

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -260,6 +260,18 @@ header.nextra-navbar nav > div.x\:max-md\:hidden:has(button) {
   font-size: 1.125rem !important;
 }
 
+/* Legacy-docs Banner - stick to top on all viewports (Nextra default is mobile-only sticky) */
+.nextra-banner {
+  position: sticky !important;
+  top: 0 !important;
+  z-index: 30 !important;
+}
+
+/* Shift the sticky navbar below the sticky banner so they stack instead of overlap */
+header.nextra-navbar {
+  top: var(--nextra-banner-height) !important;
+}
+
 /* Purple Banner wrapper - animated reveal */
 .pb-wrapper {
   --purple-banner-font: var(--font-cera-pro), system-ui, -apple-system, sans-serif;

--- a/docs/app/layout.jsx
+++ b/docs/app/layout.jsx
@@ -80,7 +80,7 @@ const navbar = (
 const footer = <Footer />
 
 const banner = (
-  <Banner storageKey="legacy-docs-2026">
+  <Banner dismissible={false}>
     <a href="https://docs.cube.dev" target="_blank" rel="noreferrer">
       You're looking at the old Cube documentation. Visit the new docs →
     </a>


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Two small tweaks to the "You're looking at the old Cube documentation" banner on the legacy docs site:

- Drop the close button (`dismissible={false}` on the Nextra `Banner`) so the notice can't be hidden — previously it could be dismissed and stored under a `legacy-docs-2026` localStorage key.
- Make the banner sticky on all viewports. Nextra only sticks it at `max-md` by default; this adds `position: sticky; top: 0; z-index: 30` for desktop too, and shifts `header.nextra-navbar` down by `var(--nextra-banner-height)` so the sticky navbar stacks beneath the sticky banner instead of overlapping it. The page content already has `padding-top: calc(--nextra-banner-height + --nextra-navbar-height)` applied by Nextra, so the initial layout stays correct.

Files touched:
- `docs/app/layout.jsx`
- `docs/app/globals.css`