### PR TITLE
feat(tesseract): NativeRustHandle/NativeRustBox in cubenativeutils

### DIFF
--- a/packages/cubejs-backend-native/src/bridge_test_exports.rs
+++ b/packages/cubejs-backend-native/src/bridge_test_exports.rs
@@ -11,7 +11,10 @@
 
 use cubenativeutils::wrappers::bridge_meta::{BridgeFieldKind, BridgeFieldMeta};
 use cubenativeutils::wrappers::neon::neon_guarded_funcion_call;
-use cubenativeutils::wrappers::object::{NativeArray, NativeFunction, NativeStruct, NativeType};
+use cubenativeutils::wrappers::object::{
+    NativeArray, NativeFunction, NativeRustBox, NativeStruct, NativeType,
+};
+use cubenativeutils::wrappers::rust_handle::NativeRustHandle;
 use cubenativeutils::wrappers::serializer::NativeSerialize;
 use cubenativeutils::wrappers::{inner_types::InnerTypes, NativeContextHolder, NativeObjectHandle};
 use cubenativeutils::CubeError;
@@ -906,6 +909,88 @@ fn invoke_cube_evaluator<IT: InnerTypes>(b: &NativeCubeEvaluator<IT>) -> InvokeR
     r
 }
 
+#[derive(Debug)]
+struct RustBoxProbe {
+    value: f64,
+    label: String,
+}
+
+/// Distinct probe used to exercise the type-mismatch branch of
+/// `NativeRustHandle::downcast`: callers create an `Alt` box and try to
+/// unwrap it as `RustBoxProbe`, which must fail with a message that names
+/// both the source and target types.
+#[derive(Debug)]
+struct RustBoxProbeAlt {
+    #[allow(dead_code)]
+    note: String,
+}
+
+#[derive(serde::Serialize)]
+struct RustBoxProbeView {
+    value: f64,
+    label: String,
+    type_name: String,
+}
+
+fn rust_box_create_inner<IT: InnerTypes>(
+    context: NativeContextHolder<IT>,
+    value: f64,
+    label: String,
+) -> Result<NativeObjectHandle<IT>, CubeError> {
+    let handle = NativeRustHandle::new(RustBoxProbe { value, label });
+    let rust_box = context.rust_box(handle)?;
+    Ok(NativeObjectHandle::new(rust_box.into_object()))
+}
+
+fn rust_box_create(cx: FunctionContext) -> JsResult<JsValue> {
+    neon_guarded_funcion_call(
+        cx,
+        |context_holder: NativeContextHolder<_>, value: f64, label: String| {
+            rust_box_create_inner(context_holder, value, label)
+        },
+    )
+}
+
+fn rust_box_create_alt_inner<IT: InnerTypes>(
+    context: NativeContextHolder<IT>,
+    note: String,
+) -> Result<NativeObjectHandle<IT>, CubeError> {
+    let handle = NativeRustHandle::new(RustBoxProbeAlt { note });
+    let rust_box = context.rust_box(handle)?;
+    Ok(NativeObjectHandle::new(rust_box.into_object()))
+}
+
+fn rust_box_create_alt(cx: FunctionContext) -> JsResult<JsValue> {
+    neon_guarded_funcion_call(
+        cx,
+        |context_holder: NativeContextHolder<_>, note: String| {
+            rust_box_create_alt_inner(context_holder, note)
+        },
+    )
+}
+
+fn rust_box_unwrap_inner<IT: InnerTypes>(
+    _context: NativeContextHolder<IT>,
+    obj: NativeObjectHandle<IT>,
+) -> Result<RustBoxProbeView, CubeError> {
+    let rust_box = obj.into_rust_box()?;
+    let probe = rust_box.handle().downcast::<RustBoxProbe>()?;
+    Ok(RustBoxProbeView {
+        value: probe.value,
+        label: probe.label.clone(),
+        type_name: rust_box.handle().type_name().to_string(),
+    })
+}
+
+fn rust_box_unwrap(cx: FunctionContext) -> JsResult<JsValue> {
+    neon_guarded_funcion_call(
+        cx,
+        |context_holder: NativeContextHolder<_>, obj: NativeObjectHandle<_>| {
+            rust_box_unwrap_inner(context_holder, obj)
+        },
+    )
+}
+
 pub fn register_module(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("__testBridgeCompileMemberSql", compile_member_sql)?;
     cx.export_function("__testBridgeParseArgsNames", parse_args_names)?;
@@ -917,5 +1002,8 @@ pub fn register_module(cx: &mut ModuleContext) -> NeonResult<()> {
     cx.export_function("__testBridgeParse", parse_bridge)?;
     cx.export_function("__testBridgeInvoke", invoke_bridge)?;
     cx.export_function("__testBridgeListBridgeNames", list_bridge_names)?;
+    cx.export_function("__testBridgeRustBoxCreate", rust_box_create)?;
+    cx.export_function("__testBridgeRustBoxCreateAlt", rust_box_create_alt)?;
+    cx.export_function("__testBridgeRustBoxUnwrap", rust_box_unwrap)?;
     Ok(())
 }

--- a/packages/cubejs-backend-native/test/bridge/helpers.ts
+++ b/packages/cubejs-backend-native/test/bridge/helpers.ts
@@ -134,3 +134,21 @@ export function expectAllInvocationsOk(result: InvokeResult): void {
     );
   }
 }
