### PR TITLE
feat(cubesql): Improve UX for parsing errors

### DIFF
--- a/rust/cubesql/cubesql/src/compile/parser/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/mod.rs
@@ -1,4 +1,4 @@
-mod pg;
+mod parser_pg;
 mod sql_snippet;
 
-pub use pg::*;
+pub use parser_pg::*;

--- a/rust/cubesql/cubesql/src/compile/parser/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/mod.rs
@@ -1,0 +1,4 @@
+mod pg;
+mod sql_snippet;
+
+pub use pg::*;

--- a/rust/cubesql/cubesql/src/compile/parser/parser_pg.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/parser_pg.rs
@@ -314,6 +314,99 @@ mod tests {
     }
 
     #[test]
+    fn test_syntax_error_in_large_query_stays_within_context_window() {
+        // The error is buried ~300 lines into a ~500-line query; the snippet must
+        // stay bounded to the error line plus two leading context lines and never
+        // dump the whole query (note the ~200 trailing lines the parser, stopping
+        // at the first error, never even reaches).
+        let sql = {
+            let mut sql = String::from("SELECT\n");
+
+            for col in 2..=300u64 {
+                sql.push_str(&format!("    col{},\n", col));
+            }
+
+            sql.push_str("    status MEASURE(orders.count)\n");
+
+            for col in 302..=499u64 {
+                sql.push_str(&format!("    col{},\n", col));
+            }
+
+            sql.push_str("FROM orders");
+
+            sql
+        };
+
+        assert_eq!(
+            parse_err(&sql),
+            "SQL Parser Error: Unable to parse: \
+Expected: end of statement, found: ( at Line: 301, Column: 19\n\
+\n\
+299 |     col299,
+300 |     col300,
+301 |     status MEASURE(orders.count)
+    |            ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_in_single_wide_line_is_truncated() {
+        // One very wide line, far past the 64-char limit. The snippet crops to a
+        // horizontal window centered on the caret, trimming both sides.
+        let sql = format!(
+            "SELECT {a} MEASURE(orders.count) {z} FROM orders",
+            a = "a".repeat(100),
+            z = "z".repeat(100),
+        );
+        assert_eq!(
+            parse_err(&sql),
+            "SQL Parser Error: Unable to parse: \
+Expected: end of statement, found: ( at Line: 1, Column: 116\n\
+\n\
+1 | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa MEASURE(orders.count) zzzzzzzzzz
+  |                                 ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_in_wide_line_truncates_right_only() {
+        // `status MEASURE(...)` makes the `(` the real error; a long trailing run
+        // pushes the line past the limit while the caret stays near the start, so
+        // only the right side is cropped.
+        let sql = format!(
+            "SELECT status MEASURE(orders.count) {z}",
+            z = "z".repeat(300)
+        );
+        assert_eq!(
+            parse_err(&sql),
+            "SQL Parser Error: Unable to parse: \
+Expected: end of statement, found: ( at Line: 1, Column: 22\n\
+\n\
+1 | SELECT status MEASURE(orders.count) zzzzzzzzzzzzzzzzzzzzzzzzzzzz
+  |               ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_on_wide_numeric_token() {
+        // A number cannot be an alias, so the long numeric literal after
+        // `MEASURE(orders.count)` is itself the offending token. The huge digit run
+        // in the error message must not confuse `at Line:/Column:` location parsing.
+        let sql = format!(
+            "SELECT MEASURE(orders.count) {n} FROM orders",
+            n = "1".repeat(100)
+        );
+        assert_eq!(
+            parse_err(&sql),
+            "SQL Parser Error: Unable to parse: \
+Expected: end of statement, found: 1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111 at Line: 1, Column: 30\n\
+\n\
+1 | SELECT MEASURE(orders.count) 11111111111111111111111111111111111
+  |                              ^"
+        );
+    }
+
+    #[test]
     fn test_multiple_statements_postgres() {
         let result = parse_sql_to_statement(
             &"SELECT NOW(); SELECT NOW();".to_string(),
@@ -347,12 +440,12 @@ mod tests {
                 5000"
             ),
             "SQL Parser Error: Unable to parse: \
-Expected: end of statement, found: ( at Line: 3, Column: 24\n\
+Expected: end of statement, found: ( at Line: 3, Column: 24
 \n\
-1 | SELECT DISTINCT\n\
-2 |                 orders_transactions.status\n\
-3 |                 MEASURE(orders_transactions.count)\n  \
-|                 ^"
+1 | SELECT DISTINCT
+2 |                 orders_transactions.status
+3 |                 MEASURE(orders_transactions.count)
+  |                 ^"
         );
     }
 
@@ -365,8 +458,8 @@ Expected: end of statement, found: ( at Line: 3, Column: 24\n\
             "SQL Parser Error: Unable to parse: \
 Expected: identifier, found: EOF\n\
 \n\
-1 | SELECT FROM\n  \
-|           ^"
+1 | SELECT FROM
+  |           ^"
         );
     }
 
@@ -401,8 +494,8 @@ Expected: identifier, found: EOF\n\
             "SQL Parser Error: Unable to parse: \
 Expected an expression, found: FROM at Line: 1, Column: 16\n\
 \n\
-1 | SELECT a, FROM t\n  \
-|                ^"
+1 | SELECT a, FROM t
+  |                ^"
         );
     }
 
@@ -415,8 +508,8 @@ Expected an expression, found: FROM at Line: 1, Column: 16\n\
             "SQL Parser Error: Unable to parse: \
 Expected: an expression, found: , at Line: 1, Column: 10\n\
 \n\
-1 | SELECT a,, b FROM t\n  \
-|          ^"
+1 | SELECT a,, b FROM t
+  |          ^"
         );
     }
 
@@ -427,8 +520,8 @@ Expected: an expression, found: , at Line: 1, Column: 10\n\
             "SQL Parser Error: Unable to parse: \
 Expected: an SQL statement, found: SELET at Line: 1, Column: 1\n\
 \n\
-1 | SELET a FROM t\n  \
-| ^"
+1 | SELET a FROM t
+  | ^"
         );
     }
 
