### PR TITLE
docs: add Dashboard Agent and Workbook Agent pages

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -51,7 +51,8 @@
                 "pages": [
                   "docs/explore-analyze/workbooks/querying-data",
                   "docs/explore-analyze/workbooks/calculated-fields",
-                  "docs/explore-analyze/workbooks/source-sql-tabs"
+                  "docs/explore-analyze/workbooks/source-sql-tabs",
+                  "docs/explore-analyze/workbooks/workbook-agent"
                 ]
               },
               "docs/explore-analyze/explore",
@@ -111,7 +112,8 @@
                       "docs/explore-analyze/dashboards/widgets/ai-summary"
                     ]
                   },
-                  "docs/explore-analyze/dashboards/styling"
+                  "docs/explore-analyze/dashboards/styling",
+                  "docs/explore-analyze/dashboards/dashboard-agent"
                 ]
               },
               "docs/explore-analyze/scheduled-refreshes",

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -1,0 +1,115 @@
+---
+title: Dashboard Agent
+description: Ask questions about a dashboard and its charts using a conversational AI assistant docked alongside the dashboard.
+---
+
+The Dashboard Agent is a conversational assistant docked as a panel on a
+[published or embedded dashboard][ref-dashboards]. Ask it questions in plain
+language about what's on the dashboard — and it answers using **live queries
+against your semantic model**, not just the numbers already rendered on screen.
+
+Because it queries the model directly, the agent can go beyond what a chart
+shows. It can drill into a single chart, re-aggregate a metric, break a number
+down by a dimension, pull a longer time range than the chart displays, and
+summarize trends across the dashboard.
+
+<Frame>
+  <img
+    src="https://lgo0ecceic.ucarecd.net/a50f87dd-126d-44ad-87e9-6c9a0af81c1a/"
+    alt="Dashboard Agent panel docked alongside a published dashboard"
+  />
+</Frame>
+
+<Note>
+  There are **two different agent surfaces** with different capabilities:
+
+  - **Dashboard Agent** (this page) — read-only Q&A for viewers of a published
+    or embedded dashboard.
+  - **[Workbook Agent][ref-workbook-agent]** — full authoring inside a
+    [workbook][ref-workbooks]: creating reports, building and editing
+    dashboards, and running analysis.
+
+  Most of this page describes the read-only Dashboard Agent. Keep the
+  distinction in mind — the published agent intentionally cannot author or
+  change anything.
+</Note>
+
+## Opening the agent
+
+Open a published dashboard and toggle the agent panel from the dashboard header
+to start a conversation. Use **New Chat** to start a fresh thread.
+
+The panel is docked to the right side of the dashboard and is **resizable** —
+drag its edge to give the conversation more or less room. On narrow screens it
+switches to a **compact mode** so it stays usable next to the dashboard.
+
+## Focusing on a specific chart
+
+<Note>
+  Chart-level follow-ups and attached-chart chips are **rolling out**. If you
+  don't see the **Ask a follow up question** action on a chart's menu yet, it
+  hasn't reached your deployment.
+</Note>
+
+To ask about one chart in particular, open that chart tile's menu (`⋮`) and
+choose **Ask a follow up question**. This opens the agent with that chart
+**attached as context**, so your question is scoped to that chart's data.
+
+Attached charts appear as **removable chips** in the chat input. To drop a
+chart's focus, remove its chip. You can attach more than one chart to ask about
+them together.
+
+When a chart is attached, the agent receives a read-only snapshot of it — the
+underlying SQL, the data, and the chart spec — along with the dashboard's
+**current filter and time-grain state**. It uses this as context; it does not
+modify any of it.
+
+## What the Dashboard Agent can and can't do
+
+The published Dashboard Agent is **read-only by design**.
+
+**It can:**
+
+- Answer questions about what's on the dashboard from the dashboard's own data
+- Run **read-only queries** against the semantic model to go deeper — drill
+  down, break a metric down by a dimension, or pull a longer time range than a
+  chart shows
+- Explain how a metric or dimension is defined
+- Look up the values available for a dimension
+- Read the contents of [attachments](#attachments) you add to the chat
+
+**It can't:**
+
+- Edit the dashboard, or add/remove widgets
+- Change filters or the time grain (see [Limitations](#limitations))
+- Create reports or workbooks
+- Change the data model
+
+If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
+
+## Attachments
+
+You can attach uploaded files to the conversation, and the agent can read their
+contents — text, PDF, ZIP, and image files are supported.
+
+<Note>
+  Pasting an image directly from your clipboard into the chat may also be
+  supported. Confirm this in your deployment before relying on it.
+</Note>
+
+## Limitations
+
+- **Filters are read-only.** The agent can tell you which filters and time grain
+  are currently applied and reason about them, but it **cannot change them** for
+  you yet. This is the most common expectation gap — if you ask the agent to
+  "filter the dashboard to last quarter," it will explain the current state
+  rather than apply the change. This is actively being worked on.
+- **No authoring on published dashboards.** The published Dashboard Agent
+  cannot create reports or build dashboards. Those live in the
+  [Workbook Agent][ref-workbook-agent].
+- **Report search covers published reports only.** When the agent searches for
+  existing reports, it sees published reports.
+
+[ref-dashboards]: /docs/explore-analyze/dashboards
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-workbook-agent]: /docs/explore-analyze/workbooks/workbook-agent

--- a/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/workbook-agent.mdx
@@ -1,0 +1,64 @@
+---
+title: Workbook Agent
+description: Use the AI agent inside a workbook to build reports, create and edit dashboards, and run analysis with natural language.
+---
+
+Inside a [workbook][ref-workbooks], the AI agent is a full **authoring**
+assistant. Where the read-only [Dashboard Agent][ref-dashboard-agent] only
+answers questions about a published dashboard, the workbook agent can act on
+your behalf — it builds reports, and assembles and edits dashboards, all from
+plain-language requests.
+
+<Note>
+  **Workbook Agent vs. [Analytics Chat][ref-analytics-chat].** Analytics Chat is
+  a standalone, chat-first analytics experience for asking questions and saving
+  results into a workbook. The Workbook Agent lives **inside a workbook** and is
+  oriented around authoring the workbook's own reports and dashboards. Both run
+  read-only queries against your semantic model; the Workbook Agent additionally
+  creates and edits workbook content.
+</Note>
+
+## What the Workbook Agent can do
+
+In addition to everything the read-only [Dashboard Agent][ref-dashboard-agent]
+can do (answer questions, run read-only semantic-layer queries, explain metric
+and dimension definitions), the Workbook Agent can:
+
+- **Create and save reports** in the workbook from a natural-language request
+- **Search existing reports** to find and reuse work already in the workbook
+- **Build and edit dashboards** — add and configure chart, KPI, filter,
+  time-grain, and text widgets
+- **Publish dashboards**
+
+## How charts get added to a dashboard
+
+When the agent adds a chart to a dashboard, the chart widget references a
+**saved report**, not a one-off query. So to put a new chart on a dashboard, the
+agent first saves it as a report in the workbook, then adds a widget that points
+at that report. This keeps every dashboard chart backed by a reusable,
+governed report.
+
+## Getting help with Cube
+
+While working in a workbook, you can also ask the agent questions about Cube
+itself — it can answer using the Cube documentation, which is handy for
+"how do I…" questions without leaving your analysis.
+
+## Limitations
+
+- **Report search covers published reports only.** When the agent searches for
+  existing reports to reuse, it sees published reports.
+
+## Learn more
+
+- [Dashboard Agent][ref-dashboard-agent] — the read-only Q&A assistant on
+  published and embedded dashboards
+- [Querying data in workbooks][ref-querying-data] — point-and-click, AI agent,
+  and Semantic SQL
+- [Analytics Chat][ref-analytics-chat] — the standalone conversational
+  analytics experience
+
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-dashboard-agent]: /docs/explore-analyze/dashboards/dashboard-agent
+[ref-analytics-chat]: /docs/explore-analyze/analytics-chat
+[ref-querying-data]: /docs/explore-analyze/workbooks/querying-data


### PR DESCRIPTION
## Summary

Adds end-user documentation for Cube Cloud's conversational AI assistants, aimed at dashboard viewers and workbook authors (analysts/business users), not platform engineers.

- **Dashboard Agent** (`docs/explore-analyze/dashboards/dashboard-agent`) — the read-only Q&A panel docked on published/embedded dashboards. Covers opening the panel, focusing on a specific chart, what it can/can't do, attachments, and limitations.
- **Workbook Agent** (`docs/explore-analyze/workbooks/workbook-agent`) — the in-workbook authoring assistant (creating reports, building/editing/publishing dashboards). Includes a note distinguishing it from Analytics Chat.
- Wires both pages into the explore-analyze navigation in `docs.json`.

The two surfaces are kept clearly separated: published Dashboard Agent is read-only; the Workbook Agent does authoring.

## Reviewer notes

- **Behavior is written from a product brief, not verified against the running app or the (private) Cube Cloud source.** Please sanity-check UI labels and behavior before merge — in particular the chart-tile "Ask a follow up question" action, attached-chart chips, and the read-only follow-up query flow, which are marked **"rolling out"** in the doc since I couldn't confirm they've merged.
- Clipboard-image paste is flagged as "confirm before relying on it" rather than asserted.
- The read-only-filters limitation is described as "actively being worked on" (no internal tracking reference included).
- The Dashboard Agent screenshot currently points at an external ucarecdn URL; consider rehosting on `static.cube.dev` for consistency with other docs images.

## Test plan

- [ ] `cd docs-mintlify && yarn dev` and verify both pages render
- [ ] Confirm both pages appear in the left nav under Present & Share → Dashboards and Workbooks
- [ ] Verify all cross-links resolve (Dashboard Agent ↔ Workbook Agent, Analytics Chat)
- [ ] Confirm screenshot loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)