+
+export interface RustBoxProbeView {
+  value: number;
+  label: string;
+  type_name: string;
+}
+
+export function createRustBoxProbe(value: number, label: string): unknown {
+  return native.__testBridgeRustBoxCreate(value, label);
+}
+
+export function createRustBoxProbeAlt(note: string): unknown {
+  return native.__testBridgeRustBoxCreateAlt(note);
+}
+
+export function unwrapRustBoxProbe(handle: unknown): RustBoxProbeView {
+  return native.__testBridgeRustBoxUnwrap(handle);
+}

--- a/packages/cubejs-backend-native/test/bridge/rust-box.test.ts
+++ b/packages/cubejs-backend-native/test/bridge/rust-box.test.ts
@@ -1,0 +1,79 @@
+import {
+  bridgeHarnessAvailable,
+  createRustBoxProbe,
+  createRustBoxProbeAlt,
+  unwrapRustBoxProbe,
+} from './helpers';
+
+const describeBridge = bridgeHarnessAvailable ? describe : describe.skip;
+
+describeBridge('bridge: NativeRustHandle / JsBox roundtrip', () => {
+  describe('happy path', () => {
+    it('returns the same value and label after a roundtrip through JS', () => {
+      const handle = createRustBoxProbe(42.5, 'hello');
+      const view = unwrapRustBoxProbe(handle);
+      expect(view.value).toBe(42.5);
+      expect(view.label).toBe('hello');
+      expect(view.type_name).toContain('RustBoxProbe');
+    });
+
+    it('keeps independent state across multiple boxes', () => {
+      const a = createRustBoxProbe(1, 'a');
+      const b = createRustBoxProbe(2, 'b');
+      expect(unwrapRustBoxProbe(a).value).toBe(1);
+      expect(unwrapRustBoxProbe(b).value).toBe(2);
+      expect(unwrapRustBoxProbe(a).label).toBe('a');
+      expect(unwrapRustBoxProbe(b).label).toBe('b');
+    });
+
+    it('survives many unwrap calls on the same handle', () => {
+      const handle = createRustBoxProbe(7, 'persist');
+      for (let i = 0; i < 100; i += 1) {
+        const view = unwrapRustBoxProbe(handle);
+        expect(view.value).toBe(7);
+        expect(view.label).toBe('persist');
+      }
+    });
+  });
+
+  describe('non-RustBox arguments', () => {
+    // RootHolder dispatch path: `is_a::<JsBox<NativeRustHandle>>` is false,
+    // value gets classified as some other JS type (or null/undefined),
+    // `.into_rust_box()` then surfaces the "Object is not a Rust box" error.
+    const message = /Object is not a Rust box/;
+
+    it('rejects a plain object', () => {
+      expect(() => unwrapRustBoxProbe({})).toThrow(message);
+    });
+
+    it('rejects a string', () => {
+      expect(() => unwrapRustBoxProbe('not a box')).toThrow(message);
+    });
+
+    it('rejects a number', () => {
+      expect(() => unwrapRustBoxProbe(123)).toThrow(message);
+    });
+
+    it('rejects null', () => {
+      expect(() => unwrapRustBoxProbe(null)).toThrow(message);
+    });
+
+    it('rejects undefined', () => {
+      expect(() => unwrapRustBoxProbe(undefined)).toThrow(message);
+    });
+  });
+
+  describe('type-mismatch on downcast', () => {
+    // RootHolder accepts the value (it really is JsBox<NativeRustHandle>),
+    // but the inner type tag does not match: NativeRustHandle::downcast
+    // surfaces a message naming both the stored and the requested type.
+    // The format is the public diagnostic contract for cache misses and
+    // similar lookups, so we pin it down with a regex.
+    it('reports source and target type names in the error', () => {
+      const altHandle = createRustBoxProbeAlt('payload');
+      expect(() => unwrapRustBoxProbe(altHandle)).toThrow(
+        /cannot downcast.*RustBoxProbeAlt.*RustBoxProbe(?!Alt)/
+      );
+    });
+  });
+});

