### PR TITLE
chore(cubesql): DFWrapper - reduce stack usage

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2260,253 +2260,20 @@ impl WrappedSelectNode {
             Expr::Literal(literal) => {
                 Self::generate_sql_for_literal(sql_query, sql_generator, literal)
             }
-            Expr::ScalarUDF { fun, args } => {
-                let date_part_err = |dp| {
-                    DataFusionError::Internal(format!(
-                        "Can't generate SQL for scalar function: date part '{}' is not supported",
-                        dp
-                    ))
-                };
-                let date_part = match fun.name.as_str() {
-                    "datediff" | "dateadd" => match &args[0] {
-                        Expr::Literal(ScalarValue::Utf8(Some(date_part))) => {
-                            // Security check to prevent SQL injection
-                            if DATE_PART_REGEX.is_match(date_part) {
-                                Ok(Some(date_part.to_string()))
-                            } else {
-                                Err(date_part_err(date_part.to_string()))
-                            }
-                        }
-                        _ => Err(date_part_err(args[0].to_string())),
-                    },
-                    "date_add" => match &args[1] {
-                        Expr::Literal(ScalarValue::IntervalDayTime(Some(interval))) => {
-                            let days = (*interval >> 32) as i32;
-                            let ms = (*interval & 0xFFFF_FFFF) as i32;
-
-                            if days != 0 && ms == 0 {
-                                Ok(Some("DAY".to_string()))
-                            } else if ms != 0 && days == 0 {
-                                Ok(Some("MILLISECOND".to_string()))
-                            } else {
-                                Err(DataFusionError::Internal(format!(
-                                    "Unsupported mixed IntervalDayTime: days = {days}, ms = {ms}"
-                                )))
-                            }
-                        }
-                        Expr::Literal(ScalarValue::IntervalYearMonth(Some(_months))) => {
-                            Ok(Some("MONTH".to_string()))
-                        }
-                        Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(interval))) => {
-                            let months = (interval >> 96) as i32;
-                            let days = ((interval >> 64) & 0xFFFF_FFFF) as i32;
-                            let nanos = *interval as i64;
-
-                            if months != 0 && days == 0 && nanos == 0 {
-                                Ok(Some("MONTH".to_string()))
-                            } else if days != 0 && months == 0 && nanos == 0 {
-                                Ok(Some("DAY".to_string()))
-                            } else if nanos != 0 && months == 0 && days == 0 {
-                                Ok(Some("NANOSECOND".to_string()))
-                            } else {
-                                Err(DataFusionError::Internal(format!(
-                                    "Unsupported mixed IntervalMonthDayNano: months = {months}, days = {days}, nanos = {nanos}"
-                                )))
-                            }
-                        }
-                        _ => Err(date_part_err(args[1].to_string())),
-                    },
-                    _ => Ok(None),
-                }?;
-                let interval = match fun.name.as_str() {
-                    "dateadd" => match &args[1] {
-                        Expr::Literal(ScalarValue::Int64(Some(interval))) => {
-                            Ok(Some(interval.to_string()))
-                        }
-                        _ => Err(DataFusionError::Internal(format!(
-                            "Can't generate SQL for scalar function: interval must be Int64"
-                        ))),
-                    },
-                    "date_add" => match &args[1] {
-                        Expr::Literal(ScalarValue::IntervalDayTime(Some(interval))) => {
-                            let days = (*interval >> 32) as i32;
-                            let ms = (*interval & 0xFFFF_FFFF) as i32;
-
-                            if days != 0 && ms == 0 {
-                                Ok(Some(days.to_string()))
-                            } else if ms != 0 && days == 0 {
-                                Ok(Some(ms.to_string()))
-                            } else {
-                                Err(DataFusionError::Internal(format!(
-                                    "Unsupported mixed IntervalDayTime: days = {days}, ms = {ms}"
-                                )))
-                            }
-                        }
-                        Expr::Literal(ScalarValue::IntervalYearMonth(Some(months))) => {
-                            Ok(Some(months.to_string()))
-                        }
-                        Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(interval))) => {
-                            let months = (interval >> 96) as i32;
-                            let days = ((interval >> 64) & 0xFFFF_FFFF) as i32;
-                            let nanos = *interval as i64;
-
-                            if months != 0 && days == 0 && nanos == 0 {
-                                Ok(Some(months.to_string()))
-                            } else if days != 0 && months == 0 && nanos == 0 {
-                                Ok(Some(days.to_string()))
-                            } else if nanos != 0 && months == 0 && days == 0 {
-                                Ok(Some(nanos.to_string()))
-                            } else {
-                                Err(DataFusionError::Internal(format!(
-                                    "Unsupported mixed IntervalMonthDayNano: months = {months}, days = {days}, nanos = {nanos}"
-                                )))
-                            }
-                        }
-                        _ => Err(date_part_err(args[1].to_string())),
-                    },
-                    _ => Ok(None),
-                }?;
-                let mut sql_args = Vec::new();
-                for arg in args {
-                    let (sql, query) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        arg,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = query;
-                    sql_args.push(sql);
-                }
-                Ok((
-                    sql_generator
-                        .get_sql_templates()
-                        .scalar_function(fun.name.to_string(), sql_args, date_part, interval)
-                        .map_err(|e| {
-                            DataFusionError::Internal(format!(
-                                "Can't generate SQL for scalar function: {}",
-                                e
-                            ))
-                        })?,
-                    sql_query,
-                ))
-            }
-            Expr::ScalarFunction { fun, args } => {
-                if args.len() == 2 {
-                    if let (
-                        BuiltinScalarFunction::DateTrunc,
-                        Expr::Literal(ScalarValue::Utf8(Some(granularity))),
-                        Expr::Column(column),
-                        Some(PushToCubeContext {
-                            ungrouped_scan_node,
-                            known_join_subqueries,
-                        }),
-                    ) = (&fun, &args[0], &args[1], push_to_cube_context)
-                    {
-                        let granularity = granularity.to_ascii_lowercase();
-                        // Security check to prevent SQL injection
-                        if granularity_str_to_int_order(&granularity, Some(false)).is_some()
-                            && subqueries.get(&column.flat_name()).is_none()
-                            && !column
-                                .relation
-                                .as_ref()
-                                .map(|relation| known_join_subqueries.contains(relation))
-                                .unwrap_or(false)
-                        {
-                            if let Ok(MemberField::Member(regular_member)) =
-                                Self::find_member_in_ungrouped_scan(ungrouped_scan_node, column)
-                            {
-                                // TODO: check if member is a time dimension
-                                if let MemberField::Member(time_dimension_member) =
-                                    MemberField::time_dimension(
-                                        regular_member.member.clone(),
-                                        granularity,
-                                    )
-                                {
-                                    return Ok((
-                                        format!("${{{}}}", time_dimension_member.field_name),
-                                        sql_query,
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-                if let BuiltinScalarFunction::DatePart = &fun {
-                    if args.len() >= 2 {
-                        match &args[0] {
-                            Expr::Literal(ScalarValue::Utf8(Some(date_part))) => {
-                                // Security check to prevent SQL injection
-                                if !DATE_PART_REGEX.is_match(date_part) {
-                                    return Err(DataFusionError::Internal(format!(
-                                        "Can't generate SQL for scalar function: date part '{}' is not supported",
-                                        date_part
-                                    )));
-                                }
-                                let (arg_sql, query) = Self::generate_sql_for_expr(
-                                    sql_query,
-                                    sql_generator.clone(),
-                                    args[1].clone(),
-                                    push_to_cube_context,
-                                    subqueries,
-                                )?;
-                                return Ok((
-                                    sql_generator
-                                        .get_sql_templates()
-                                        .extract_expr(date_part.to_string(), arg_sql)
-                                        .map_err(|e| {
-                                            DataFusionError::Internal(format!(
-                                                "Can't generate SQL for scalar function: {}",
-                                                e
-                                            ))
-                                        })?,
-                                    query,
-                                ));
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                let date_part = if let BuiltinScalarFunction::DateTrunc = &fun {
-                    match &args[0] {
-                        Expr::Literal(ScalarValue::Utf8(Some(date_part))) => {
-                            // Security check to prevent SQL injection
-                            if DATE_PART_REGEX.is_match(date_part) {
-                                Some(date_part.to_string())
-                            } else {
-                                None
-                            }
-                        }
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-                let mut sql_args = Vec::new();
-                for arg in args {
-                    let (sql, query) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        arg,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = query;
-                    sql_args.push(sql);
-                }
-                Ok((
-                    sql_generator
-                        .get_sql_templates()
-                        .scalar_function(fun.to_string(), sql_args, date_part, None)
-                        .map_err(|e| {
-                            DataFusionError::Internal(format!(
-                                "Can't generate SQL for scalar function: {}",
-                                e
-                            ))
-                        })?,
-                    sql_query,
-                ))
-            }
+            expr @ Expr::ScalarUDF { .. } => Self::generate_sql_for_scalar_udf(
+                sql_query,
+                sql_generator,
+                expr,
+                push_to_cube_context,
+                subqueries,
+            ),
+            expr @ Expr::ScalarFunction { .. } => Self::generate_sql_for_scalar_function(
+                sql_query,
+                sql_generator,
+                expr,
+                push_to_cube_context,
+                subqueries,
+            ),
             Expr::AggregateFunction {
                 fun,
                 args,
@@ -2680,87 +2447,13 @@ impl WrappedSelectNode {
                     })?;
                 Ok((resulting_sql, sql_query))
             }
-            Expr::AggregateUDF {
-                ref fun,
-                ref args,
-                distinct,
-            } => {
-                match fun.name.as_str() {
-                    // TODO allow this only in agg expr
-                    MEASURE_UDAF_NAME => {
-                        if distinct {
-                            return Err(DataFusionError::Internal(
-                                "MEASURE function with DISTINCT flag is not supported".to_string(),
-                            ));
-                        }
-
-                        let Some(PushToCubeContext {
-                            ungrouped_scan_node,
-                            ..
-                        }) = push_to_cube_context
-                        else {
-                            return Err(DataFusionError::Internal(format!(
-                                "Unexpected {} UDAF expression without push-to-Cube context: {expr}",
-                                fun.name,
-                            )));
-                        };
-
-                        let measure_column = match args.as_slice() {
-                            [Expr::Column(measure_column)] => measure_column,
-                            _ => {
-                                return Err(DataFusionError::Internal(format!(
-                                    "Unexpected arguments for {} UDAF: {expr}",
-                                    fun.name,
-                                )))
-                            }
-                        };
-
-                        let member = Self::find_member_in_ungrouped_scan(
-                            ungrouped_scan_node,
-                            measure_column,
-                        )?;
-
-                        let MemberField::Member(member) = member else {
-                            return Err(DataFusionError::Internal(format!(
-                                "First argument for {} UDAF should reference regular member, not literal: {expr}",
-                                fun.name,
-                            )));
-                        };
-
-                        Ok((format!("${{{}}}", member.field_name), sql_query))
-                    }
-                    PATCH_MEASURE_UDAF_NAME => Err(DataFusionError::Internal(format!(
-                        "{} UDAF should generate SQL via different path: {expr}",
-                        fun.name
-                    ))),
-                    _ => {
-                        let mut sql_args = Vec::new();
-                        for arg in args {
-                            let (sql, query) = Self::generate_sql_for_expr(
-                                sql_query,
-                                sql_generator.clone(),
-                                arg.clone(),
-                                push_to_cube_context,
-                                subqueries,
-                            )?;
-                            sql_query = query;
-                            sql_args.push(sql);
-                        }
-                        Ok((
-                            sql_generator
-                                .get_sql_templates()
-                                .udaf_function(&fun, sql_args, distinct)
-                                .map_err(|e| {
-                                    DataFusionError::Internal(format!(
-                                        "Can't generate SQL for UDAF: {}",
-                                        e
-                                    ))
-                                })?,
-                            sql_query,
-                        ))
-                    }
-                }
-            }
+            expr @ Expr::AggregateUDF { .. } => Self::generate_sql_for_aggregate_udf(
+                sql_query,
+                sql_generator,
+                expr,
+                push_to_cube_context,
+                subqueries,
+            ),
             Expr::InList {
                 expr,
                 list,
@@ -3114,6 +2807,364 @@ impl WrappedSelectNode {
                 )));
             }
         })
+    }
+
+    #[inline(never)]
+    fn generate_sql_for_scalar_udf<'ctx>(
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::ScalarUDF { fun, args } = expr else {
+            return Err(DataFusionError::Internal(
+                "generate_sql_for_scalar_udf called with non-ScalarUDF expr".to_string(),
+            ));
+        };
+        let date_part_err = |dp| {
+            DataFusionError::Internal(format!(
+                "Can't generate SQL for scalar function: date part '{}' is not supported",
+                dp
+            ))
+        };
+        let date_part = match fun.name.as_str() {
+            "datediff" | "dateadd" => match &args[0] {
+                Expr::Literal(ScalarValue::Utf8(Some(date_part))) => {
+                    // Security check to prevent SQL injection
+                    if DATE_PART_REGEX.is_match(date_part) {
+                        Ok(Some(date_part.to_string()))
+                    } else {
+                        Err(date_part_err(date_part.to_string()))
+                    }
+                }
+                _ => Err(date_part_err(args[0].to_string())),
+            },
+            "date_add" => match &args[1] {
+                Expr::Literal(ScalarValue::IntervalDayTime(Some(interval))) => {
+                    let days = (*interval >> 32) as i32;
+                    let ms = (*interval & 0xFFFF_FFFF) as i32;
+
+                    if days != 0 && ms == 0 {
+                        Ok(Some("DAY".to_string()))
+                    } else if ms != 0 && days == 0 {
+                        Ok(Some("MILLISECOND".to_string()))
+                    } else {
+                        Err(DataFusionError::Internal(format!(
+                            "Unsupported mixed IntervalDayTime: days = {days}, ms = {ms}"
+                        )))
+                    }
+                }
+                Expr::Literal(ScalarValue::IntervalYearMonth(Some(_months))) => {
+                    Ok(Some("MONTH".to_string()))
+                }
+                Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(interval))) => {
+                    let months = (interval >> 96) as i32;
+                    let days = ((interval >> 64) & 0xFFFF_FFFF) as i32;
+                    let nanos = *interval as i64;
+
+                    if months != 0 && days == 0 && nanos == 0 {
+                        Ok(Some("MONTH".to_string()))
+                    } else if days != 0 && months == 0 && nanos == 0 {
+                        Ok(Some("DAY".to_string()))
+                    } else if nanos != 0 && months == 0 && days == 0 {
+                        Ok(Some("NANOSECOND".to_string()))
+                    } else {
+                        Err(DataFusionError::Internal(format!(
+                                    "Unsupported mixed IntervalMonthDayNano: months = {months}, days = {days}, nanos = {nanos}"
+                                )))
+                    }
+                }
+                _ => Err(date_part_err(args[1].to_string())),
+            },
+            _ => Ok(None),
+        }?;
+        let interval = match fun.name.as_str() {
+            "dateadd" => match &args[1] {
+                Expr::Literal(ScalarValue::Int64(Some(interval))) => Ok(Some(interval.to_string())),
+                _ => Err(DataFusionError::Internal(format!(
+                    "Can't generate SQL for scalar function: interval must be Int64"
+                ))),
+            },
+            "date_add" => match &args[1] {
+                Expr::Literal(ScalarValue::IntervalDayTime(Some(interval))) => {
+                    let days = (*interval >> 32) as i32;
+                    let ms = (*interval & 0xFFFF_FFFF) as i32;
+
+                    if days != 0 && ms == 0 {
+                        Ok(Some(days.to_string()))
+                    } else if ms != 0 && days == 0 {
+                        Ok(Some(ms.to_string()))
+                    } else {
+                        Err(DataFusionError::Internal(format!(
+                            "Unsupported mixed IntervalDayTime: days = {days}, ms = {ms}"
+                        )))
+                    }
+                }
+                Expr::Literal(ScalarValue::IntervalYearMonth(Some(months))) => {
+                    Ok(Some(months.to_string()))
+                }
+                Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(interval))) => {
+                    let months = (interval >> 96) as i32;
+                    let days = ((interval >> 64) & 0xFFFF_FFFF) as i32;
+                    let nanos = *interval as i64;
+
+                    if months != 0 && days == 0 && nanos == 0 {
+                        Ok(Some(months.to_string()))
+                    } else if days != 0 && months == 0 && nanos == 0 {
+                        Ok(Some(days.to_string()))
+                    } else if nanos != 0 && months == 0 && days == 0 {
+                        Ok(Some(nanos.to_string()))
+                    } else {
+                        Err(DataFusionError::Internal(format!(
+                                    "Unsupported mixed IntervalMonthDayNano: months = {months}, days = {days}, nanos = {nanos}"
+                                )))
+                    }
+                }
+                _ => Err(date_part_err(args[1].to_string())),
+            },
+            _ => Ok(None),
+        }?;
+        let mut sql_args = Vec::new();
+        for arg in args {
+            let (sql, query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                arg,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = query;
+            sql_args.push(sql);
+        }
+        Ok((
+            sql_generator
+                .get_sql_templates()
+                .scalar_function(fun.name.to_string(), sql_args, date_part, interval)
+                .map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "Can't generate SQL for scalar function: {}",
+                        e
+                    ))
+                })?,
+            sql_query,
+        ))
+    }
+
+    #[inline(never)]
+    fn generate_sql_for_scalar_function<'ctx>(
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::ScalarFunction { fun, args } = expr else {
+            return Err(DataFusionError::Internal(
+                "generate_sql_for_scalar_function called with non-ScalarFunction expr".to_string(),
+            ));
+        };
+        if args.len() == 2 {
+            if let (
+                BuiltinScalarFunction::DateTrunc,
+                Expr::Literal(ScalarValue::Utf8(Some(granularity))),
+                Expr::Column(column),
+                Some(PushToCubeContext {
+                    ungrouped_scan_node,
+                    known_join_subqueries,
+                }),
+            ) = (&fun, &args[0], &args[1], push_to_cube_context)
+            {
+                let granularity = granularity.to_ascii_lowercase();
+                // Security check to prevent SQL injection
+                if granularity_str_to_int_order(&granularity, Some(false)).is_some()
+                    && subqueries.get(&column.flat_name()).is_none()
+                    && !column
+                        .relation
+                        .as_ref()
+                        .map(|relation| known_join_subqueries.contains(relation))
+                        .unwrap_or(false)
+                {
+                    if let Ok(MemberField::Member(regular_member)) =
+                        Self::find_member_in_ungrouped_scan(ungrouped_scan_node, column)
+                    {
+                        // TODO: check if member is a time dimension
+                        if let MemberField::Member(time_dimension_member) =
+                            MemberField::time_dimension(regular_member.member.clone(), granularity)
+                        {
+                            return Ok((
+                                format!("${{{}}}", time_dimension_member.field_name),
+                                sql_query,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        if let BuiltinScalarFunction::DatePart = &fun {
+            if args.len() >= 2 {
+                match &args[0] {
+                    Expr::Literal(ScalarValue::Utf8(Some(date_part))) => {
+                        // Security check to prevent SQL injection
+                        if !DATE_PART_REGEX.is_match(date_part) {
+                            return Err(DataFusionError::Internal(format!(
+                                        "Can't generate SQL for scalar function: date part '{}' is not supported",
+                                        date_part
+                                    )));
+                        }
+                        let (arg_sql, query) = Self::generate_sql_for_expr(
+                            sql_query,
+                            sql_generator.clone(),
+                            args[1].clone(),
+                            push_to_cube_context,
+                            subqueries,
+                        )?;
+                        return Ok((
+                            sql_generator
+                                .get_sql_templates()
+                                .extract_expr(date_part.to_string(), arg_sql)
+                                .map_err(|e| {
+                                    DataFusionError::Internal(format!(
+                                        "Can't generate SQL for scalar function: {}",
+                                        e
+                                    ))
+                                })?,
+                            query,
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let date_part = if let BuiltinScalarFunction::DateTrunc = &fun {
+            match &args[0] {
+                Expr::Literal(ScalarValue::Utf8(Some(date_part))) => {
+                    // Security check to prevent SQL injection
+                    if DATE_PART_REGEX.is_match(date_part) {
+                        Some(date_part.to_string())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+        let mut sql_args = Vec::new();
+        for arg in args {
+            let (sql, query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                arg,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = query;
+            sql_args.push(sql);
+        }
+        Ok((
+            sql_generator
+                .get_sql_templates()
+                .scalar_function(fun.to_string(), sql_args, date_part, None)
+                .map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "Can't generate SQL for scalar function: {}",
+                        e
+                    ))
+                })?,
+            sql_query,
+        ))
+    }
+
+    #[inline(never)]
+    fn generate_sql_for_aggregate_udf<'ctx>(
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::AggregateUDF {
+            ref fun,
+            ref args,
+            distinct,
+        } = expr
+        else {
+            return Err(DataFusionError::Internal(
+                "generate_sql_for_aggregate_udf called with non-AggregateUDF expr".to_string(),
+            ));
+        };
+        match fun.name.as_str() {
+            // TODO allow this only in agg expr
+            MEASURE_UDAF_NAME => {
+                if distinct {
+                    return Err(DataFusionError::Internal(
+                        "MEASURE function with DISTINCT flag is not supported".to_string(),
+                    ));
+                }
+
+                let Some(PushToCubeContext {
+                    ungrouped_scan_node,
+                    ..
+                }) = push_to_cube_context
+                else {
+                    return Err(DataFusionError::Internal(format!(
+                        "Unexpected {} UDAF expression without push-to-Cube context: {expr}",
+                        fun.name,
+                    )));
+                };
+
+                let measure_column = match args.as_slice() {
+                    [Expr::Column(measure_column)] => measure_column,
+                    _ => {
+                        return Err(DataFusionError::Internal(format!(
+                            "Unexpected arguments for {} UDAF: {expr}",
+                            fun.name,
+                        )))
+                    }
+                };
+
+                let member =
+                    Self::find_member_in_ungrouped_scan(ungrouped_scan_node, measure_column)?;
+
+                let MemberField::Member(member) = member else {
+                    return Err(DataFusionError::Internal(format!(
+                                "First argument for {} UDAF should reference regular member, not literal: {expr}",
+                                fun.name,
+                            )));
+                };
+
+                Ok((format!("${{{}}}", member.field_name), sql_query))
+            }
+            PATCH_MEASURE_UDAF_NAME => Err(DataFusionError::Internal(format!(
+                "{} UDAF should generate SQL via different path: {expr}",
+                fun.name
+            ))),
+            _ => {
+                let mut sql_args = Vec::new();
+                for arg in args {
+                    let (sql, query) = Self::generate_sql_for_expr(
+                        sql_query,
+                        sql_generator.clone(),
+                        arg.clone(),
+                        push_to_cube_context,
+                        subqueries,
+                    )?;
+                    sql_query = query;
+                    sql_args.push(sql);
+                }
+                Ok((
+                    sql_generator
+                        .get_sql_templates()
+                        .udaf_function(&fun, sql_args, distinct)
+                        .map_err(|e| {
+                            DataFusionError::Internal(format!("Can't generate SQL for UDAF: {}", e))
+                        })?,
+                    sql_query,
+                ))
+            }
+        }
     }
 
     fn find_member_in_ungrouped_scan<'scan, 'col>(

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -953,8 +953,7 @@ impl CubeScanWrapperNode {
                     expr,
                     None,
                     &HashMap::new(),
-                )
-                .await?;
+                )?;
                 columns.push(AliasedColumn { expr, alias });
                 new_sql = sql;
             }
@@ -1352,8 +1351,7 @@ impl WrappedSelectNode {
                             filter.clone(),
                             Some(push_to_cube_context),
                             subqueries,
-                        )
-                        .await?;
+                        )?;
 
                         let used_cubes = Self::prepare_used_cubes(&used_members);
 
@@ -1753,8 +1751,7 @@ impl WrappedSelectNode {
                 expr.clone(),
                 push_to_cube_context,
                 subqueries,
-            )
-            .await?;
+            )?;
             let expr_sql =
                 Self::escape_interpolation_quotes(expr_sql, push_to_cube_context.is_some());
             sql = new_sql_query;
@@ -1812,9 +1809,7 @@ impl WrappedSelectNode {
         Self::generate_typed_null(sql_generator, Some(data_type))
     }
 
-    /// This function is async to be able to call to JS land,
-    /// in case some SQL generation could not be done through Jinja
-    pub async fn generate_sql_for_expr<'ctx>(
+    pub fn generate_sql_for_expr<'ctx>(
         mut sql_query: SqlQuery,
         sql_generator: Arc<dyn SqlGenerator>,
         expr: Expr,
@@ -1823,17 +1818,15 @@ impl WrappedSelectNode {
     ) -> Result<(String, SqlQuery)> {
         match expr {
             Expr::Alias(expr, _) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 Ok((expr, sql_query))
             }
-            // Expr::OuterColumn(_, _) => {}
             Expr::Column(ref c) => {
                 if let Some(subquery) = subqueries.get(&c.flat_name()) {
                     Ok((
@@ -1859,14 +1852,13 @@ impl WrappedSelectNode {
                             // It means we don't need to use member expressions here, and can just use that fixed alias
                             // So we can generate that as if it were regular column expression
 
-                            return Self::generate_sql_for_expr_rec(
+                            return Self::generate_sql_for_expr(
                                 sql_query,
                                 sql_generator.clone(),
                                 expr,
                                 None,
                                 subqueries,
-                            )
-                            .await;
+                            );
                         }
                     }
 
@@ -1876,16 +1868,13 @@ impl WrappedSelectNode {
                         MemberField::Member(member) => {
                             Ok((format!("${{{}}}", member.field_name), sql_query))
                         }
-                        MemberField::Literal(value) => {
-                            Self::generate_sql_for_expr_rec(
-                                sql_query,
-                                sql_generator.clone(),
-                                Expr::Literal(value.clone()),
-                                push_to_cube_context,
-                                subqueries,
-                            )
-                            .await
-                        }
+                        MemberField::Literal(value) => Self::generate_sql_for_expr(
+                            sql_query,
+                            sql_generator.clone(),
+                            Expr::Literal(value.clone()),
+                            push_to_cube_context,
+                            subqueries,
+                        ),
                     }
                 } else {
                     Ok((
@@ -1927,22 +1916,20 @@ impl WrappedSelectNode {
             }
             // Expr::ScalarVariable(_, _) => {}
             Expr::BinaryExpr { left, op, right } => {
-                let (left, sql_query) = Self::generate_sql_for_expr_rec(
+                let (left, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *left,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
-                let (right, sql_query) = Self::generate_sql_for_expr_rec(
+                )?;
+                let (right, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *right,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql = match op {
                     Operator::Like => sql_generator.get_sql_templates().like_expr(
                         LikeType::Like,
@@ -1983,32 +1970,29 @@ impl WrappedSelectNode {
             }
             // Expr::AnyExpr { .. } => {}
             Expr::Like(like) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *like.expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
-                let (pattern, sql_query) = Self::generate_sql_for_expr_rec(
+                )?;
+                let (pattern, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *like.pattern,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let (escape_char, sql_query) = match like.escape_char {
                     Some(escape_char) => {
-                        let (escape_char, sql_query) = Self::generate_sql_for_expr_rec(
+                        let (escape_char, sql_query) = Self::generate_sql_for_expr(
                             sql_query,
                             sql_generator.clone(),
                             Expr::Literal(ScalarValue::Utf8(Some(escape_char.to_string()))),
                             push_to_cube_context,
                             subqueries,
-                        )
-                        .await?;
+                        )?;
                         (Some(escape_char), sql_query)
                     }
                     None => (None, sql_query),
@@ -2025,32 +2009,29 @@ impl WrappedSelectNode {
                 Ok((resulting_sql, sql_query))
             }
             Expr::ILike(ilike) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *ilike.expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
-                let (pattern, sql_query) = Self::generate_sql_for_expr_rec(
+                )?;
+                let (pattern, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *ilike.pattern,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let (escape_char, sql_query) = match ilike.escape_char {
                     Some(escape_char) => {
-                        let (escape_char, sql_query) = Self::generate_sql_for_expr_rec(
+                        let (escape_char, sql_query) = Self::generate_sql_for_expr(
                             sql_query,
                             sql_generator.clone(),
                             Expr::Literal(ScalarValue::Utf8(Some(escape_char.to_string()))),
                             push_to_cube_context,
                             subqueries,
-                        )
-                        .await?;
+                        )?;
                         (Some(escape_char), sql_query)
                     }
                     None => (None, sql_query),
@@ -2068,14 +2049,13 @@ impl WrappedSelectNode {
             }
             // Expr::SimilarTo(_) => {}
             Expr::Not(expr) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql =
                     sql_generator
                         .get_sql_templates()
@@ -2089,14 +2069,13 @@ impl WrappedSelectNode {
                 Ok((resulting_sql, sql_query))
             }
             Expr::IsNotNull(expr) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql = sql_generator
                     .get_sql_templates()
                     .is_null_expr(expr, true)
@@ -2109,14 +2088,13 @@ impl WrappedSelectNode {
                 Ok((resulting_sql, sql_query))
             }
             Expr::IsNull(expr) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql = sql_generator
                     .get_sql_templates()
                     .is_null_expr(expr, false)
@@ -2129,14 +2107,13 @@ impl WrappedSelectNode {
                 Ok((resulting_sql, sql_query))
             }
             Expr::Negative(expr) => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql = sql_generator
                     .get_sql_templates()
                     .negative_expr(expr)
@@ -2152,30 +2129,27 @@ impl WrappedSelectNode {
                 low,
                 high,
             } => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
-                let (low, sql_query) = Self::generate_sql_for_expr_rec(
+                )?;
+                let (low, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *low,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
-                let (high, sql_query) = Self::generate_sql_for_expr_rec(
+                )?;
+                let (high, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *high,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql = sql_generator
                     .get_sql_templates()
                     .between_expr(expr, negated, low, high)
@@ -2193,14 +2167,13 @@ impl WrappedSelectNode {
                 else_expr,
             } => {
                 let expr = if let Some(expr) = expr {
-                    let (expr, sql_query_next) = Self::generate_sql_for_expr_rec(
+                    let (expr, sql_query_next) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         *expr,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = sql_query_next;
                     Some(expr)
                 } else {
@@ -2208,34 +2181,31 @@ impl WrappedSelectNode {
                 };
                 let mut when_then_expr_sql = Vec::new();
                 for (when, then) in when_then_expr {
-                    let (when, sql_query_next) = Self::generate_sql_for_expr_rec(
+                    let (when, sql_query_next) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         *when,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
-                    let (then, sql_query_next) = Self::generate_sql_for_expr_rec(
+                    )?;
+                    let (then, sql_query_next) = Self::generate_sql_for_expr(
                         sql_query_next,
                         sql_generator.clone(),
                         *then,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = sql_query_next;
                     when_then_expr_sql.push((when, then));
                 }
                 let else_expr = if let Some(else_expr) = else_expr {
-                    let (else_expr, sql_query_next) = Self::generate_sql_for_expr_rec(
+                    let (else_expr, sql_query_next) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         *else_expr,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = sql_query_next;
                     Some(else_expr)
                 } else {
@@ -2250,14 +2220,13 @@ impl WrappedSelectNode {
                 Ok((resulting_sql, sql_query))
             }
             Expr::Cast { expr, data_type } => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let data_type = Self::generate_sql_type(sql_generator.clone(), data_type)?;
                 let resulting_sql = Self::generate_sql_cast_expr(sql_generator, expr, data_type)?;
                 Ok((resulting_sql, sql_query))
@@ -2268,14 +2237,13 @@ impl WrappedSelectNode {
                 asc,
                 nulls_first,
             } => {
-                let (expr, sql_query) = Self::generate_sql_for_expr_rec(
+                let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 let resulting_sql = sql_generator
                     .get_sql_templates()
                     .sort_expr(expr, asc, nulls_first)
@@ -2290,275 +2258,7 @@ impl WrappedSelectNode {
 
             // Expr::TableUDF { .. } => {}
             Expr::Literal(literal) => {
-                Ok(match literal {
-                    ScalarValue::Boolean(b) => (
-                        b.map(|b| {
-                            sql_generator
-                                .get_sql_templates()
-                                .literal_bool_expr(b)
-                                .map_err(|e| {
-                                    DataFusionError::Internal(format!(
-                                        "Can't generate SQL for literal bool: {}",
-                                        e
-                                    ))
-                                })
-                        })
-                        .transpose()?
-                        .map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Float32(f) => (
-                        f.map(|f| format!("{f}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Float64(f) => (
-                        f.map(|f| format!("{f}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Decimal128(x, precision, scale) => {
-                        // In Postgres, NUMERIC or DECIMAL scale can be negative.  But it's unsigned, here.
-                        let scale: usize = scale;
-
-                        (
-                            if let Some(x) = x {
-                                let number = Decimal::format_string(x, scale);
-                                let data_type = Self::generate_sql_type(
-                                    sql_generator.clone(),
-                                    DataType::Decimal(precision, scale),
-                                )?;
-                                Self::generate_sql_cast_expr(
-                                    sql_generator,
-                                    format!("'{}'", number),
-                                    data_type,
-                                )?
-                            } else {
-                                Self::generate_null_for_literal(sql_generator, &literal)?
-                            },
-                            sql_query,
-                        )
-                    }
-                    ScalarValue::Int8(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Int16(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Int32(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Int64(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::UInt8(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::UInt16(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::UInt32(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::UInt64(x) => (
-                        x.map(|x| format!("{x}")).map_or_else(
-                            || Self::generate_null_for_literal(sql_generator, &literal),
-                            Ok,
-                        )?,
-                        sql_query,
-                    ),
-                    ScalarValue::Utf8(x) => {
-                        if x.is_some() {
-                            let param_index = sql_query.add_value(x);
-                            (format!("${}$", param_index), sql_query)
-                        } else {
-                            (
-                                Self::generate_typed_null(sql_generator, Some(DataType::Utf8))?,
-                                sql_query,
-                            )
-                        }
-                    }
-                    // ScalarValue::LargeUtf8(_) => {}
-                    // ScalarValue::Binary(_) => {}
-                    // ScalarValue::LargeBinary(_) => {}
-                    // ScalarValue::List(_, _) => {}
-                    ScalarValue::Date32(x) => {
-                        if let Some(x) = x {
-                            let days = Days::new(x.abs().try_into().unwrap());
-                            let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                            let new_date = if x < 0 {
-                                epoch.checked_sub_days(days)
-                            } else {
-                                epoch.checked_add_days(days)
-                            };
-                            let Some(new_date) = new_date else {
-                                return Err(DataFusionError::Internal(format!(
-                                    "Can't generate SQL for date: day out of bounds ({})",
-                                    x
-                                )));
-                            };
-                            let formatted_date = new_date.format("%Y-%m-%d").to_string();
-                            (
-                                sql_generator
-                                    .get_sql_templates()
-                                    .scalar_function(
-                                        "DATE".to_string(),
-                                        vec![format!("'{}'", formatted_date)],
-                                        None,
-                                        None,
-                                    )
-                                    .map_err(|e| {
-                                        DataFusionError::Internal(format!(
-                                            "Can't generate SQL for date: {}",
-                                            e
-                                        ))
-                                    })?,
-                                sql_query,
-                            )
-                        } else {
-                            (
-                                Self::generate_null_for_literal(sql_generator, &literal)?,
-                                sql_query,
-                            )
-                        }
-                    }
-                    // ScalarValue::Date64(_) => {}
-
-                    // generate_sql_for_timestamp will call Utc constructors, so only support UTC zone for now
-                    // DataFusion can return "UTC" for stuff like `NOW()` during constant folding
-                    ScalarValue::TimestampSecond(s, ref tz)
-                        if matches!(tz.as_deref(), None | Some("UTC")) =>
-                    {
-                        generate_sql_for_timestamp!(literal, s, timestamp, sql_generator, sql_query)
-                    }
-                    ScalarValue::TimestampMillisecond(ms, ref tz)
-                        if matches!(tz.as_deref(), None | Some("UTC")) =>
-                    {
-                        generate_sql_for_timestamp!(
-                            literal,
-                            ms,
-                            timestamp_millis_opt,
-                            sql_generator,
-                            sql_query
-                        )
-                    }
-                    ScalarValue::TimestampMicrosecond(ms, ref tz)
-                        if matches!(tz.as_deref(), None | Some("UTC")) =>
-                    {
-                        generate_sql_for_timestamp!(
-                            literal,
-                            ms,
-                            timestamp_micros,
-                            sql_generator,
-                            sql_query
-                        )
-                    }
-                    ScalarValue::TimestampNanosecond(nanoseconds, ref tz)
-                        if matches!(tz.as_deref(), None | Some("UTC")) =>
-                    {
-                        generate_sql_for_timestamp!(
-                            literal,
-                            nanoseconds,
-                            timestamp_nanos,
-                            sql_generator,
-                            sql_query
-                        )
-                    }
-                    ScalarValue::IntervalYearMonth(x) => {
-                        if let Some(x) = x {
-                            let (num, date_part) = (x, "MONTH");
-                            let interval = format!("{} {}", num, date_part);
-                            (
-                                sql_generator
-                                    .get_sql_templates()
-                                    .interval_any_expr(interval, num.into(), date_part)
-                                    .map_err(|e| {
-                                        DataFusionError::Internal(format!(
-                                            "Can't generate SQL for interval: {}",
-                                            e
-                                        ))
-                                    })?,
-                                sql_query,
-                            )
-                        } else {
-                            (
-                                Self::generate_null_for_literal(sql_generator, &literal)?,
-                                sql_query,
-                            )
-                        }
-                    }
-                    ScalarValue::IntervalDayTime(x) => {
-                        if let Some(x) = x {
-                            let templates = sql_generator.get_sql_templates();
-                            let decomposed = DecomposedDayTime::from_raw_interval_value(x);
-                            let generated_sql = decomposed.generate_interval_sql(&templates)?;
-                            (generated_sql, sql_query)
-                        } else {
-                            (
-                                Self::generate_null_for_literal(sql_generator, &literal)?,
-                                sql_query,
-                            )
-                        }
-                    }
-                    ScalarValue::IntervalMonthDayNano(x) => {
-                        if let Some(x) = x {
-                            let templates = sql_generator.get_sql_templates();
-                            let decomposed = DecomposedMonthDayNano::from_raw_interval_value(x);
-                            let generated_sql = decomposed.generate_interval_sql(&templates)?;
-                            (generated_sql, sql_query)
-                        } else {
-                            (
-                                Self::generate_null_for_literal(sql_generator, &literal)?,
-                                sql_query,
-                            )
-                        }
-                    }
-                    // ScalarValue::Struct(_, _) => {}
-                    ScalarValue::Null => {
-                        (Self::generate_typed_null(sql_generator, None)?, sql_query)
-                    }
-                    x => {
-                        return Err(DataFusionError::Internal(format!(
-                            "Can't generate SQL for literal: {:?}",
-                            x
-                        )));
-                    }
-                })
+                Self::generate_sql_for_literal(sql_query, sql_generator, literal)
             }
             Expr::ScalarUDF { fun, args } => {
                 let date_part_err = |dp| {
@@ -2668,14 +2368,13 @@ impl WrappedSelectNode {
                 }?;
                 let mut sql_args = Vec::new();
                 for arg in args {
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         arg,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_args.push(sql);
                 }
@@ -2744,14 +2443,13 @@ impl WrappedSelectNode {
                                         date_part
                                     )));
                                 }
-                                let (arg_sql, query) = Self::generate_sql_for_expr_rec(
+                                let (arg_sql, query) = Self::generate_sql_for_expr(
                                     sql_query,
                                     sql_generator.clone(),
                                     args[1].clone(),
                                     push_to_cube_context,
                                     subqueries,
-                                )
-                                .await?;
+                                )?;
                                 return Ok((
                                     sql_generator
                                         .get_sql_templates()
@@ -2786,14 +2484,13 @@ impl WrappedSelectNode {
                 };
                 let mut sql_args = Vec::new();
                 for arg in args {
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         arg,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_args.push(sql);
                 }
@@ -2827,27 +2524,25 @@ impl WrappedSelectNode {
                             }
                         }
                     }
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         arg,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_args.push(sql);
                 }
                 if let Some(within_group) = within_group {
                     for expr in within_group {
-                        let (sql, query) = Self::generate_sql_for_expr_rec(
+                        let (sql, query) = Self::generate_sql_for_expr(
                             sql_query,
                             sql_generator.clone(),
                             expr,
                             push_to_cube_context,
                             subqueries,
-                        )
-                        .await?;
+                        )?;
                         sql_query = query;
                         sql_within_group.push(sql);
                     }
@@ -2869,14 +2564,13 @@ impl WrappedSelectNode {
                 datafusion::logical_plan::GroupingSet::Rollup(exprs) => {
                     let mut sql_exprs = Vec::new();
                     for expr in exprs {
-                        let (sql, query) = Self::generate_sql_for_expr_rec(
+                        let (sql, query) = Self::generate_sql_for_expr(
                             sql_query,
                             sql_generator.clone(),
                             expr,
                             push_to_cube_context,
                             subqueries,
-                        )
-                        .await?;
+                        )?;
                         sql_query = query;
                         sql_exprs.push(sql);
                     }
@@ -2896,14 +2590,13 @@ impl WrappedSelectNode {
                 datafusion::logical_plan::GroupingSet::Cube(exprs) => {
                     let mut sql_exprs = Vec::new();
                     for expr in exprs {
-                        let (sql, query) = Self::generate_sql_for_expr_rec(
+                        let (sql, query) = Self::generate_sql_for_expr(
                             sql_query,
                             sql_generator.clone(),
                             expr,
                             push_to_cube_context,
                             subqueries,
-                        )
-                        .await?;
+                        )?;
                         sql_query = query;
                         sql_exprs.push(sql);
                     }
@@ -2936,40 +2629,37 @@ impl WrappedSelectNode {
             } => {
                 let mut sql_args = Vec::new();
                 for arg in args {
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         arg,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_args.push(sql);
                 }
                 let mut sql_partition_by = Vec::new();
                 for arg in partition_by {
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         arg,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_partition_by.push(sql);
                 }
                 let mut sql_order_by = Vec::new();
                 for arg in order_by {
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         arg,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_order_by.push(sql);
                 }
@@ -3046,14 +2736,13 @@ impl WrappedSelectNode {
                     _ => {
                         let mut sql_args = Vec::new();
                         for arg in args {
-                            let (sql, query) = Self::generate_sql_for_expr_rec(
+                            let (sql, query) = Self::generate_sql_for_expr(
                                 sql_query,
                                 sql_generator.clone(),
                                 arg.clone(),
                                 push_to_cube_context,
                                 subqueries,
-                            )
-                            .await?;
+                            )?;
                             sql_query = query;
                             sql_args.push(sql);
                         }
@@ -3078,25 +2767,23 @@ impl WrappedSelectNode {
                 negated,
             } => {
                 let mut sql_query = sql_query;
-                let (sql_expr, query) = Self::generate_sql_for_expr_rec(
+                let (sql_expr, query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 sql_query = query;
                 let mut sql_in_exprs = Vec::new();
                 for expr in list {
-                    let (sql, query) = Self::generate_sql_for_expr_rec(
+                    let (sql, query) = Self::generate_sql_for_expr(
                         sql_query,
                         sql_generator.clone(),
                         expr,
                         push_to_cube_context,
                         subqueries,
-                    )
-                    .await?;
+                    )?;
                     sql_query = query;
                     sql_in_exprs.push(sql);
                 }
@@ -3119,23 +2806,21 @@ impl WrappedSelectNode {
                 negated,
             } => {
                 let mut sql_query = sql_query;
-                let (sql_expr, query) = Self::generate_sql_for_expr_rec(
+                let (sql_expr, query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *expr,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 sql_query = query;
-                let (subquery_sql, query) = Self::generate_sql_for_expr_rec(
+                let (subquery_sql, query) = Self::generate_sql_for_expr(
                     sql_query,
                     sql_generator.clone(),
                     *subquery,
                     push_to_cube_context,
                     subqueries,
-                )
-                .await?;
+                )?;
                 sql_query = query;
 
                 Ok((
@@ -3162,23 +2847,273 @@ impl WrappedSelectNode {
         }
     }
 
-    /// This function is async to be able to call to JS land,
-    /// in case some SQL generation could not be done through Jinja
-    fn generate_sql_for_expr_rec<'ctx>(
-        sql_query: SqlQuery,
+    #[inline(never)]
+    fn generate_sql_for_literal(
+        mut sql_query: SqlQuery,
         sql_generator: Arc<dyn SqlGenerator>,
-        expr: Expr,
-        push_to_cube_context: Option<&'ctx PushToCubeContext>,
-        subqueries: &'ctx HashMap<String, String>,
-    ) -> Pin<Box<dyn Future<Output = Result<(String, SqlQuery)>> + Send + 'ctx>> {
-        Self::generate_sql_for_expr(
-            sql_query,
-            sql_generator,
-            expr,
-            push_to_cube_context,
-            subqueries,
-        )
-        .boxed()
+        literal: ScalarValue,
+    ) -> Result<(String, SqlQuery)> {
+        Ok(match literal {
+            ScalarValue::Boolean(b) => (
+                b.map(|b| {
+                    sql_generator
+                        .get_sql_templates()
+                        .literal_bool_expr(b)
+                        .map_err(|e| {
+                            DataFusionError::Internal(format!(
+                                "Can't generate SQL for literal bool: {}",
+                                e
+                            ))
+                        })
+                })
+                .transpose()?
+                .map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Float32(f) => (
+                f.map(|f| format!("{f}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Float64(f) => (
+                f.map(|f| format!("{f}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Decimal128(x, precision, scale) => {
+                // In Postgres, NUMERIC or DECIMAL scale can be negative.  But it's unsigned, here.
+                let scale: usize = scale;
+
+                (
+                    if let Some(x) = x {
+                        let number = Decimal::format_string(x, scale);
+                        let data_type = Self::generate_sql_type(
+                            sql_generator.clone(),
+                            DataType::Decimal(precision, scale),
+                        )?;
+                        Self::generate_sql_cast_expr(
+                            sql_generator,
+                            format!("'{}'", number),
+                            data_type,
+                        )?
+                    } else {
+                        Self::generate_null_for_literal(sql_generator, &literal)?
+                    },
+                    sql_query,
+                )
+            }
+            ScalarValue::Int8(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Int16(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Int32(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Int64(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::UInt8(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::UInt16(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::UInt32(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::UInt64(x) => (
+                x.map(|x| format!("{x}")).map_or_else(
+                    || Self::generate_null_for_literal(sql_generator, &literal),
+                    Ok,
+                )?,
+                sql_query,
+            ),
+            ScalarValue::Utf8(x) => {
+                if x.is_some() {
+                    let param_index = sql_query.add_value(x);
+                    (format!("${}$", param_index), sql_query)
+                } else {
+                    (
+                        Self::generate_typed_null(sql_generator, Some(DataType::Utf8))?,
+                        sql_query,
+                    )
+                }
+            }
+            // ScalarValue::LargeUtf8(_) => {}
+            // ScalarValue::Binary(_) => {}
+            // ScalarValue::LargeBinary(_) => {}
+            // ScalarValue::List(_, _) => {}
+            ScalarValue::Date32(x) => {
+                if let Some(x) = x {
+                    let days = Days::new(x.abs().try_into().unwrap());
+                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+                    let new_date = if x < 0 {
+                        epoch.checked_sub_days(days)
+                    } else {
+                        epoch.checked_add_days(days)
+                    };
+                    let Some(new_date) = new_date else {
+                        return Err(DataFusionError::Internal(format!(
+                            "Can't generate SQL for date: day out of bounds ({})",
+                            x
+                        )));
+                    };
+                    let formatted_date = new_date.format("%Y-%m-%d").to_string();
+                    (
+                        sql_generator
+                            .get_sql_templates()
+                            .scalar_function(
+                                "DATE".to_string(),
+                                vec![format!("'{}'", formatted_date)],
+                                None,
+                                None,
+                            )
+                            .map_err(|e| {
+                                DataFusionError::Internal(format!(
+                                    "Can't generate SQL for date: {}",
+                                    e
+                                ))
+                            })?,
+                        sql_query,
+                    )
+                } else {
+                    (
+                        Self::generate_null_for_literal(sql_generator, &literal)?,
+                        sql_query,
+                    )
+                }
+            }
+            // ScalarValue::Date64(_) => {}
+
+            // generate_sql_for_timestamp will call Utc constructors, so only support UTC zone for now
+            // DataFusion can return "UTC" for stuff like `NOW()` during constant folding
+            ScalarValue::TimestampSecond(s, ref tz)
+                if matches!(tz.as_deref(), None | Some("UTC")) =>
+            {
+                generate_sql_for_timestamp!(literal, s, timestamp, sql_generator, sql_query)
+            }
+            ScalarValue::TimestampMillisecond(ms, ref tz)
+                if matches!(tz.as_deref(), None | Some("UTC")) =>
+            {
+                generate_sql_for_timestamp!(
+                    literal,
+                    ms,
+                    timestamp_millis_opt,
+                    sql_generator,
+                    sql_query
+                )
+            }
+            ScalarValue::TimestampMicrosecond(ms, ref tz)
+                if matches!(tz.as_deref(), None | Some("UTC")) =>
+            {
+                generate_sql_for_timestamp!(literal, ms, timestamp_micros, sql_generator, sql_query)
+            }
+            ScalarValue::TimestampNanosecond(nanoseconds, ref tz)
+                if matches!(tz.as_deref(), None | Some("UTC")) =>
+            {
+                generate_sql_for_timestamp!(
+                    literal,
+                    nanoseconds,
+                    timestamp_nanos,
+                    sql_generator,
+                    sql_query
+                )
+            }
+            ScalarValue::IntervalYearMonth(x) => {
+                if let Some(x) = x {
+                    let (num, date_part) = (x, "MONTH");
+                    let interval = format!("{} {}", num, date_part);
+                    (
+                        sql_generator
+                            .get_sql_templates()
+                            .interval_any_expr(interval, num.into(), date_part)
+                            .map_err(|e| {
+                                DataFusionError::Internal(format!(
+                                    "Can't generate SQL for interval: {}",
+                                    e
+                                ))
+                            })?,
+                        sql_query,
+                    )
+                } else {
+                    (
+                        Self::generate_null_for_literal(sql_generator, &literal)?,
+                        sql_query,
+                    )
+                }
+            }
+            ScalarValue::IntervalDayTime(x) => {
+                if let Some(x) = x {
+                    let templates = sql_generator.get_sql_templates();
+                    let decomposed = DecomposedDayTime::from_raw_interval_value(x);
+                    let generated_sql = decomposed.generate_interval_sql(&templates)?;
+                    (generated_sql, sql_query)
+                } else {
+                    (
+                        Self::generate_null_for_literal(sql_generator, &literal)?,
+                        sql_query,
+                    )
+                }
+            }
+            ScalarValue::IntervalMonthDayNano(x) => {
+                if let Some(x) = x {
+                    let templates = sql_generator.get_sql_templates();
+                    let decomposed = DecomposedMonthDayNano::from_raw_interval_value(x);
+                    let generated_sql = decomposed.generate_interval_sql(&templates)?;
+                    (generated_sql, sql_query)
+                } else {
+                    (
+                        Self::generate_null_for_literal(sql_generator, &literal)?,
+                        sql_query,
+                    )
+                }
+            }
+            // ScalarValue::Struct(_, _) => {}
+            ScalarValue::Null => (Self::generate_typed_null(sql_generator, None)?, sql_query),
+            x => {
+                return Err(DataFusionError::Internal(format!(
+                    "Can't generate SQL for literal: {:?}",
+                    x
+                )));
+            }
+        })
     }
 
     fn find_member_in_ungrouped_scan<'scan, 'col>(
@@ -3780,8 +3715,7 @@ impl WrappedSelectNode {
                 join_condition.clone(),
                 None,
                 &HashMap::new(),
-            )
-            .await?;
+            )?;
 
             let (join_sql_str, new_values) = join_sql.unpack();
             sql.extend_values(new_values);

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -1827,93 +1827,13 @@ impl WrappedSelectNode {
                 )?;
                 Ok((expr, sql_query))
             }
-            Expr::Column(ref c) => {
-                if let Some(subquery) = subqueries.get(&c.flat_name()) {
-                    Ok((
-                        sql_generator
-                            .get_sql_templates()
-                            .subquery_expr(subquery.clone())
-                            .map_err(|e| {
-                                DataFusionError::Internal(format!(
-                                    "Can't generate SQL for subquery expr: {}",
-                                    e
-                                ))
-                            })?,
-                        sql_query,
-                    ))
-                } else if let Some(PushToCubeContext {
-                    ungrouped_scan_node,
-                    known_join_subqueries,
-                }) = push_to_cube_context
-                {
-                    if let Some(relation) = c.relation.as_ref() {
-                        if known_join_subqueries.contains(relation) {
-                            // SQL API passes fixed aliases to Cube.js for join subqueries
-                            // It means we don't need to use member expressions here, and can just use that fixed alias
-                            // So we can generate that as if it were regular column expression
-
-                            return Self::generate_sql_for_expr(
-                                sql_query,
-                                sql_generator.clone(),
-                                expr,
-                                None,
-                                subqueries,
-                            );
-                        }
-                    }
-
-                    let member = Self::find_member_in_ungrouped_scan(ungrouped_scan_node, c)?;
-
-                    match member {
-                        MemberField::Member(member) => {
-                            Ok((format!("${{{}}}", member.field_name), sql_query))
-                        }
-                        MemberField::Literal(value) => Self::generate_sql_for_expr(
-                            sql_query,
-                            sql_generator.clone(),
-                            Expr::Literal(value.clone()),
-                            push_to_cube_context,
-                            subqueries,
-                        ),
-                    }
-                } else {
-                    Ok((
-                        match c.relation.as_ref() {
-                            Some(r) => format!(
-                                "{}.{}",
-                                sql_generator
-                                    .get_sql_templates()
-                                    .quote_identifier(&r)
-                                    .map_err(|e| {
-                                        DataFusionError::Internal(format!(
-                                            "Can't generate SQL for column: {}",
-                                            e
-                                        ))
-                                    })?,
-                                sql_generator
-                                    .get_sql_templates()
-                                    .quote_identifier(&c.name)
-                                    .map_err(|e| {
-                                        DataFusionError::Internal(format!(
-                                            "Can't generate SQL for column: {}",
-                                            e
-                                        ))
-                                    })?
-                            ),
-                            None => sql_generator
-                                .get_sql_templates()
-                                .quote_identifier(&c.name)
-                                .map_err(|e| {
-                                    DataFusionError::Internal(format!(
-                                        "Can't generate SQL for column: {}",
-                                        e
-                                    ))
-                                })?,
-                        },
-                        sql_query,
-                    ))
-                }
-            }
+            expr @ Expr::Column(_) => Self::generate_sql_for_column(
+                sql_query,
+                sql_generator,
+                expr,
+                push_to_cube_context,
+                subqueries,
+            ),
             // Expr::ScalarVariable(_, _) => {}
             Expr::BinaryExpr { left, op, right } => {
                 let (left, sql_query) = Self::generate_sql_for_expr(
@@ -2161,64 +2081,13 @@ impl WrappedSelectNode {
                     })?;
                 Ok((resulting_sql, sql_query))
             }
-            Expr::Case {
+            expr @ Expr::Case { .. } => Self::generate_sql_for_case(
+                sql_query,
+                sql_generator,
                 expr,
-                when_then_expr,
-                else_expr,
-            } => {
-                let expr = if let Some(expr) = expr {
-                    let (expr, sql_query_next) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        *expr,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = sql_query_next;
-                    Some(expr)
-                } else {
-                    None
-                };
-                let mut when_then_expr_sql = Vec::new();
-                for (when, then) in when_then_expr {
-                    let (when, sql_query_next) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        *when,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    let (then, sql_query_next) = Self::generate_sql_for_expr(
-                        sql_query_next,
-                        sql_generator.clone(),
-                        *then,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = sql_query_next;
-                    when_then_expr_sql.push((when, then));
-                }
-                let else_expr = if let Some(else_expr) = else_expr {
-                    let (else_expr, sql_query_next) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        *else_expr,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = sql_query_next;
-                    Some(else_expr)
-                } else {
-                    None
-                };
-                let resulting_sql = sql_generator
-                    .get_sql_templates()
-                    .case(expr, when_then_expr_sql, else_expr)
-                    .map_err(|e| {
-                        DataFusionError::Internal(format!("Can't generate SQL for case: {}", e))
-                    })?;
-                Ok((resulting_sql, sql_query))
-            }
+                push_to_cube_context,
+                subqueries,
+            ),
             Expr::Cast { expr, data_type } => {
                 let (expr, sql_query) = Self::generate_sql_for_expr(
                     sql_query,
@@ -2274,59 +2143,13 @@ impl WrappedSelectNode {
                 push_to_cube_context,
                 subqueries,
             ),
-            Expr::AggregateFunction {
-                fun,
-                args,
-                distinct,
-                within_group,
-            } => {
-                let mut sql_args = Vec::new();
-                let mut sql_within_group = Vec::new();
-                for arg in args {
-                    if let AggregateFunction::Count = fun {
-                        if !distinct {
-                            if let Expr::Literal(_) = arg {
-                                sql_args.push("*".to_string());
-                                break;
-                            }
-                        }
-                    }
-                    let (sql, query) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        arg,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = query;
-                    sql_args.push(sql);
-                }
-                if let Some(within_group) = within_group {
-                    for expr in within_group {
-                        let (sql, query) = Self::generate_sql_for_expr(
-                            sql_query,
-                            sql_generator.clone(),
-                            expr,
-                            push_to_cube_context,
-                            subqueries,
-                        )?;
-                        sql_query = query;
-                        sql_within_group.push(sql);
-                    }
-                }
-                Ok((
-                    sql_generator
-                        .get_sql_templates()
-                        .aggregate_function(fun, sql_args, distinct, sql_within_group)
-                        .map_err(|e| {
-                            DataFusionError::Internal(format!(
-                                "Can't generate SQL for aggregate function: {}",
-                                e
-                            ))
-                        })?,
-                    sql_query,
-                ))
-            }
+            expr @ Expr::AggregateFunction { .. } => Self::generate_sql_for_aggregate_function(
+                sql_query,
+                sql_generator,
+                expr,
+                push_to_cube_context,
+                subqueries,
+            ),
             Expr::GroupingSet(grouping_set) => match grouping_set {
                 datafusion::logical_plan::GroupingSet::Rollup(exprs) => {
                     let mut sql_exprs = Vec::new();
@@ -2387,66 +2210,13 @@ impl WrappedSelectNode {
                 }
             },
 
-            Expr::WindowFunction {
-                fun,
-                args,
-                partition_by,
-                order_by,
-                window_frame,
-            } => {
-                let mut sql_args = Vec::new();
-                for arg in args {
-                    let (sql, query) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        arg,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = query;
-                    sql_args.push(sql);
-                }
-                let mut sql_partition_by = Vec::new();
-                for arg in partition_by {
-                    let (sql, query) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        arg,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = query;
-                    sql_partition_by.push(sql);
-                }
-                let mut sql_order_by = Vec::new();
-                for arg in order_by {
-                    let (sql, query) = Self::generate_sql_for_expr(
-                        sql_query,
-                        sql_generator.clone(),
-                        arg,
-                        push_to_cube_context,
-                        subqueries,
-                    )?;
-                    sql_query = query;
-                    sql_order_by.push(sql);
-                }
-                let resulting_sql = sql_generator
-                    .get_sql_templates()
-                    .window_function_expr(
-                        fun,
-                        sql_args,
-                        sql_partition_by,
-                        sql_order_by,
-                        window_frame,
-                    )
-                    .map_err(|e| {
-                        DataFusionError::Internal(format!(
-                            "Can't generate SQL for window function: {}",
-                            e
-                        ))
-                    })?;
-                Ok((resulting_sql, sql_query))
-            }
+            expr @ Expr::WindowFunction { .. } => Self::generate_sql_for_window_function(
+                sql_query,
+                sql_generator,
+                expr,
+                push_to_cube_context,
+                subqueries,
+            ),
             expr @ Expr::AggregateUDF { .. } => Self::generate_sql_for_aggregate_udf(
                 sql_query,
                 sql_generator,
@@ -2540,6 +2310,309 @@ impl WrappedSelectNode {
         }
     }
 
+    #[inline(never)]
+    fn generate_sql_for_column<'ctx>(
+        sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::Column(ref c) = expr else {
+            return Err(DataFusionError::Internal(format!(
+                "generate_sql_for_column called with unexpected expr: {expr:?}"
+            )));
+        };
+        if let Some(subquery) = subqueries.get(&c.flat_name()) {
+            Ok((
+                sql_generator
+                    .get_sql_templates()
+                    .subquery_expr(subquery.clone())
+                    .map_err(|e| {
+                        DataFusionError::Internal(format!(
+                            "Can't generate SQL for subquery expr: {}",
+                            e
+                        ))
+                    })?,
+                sql_query,
+            ))
+        } else if let Some(PushToCubeContext {
+            ungrouped_scan_node,
+            known_join_subqueries,
+        }) = push_to_cube_context
+        {
+            if let Some(relation) = c.relation.as_ref() {
+                if known_join_subqueries.contains(relation) {
+                    // SQL API passes fixed aliases to Cube.js for join subqueries
+                    // It means we don't need to use member expressions here, and can just use that fixed alias
+                    // So we can generate that as if it were regular column expression
+
+                    return Self::generate_sql_for_expr(
+                        sql_query,
+                        sql_generator.clone(),
+                        expr,
+                        None,
+                        subqueries,
+                    );
+                }
+            }
+
+            let member = Self::find_member_in_ungrouped_scan(ungrouped_scan_node, c)?;
+
+            match member {
+                MemberField::Member(member) => {
+                    Ok((format!("${{{}}}", member.field_name), sql_query))
+                }
+                MemberField::Literal(value) => Self::generate_sql_for_expr(
+                    sql_query,
+                    sql_generator.clone(),
+                    Expr::Literal(value.clone()),
+                    push_to_cube_context,
+                    subqueries,
+                ),
+            }
+        } else {
+            Ok((
+                match c.relation.as_ref() {
+                    Some(r) => format!(
+                        "{}.{}",
+                        sql_generator
+                            .get_sql_templates()
+                            .quote_identifier(&r)
+                            .map_err(|e| {
+                                DataFusionError::Internal(format!(
+                                    "Can't generate SQL for column: {}",
+                                    e
+                                ))
+                            })?,
+                        sql_generator
+                            .get_sql_templates()
+                            .quote_identifier(&c.name)
+                            .map_err(|e| {
+                                DataFusionError::Internal(format!(
+                                    "Can't generate SQL for column: {}",
+                                    e
+                                ))
+                            })?
+                    ),
+                    None => sql_generator
+                        .get_sql_templates()
+                        .quote_identifier(&c.name)
+                        .map_err(|e| {
+                            DataFusionError::Internal(format!(
+                                "Can't generate SQL for column: {}",
+                                e
+                            ))
+                        })?,
+                },
+                sql_query,
+            ))
+        }
+    }
+
+    #[inline(never)]
+    fn generate_sql_for_case<'ctx>(
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::Case {
+            expr,
+            when_then_expr,
+            else_expr,
+        } = expr
+        else {
+            return Err(DataFusionError::Internal(format!(
+                "generate_sql_for_case called with unexpected expr: {expr:?}"
+            )));
+        };
+        let expr = if let Some(expr) = expr {
+            let (expr, sql_query_next) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                *expr,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = sql_query_next;
+            Some(expr)
+        } else {
+            None
+        };
+        let mut when_then_expr_sql = Vec::new();
+        for (when, then) in when_then_expr {
+            let (when, sql_query_next) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                *when,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            let (then, sql_query_next) = Self::generate_sql_for_expr(
+                sql_query_next,
+                sql_generator.clone(),
+                *then,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = sql_query_next;
+            when_then_expr_sql.push((when, then));
+        }
+        let else_expr = if let Some(else_expr) = else_expr {
+            let (else_expr, sql_query_next) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                *else_expr,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = sql_query_next;
+            Some(else_expr)
+        } else {
+            None
+        };
+        let resulting_sql = sql_generator
+            .get_sql_templates()
+            .case(expr, when_then_expr_sql, else_expr)
+            .map_err(|e| {
+                DataFusionError::Internal(format!("Can't generate SQL for case: {}", e))
+            })?;
+        Ok((resulting_sql, sql_query))
+    }
+
+    #[inline(never)]
+    fn generate_sql_for_aggregate_function<'ctx>(
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::AggregateFunction {
+            fun,
+            args,
+            distinct,
+            within_group,
+        } = expr
+        else {
+            return Err(DataFusionError::Internal(format!(
+                "generate_sql_for_aggregate_function called with unexpected expr: {expr:?}"
+            )));
+        };
+        let mut sql_args = Vec::new();
+        let mut sql_within_group = Vec::new();
+        for arg in args {
+            if let AggregateFunction::Count = fun {
+                if !distinct {
+                    if let Expr::Literal(_) = arg {
+                        sql_args.push("*".to_string());
+                        break;
+                    }
+                }
+            }
+            let (sql, query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                arg,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = query;
+            sql_args.push(sql);
+        }
+        if let Some(within_group) = within_group {
+            for expr in within_group {
+                let (sql, query) = Self::generate_sql_for_expr(
+                    sql_query,
+                    sql_generator.clone(),
+                    expr,
+                    push_to_cube_context,
+                    subqueries,
+                )?;
+                sql_query = query;
+                sql_within_group.push(sql);
+            }
+        }
+        Ok((
+            sql_generator
+                .get_sql_templates()
+                .aggregate_function(fun, sql_args, distinct, sql_within_group)
+                .map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "Can't generate SQL for aggregate function: {}",
+                        e
+                    ))
+                })?,
+            sql_query,
+        ))
+    }
+
+    #[inline(never)]
+    fn generate_sql_for_window_function<'ctx>(
+        mut sql_query: SqlQuery,
+        sql_generator: Arc<dyn SqlGenerator>,
+        expr: Expr,
+        push_to_cube_context: Option<&'ctx PushToCubeContext<'ctx>>,
+        subqueries: &HashMap<String, String>,
+    ) -> Result<(String, SqlQuery)> {
+        let Expr::WindowFunction {
+            fun,
+            args,
+            partition_by,
+            order_by,
+            window_frame,
+        } = expr
+        else {
+            return Err(DataFusionError::Internal(format!(
+                "generate_sql_for_window_function called with unexpected expr: {expr:?}"
+            )));
+        };
+        let mut sql_args = Vec::new();
+        for arg in args {
+            let (sql, query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                arg,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = query;
+            sql_args.push(sql);
+        }
+        let mut sql_partition_by = Vec::new();
+        for arg in partition_by {
+            let (sql, query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                arg,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = query;
+            sql_partition_by.push(sql);
+        }
+        let mut sql_order_by = Vec::new();
+        for arg in order_by {
+            let (sql, query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                arg,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            sql_query = query;
+            sql_order_by.push(sql);
+        }
+        let resulting_sql = sql_generator
+            .get_sql_templates()
+            .window_function_expr(fun, sql_args, sql_partition_by, sql_order_by, window_frame)
+            .map_err(|e| {
+                DataFusionError::Internal(format!("Can't generate SQL for window function: {}", e))
+            })?;
+        Ok((resulting_sql, sql_query))
+    }
     #[inline(never)]
     fn generate_sql_for_literal(
         mut sql_query: SqlQuery,

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -2613,6 +2613,7 @@ impl WrappedSelectNode {
             })?;
         Ok((resulting_sql, sql_query))
     }
+
     #[inline(never)]
     fn generate_sql_for_literal(
         mut sql_query: SqlQuery,


### PR DESCRIPTION
Motivated by a stack overflow hit in a test running in dev mode after upgrading sqlparser.

Convert generate_sql_for_expr from async to a synchronous function, dropping the boxed-future recursion shim, and extract the large Expr::Literal match arm into a separate #[inline(never)] helper. This shrinks the per-level recursive stack frame for deeply nested expression trees.

There was a comment explaining that the function was async to be able to call into JS land in case some SQL generation could not be done through Jinja. I don't believe that's the right approach: if we ever need that, we should move the dialect to the Rust side rather than communicating with JS. In any case it's not used right now - Jinja templates are enough - so dropping the async is safe.

On top of that, the heaviest match arms are pulled out into separate `#[inline(never)]` helpers. The recursive frame is sized by the largest arm, so even though deep recursion runs through the light arms, every level used to pay for the big ones.

## Stack frame measurements

Stack frame of `generate_sql_for_expr`, read from the function prologue stack allocation (debug / `opt-level=0`, `codegen-units=1`, aarch64). Frame = `pages * 4096 + tail`.

| step | prologue alloc | frame size | vs prev | vs async |
| ---- | -------------- | ---------- | ------- | -------- |
| (before) `async fn` | `15 * 4096 + 3360` | ~64800 B (~63.3 KiB) \* | – | – |
| async → sync (+ Literal helper) | `12 * 4096 + 2816` | 51968 B (~50.8 KiB) | -19.8% | -19.8% |
| + Tier 1: ScalarUDF / ScalarFunction / AggregateUDF | `10 * 4096 + 64` | 41024 B (~40.1 KiB) | -21.1% | -36.7% |
| + Tier 2: Column / Case / AggregateFunction / WindowFunction | `6 * 4096 + 3568` | 28144 B (~27.5 KiB) | -31.4% | **-56.6%** |

\* The async figure is the generator's `poll` frame; on top of that, every recursion level also heap-allocated a boxed future (`.boxed()`), which the synchronous version removes entirely.

### Release build

The overflow was a dev-mode problem (debug never reuses stack slots). For completeness, the same `generate_sql_for_expr` frame in a release build (`opt-level=3`, `codegen-units=1`, aarch64):

| step | release frame | dev frame | release vs dev |
| ---- | ------------- | --------- | -------------- |
| (before) `async fn` | ~3808 B (~3.7 KiB) \*\* | ~64800 B | ~17x smaller |
| async → sync (+ Literal helper) | 3888 B (~3.8 KiB) | 51968 B | ~13x |
| + Tier 1 | 3520 B (~3.4 KiB) | 41024 B | ~12x |
| + Tier 2 | 2752 B (~2.7 KiB) | 28144 B | ~10x |

\*\* release async figure is the generator's `poll` closure frame; the per-level heap-allocated boxed future is still there, it just doesn't show up in the stack frame.