@@ -439,8 +532,8 @@ Expected: an SQL statement, found: SELET at Line: 1, Column: 1\n\
             "SQL Parser Error: Unable to parse: \
 Expected: ), found: FROM at Line: 1, Column: 16\n\
 \n\
-1 | SELECT count(a FROM t\n  \
-|                ^"
+1 | SELECT count(a FROM t
+  |                ^"
         );
     }
 
@@ -452,8 +545,8 @@ Expected: ), found: FROM at Line: 1, Column: 16\n\
             "SQL Parser Error: Unable to parse: \
 Expected: an expression, found: EOF\n\
 \n\
-1 | SELECT a FROM t WHERE\n  \
-|                     ^"
+1 | SELECT a FROM t WHERE
+  |                     ^"
         );
     }
 
@@ -465,8 +558,8 @@ Expected: an expression, found: EOF\n\
             "SQL Parser Error: Unable to parse: \
 Unterminated string literal at Line: 1, Column: 8\n\
 \n\
-1 | SELECT 'abc FROM t\n  \
-|        ^^^^"
+1 | SELECT 'abc FROM t
+  |        ^^^^"
         );
     }
 
@@ -478,8 +571,8 @@ Unterminated string literal at Line: 1, Column: 8\n\
             "SQL Parser Error: Unable to parse: \
 Expected: identifier, found: ; at Line: 1, Column: 12\n\
 \n\
-1 | SELECT FROM;\n  \
-|           ^"
+1 | SELECT FROM;
+  |           ^"
         );
     }
 
@@ -490,8 +583,8 @@ Expected: identifier, found: ; at Line: 1, Column: 12\n\
             "SQL Parser Error: Unable to parse: \
 Expected: an expression, found: EOF\n\
 \n\
-1 | SELECT a FROM t GROUP BY\n  \
-|                        ^"
+1 | SELECT a FROM t GROUP BY
+  |                        ^"
         );
     }
 }

--- a/rust/cubesql/cubesql/src/compile/parser/pg.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/pg.rs
@@ -1,11 +1,15 @@
 use std::{collections::HashMap, sync::LazyLock};
 
+use crate::compile::{qtrace::Qtrace, CompilationError, CompilationResult, DatabaseProtocol};
 use regex::Regex;
-use sqlparser::{ast::Statement, dialect::PostgreSqlDialect, parser::Parser};
+use sqlparser::{
+    ast::Statement,
+    dialect::PostgreSqlDialect,
+    parser::{Parser, ParserError},
+    tokenizer::Tokenizer,
+};
 
-use super::{qtrace::Qtrace, CompilationError, DatabaseProtocol};
-
-use super::CompilationResult;
+use super::sql_snippet;
 
 static SIGMA_WORKAROUND: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?s)^\s*with\s+nsp\sas\s\(.*nspname\s=\s.*\),\s+tbl\sas\s\(.*relname\s=\s.*\).*select\s+attname.*from\spg_attribute.*$"#).unwrap()
@@ -189,15 +193,66 @@ pub fn parse_sql_to_statements(
         qtrace.set_replaced_query(&query)
     }
 