--- a/rust/cube/cubenativeutils/src/wrappers/context.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/context.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use super::FunctionArgsDef;
-use super::{inner_types::InnerTypes, object_handle::NativeObjectHandle};
+use super::{inner_types::InnerTypes, object_handle::NativeObjectHandle, NativeRustHandle};
 use crate::wrappers::serializer::NativeSerialize;
 use crate::CubeError;
 
@@ -13,6 +13,7 @@ pub trait NativeContext<IT: InnerTypes>: Clone {
     fn null(&self) -> Result<NativeObjectHandle<IT>, CubeError>;
     fn empty_array(&self) -> Result<IT::Array, CubeError>;
     fn empty_struct(&self) -> Result<IT::Struct, CubeError>;
+    fn rust_box(&self, handle: NativeRustHandle) -> Result<IT::RustBox, CubeError>;
     fn to_string_fn(&self, result: String) -> Result<IT::Function, CubeError>;
     fn global(&self, name: &str) -> Result<NativeObjectHandle<IT>, CubeError>;
     fn make_function<In, Rt, F: FunctionArgsDef<IT::FunctionIT, In, Rt> + 'static>(
@@ -84,6 +85,9 @@ impl<IT: InnerTypes> NativeContextHolder<IT> {
     }
     pub fn empty_struct(&self) -> Result<IT::Struct, CubeError> {
         self.context.empty_struct()
+    }
+    pub fn rust_box(&self, handle: NativeRustHandle) -> Result<IT::RustBox, CubeError> {
+        self.context.rust_box(handle)
     }
     #[allow(dead_code)]
     pub fn to_string_fn(&self, result: String) -> Result<IT::Function, CubeError> {

--- a/rust/cube/cubenativeutils/src/wrappers/inner_types.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/inner_types.rs
@@ -1,8 +1,8 @@
 use super::{
     context::NativeContext,
     object::{
-        NativeArray, NativeBoolean, NativeFunction, NativeNumber, NativeObject, NativeString,
-        NativeStruct,
+        NativeArray, NativeBoolean, NativeFunction, NativeNumber, NativeObject, NativeRustBox,
+        NativeString, NativeStruct,
     },
 };
 pub trait InnerTypes: Clone + 'static {
@@ -13,6 +13,7 @@ pub trait InnerTypes: Clone + 'static {
     type Boolean: NativeBoolean<Self>;
     type Function: NativeFunction<Self>;
     type Number: NativeNumber<Self>;
+    type RustBox: NativeRustBox<Self>;
     type Context: NativeContext<Self>;
     type FunctionIT: InnerTypes;
 }

--- a/rust/cube/cubenativeutils/src/wrappers/mod.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/mod.rs
@@ -6,6 +6,7 @@ pub mod neon;
 pub mod object;
 pub mod object_handle;
 mod proxy;
+pub mod rust_handle;
 pub mod serializer;
 
 pub use context::*;
@@ -13,3 +14,4 @@ pub use functions_args_def::*;
 pub use object::*;
 pub use object_handle::NativeObjectHandle;
 pub use proxy::*;
+pub use rust_handle::NativeRustHandle;

--- a/rust/cube/cubenativeutils/src/wrappers/neon/context.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/context.rs
@@ -3,13 +3,15 @@ use super::*;
 use super::{
     inner_types::NeonInnerTypes,
     object::{
-        base_types::*, neon_array::NeonArray, neon_function::NeonFunction, neon_struct::NeonStruct,
-        NeonObject,
+        base_types::*, neon_array::NeonArray, neon_function::NeonFunction,
+        neon_rust_box::NeonRustBox, neon_struct::NeonStruct,
+        object_root_holder::ObjectNeonTypeHolder, NeonObject,
     },
     ContextWrapper,
 };
 use crate::wrappers::neon::object::IntoNeonObject;
 use crate::wrappers::object::*;
+use crate::wrappers::rust_handle::NativeRustHandle;
 use crate::wrappers::serializer::NativeSerialize;
 use crate::wrappers::{
     context::NativeContext, functions_args_def::FunctionArgsDef, object::NativeObject,
@@ -144,6 +146,14 @@ impl<C: Context<'static> + 'static> NativeContext<NeonInnerTypes<C>> for Context
     fn empty_struct(&self) -> Result<NeonStruct<C>, CubeError> {
         let obj = NeonObject::new(self.clone(), self.with_context(|cx| cx.empty_object())?)?;
         obj.into_struct()
+    }
+    fn rust_box(&self, handle: NativeRustHandle) -> Result<NeonRustBox<C>, CubeError> {
+        let cached = handle.clone();
+        let obj_holder = self.with_context(|cx| {
+            let js_box = cx.boxed(handle);
+            ObjectNeonTypeHolder::new(self.clone(), js_box, cx)
+        })?;
+        Ok(NeonRustBox::new(obj_holder, cached))
     }
     fn to_string_fn(&self, result: String) -> Result<NeonFunction<C>, CubeError> {
         let obj = self

--- a/rust/cube/cubenativeutils/src/wrappers/neon/inner_types.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/inner_types.rs
@@ -1,8 +1,8 @@
 use super::{
     context::ContextHolder,
     object::{
-        base_types::*, neon_array::NeonArray, neon_function::NeonFunction, neon_struct::NeonStruct,
-        NeonObject,
+        base_types::*, neon_array::NeonArray, neon_function::NeonFunction,
+        neon_rust_box::NeonRustBox, neon_struct::NeonStruct, NeonObject,
     },
 };
 use crate::wrappers::inner_types::InnerTypes;
@@ -30,5 +30,6 @@ impl<C: Context<'static> + 'static> InnerTypes for NeonInnerTypes<C> {
     type Boolean = NeonBoolean<C>;
     type Function = NeonFunction<C>;
     type Number = NeonNumber<C>;
+    type RustBox = NeonRustBox<C>;
     type FunctionIT = NeonInnerTypes<FunctionContext<'static>>;
 }

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/base_types.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/base_types.rs
@@ -19,7 +19,7 @@ impl<C: Context<'static>> NeonString<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonString<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.holder);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 
@@ -43,7 +43,7 @@ impl<C: Context<'static>> NeonNumber<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonNumber<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.holder);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 
@@ -67,7 +67,7 @@ impl<C: Context<'static>> NeonBoolean<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonBoolean<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.holder);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/mod.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/mod.rs
@@ -2,12 +2,14 @@ pub mod base_types;
 pub mod neon_array;
 pub mod neon_function;
 pub mod neon_object;
+pub mod neon_rust_box;
 pub mod neon_struct;
 pub mod object_root_holder;
 pub mod primitive_root_holder;
 pub mod root_holder;
 
 pub use neon_object::*;
+pub use neon_rust_box::NeonRustBox;
 use object_root_holder::*;
 use primitive_root_holder::*;
 use root_holder::*;

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_array.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_array.rs
@@ -28,7 +28,7 @@ impl<C: Context<'static>> Clone for NeonArray<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonArray<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.object);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_function.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_function.rs
@@ -30,7 +30,7 @@ impl<C: Context<'static>> Clone for NeonFunction<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonFunction<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.object);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_object.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_object.rs
@@ -2,12 +2,14 @@ use super::{
     base_types::{NeonBoolean, NeonNumber, NeonString},
     neon_array::NeonArray,
     neon_function::NeonFunction,
+    neon_rust_box::NeonRustBox,
     neon_struct::NeonStruct,
     RootHolder,
 };
 use crate::wrappers::object::NativeObject;
 use crate::wrappers::{
     neon::{context::ContextHolder, inner_types::NeonInnerTypes},
+    rust_handle::NativeRustHandle,
     NativeObjectHandle,
 };
 use crate::CubeError;
@@ -50,6 +52,7 @@ impl<C: Context<'static> + 'static> NeonObject<C> {
             RootHolder::Array(v) => v.map_neon_object(|_cx, obj| Ok(obj.upcast())),
             RootHolder::Function(v) => v.map_neon_object(|_cx, obj| Ok(obj.upcast())),
             RootHolder::Struct(v) => v.map_neon_object(|_cx, obj| Ok(obj.upcast())),
+            RootHolder::RustBox(v) => v.map_neon_object(|_cx, obj| Ok(obj.upcast())),
         }
     }
 
@@ -81,6 +84,12 @@ impl<C: Context<'static> + 'static> NativeObject<NeonInnerTypes<C>> for NeonObje
     fn into_function(self) -> Result<NeonFunction<C>, CubeError> {
         let obj_holder = self.root_holder.into_function()?;
         Ok(NeonFunction::new(obj_holder))
+    }
+    fn into_rust_box(self) -> Result<NeonRustBox<C>, CubeError> {
+        let obj_holder = self.root_holder.into_rust_box()?;
+        let handle: NativeRustHandle =
+            obj_holder.map_neon_object(|_cx, js_box| Ok((**js_box).clone()))?;
+        Ok(NeonRustBox::new(obj_holder, handle))
     }
     fn into_array(self) -> Result<NeonArray<C>, CubeError> {
         let obj_holder = self.root_holder.into_array()?;

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_object.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_object.rs
@@ -38,7 +38,7 @@ impl<C: Context<'static> + 'static> NeonObject<C> {
         Ok(Self { root_holder })
     }
 
-    pub fn form_root(root: RootHolder<C>) -> Self {
+    pub fn from_root(root: RootHolder<C>) -> Self {
         Self { root_holder: root }
     }
 

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_rust_box.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_rust_box.rs
@@ -40,7 +40,7 @@ impl<C: Context<'static>> Clone for NeonRustBox<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonRustBox<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.object);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_rust_box.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_rust_box.rs
@@ -1,0 +1,51 @@
+use super::{NeonObject, ObjectNeonTypeHolder, RootHolder};
+use crate::wrappers::{
+    neon::inner_types::NeonInnerTypes,
+    object::{NativeRustBox, NativeType},
+    rust_handle::NativeRustHandle,
+};
+use neon::prelude::*;
+
+impl Finalize for NativeRustHandle {}
+
+/// Neon-backed `NativeRustBox`.
+///
+/// Holds the JS-side `Root<JsBox<NativeRustHandle>>` (so the JS reference
+/// keeps the box alive), plus a cheap Rc-clone of the handle on the Rust
+/// side. Reading the handle does not need the JS context — `Rc<dyn Any>`
+/// inside is self-contained — which keeps the trait API context-free.
+pub struct NeonRustBox<C: Context<'static>> {
+    object: ObjectNeonTypeHolder<C, JsBox<NativeRustHandle>>,
+    handle: NativeRustHandle,
+}
+
+impl<C: Context<'static> + 'static> NeonRustBox<C> {
+    pub fn new(
+        object: ObjectNeonTypeHolder<C, JsBox<NativeRustHandle>>,
+        handle: NativeRustHandle,
+    ) -> Self {
+        Self { object, handle }
+    }
+}
+
+impl<C: Context<'static>> Clone for NeonRustBox<C> {
+    fn clone(&self) -> Self {
+        Self {
+            object: self.object.clone(),
+            handle: self.handle.clone(),
+        }
+    }
+}
+
+impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonRustBox<C> {
+    fn into_object(self) -> NeonObject<C> {
+        let root_holder = RootHolder::from_typed(self.object);
+        NeonObject::form_root(root_holder)
+    }
+}
+
+impl<C: Context<'static> + 'static> NativeRustBox<NeonInnerTypes<C>> for NeonRustBox<C> {
+    fn handle(&self) -> &NativeRustHandle {
+        &self.handle
+    }
+}

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_struct.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/neon_struct.rs
@@ -28,7 +28,7 @@ impl<C: Context<'static>> Clone for NeonStruct<C> {
 impl<C: Context<'static> + 'static> NativeType<NeonInnerTypes<C>> for NeonStruct<C> {
     fn into_object(self) -> NeonObject<C> {
         let root_holder = RootHolder::from_typed(self.object);
-        NeonObject::form_root(root_holder)
+        NeonObject::from_root(root_holder)
     }
 }
 

--- a/rust/cube/cubenativeutils/src/wrappers/neon/object/root_holder.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/neon/object/root_holder.rs
@@ -1,5 +1,6 @@
 use super::{ObjectNeonTypeHolder, PrimitiveNeonTypeHolder};
 use crate::wrappers::neon::context::ContextHolder;
+use crate::wrappers::rust_handle::NativeRustHandle;
 use crate::CubeError;
 use neon::prelude::*;
 pub trait Upcast<C: Context<'static> + 'static> {
@@ -57,6 +58,7 @@ impl_upcast!(
     ObjectNeonTypeHolder<C, JsArray> => Array,
     ObjectNeonTypeHolder<C, JsFunction> => Function,
     ObjectNeonTypeHolder<C, JsObject> => Struct,
+    ObjectNeonTypeHolder<C, JsBox<NativeRustHandle>> => RustBox,
 );
 
 pub enum RootHolder<C: Context<'static> + 'static> {
@@ -68,6 +70,7 @@ pub enum RootHolder<C: Context<'static> + 'static> {
     Array(ObjectNeonTypeHolder<C, JsArray>),
     Function(ObjectNeonTypeHolder<C, JsFunction>),
     Struct(ObjectNeonTypeHolder<C, JsObject>),
+    RustBox(ObjectNeonTypeHolder<C, JsBox<NativeRustHandle>>),
 }
 
 impl<C: Context<'static> + 'static> RootHolder<C> {
@@ -84,6 +87,7 @@ impl<C: Context<'static> + 'static> RootHolder<C> {
                 String => JsString => PrimitiveNeonTypeHolder,
                 Array => JsArray => ObjectNeonTypeHolder,
                 Function => JsFunction => ObjectNeonTypeHolder,
+                RustBox => JsBox<NativeRustHandle> => ObjectNeonTypeHolder,
                 Struct => JsObject => ObjectNeonTypeHolder,
             });
 
@@ -107,6 +111,7 @@ impl<C: Context<'static> + 'static> RootHolder<C> {
             Self::Array(v) => v.get_context(),
             Self::Function(v) => v.get_context(),
             Self::Struct(v) => v.get_context(),
+            Self::RustBox(v) => v.get_context(),
         }
     }
 
@@ -118,6 +123,7 @@ impl<C: Context<'static> + 'static> RootHolder<C> {
     define_into_method!(into_array, Array, ObjectNeonTypeHolder<C, JsArray>, "Object is not the Array object");
     define_into_method!(into_function, Function, ObjectNeonTypeHolder<C, JsFunction>, "Object is not the Function object");
     define_into_method!(into_struct, Struct, ObjectNeonTypeHolder<C, JsObject>, "Object is not the Struct object");
+    define_into_method!(into_rust_box, RustBox, ObjectNeonTypeHolder<C, JsBox<NativeRustHandle>>, "Object is not a Rust box");
 
     pub fn clone_to_context<CC: Context<'static> + 'static>(
         &self,
@@ -132,6 +138,7 @@ impl<C: Context<'static> + 'static> RootHolder<C> {
             Self::Array(v) => RootHolder::Array(v.clone_to_context(context)),
             Self::Function(v) => RootHolder::Function(v.clone_to_context(context)),
             Self::Struct(v) => RootHolder::Struct(v.clone_to_context(context)),
+            Self::RustBox(v) => RootHolder::RustBox(v.clone_to_context(context)),
         }
     }
 }
@@ -147,6 +154,7 @@ impl<C: Context<'static> + 'static> Clone for RootHolder<C> {
             Self::Array(v) => Self::Array(v.clone()),
             Self::Function(v) => Self::Function(v.clone()),
             Self::Struct(v) => Self::Struct(v.clone()),
+            Self::RustBox(v) => Self::RustBox(v.clone()),
         }
     }
 }

--- a/rust/cube/cubenativeutils/src/wrappers/object.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/object.rs
@@ -1,4 +1,4 @@
-use super::{inner_types::InnerTypes, object_handle::NativeObjectHandle};
+use super::{inner_types::InnerTypes, object_handle::NativeObjectHandle, NativeRustHandle};
 use crate::CubeError;
 
 pub trait NativeObject<IT: InnerTypes>: Clone {
@@ -10,6 +10,7 @@ pub trait NativeObject<IT: InnerTypes>: Clone {
     fn into_number(self) -> Result<IT::Number, CubeError>;
     fn into_boolean(self) -> Result<IT::Boolean, CubeError>;
     fn into_function(self) -> Result<IT::Function, CubeError>;
+    fn into_rust_box(self) -> Result<IT::RustBox, CubeError>;
     fn is_null(&self) -> Result<bool, CubeError>;
     fn is_undefined(&self) -> Result<bool, CubeError>;
     fn clone_to_context(&self, context: &IT::Context) -> Self;
@@ -66,8 +67,8 @@ pub trait NativeBoolean<IT: InnerTypes>: NativeType<IT> {
     fn value(&self) -> Result<bool, CubeError>;
 }
 
-pub trait NativeBox<IT: InnerTypes, T: 'static>: NativeType<IT> {
-    fn deref_value(&self) -> &T;
+pub trait NativeRustBox<IT: InnerTypes>: NativeType<IT> {
+    fn handle(&self) -> &NativeRustHandle;
 }
 
 pub trait NativeProxy<IT: InnerTypes> {

--- a/rust/cube/cubenativeutils/src/wrappers/object_handle.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/object_handle.rs
@@ -41,6 +41,12 @@ impl<IT: InnerTypes> NativeObjectHandle<IT> {
     pub fn into_boolean(self) -> Result<IT::Boolean, CubeError> {
         self.object.into_boolean()
     }
+    pub fn into_rust_box(self) -> Result<IT::RustBox, CubeError> {
+        self.object.into_rust_box()
+    }
+    pub fn to_rust_box(&self) -> Result<IT::RustBox, CubeError> {
+        self.object.clone().into_rust_box()
+    }
     pub fn to_struct(&self) -> Result<IT::Struct, CubeError> {
         self.object.clone().into_struct()
     }

--- a/rust/cube/cubenativeutils/src/wrappers/rust_handle.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/rust_handle.rs
@@ -1,0 +1,115 @@
+use crate::CubeError;
+use std::any::{type_name, Any};
+use std::rc::Rc;
+
+/// Type-erased handle to a Rust value passed across the JS boundary.
+///
+/// Stores `Rc<dyn Any>` so any concrete `T: Any + 'static` can be put inside
+/// and later recovered with [`Self::downcast`]. Tesseract is single-threaded;
+/// `Rc` is sufficient and avoids the atomic overhead of `Arc`.
+#[derive(Clone)]
+pub struct NativeRustHandle {
+    inner: Rc<dyn Any + 'static>,
+    type_name: &'static str,
+}
+
+impl NativeRustHandle {
+    pub fn new<T: Any + 'static>(value: T) -> Self {
+        Self {
+            inner: Rc::new(value),
+            type_name: type_name::<T>(),
+        }
+    }
+
+    pub fn from_rc<T: Any + 'static>(value: Rc<T>) -> Self {
+        Self {
+            inner: value,
+            type_name: type_name::<T>(),
+        }
+    }
+
+    pub fn downcast<T: Any + 'static>(&self) -> Result<Rc<T>, CubeError> {
+        Rc::clone(&self.inner).downcast::<T>().map_err(|_| {
+            CubeError::internal(format!(
+                "NativeRustHandle: cannot downcast from {} to {}",
+                self.type_name,
+                type_name::<T>()
+            ))
+        })
+    }
+
+    pub fn type_name(&self) -> &'static str {
+        self.type_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct Probe {
+        value: i32,
+        tag: String,
+    }
+
+    #[derive(Debug)]
+    struct Other(#[allow(dead_code)] u8);
+
+    #[test]
+    fn new_and_downcast_roundtrip() {
+        let handle = NativeRustHandle::new(Probe {
+            value: 42,
+            tag: "hello".to_string(),
+        });
+        let probe = handle.downcast::<Probe>().expect("downcast must succeed");
+        assert_eq!(probe.value, 42);
+        assert_eq!(probe.tag, "hello");
+    }
+
+    #[test]
+    fn from_rc_preserves_identity() {
+        let original = Rc::new(Probe {
+            value: 7,
+            tag: "x".to_string(),
+        });
+        let handle = NativeRustHandle::from_rc(original.clone());
+        let recovered = handle.downcast::<Probe>().expect("downcast");
+        assert!(Rc::ptr_eq(&original, &recovered));
+    }
+
+    #[test]
+    fn downcast_wrong_type_reports_names() {
+        let handle = NativeRustHandle::new(Probe {
+            value: 0,
+            tag: String::new(),
+        });
+        let err = handle.downcast::<Other>().expect_err("must fail");
+        let msg = err.message;
+        assert!(msg.contains("Probe"), "missing source type: {msg}");
+        assert!(msg.contains("Other"), "missing target type: {msg}");
+    }
+
+    #[test]
+    fn clone_shares_inner() {
+        let handle = NativeRustHandle::new(Probe {
+            value: 1,
+            tag: String::new(),
+        });
+        let a = handle.downcast::<Probe>().unwrap();
+        let cloned = handle.clone();
+        let b = cloned.downcast::<Probe>().unwrap();
+        assert!(Rc::ptr_eq(&a, &b));
+        assert_eq!(Rc::strong_count(&a), 4);
+        // 4 = original handle, cloned handle, plus the two Rc<Probe> we just downcast.
+    }
+
+    #[test]
+    fn type_name_is_recorded() {
+        let handle = NativeRustHandle::new(Probe {
+            value: 0,
+            tag: String::new(),
+        });
+        assert!(handle.type_name().ends_with("Probe"));
+    }
+}

--- a/rust/cube/cubenativeutils/src/wrappers/serializer/deserializer.rs
+++ b/rust/cube/cubenativeutils/src/wrappers/serializer/deserializer.rs
@@ -235,7 +235,8 @@ impl<'de, IT: InnerTypes> MapAccess<'de> for NativeMapDeserializer<IT> {
 
         self.value_idx += 1;
         let de = NativeSerdeDeserializer::new(value);
-        let res = seed.deserialize(de)?;
-        Ok(res)
+        seed.deserialize(de).map_err(|err| {
+            NativeObjSerializerError::Message(format!("field `{prop_string}`: {err}"))
+        })
     }
 }

--- a/rust/cube/cubesqlplanner/nativebridge/src/lib.rs
+++ b/rust/cube/cubesqlplanner/nativebridge/src/lib.rs
@@ -501,6 +501,9 @@ impl NativeService {
                         #required_field_check
                         Ok(Self {native_object, static_data} )
                     }
+                    pub fn native_object(&self) -> &NativeObjectHandle<IT> {
+                        &self.native_object
+                    }
                 }
             }
         } else {
@@ -509,6 +512,9 @@ impl NativeService {
                     pub fn try_new(native_object: NativeObjectHandle<IT>) -> Result<Self, CubeError> {
                         #required_field_check
                         Ok(Self {native_object} )
+                    }
+                    pub fn native_object(&self) -> &NativeObjectHandle<IT> {
+                        &self.native_object
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Land the cubenativeutils foundation for passing Rust values across the JS boundary — `NativeRustHandle` / `NativeRustBox` — independently of the model-caching layer that consumes it. This is the nativeutils-only subset, extracted and re-verified so it can merge ahead of the larger feature.

## Changes

- Add `NativeRustHandle`: a type-erased `Rc<dyn Any>` handle with `downcast`/`type_name` and a self-contained error message naming both source and target types
- Add `NativeRustBox` (Neon-backed `JsBox<NativeRustHandle>`): JS reference keeps the box alive, a cheap `Rc`-clone on the Rust side keeps the trait API context-free
- Thread a `RustBox` variant through `RootHolder` (classify before `Struct`, upcast, `into_rust_box`); add `rust_box()` to `NativeContext` and `into_rust_box`/`to_rust_box` to the object handle
- Replace the unused `NativeBox<IT, T>` trait with `NativeRustBox<IT>`
- Include the field name in deserializer errors (`` field `x`: ... ``)
- Generate a `native_object()` accessor in the nativebridge macro

## Testing

- `cargo test --lib` (cubenativeutils): 11/11 pass, incl. 5 new `rust_handle` unit tests
- `cargo build --features bridge-test-harness` (native) and `cargo check` (cubesqlplanner macro expansion): clean
- Bridge harness via real V8: 201/201 pass, incl. 10 new `rust-box` tests covering roundtrip, box isolation, non-box rejection, and downcast type-mismatch diagnostics
- `cargo fmt --check`: clean across all touched crates