### PR TITLE
chore(ci): CC review - allow triggering via /bot-review PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,13 +33,20 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pull all event-controlled inputs through env vars instead of
+          # interpolating directly into the script — branch names are
+          # attacker-controlled and could carry shell metacharacters.
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF_FROM_EVENT: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ -n "${{ inputs.pr_number }}" ]; then
-            number="${{ inputs.pr_number }}"
-            ref=$(gh pr view "$number" --repo "${{ github.repository }}" --json headRefName --jq .headRefName)
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            number="$INPUT_PR_NUMBER"
+            ref=$(gh pr view "$number" --repo "$REPO" --json headRefName --jq .headRefName)
           else
-            number="${{ github.event.pull_request.number }}"
-            ref="${{ github.event.pull_request.head.ref }}"
+            number="$PR_NUMBER_FROM_EVENT"
+            ref="$PR_HEAD_REF_FROM_EVENT"
           fi
           echo "number=$number" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,27 +2,52 @@ name: Claude Code PR Review
 on:
   pull_request:
     types: [opened, ready_for_review, reopened, synchronize]
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
 
 concurrency:
-  group: claude-code-review-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  # PR number lives in different fields depending on entry point — coalesce so
+  # the same PR shares a group regardless of whether we got here via push or
+  # via the /bot-review proxy.
+  group: claude-code-review-${{ inputs.pr_number || github.event.pull_request.number }}-${{ github.event.action || 'manual' }}
   cancel-in-progress: true
 
 jobs:
   review-with-tracking:
-    # Skip draft PRs — they get noisy synchronize pushes while WIP, and
-    # running a full Claude review on every intermediate commit gets expensive
-    # fast. The ready_for_review event will pick up the review the moment the
-    # PR exits draft.
-    if: github.event.pull_request.draft == false
+    # On `pull_request`, skip draft PRs — they get noisy synchronize pushes
+    # while WIP, and running a full Claude review on every intermediate commit
+    # gets expensive fast. ready_for_review picks it up on draft exit.
+    # On `workflow_call`, trust the caller; the proxy workflow handles its own
+    # auth gates.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       id-token: write
     steps:
+      - name: Resolve PR ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            number="${{ inputs.pr_number }}"
+            ref=$(gh pr view "$number" --repo "${{ github.repository }}" --json headRefName --jq .headRefName)
+          else
+            number="${{ github.event.pull_request.number }}"
+            ref="${{ github.event.pull_request.head.ref }}"
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.pr.outputs.ref }}
           fetch-depth: 1
 
       - name: Configure gh aliases for review-thread operations
@@ -36,7 +61,7 @@ jobs:
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ steps.pr.outputs.number }}
 
             Perform a comprehensive code review with the following focus areas:
 
@@ -90,7 +115,7 @@ jobs:
             Before posting new comments, list existing review threads on this PR using the
             preconfigured alias:
 
-              gh list-review-threads ${{ github.repository_owner }} ${{ github.event.repository.name }} ${{ github.event.pull_request.number }}
+              gh list-review-threads ${{ github.repository_owner }} ${{ github.event.repository.name }} ${{ steps.pr.outputs.number }}
 
             For each thread where ALL of the following hold:
               - `isResolved` is false

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -45,3 +45,21 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  # `/bot-review` command in a PR comment
+  # Only Cube team can trigger review for now
+  bot-review:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/bot-review') &&
+      github.event.sender.type == 'User' &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/claude-code-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+    secrets: inherit


### PR DESCRIPTION
Add a `bot-review` job in claude-code.yml that delegates to the existing PR-review workflow via workflow_call when a Cube team member comments `/bot-review` on a PR. To support this:

- claude-code-review.yml accepts a `workflow_call` entry point with a `pr_number` input; the existing pull_request trigger is unchanged.
- The Resolve PR ref step coalesces input/event sources and uses `gh pr view` to look up the head ref when called manually.
- Concurrency group keys off whichever event payload carries the PR number.