### PR TITLE
docs: add changelog link to navbar

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -680,6 +680,10 @@
   "navbar": {
     "links": [
       {
+        "label": "Changelog",
+        "href": "https://cube.dev/changelog"
+      },
+      {
         "label": "Community",
         "href": "https://slack.cube.dev"
       }


### PR DESCRIPTION
## Summary

- Adds a **Changelog** link (https://cube.dev/changelog) to the Mintlify docs navbar, placed before the existing "Community" link.

## Why

The changelog wasn't reachable from the docs. The navbar renders on every page, so this makes it discoverable site-wide.

## Notes

- Single-line addition to `docs-mintlify/docs.json` under `navbar.links`; JSON validated and verified locally with `mintlify dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)