### PR TITLE
fix(drivers): athena custom-granularity pre-aggregation build

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -59,7 +59,10 @@ export class PrestodbQuery extends BaseQuery {
   /**
    * Returns sql for source expression floored to timestamps aligned with
    * intervals relative to origin timestamp point.
-   * Athena doesn't support INTERVALs directly — using date_diff/date_add
+   * Athena doesn't support INTERVALs directly — using date_diff/date_add.
+   * Origin is wrapped in `CAST(... AS TIMESTAMP)` so that `date_add` returns
+   * a plain TIMESTAMP rather than `timestamp with time zone` — Hive cannot
+   * write the TZ-aware type into an export bucket.
    */
   public dateBin(interval: string, source: string, origin: string): string {
     const intervalParsed = parseSqlInterval(interval);
@@ -70,7 +73,7 @@ export class PrestodbQuery extends BaseQuery {
     }
 
     const [unit, count] = intervalParts[0];
-    const originExpr = this.timeStampCast(`'${origin}'`);
+    const originExpr = `CAST(${this.timeStampCast(`'${origin}'`)} AS TIMESTAMP)`;
 
     return `date_add('${unit}',
       floor(

--- a/packages/cubejs-schema-compiler/test/unit/athena-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/athena-query.test.ts
@@ -17,12 +17,25 @@ describe('AthenaQuery', () => {
         },
         created_at: {
           sql: \`created_at\`,
-          type: 'time'
+          type: 'time',
+          granularities: {
+            ten_seconds: {
+              interval: '10 seconds',
+            },
+          },
         }
       },
       measures: {
         count: {
           type: 'count',
+        }
+      },
+      preAggregations: {
+        by_ten_seconds: {
+          measures: [count],
+          timeDimension: created_at,
+          granularity: 'ten_seconds',
+          partitionGranularity: 'day',
         }
       }
     });
@@ -49,5 +62,32 @@ describe('AthenaQuery', () => {
     expect(sql).not.toMatch(
       /CAST\(\(.*AT TIME ZONE.*\) AS TIMESTAMP\)/
     );
+  });
+
+  // Pre-aggregation load SQL for a custom granularity must not expose
+  // `timestamp with time zone` columns — Athena/Hive rejects that type when
+  // writing to an export bucket. `from_iso8601_timestamp(...)` returns a
+  // TZ-aware timestamp and `date_add` inherits the type of its third
+  // argument, so the origin must be cast to a plain TIMESTAMP.
+  it('custom granularity pre-aggregation loadSql casts dateBin origin to TIMESTAMP', async () => {
+    await compiler.compile();
+
+    const query = new AthenaQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['orders.count'],
+      timeDimensions: [{
+        dimension: 'orders.created_at',
+        granularity: 'ten_seconds',
+        dateRange: ['2026-04-11', '2026-04-12'],
+      }],
+      timezone: 'UTC',
+    });
+
+    const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+    expect(preAggregationsDescription.length).toBeGreaterThan(0);
+
+    const loadSql = preAggregationsDescription[0].loadSql[0] as string;
+
+    expect(loadSql).toMatch(/CAST\(from_iso8601_timestamp\('[^']+'\) AS TIMESTAMP\)/);
+    expect(loadSql).not.toMatch(/date_add\([^)]*from_iso8601_timestamp\('[^']+'\)\s*\)/);
   });
 });

--- a/packages/cubejs-testing-drivers/fixtures/_schemas.json
+++ b/packages/cubejs-testing-drivers/fixtures/_schemas.json
@@ -110,6 +110,11 @@
               "name": "three_months_by_march",
               "interval": "3 month 3 days 3 hours",
               "origin": "2020-03-15"
+            },
+            {
+              "name": "build_only_half_year",
+              "interval": "6 months",
+              "origin": "2024-01-01"
             }
           ]
         },

--- a/packages/cubejs-testing-drivers/fixtures/athena.json
+++ b/packages/cubejs-testing-drivers/fixtures/athena.json
@@ -79,6 +79,16 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/bigquery.json
+++ b/packages/cubejs-testing-drivers/fixtures/bigquery.json
@@ -81,6 +81,16 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/clickhouse.json
+++ b/packages/cubejs-testing-drivers/fixtures/clickhouse.json
@@ -133,7 +133,11 @@
         "dimensions": ["CUBE.productName"],
         "measures": [
           "CUBE.totalQuantity"
-        ]
+        ],
+        "indexes": [{
+          "name": "category_index",
+          "columns": ["CUBE.productName"]
+        }]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/clickhouse.json
+++ b/packages/cubejs-testing-drivers/fixtures/clickhouse.json
@@ -124,6 +124,16 @@
           "name": "category_index",
           "columns": ["CUBE.productName"]
         }]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/databricks-jdbc.json
+++ b/packages/cubejs-testing-drivers/fixtures/databricks-jdbc.json
@@ -141,6 +141,16 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/mssql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mssql.json
@@ -78,6 +78,16 @@
           "CUBE.totalSales",
           "CUBE.totalProfit"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/mysql.json
+++ b/packages/cubejs-testing-drivers/fixtures/mysql.json
@@ -78,6 +78,16 @@
           "CUBE.totalSales",
           "CUBE.totalProfit"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/postgres.json
+++ b/packages/cubejs-testing-drivers/fixtures/postgres.json
@@ -122,6 +122,16 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/redshift.json
+++ b/packages/cubejs-testing-drivers/fixtures/redshift.json
@@ -112,6 +112,16 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/fixtures/snowflake.json
+++ b/packages/cubejs-testing-drivers/fixtures/snowflake.json
@@ -180,6 +180,16 @@
         "measures": [
           "CUBE.countApproxByCustomer"
         ]
+      },
+      {
+        "name": "TBuildOnlyHalfYear",
+        "time_dimension": "CUBE.orderDate",
+        "granularity": "build_only_half_year",
+        "partition_granularity": "year",
+        "dimensions": ["CUBE.productName"],
+        "measures": [
+          "CUBE.totalQuantity"
+        ]
       }
     ],
     "BigECommerce": [

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -226,6 +226,20 @@ export function testQueries(type: string, { includeIncrementalSchemaSuite, exten
 
         await delay(OP_DELAY);
       }
+
+      // Exercise pre-aggregation build with a custom granularity against the
+      // export bucket. The granularity name `build_only_half_year` is unique
+      // to this rollup — no query test references it, so the rollup cannot
+      // match any test query and only the build path is exercised.
+      if (type === 'athena') {
+        await buildPreaggs(env.cube.port, apiToken, {
+          timezones: ['UTC'],
+          preAggregations: ['ECommerce.TBuildOnlyHalfYearExternal'],
+          contexts: [{ securityContext: { tenant: 't1' } }],
+        });
+
+        await delay(OP_DELAY);
+      }
     });
 
     execute('must not fetch a hidden cube', async () => {

--- a/packages/cubejs-testing-drivers/src/tests/testQueries.ts
+++ b/packages/cubejs-testing-drivers/src/tests/testQueries.ts
@@ -227,19 +227,17 @@ export function testQueries(type: string, { includeIncrementalSchemaSuite, exten
         await delay(OP_DELAY);
       }
 
-      // Exercise pre-aggregation build with a custom granularity against the
-      // export bucket. The granularity name `build_only_half_year` is unique
-      // to this rollup — no query test references it, so the rollup cannot
-      // match any test query and only the build path is exercised.
-      if (type === 'athena') {
-        await buildPreaggs(env.cube.port, apiToken, {
-          timezones: ['UTC'],
-          preAggregations: ['ECommerce.TBuildOnlyHalfYearExternal'],
-          contexts: [{ securityContext: { tenant: 't1' } }],
-        });
+      // Exercise pre-aggregation build with a custom granularity for every
+      // driver. The granularity name `build_only_half_year` is unique to this
+      // rollup — no query test references it, so the rollup cannot match any
+      // test query and only the build path is exercised.
+      await buildPreaggs(env.cube.port, apiToken, {
+        timezones: ['UTC'],
+        preAggregations: ['ECommerce.TBuildOnlyHalfYearExternal'],
+        contexts: [{ securityContext: { tenant: 't1' } }],
+      });
 
-        await delay(OP_DELAY);
-      }
+      await delay(OP_DELAY);
     });
 
     execute('must not fetch a hidden cube', async () => {


### PR DESCRIPTION
## Summary

CORE-410: Athena pre-aggregation builds for custom granularities fail when an export bucket is configured (`NOT_SUPPORTED: Unsupported Hive type: timestamp(3) with time zone`). Cast `dateBin` origin to plain `TIMESTAMP` so Hive can serialize the rollup output column.

## Changes

- `PrestodbQuery.dateBin`: wrap origin in `CAST(... AS TIMESTAMP)` so `date_add` returns a plain `TIMESTAMP` instead of `timestamp with time zone`. Inherited by Athena and Trino, brings the custom-granularity rollup column shape in line with what `timeGroupedColumn`/`date_trunc` already emits for standard granularities.
- Add a unit regression in `athena-query.test.ts` asserting the new `loadSql` shape for a custom-granularity rollup.
- Close a coverage gap in `cubejs-testing-drivers`: introduce a unique `build_only_half_year` granularity and a `ECommerce.TBuildOnlyHalfYear` rollup, built explicitly under `must built pre-aggregations` for `type === 'athena'`. The granularity name is unique to this rollup so no query test matches it — snapshots stay stable in both legacy and Tesseract planner modes.

## Testing

- `cd packages/cubejs-schema-compiler && yarn tsc && TZ=UTC node_modules/.bin/jest dist/test/unit/athena-query.test.js` — both unit tests pass; without the fix the new regression fails (TZ-aware origin leaks into `loadSql`).
- Reproduced the original Hive failure against an Athena export bucket with the fix reverted; with the fix in place the `CREATE TABLE ... AS SELECT` succeeds. CI matrix covers Athena in both `use_tesseract_sql_planner: true` and `false`.
