### PR TITLE
docs: document region map and updated point map options

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/map.mdx
@@ -1,65 +1,92 @@
 ---
 title: Map
-description: Plot geographic data using latitude and longitude coordinates on an interactive Mapbox map.
+description: Plot geographic data as point maps (latitude/longitude) or region maps (choropleth from GeoJSON polygons).
 ---
 
-Map charts visualize geographic data as interactive point maps. Each data point is plotted at its latitude/longitude coordinates and can be sized and colored by additional measures or dimensions in your query.
+Map charts visualize geographic data in two modes:
 
-{/* TODO screenshot: map chart with colored and sized point pins (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+- **Point map** — plot rows at their latitude/longitude coordinates, optionally sized and colored by additional fields.
+- **Region map** — paint polygons (countries, US states, or any custom [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON)) as a choropleth driven by a measure.
+
+<Frame>
+  <img src="https://lgo0ecceic.ucarecd.net/103102da-1470-4879-a8cf-6cf8917f9d1a/" />
+</Frame>
 
 ## When to use
 
-- Visualizing events or entities with known geographic coordinates (e.g. store locations, shipment origins, user sign-up cities)
-- Identifying geographic clusters or outliers
-- Showing how a measure varies across geographic locations
+- **Point map** — locations with known coordinates (stores, shipments, sign-ups), geographic clusters and outliers.
+- **Region map** — measures aggregated by country, state, postcode, sales territory, or any user-defined polygon set.
 
-For region-based maps (countries, states), use the [Custom visualization](/docs/explore-analyze/charts/chart-types/custom) with a Vega-Lite geographic spec.
+## Chart type
 
-## Data structure
-
-A map chart requires at minimum:
-- A **Latitude** field — a numeric measure or dimension containing decimal latitude values
-- A **Longitude** field — a numeric measure or dimension containing decimal longitude values
-
-Optionally:
-- A **Size** field — a numeric measure that scales point radius proportionally
-- A **Color** field — a dimension or measure that colors points by category or value
-
-{/* TODO screenshot: map builder panel with latitude, longitude, size, and color fields assigned (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
-
-## Configuring the map
-
-### Point color
-
-When no **Color** field is assigned, all points render in a single configurable color. Use the color picker in the style panel to change it.
-
-When a dimension is assigned to the **Color** channel, each unique dimension value gets a distinct color from the active [color palette](/docs/explore-analyze/charts/configuration/color-and-stacking).
-
-### Point size
-
-Assign a numeric measure to the **Size** channel to scale point radius by value. The size range (minimum and maximum radius in pixels) can be configured in the style panel.
-
-When no Size field is assigned, all points render at the same fixed radius.
-
-### Tooltip fields
-
-Add fields to the **Tooltip** channel to control what appears when a user hovers over a point. By default, all mapped fields (latitude, longitude, size, color) appear in the tooltip. Remove or reorder them in the **Tooltips** section of the Fields tab.
-
-See [Tooltips](/docs/explore-analyze/charts/configuration/tooltips) for details.
+Pick **Point** or **Region** in the chart settings panel's **Type** row. The default is **Point**.
 
 ## Projection
-
-The map supports two projection types:
 
 | Projection | Description |
 |---|---|
 | **Mercator (2D)** | Standard flat map projection — best for most use cases |
 | **Globe (3D)** | Spherical globe view — useful for data spanning multiple continents |
 
-Switch the projection in the style panel.
+Both modes support either projection.
 
-{/* TODO screenshot: Mercator vs Globe projection side-by-side (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+## Point map
+
+A point map requires:
+
+- **Latitude** — numeric field containing decimal latitude.
+- **Longitude** — numeric field containing decimal longitude.
+
+Optional:
+
+- **Size** — numeric measure that scales point radius proportionally.
+- **Color** — dimension or measure that colors points by category or value.
+
+### Point color
+
+When no **Color** field is assigned, all points render in the configurable **Default color**. When a dimension is assigned, each unique value gets a distinct color from the active palette — pick from the built-in palettes or supply a custom one, see [Color and stacking](/docs/explore-analyze/charts/configuration/color-and-stacking).
+
+### Point size
+
+Assign a numeric measure to the **Size** channel to scale point radius by value. The size range (minimum and maximum radius in pixels) is configurable in the settings panel.
+
+### Clustering
+
+Clustering groups nearby points into a single circle that expands on zoom. It is **off by default** and can be enabled in the settings panel.
+
+## Region map
+
+A region map requires:
+
+- **Source** — the GeoJSON to render: `World countries`, `US states`, or `Custom`.
+- **Property** — which property in each GeoJSON feature acts as the join key (e.g. `name`, `ISO3166-1-Alpha-2`, `state_code`).
+- **Dimension** — which column from your query joins to **Property**.
+- **Measure** — the numeric measure that drives the choropleth fill.
+
+Built-in sources expose a fixed list of allowed properties. **Custom** lets you point at any public GeoJSON URL; the property dropdown then enumerates every key present in the feature collection.
+
+When the chart enters Region mode, the join dimension and measure are auto-picked when an unambiguous match exists in your query.
+
+The choropleth gradient comes from the active palette — pick from the built-in palettes or supply a custom one, see [Color and stacking](/docs/explore-analyze/charts/configuration/color-and-stacking).
+
+### Custom GeoJSON
+
+When **Source** is set to **Custom**, paste a URL serving a GeoJSON `FeatureCollection`. Requirements:
+
+- Served over HTTPS with CORS enabled.
+- Polygons or multipolygons (not points or lines).
+- Each feature must have a `properties` object containing the join key.
+
+The fetched GeoJSON is cached for the session.
+
+### Unmatched regions
+
+Regions in the GeoJSON with no matching data row are hidden by default. Toggle **Fill unmatched** in the settings panel to render them with the **Default color** at reduced opacity instead.
+
+## Tooltip fields
+
+The **Tooltips** section controls which fields appear when a user hovers over a point or region. See [Tooltips](/docs/explore-analyze/charts/configuration/tooltips).
 
 ## Map interaction
 
-The map is interactive by default — users can pan and zoom. Initial center coordinates and zoom level can be configured in the style panel.
+The map is interactive — users can pan and zoom. Viewport changes persist while you edit other settings; switching the data source or projection re-fits the camera to the new bounds.


### PR DESCRIPTION
## Summary

- Rewrites `chart-types/map.mdx` to cover both Point map (lat/lng) and Region map (GeoJSON choropleth) modes that the Map chart now supports.
- Documents the built-in `World countries` / `US states` sources, the Custom GeoJSON URL flow, region property selection, join dimension, measure-driven choropleth fill, and the Fill unmatched toggle.
- Notes that clustering is now off by default in Point mode.
- Drops the now-outdated redirect that told users to use a Custom Vega-Lite visualization for region maps.

## Test plan

- [x] Mintlify dev server renders the page cleanly (`mint dev` in `docs-mintlify/`).
- [x] Internal links (`color-and-stacking`, `tooltips`) resolve.
- [ ] CI must pass.