-    let parse_result = match protocol {
-        DatabaseProtocol::PostgreSQL => Parser::parse_sql(&PostgreSqlDialect {}, query.as_str()),
+    let dialect = match protocol {
+        DatabaseProtocol::PostgreSQL => PostgreSqlDialect {},
         DatabaseProtocol::Extension(_) => unimplemented!(),
     };
 
+    let tokens = match Tokenizer::new(&dialect, query.as_str()).tokenize_with_location() {
+        Ok(d) => d,
+        Err(err) => {
+            let mut message = format!("Unable to parse: {}", err);
+
+            let snippet = sql_snippet::snippet_for_tokenizer_error(query.as_str(), &err);
+            if let Some(snippet) = snippet {
+                message.push_str("\n\n");
+                message.push_str(&snippet);
+            }
+
+            return Err(CompilationError::SqlParser(
+                message,
+                Some(HashMap::from([(
+                    "query".to_string(),
+                    original_query.to_string(),
+                )])),
+            ));
+        }
+    };
+
+    let parse_result = Parser::new(&dialect)
+        .with_tokens_with_locations(tokens)
+        .parse_statements();
+
     parse_result.map_err(|err| {
-        CompilationError::sql_parser(format!("Unable to parse: {:?}", err)).with_meta(Some(
-            HashMap::from([("query".to_string(), original_query.to_string())]),
-        ))
+        // We don't need a prefix "sql parser error: "
+        let body = match &err {
+            ParserError::TokenizerError(message) | ParserError::ParserError(message) => {
+                message.as_str()
+            }
+            ParserError::RecursionLimitExceeded => &"Recursion limit exceeded",
+        };
+        let mut message = format!("Unable to parse: {}", body);
+
+        // The parser consumed the tokens above, so re-tokenize
+        let snippet = Tokenizer::new(&dialect, query.as_str())
+            .tokenize_with_location()
+            .ok()
+            .and_then(|tokens| {
+                sql_snippet::snippet_for_parser_error(query.as_str(), &tokens, &err.to_string())
+            });
+
+        if let Some(snippet) = snippet {
+            message.push_str("\n\n");
+            message.push_str(&snippet);
+        }
+
+        CompilationError::SqlParser(
+            message,
+            Some(HashMap::from([(
+                "query".to_string(),
+                original_query.to_string(),
+            )])),
+        )
     })
 }
 
@@ -251,6 +306,13 @@ mod tests {
         }
     }
 
