### PR TITLE
fix(schema-compiler): use Snowflake-compatible unix timestamp SQL

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
@@ -90,6 +90,10 @@ export class SnowflakeQuery extends BaseQuery {
     return 'CURRENT_TIMESTAMP';
   }
 
+  public unixTimestampSql() {
+    return `DATE_PART('EPOCH_SECOND', ${this.nowTimestampSql()})`;
+  }
+
   public hllInit(sql) {
     return `HLL_EXPORT(HLL_ACCUMULATE(${sql}))`;
   }

--- a/packages/cubejs-schema-compiler/test/unit/snowflake-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/snowflake-query.test.ts
@@ -1,0 +1,56 @@
+import moment from 'moment-timezone';
+import { SnowflakeQuery } from '../../src/adapter/SnowflakeQuery';
+import { BaseQuery } from '../../src/adapter/BaseQuery';
+import { prepareJsCompiler } from './PrepareCompiler';
+
+describe('SnowflakeQuery', () => {
+  const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+    cube(\`visitors\`, {
+      sql: \`select * from visitors\`,
+
+      measures: {
+        count: {
+          type: 'count'
+        },
+      },
+
+      dimensions: {
+        id: {
+          sql: 'id',
+          type: 'number',
+          primaryKey: true,
+        },
+
+        createdAt: {
+          type: 'time',
+          sql: 'created_at'
+        },
+      }
+    })
+    `);
+
+  it('uses Snowflake DATE_PART EPOCH_SECOND for unix timestamps', () => compiler.compile().then(() => {
+    const query = new SnowflakeQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      { measures: ['visitors.count'] }
+    );
+
+    expect(query.unixTimestampSql()).toEqual("DATE_PART('EPOCH_SECOND', CURRENT_TIMESTAMP)");
+  }));
+
+  it('uses the Snowflake unix timestamp in everyRefreshKeySql', () => compiler.compile().then(() => {
+    const timezone = 'America/Los_Angeles';
+    const query = new SnowflakeQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      { measures: ['visitors.count'], timezone }
+    );
+
+    const utcOffset = moment.tz(timezone).utcOffset() * 60;
+
+    expect(query.everyRefreshKeySql({ every: '1 hour', timezone }))
+      .toEqual([`FLOOR((${utcOffset} + DATE_PART('EPOCH_SECOND', CURRENT_TIMESTAMP)) / 3600)`, false, expect.any(BaseQuery)]);
+
+    expect(query.everyRefreshKeySql({ every: '0 10 * * *', timezone }))
+      .toEqual([`FLOOR((${utcOffset} + DATE_PART('EPOCH_SECOND', CURRENT_TIMESTAMP) - 36000) / 86400)`, false, expect.any(BaseQuery)]);
+  }));
+});

--- a/packages/cubejs-schema-compiler/test/unit/snowflake-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/snowflake-query.test.ts
@@ -35,7 +35,7 @@ describe('SnowflakeQuery', () => {
       { measures: ['visitors.count'] }
     );
 
-    expect(query.unixTimestampSql()).toEqual("DATE_PART('EPOCH_SECOND', CURRENT_TIMESTAMP)");
+    expect(query.unixTimestampSql()).toEqual('DATE_PART(\'EPOCH_SECOND\', CURRENT_TIMESTAMP)');
   }));
 
   it('uses the Snowflake unix timestamp in everyRefreshKeySql', () => compiler.compile().then(() => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

`BaseQuery.unixTimestampSql()` emits `EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)`, which is Postgres-only syntax. `SnowflakeQuery` inherits this without overriding, so refresh-key TTL math on Snowflake fails with:

> `SQL compilation error: invalid value [EPOCH] for parameter 'EXTRACT date/time part'`

The error surfaces in the renew cycle as `Error while renew cycle` log lines and prevents pre-aggregation refresh-key checks from completing.

To fix, we're overriding `unixTimestampSql()` in `SnowflakeQuery` to use Snowflake's native `DATE_PART('EPOCH_SECOND', CURRENT_TIMESTAMP)`. This mirrors how other dialects (`BigqueryQuery`, `PrestodbQuery`, `ClickHouseQuery`, `MssqlQuery`, etc.) provide their own dialect-specific implementations.

Also, added unit coverage asserting both the raw `unixTimestampSql()` output and its use within `everyRefreshKeySql()` (duration and cron branches).