### PR TITLE
chore(ci): CC review - skip drafts and cancel stale synchronize runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,8 +3,17 @@ on:
   pull_request:
     types: [opened, ready_for_review, reopened, synchronize]
 
+concurrency:
+  group: claude-code-review-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: true
+
 jobs:
   review-with-tracking:
+    # Skip draft PRs — they get noisy synchronize pushes while WIP, and
+    # running a full Claude review on every intermediate commit gets expensive
+    # fast. The ready_for_review event will pick up the review the moment the
+    # PR exits draft.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Skip the review on draft PRs entirely. Running a full Claude review on every WIP commit gets expensive fast; the ready_for_review event picks up review the moment the PR exits draft.
- Add a concurrency group keyed by PR number and event action so a newer push cancels the in-flight synchronize review, while one-shot events (opened / ready_for_review / reopened) stay in their own groups.