+    fn parse_err(sql: &str) -> String {
+        match parse_sql_to_statement(&sql.to_string(), DatabaseProtocol::PostgreSQL, &mut None) {
+            Ok(_) => panic!("expected a parse error for: {}", sql),
+            Err(err) => err.to_string(),
+        }
+    }
+
     #[test]
     fn test_multiple_statements_postgres() {
         let result = parse_sql_to_statement(
@@ -268,9 +330,13 @@ mod tests {
 
     #[test]
     fn test_syntax_error_missing_comma_postgres() {
-        // Missing comma between the two projection items (`status` and `MEASURE(...)`)
-        let result = parse_sql_to_statement(
-            &"SELECT DISTINCT
+        // Missing comma between the two projection items (`status` and `MEASURE(...)`).
+        // The parser stops on the `(` (column 24) after parsing the un-separated
+        // `MEASURE` as an alias, but the snippet caret snaps back to the start of
+        // the offending `MEASURE` token.
+        assert_eq!(
+            parse_err(
+                "SELECT DISTINCT
                 orders_transactions.status
                 MEASURE(orders_transactions.count)
             FROM
@@ -279,43 +345,29 @@ mod tests {
                 1
             LIMIT
                 5000"
-                .to_string(),
-            DatabaseProtocol::PostgreSQL,
-            &mut None,
+            ),
+            "SQL Parser Error: Unable to parse: \
+Expected: end of statement, found: ( at Line: 3, Column: 24\n\
+\n\
+1 | SELECT DISTINCT\n\
+2 |                 orders_transactions.status\n\
+3 |                 MEASURE(orders_transactions.count)\n  \
+|                 ^"
         );
-        match result {
-            Ok(_) => panic!("This test should throw an error"),
-            Err(err) => {
-                let msg = err.to_string();
-                assert!(
-                    msg.contains("Unable to parse"),
-                    "expected a parser error, got: {}",
-                    msg
-                );
-                assert!(
-                    msg.contains("Expected"),
-                    "expected an \"Expected ...\" syntax error, got: {}",
-                    msg
-                );
-            }
-        }
     }
 
     #[test]
     fn test_syntax_error_dangling_from_postgres() {
-        let result = parse_sql_to_statement(
-            &"SELECT FROM".to_string(),
-            DatabaseProtocol::PostgreSQL,
-            &mut None,
+        // The parser reports no location for an unexpected EOF, so the caret is
+        // anchored at the end of the last token (`FROM`).
+        assert_eq!(
+            parse_err("SELECT FROM"),
+            "SQL Parser Error: Unable to parse: \
+Expected: identifier, found: EOF\n\
+\n\
+1 | SELECT FROM\n  \
+|           ^"
         );
-        match result {
-            Ok(_) => panic!("This test should throw an error"),
-            Err(err) => assert!(
-                err.to_string().contains("Unable to parse"),
-                "expected a parser error, got: {}",
-                err
-            ),
-        }
     }
 
     #[test]
@@ -338,5 +390,108 @@ mod tests {
             Ok(_) => {}
             Err(err) => panic!("{}", err),
         }
+    }
+
+    #[test]
+    fn test_syntax_error_trailing_comma() {
+        // Dangling comma in the projection list: caret points at the `FROM` that
+        // the parser found where it expected another expression.
+        assert_eq!(
+            parse_err("SELECT a, FROM t"),
+            "SQL Parser Error: Unable to parse: \
+Expected an expression, found: FROM at Line: 1, Column: 16\n\
+\n\
+1 | SELECT a, FROM t\n  \
+|                ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_double_comma() {
+        // The extra comma is the offending token; it is preceded by another
+        // comma (not a word), so the caret stays on it.
+        assert_eq!(
+            parse_err("SELECT a,, b FROM t"),
+            "SQL Parser Error: Unable to parse: \
+Expected: an expression, found: , at Line: 1, Column: 10\n\
+\n\
+1 | SELECT a,, b FROM t\n  \
+|          ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_misspelled_keyword() {
+        assert_eq!(
+            parse_err("SELET a FROM t"),
+            "SQL Parser Error: Unable to parse: \
+Expected: an SQL statement, found: SELET at Line: 1, Column: 1\n\
+\n\
+1 | SELET a FROM t\n  \
+| ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_unclosed_paren() {
+        assert_eq!(
+            parse_err("SELECT count(a FROM t"),
+            "SQL Parser Error: Unable to parse: \
+Expected: ), found: FROM at Line: 1, Column: 16\n\
+\n\
+1 | SELECT count(a FROM t\n  \
+|                ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_where_without_expr() {
+        // Trailing `WHERE` hits EOF; the caret is anchored at the end of `WHERE`.
+        assert_eq!(
+            parse_err("SELECT a FROM t WHERE"),
+            "SQL Parser Error: Unable to parse: \
+Expected: an expression, found: EOF\n\
+\n\
+1 | SELECT a FROM t WHERE\n  \
+|                     ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_unterminated_string() {
+        // The whole visible literal `'abc` is underlined, not just the quote.
+        assert_eq!(
+            parse_err("SELECT 'abc FROM t"),
+            "SQL Parser Error: Unable to parse: \
+Unterminated string literal at Line: 1, Column: 8\n\
+\n\
+1 | SELECT 'abc FROM t\n  \
+|        ^^^^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_dangling_from_semicolon() {
+        // `SELECT FROM;` stops on the `;`; the caret sits on the end of `FROM`.
+        assert_eq!(
+            parse_err("SELECT FROM;"),
+            "SQL Parser Error: Unable to parse: \
+Expected: identifier, found: ; at Line: 1, Column: 12\n\
+\n\
+1 | SELECT FROM;\n  \
+|           ^"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_group_by_without_expr() {
+        assert_eq!(
+            parse_err("SELECT a FROM t GROUP BY"),
+            "SQL Parser Error: Unable to parse: \
+Expected: an expression, found: EOF\n\
+\n\
+1 | SELECT a FROM t GROUP BY\n  \
+|                        ^"
+        );
     }
 }

--- a/rust/cubesql/cubesql/src/compile/parser/sql_snippet.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/sql_snippet.rs
@@ -26,6 +26,10 @@ use sqlparser::tokenizer::{Location, Span, Token, TokenWithSpan, TokenizerError}
 /// Number of source lines shown before the line that contains the error.
 const CONTEXT_LINES: u64 = 2;
 
+/// Maximum number of source characters shown per line. Longer lines are cropped
+/// to a horizontal window around the caret.
+const MAX_LINE_WIDTH: usize = 64;
+
 /// Extract the error [`Location`] from a parser error message.
 pub(crate) fn location_from_parser_error(msg: &str) -> Option<Location> {
     static LOCATION_RE: LazyLock<Regex> =
@@ -60,25 +64,13 @@ pub(crate) fn render_query_snippet(sql: &str, span: Span) -> Option<String> {
 
     let first_context_line = start.line.saturating_sub(CONTEXT_LINES).max(1);
 
-    let mut out = String::new();
-
-    for line_no in first_context_line..=start.line {
-        let text = lines[(line_no - 1) as usize];
-        out.push_str(&format!(
-            "{:>width$} | {}\n",
-            line_no,
-            text,
-            width = gutter_width
-        ));
-    }
-
-    // Pointer line: blank gutter, spaces up to the start column, then carets.
-    let error_line = lines[start_idx];
-    let error_line_len = error_line.chars().count() as u64;
+    // Caret geometry on the error line, in 0-based char offsets.
+    let error_chars: Vec<char> = lines[start_idx].chars().collect();
+    let error_line_len = error_chars.len() as u64;
 
     // Clamp the start column into the line (columns are 1-based).
     let start_col = start.column.min(error_line_len + 1);
-    let lead = (start_col - 1) as usize;
+    let caret_start = (start_col - 1) as usize;
 
     // Caret width (span ends are inclusive here):
     // - same-line span: cover start..=end, clamped to the line
@@ -92,16 +84,66 @@ pub(crate) fn render_query_snippet(sql: &str, span: Span) -> Option<String> {
     } else {
         1
     };
+    let caret_end = caret_start + caret_width.max(1); // exclusive, 0-based
+
+    // Horizontal window shared by every printed line so columns stay aligned.
+    // Only crops when some displayed line is wider than MAX_LINE_WIDTH.
+    let widest = (first_context_line..=start.line)
+        .map(|n| lines[(n - 1) as usize].chars().count())
+        .max()
+        .unwrap_or(0);
+
+    let (win_start, win_end) = if widest <= MAX_LINE_WIDTH {
+        (0, widest)
+    } else {
+        // Keep the caret roughly centered within the window.
+        let half = MAX_LINE_WIDTH / 2;
+        let mut ws = caret_start.saturating_sub(half);
+        let mut we = ws + MAX_LINE_WIDTH;
+        if we > widest {
+            we = widest;
+            ws = we.saturating_sub(MAX_LINE_WIDTH);
+        }
+        (ws, we)
+    };
+
+    let mut out = String::new();
+
+    for line_no in first_context_line..=start.line {
+        let chars: Vec<char> = lines[(line_no - 1) as usize].chars().collect();
+        let text = crop_to_window(&chars, win_start, win_end);
+        out.push_str(&format!(
+            "{:>width$} | {}\n",
+            line_no,
+            text,
+            width = gutter_width
+        ));
+    }
+
+    // Pointer line: blank gutter, spaces up to the caret (relative to the window
+    // start), then carets.
+    let visible_caret_start = caret_start.saturating_sub(win_start);
+    let visible_caret_end = caret_end.min(win_end).saturating_sub(win_start);
+    let visible_caret_width = visible_caret_end.saturating_sub(visible_caret_start).max(1);
+    let lead = visible_caret_start;
 
     out.push_str(&format!(
         "{:>width$} | {}{}",
         "",
         " ".repeat(lead),
-        "^".repeat(caret_width.max(1)),
+        "^".repeat(visible_caret_width),
         width = gutter_width
     ));
 
     Some(out)
+}
+
+/// Crop a line's characters to `[win_start, win_end)`.
+fn crop_to_window(chars: &[char], win_start: usize, win_end: usize) -> String {
+    let len = chars.len();
+    let s = win_start.min(len);
+    let e = win_end.min(len);
+    chars[s..e].iter().collect()
 }
 
 /// Extend a point location into a span covering the contiguous run of

--- a/rust/cubesql/cubesql/src/compile/parser/sql_snippet.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/sql_snippet.rs
@@ -77,8 +77,8 @@ pub(crate) fn render_query_snippet(sql: &str, span: Span) -> Option<String> {
     // - multi-line span: underline from start column to the end of the line
     // - point location (start == end): a single caret
     let caret_width = if end.line == start.line && end.column >= start.column {
-        let end_col = end.column.min(error_line_len.max(start_col));
-        ((end_col - start.column) + 1) as usize
+        let end_col = end.column.min(error_line_len + 1).max(start_col);
+        ((end_col - start_col) + 1) as usize
     } else if end.line > start.line {
         ((error_line_len + 1).saturating_sub(start_col)).max(1) as usize
     } else {

--- a/rust/cubesql/cubesql/src/compile/parser/sql_snippet.rs
+++ b/rust/cubesql/cubesql/src/compile/parser/sql_snippet.rs
@@ -1,0 +1,350 @@
+//! Rendering of source-location snippets for SQL errors.
+//!
+//! Parsing happens in two phases (see `parse_sql_to_statements`): tokenize, then
+//! parse. This module turns a failure of either phase into a human-friendly
+//! fragment of the original query with a `^` pointer, e.g.:
+//!
+//! ```text
+//!   2 |                 orders_transactions.status
+//!   3 |                 MEASURE(orders_transactions.count)
+//!     |                 ^
+//! ```
+//!
+//! - Tokenizer errors carry a structured [`Location`], used directly.
+//! - Parser errors only carry a message string with a `" at Line: N, Column: N"`
+//!   suffix; we extract that location and map it onto the token stream to place
+//!   the caret on the most relevant token.
+//!
+//! The renderer accepts a [`Span`] directly so it can be reused later for
+//! semantic errors that obtain a span from `node.span()`.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use sqlparser::tokenizer::{Location, Span, Token, TokenWithSpan, TokenizerError};
+
+/// Number of source lines shown before the line that contains the error.
+const CONTEXT_LINES: u64 = 2;
+
+/// Extract the error [`Location`] from a parser error message.
+pub(crate) fn location_from_parser_error(msg: &str) -> Option<Location> {
+    static LOCATION_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"at Line: (\d+), Column: (\d+)").unwrap());
+
+    let caps = LOCATION_RE.captures_iter(msg).last()?;
+    let line = caps.get(1)?.as_str().parse::<u64>().ok()?;
+    let column = caps.get(2)?.as_str().parse::<u64>().ok()?;
+
+    Some(Location::new(line, column))
+}
+
+pub(crate) fn render_query_snippet(sql: &str, span: Span) -> Option<String> {
+    let start = span.start;
+    let end = span.end;
+
+    if start.line == 0 || start.column == 0 {
+        return None;
+    }
+
+    let lines: Vec<&str> = sql.split('\n').collect();
+
+    // `start.line` is 1-based; bail out if it is out of range.
+    let start_idx = (start.line as usize).checked_sub(1)?;
+    if start_idx >= lines.len() {
+        return None;
+    }
+
+    // Widest line number we will print determines the gutter width.
+    let max_line_no = start.line;
+    let gutter_width = max_line_no.to_string().len();
+
+    let first_context_line = start.line.saturating_sub(CONTEXT_LINES).max(1);
+
+    let mut out = String::new();
+
+    for line_no in first_context_line..=start.line {
+        let text = lines[(line_no - 1) as usize];
+        out.push_str(&format!(
+            "{:>width$} | {}\n",
+            line_no,
+            text,
+            width = gutter_width
+        ));
+    }
+
+    // Pointer line: blank gutter, spaces up to the start column, then carets.
+    let error_line = lines[start_idx];
+    let error_line_len = error_line.chars().count() as u64;
+
+    // Clamp the start column into the line (columns are 1-based).
+    let start_col = start.column.min(error_line_len + 1);
+    let lead = (start_col - 1) as usize;
+
+    // Caret width (span ends are inclusive here):
+    // - same-line span: cover start..=end, clamped to the line
+    // - multi-line span: underline from start column to the end of the line
+    // - point location (start == end): a single caret
+    let caret_width = if end.line == start.line && end.column >= start.column {
+        let end_col = end.column.min(error_line_len.max(start_col));
+        ((end_col - start.column) + 1) as usize
+    } else if end.line > start.line {
+        ((error_line_len + 1).saturating_sub(start_col)).max(1) as usize
+    } else {
+        1
+    };
+
+    out.push_str(&format!(
+        "{:>width$} | {}{}",
+        "",
+        " ".repeat(lead),
+        "^".repeat(caret_width.max(1)),
+        width = gutter_width
+    ));
+
+    Some(out)
+}
+
+/// Extend a point location into a span covering the contiguous run of
+/// non-whitespace characters starting at it.
+fn extend_to_token_end(sql: &str, span: Span) -> Span {
+    let Some(line_idx) = (span.start.line as usize).checked_sub(1) else {
+        return span;
+    };
+
+    let Some(line) = sql.split('\n').nth(line_idx) else {
+        return span;
+    };
+
+    let chars: Vec<char> = line.chars().collect();
+    if chars.is_empty() {
+        return span;
+    }
+
+    let start_i = (span.start.column as usize)
+        .saturating_sub(1)
+        .min(chars.len() - 1);
+    let mut end_i = start_i;
+    while end_i + 1 < chars.len() && !chars[end_i + 1].is_whitespace() {
+        end_i += 1;
+    }
+    let end = Location::new(span.start.line, (end_i + 1) as u64);
+    Span::new(span.start, end)
+}
+
+fn is_whitespace_token(token: &TokenWithSpan) -> bool {
+    matches!(token.token, Token::Whitespace(_))
+}
+
+fn token_end(token: &TokenWithSpan) -> Location {
+    let end = token.span.end;
+    Location::new(end.line, end.column.saturating_sub(1).max(1))
+}
+
+fn last_token_end(tokens: &[TokenWithSpan]) -> Option<Location> {
+    tokens
+        .iter()
+        .rev()
+        .find(|t| !is_whitespace_token(t))
+        .map(token_end)
+}
+
+/// Map the location the parser reported (the start of the token it stopped on)
+/// onto the most relevant token, à la Postgres' "at or near ...".
+fn place_parser_caret(tokens: &[TokenWithSpan], reported: Location) -> Location {
+    let Some(idx) = tokens.iter().position(|t| t.span.start == reported) else {
+        return reported;
+    };
+    let found = &tokens[idx];
+
+    // A statement terminator means the real problem is the missing input *before*
+    // it, so point at the end of the previous significant token (e.g. the `M` of
+    // a dangling `FROM;`).
+    if matches!(found.token, Token::SemiColon) {
+        if let Some(prev) = tokens[..idx].iter().rev().find(|t| !is_whitespace_token(t)) {
+            return token_end(prev);
+        }
+        return reported;
+    }
+
+    // A delimiter glued to a preceding word (e.g. the `(` in `MEASURE(`): the
+    // word is the offending token, so point at its start.
+    if !matches!(found.token, Token::Word(_)) {
+        if idx > 0 {
+            let prev = &tokens[idx - 1];
+            if matches!(prev.token, Token::Word(_)) {
+                return prev.span.start;
+            }
+        }
+        return found.span.start;
+    }
+
+    // Otherwise point at the start of the token the parser stopped on.
+    found.span.start
+}
+
+pub(crate) fn snippet_for_parser_error(
+    sql: &str,
+    tokens: &[TokenWithSpan],
+    err_msg: &str,
+) -> Option<String> {
+    let location = if let Some(reported) = location_from_parser_error(err_msg) {
+        place_parser_caret(tokens, reported)
+    } else if err_msg.contains("found: EOF") {
+        last_token_end(tokens)?
+    } else {
+        return None;
+    };
+
+    render_query_snippet(sql, Span::new(location, location))
+}
+
+pub(crate) fn snippet_for_tokenizer_error(sql: &str, err: &TokenizerError) -> Option<String> {
+    if err.location.line == 0 {
+        return None;
+    }
+
+    let span = extend_to_token_end(sql, Span::new(err.location, err.location));
+    render_query_snippet(sql, span)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlparser::{dialect::PostgreSqlDialect, tokenizer::Tokenizer};
+
+    fn tokens(sql: &str) -> Vec<TokenWithSpan> {
+        Tokenizer::new(&PostgreSqlDialect {}, sql)
+            .tokenize_with_location()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_location_from_parser_error() {
+        let loc = location_from_parser_error(
+            "Expected: an expression, found: MEASURE at Line: 3, Column: 17",
+        )
+        .expect("should extract a location");
+        assert_eq!(loc, Location::new(3, 17));
+    }
+
+    #[test]
+    fn test_location_from_parser_error_takes_last() {
+        // Defensive: if several locations appear, the most specific (last) wins.
+        let loc = location_from_parser_error(
+            "outer at Line: 1, Column: 1 -- inner at Line: 5, Column: 9",
+        )
+        .unwrap();
+        assert_eq!(loc, Location::new(5, 9));
+    }
+
+    #[test]
+    fn test_location_from_parser_error_missing() {
+        assert!(location_from_parser_error("some error without a location").is_none());
+    }
+
+    #[test]
+    fn test_render_point_caret() {
+        let sql = "SELECT a\nFROM t\nWHERE";
+        let span = Span::new(Location::new(3, 1), Location::new(3, 1));
+        let snippet = render_query_snippet(sql, span).unwrap();
+        let expected = "\
+1 | SELECT a
+2 | FROM t
+3 | WHERE
+  | ^";
+        assert_eq!(snippet, expected);
+    }
+
+    #[test]
+    fn test_render_same_line_range() {
+        let sql = "SELECT foobar FROM t";
+        // Underline `foobar` (columns 8..=13).
+        let span = Span::new(Location::new(1, 8), Location::new(1, 13));
+        let snippet = render_query_snippet(sql, span).unwrap();
+        let expected = "\
+1 | SELECT foobar FROM t
+  |        ^^^^^^";
+        assert_eq!(snippet, expected);
+    }
+
+    #[test]
+    fn test_render_multiline_span() {
+        let sql = "SELECT a,\n       b\nFROM t";
+        // Span starting on line 1 col 8 and ending on line 2: underline to EOL of line 1.
+        let span = Span::new(Location::new(1, 8), Location::new(2, 8));
+        let snippet = render_query_snippet(sql, span).unwrap();
+        let expected = "\
+1 | SELECT a,
+  |        ^^";
+        assert_eq!(snippet, expected);
+    }
+
+    #[test]
+    fn test_render_out_of_bounds() {
+        let sql = "SELECT 1";
+        let span = Span::new(Location::new(5, 1), Location::new(5, 1));
+        assert!(render_query_snippet(sql, span).is_none());
+    }
+
+    #[test]
+    fn test_render_empty_span() {
+        let sql = "SELECT 1";
+        assert!(render_query_snippet(sql, Span::empty()).is_none());
+    }
+
+    #[test]
+    fn test_parser_error_snaps_delimiter_to_token_start() {
+        // The parser stops on the `(` (column 12) after the un-separated
+        // `MEASURE`; the caret must snap back to the start of `MEASURE`.
+        let sql = "SELECT DISTINCT\n    orders.status\n    MEASURE(orders.count)\nFROM orders";
+        let err = "Expected: end of statement, found: ( at Line: 3, Column: 12";
+        let snippet = snippet_for_parser_error(sql, &tokens(sql), err).unwrap();
+        let expected = "\
+1 | SELECT DISTINCT
+2 |     orders.status
+3 |     MEASURE(orders.count)
+  |     ^";
+        assert_eq!(snippet, expected);
+    }
+
+    #[test]
+    fn test_parser_error_terminator_points_at_end_of_last_token() {
+        // `SELECT FROM;` stops on the `;`; the caret should sit on the end of
+        // `FROM` (the `M`), not snap to its start.
+        let sql = "SELECT FROM;";
+        let err = "Expected: identifier, found: ; at Line: 1, Column: 12";
+        let snippet = snippet_for_parser_error(sql, &tokens(sql), err).unwrap();
+        let expected = "\
+1 | SELECT FROM;
+  |           ^";
+        assert_eq!(snippet, expected);
+    }
+
+    #[test]
+    fn test_parser_error_eof_points_at_end_of_last_token() {
+        // `SELECT FROM` fails at EOF (no location); anchor at the end of `FROM`.
+        let sql = "SELECT FROM";
+        let err = "Expected: identifier, found: EOF";
+        let snippet = snippet_for_parser_error(sql, &tokens(sql), err).unwrap();
+        let expected = "\
+1 | SELECT FROM
+  |           ^";
+        assert_eq!(snippet, expected);
+    }
+
+    #[test]
+    fn test_tokenizer_error_underlines_literal() {
+        // The tokenizer reports only the opening quote; underline the whole
+        // visible literal `'abc` up to the next whitespace.
+        let sql = "SELECT 'abc FROM t";
+        let err = TokenizerError {
+            message: "Unterminated string literal".to_string(),
+            location: Location::new(1, 8),
+        };
+        let snippet = snippet_for_tokenizer_error(sql, &err).unwrap();
+        let expected = "\
+1 | SELECT 'abc FROM t
+  |        ^^^^";
+        assert_eq!(snippet, expected);
+    }
+}


### PR DESCRIPTION
Render a source snippet with a caret under the offending location for SQL parser errors, so the user sees where the query broke instead of just a line/column number.

Locations come from the parser error message (or end-of-input for EOF), with token-aware caret placement:
- snap to the start of a word the parser stopped just after (`MEASURE(`)
- snap to the end of the last token for `;` / EOF (`SELECT FROM`)
- underline the whole literal for unterminated strings (`'abc`)

<img width="2680" height="300" alt="image" src="https://github.com/user-attachments/assets/96f55f88-7d8f-4d43-a12c-9159ea0040c8" />

<img width="2852" height="374" alt="image" src="https://github.com/user-attachments/assets/de229155-bbcc-4eab-b462-c8f05b160292" />

<img width="2558" height="288" alt="image" src="https://github.com/user-attachments/assets/08a17adc-9074-435c-acd4-c8bae23ddb42" />
