### PR TITLE
docs: fix cards and broken links on Orchestration API index

### DIFF
--- a/docs-mintlify/reference/orchestration-api/index.mdx
+++ b/docs-mintlify/reference/orchestration-api/index.mdx
@@ -3,8 +3,6 @@ title: Orchestration API
 description: "Trigger pre-aggregation refreshes from Airflow, Dagster, or Prefect instead of relying on Cube's scheduled refresh."
 ---
 
- Orchestration API
-
 Orchestration API enables Cube to work with data orchestration tools and let
 them _push_ changes from upstream data sources to Cube, as opposed to letting
 Cube _pull_ changes from upstream data sources via the
@@ -30,12 +28,15 @@ Orchestration API has integration packages to work with popular data
 orchestration tools. Check the following guides to get tool-specific
 instructions:
 
-<CardGroup cols={2}>
-  <Card title="Apache Airflow" img="https://static.cube.dev/icons/airflow.svg" href="/reference/orchestration-api/airflow">
+<CardGroup cols={3}>
+  <Card title="Apache Airflow" href="/reference/orchestration-api/airflow">
+    Trigger pre-aggregation builds from Apache Airflow DAGs.
   </Card>
-  <Card title="Dagster" img="https://static.cube.dev/icons/dagster.svg" href="/reference/orchestration-api/dagster">
+  <Card title="Dagster" href="/reference/orchestration-api/dagster">
+    Trigger pre-aggregation builds from Dagster assets and jobs.
   </Card>
-  <Card title="Prefect" img="https://static.cube.dev/icons/prefect.svg" href="/reference/orchestration-api/prefect">
+  <Card title="Prefect" href="/reference/orchestration-api/prefect">
+    Trigger pre-aggregation builds from Prefect flows.
   </Card>
 </CardGroup>
 
@@ -69,7 +70,7 @@ data from a particular date range.
 [cube-issbi]: https://cube.dev/use-cases/semantic-layer
 [cube-rta]: https://cube.dev/use-cases/real-time-analytics
 [ref-lambda-pre-aggs]: /docs/pre-aggregations/lambda-pre-aggregations
-[ref-rest-api]: /reference/rest-api
-[ref-api-scopes]: /reference/rest-api#configuration-api-scopes
-[ref-ref-jobs-endpoint]: /reference/rest-api/reference#base_pathv1pre-aggregationsjobs
+[ref-rest-api]: /reference/core-data-apis/rest-api
+[ref-api-scopes]: /reference/core-data-apis/rest-api#configuration-api-scopes
+[ref-ref-jobs-endpoint]: /reference/core-data-apis/rest-api/reference#base_pathv1pre-aggregationsjobs
 [ref-pre-agg-partitions]: /docs/pre-aggregations/using-pre-aggregations#partitioning


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Fixes the cards and broken links on the [Orchestration API index page](https://docs.cube.dev/reference/orchestration-api).

- Reworks the "Supported tools" cards to match the pattern already applied to the Monitoring Integrations index (#10922): drops the vendor-logo `img`, adds a short description to each card, and switches to `cols={3}`.
- Removes the orphan migration-leftover heading (` Orchestration API`) at the top of the page (the title already comes from frontmatter).
- Repoints the REST API references (`ref-rest-api`, `ref-api-scopes`, `ref-ref-jobs-endpoint`) to `/reference/core-data-apis/rest-api`, since the REST API page moved under `core-data-apis/` and the old `/reference/rest-api` paths 404.