### PR TITLE
refactor(tesseract): carry multiplied-count rendering in the measure symbol

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -449,7 +449,7 @@ impl PreAggregationOptimizer {
 
         // A measure sitting under a row-multiplying join can't be rolled
         // up from a partially matching pre-aggregation.
-        if match_state == MatchState::Partial && query_groups.has_multiplied_measures() {
+        if match_state == MatchState::Partial && query_groups.has_multiplied_measures()? {
             return Ok(None);
         }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -312,7 +312,6 @@ impl PreAggregationOptimizer {
                 .chain(pre_aggregation.segments.iter().cloned())
                 .collect(),
             measures: filtered_measures.clone(),
-            multiplied_measures: HashSet::new(),
         };
 
         // Set usage_index on the source table so the physical plan can generate unique placeholders
@@ -440,12 +439,20 @@ impl PreAggregationOptimizer {
         )?;
 
         let all_measures = helper.all_measures(schema, filters);
-        if !schema.multiplied_measures.is_empty() && match_state == MatchState::Partial {
-            return Ok(None);
-        }
         if match_state == MatchState::NotMatched {
             return Ok(None);
         }
+
+        // The query's join groups answer both the multiplicativity gate
+        // and the join-path comparison below, so build them once.
+        let query_groups = self.query_join_groups(schema, &all_measures)?;
+
+        // A measure sitting under a row-multiplying join can't be rolled
+        // up from a partially matching pre-aggregation.
+        if match_state == MatchState::Partial && query_groups.has_multiplied_measures() {
+            return Ok(None);
+        }
+
         let matched = self.try_match_measures(
             &all_measures,
             pre_aggregation,
@@ -455,24 +462,32 @@ impl PreAggregationOptimizer {
             return Ok(None);
         }
 
-        if !self.are_join_paths_matching(schema, &all_measures, pre_aggregation)? {
+        if !self.are_join_paths_matching(schema, &all_measures, &query_groups, pre_aggregation)? {
             return Ok(None);
         }
 
         Ok(matched)
     }
 
+    fn query_join_groups(
+        &self,
+        schema: &Rc<LogicalSchema>,
+        measures: &[Rc<MemberSymbol>],
+    ) -> Result<MultiFactJoinGroups, CubeError> {
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&schema.dimensions)
+            .add_dimensions(&schema.time_dimensions)
+            .build(measures)?;
+        MultiFactJoinGroups::try_new(self.query_tools.clone(), hints)
+    }
+
     fn are_join_paths_matching(
         &self,
         schema: &Rc<LogicalSchema>,
         measures: &[Rc<MemberSymbol>],
+        query_groups: &MultiFactJoinGroups,
         pre_aggregation: &CompiledPreAggregation,
     ) -> Result<bool, CubeError> {
-        let query_hints = MeasuresJoinHints::builder(&JoinHints::new())
-            .add_dimensions(&schema.dimensions)
-            .add_dimensions(&schema.time_dimensions)
-            .build(measures)?;
-        let query_groups = MultiFactJoinGroups::try_new(self.query_tools.clone(), query_hints)?;
         let pre_aggr_groups = &pre_aggregation.multi_fact_join_groups;
 
         for dim in schema

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/schema.rs
@@ -1,22 +1,20 @@
 use cubenativeutils::CubeError;
-use itertools::Itertools;
 
 use super::pretty_print::*;
 use crate::planner::collectors::has_multi_stage_members;
 use crate::planner::MemberSymbol;
-use std::collections::HashSet;
 use std::fmt;
 use std::rc::Rc;
 
 /// Output shape of a logical-plan node: the dimensions, time
-/// dimensions and measures it exposes, plus the full names of
-/// measures that need multiplied-aggregate handling downstream.
+/// dimensions and measures it exposes. Measures sitting under a
+/// row-multiplying join already carry their distinct render form
+/// (`MultipliedCount`), so no separate tracking is kept here.
 #[derive(Default, Clone)]
 pub struct LogicalSchema {
     pub time_dimensions: Vec<Rc<MemberSymbol>>,
     pub dimensions: Vec<Rc<MemberSymbol>>,
     pub measures: Vec<Rc<MemberSymbol>>,
-    pub multiplied_measures: HashSet<String>,
 }
 
 impl fmt::Debug for LogicalSchema {
@@ -38,11 +36,6 @@ impl LogicalSchema {
 
     pub fn set_measures(mut self, measures: Vec<Rc<MemberSymbol>>) -> Self {
         self.measures = measures;
-        self
-    }
-
-    pub fn set_multiplied_measures(mut self, multiplied_measures: HashSet<String>) -> Self {
-        self.multiplied_measures = multiplied_measures;
         self
     }
 
@@ -130,15 +123,6 @@ impl PrettyPrint for LogicalSchema {
             &format!("-measures: {}", print_symbols(&self.measures)),
             state,
         );
-        if !self.multiplied_measures.is_empty() {
-            result.println(
-                &format!(
-                    "-multiplied_measures: {}",
-                    self.multiplied_measures.iter().join(", ")
-                ),
-                state,
-            );
-        }
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/factory.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/factory.rs
@@ -27,7 +27,6 @@ pub struct SqlNodesFactory {
     render_references: RenderReferences,
     pre_aggregation_dimensions_references: RenderReferences,
     pre_aggregation_measures_references: RenderReferences,
-    rendered_as_multiplied_measures: HashSet<String>,
     ungrouped_measure_references: RenderReferences,
     cube_name_references: HashMap<String, String>,
     multi_stage_rank: Option<Vec<String>>,   //partition_by
@@ -84,10 +83,6 @@ impl SqlNodesFactory {
 
     pub fn render_references_mut(&mut self) -> &mut RenderReferences {
         &mut self.render_references
-    }
-
-    pub fn set_rendered_as_multiplied_measures(&mut self, value: HashSet<String>) {
-        self.rendered_as_multiplied_measures = value;
     }
 
     pub fn add_pre_aggregation_dimension_reference<T: Into<RenderReferencesType>>(
@@ -243,11 +238,8 @@ impl SqlNodesFactory {
         } else if self.ungrouped {
             UngroupedQueryFinalMeasureSqlNode::new(input)
         } else {
-            let final_processor: Rc<dyn SqlNode> = FinalMeasureSqlNode::new(
-                input.clone(),
-                self.rendered_as_multiplied_measures.clone(),
-                self.count_approx_as_state,
-            );
+            let final_processor: Rc<dyn SqlNode> =
+                FinalMeasureSqlNode::new(input.clone(), self.count_approx_as_state);
             let final_processor = if !self.pre_aggregation_measures_references.is_empty() {
                 FinalPreAggregationMeasureSqlNode::new(
                     final_processor,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/final_measure.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/final_measure.rs
@@ -6,29 +6,20 @@ use crate::planner::symbols::AggregateWrap;
 use crate::planner::MemberSymbol;
 use cubenativeutils::CubeError;
 use std::any::Any;
-use std::collections::HashSet;
 use std::rc::Rc;
 
 /// Applies the final aggregation wrap to a measure (sum / avg /
 /// count_distinct / pass-through, etc.) using `MeasureKind::aggregate_wrap`.
-/// Tracks measures that were classified as multiplied so the wrap
-/// switches to a distinct-count form, and routes
-/// `count_distinct_approx` through an HLL state when requested.
+/// Routes `count_distinct_approx` through an HLL state when requested.
 pub struct FinalMeasureSqlNode {
     input: Rc<dyn SqlNode>,
-    rendered_as_multiplied_measures: HashSet<String>,
     count_approx_as_state: bool,
 }
 
 impl FinalMeasureSqlNode {
-    pub fn new(
-        input: Rc<dyn SqlNode>,
-        rendered_as_multiplied_measures: HashSet<String>,
-        count_approx_as_state: bool,
-    ) -> Rc<Self> {
+    pub fn new(input: Rc<dyn SqlNode>, count_approx_as_state: bool) -> Rc<Self> {
         Rc::new(Self {
             input,
-            rendered_as_multiplied_measures,
             count_approx_as_state,
         })
     }
@@ -69,10 +60,7 @@ impl SqlNode for FinalMeasureSqlNode {
     ) -> Result<String, CubeError> {
         let res = match node.as_ref() {
             MemberSymbol::Measure(ev) => {
-                let is_multiplied = self
-                    .rendered_as_multiplied_measures
-                    .contains(&ev.full_name());
-                let wrap = ev.kind().aggregate_wrap(is_multiplied);
+                let wrap = ev.kind().aggregate_wrap();
                 let child_visitor = match wrap {
                     AggregateWrap::PassThrough => visitor.clone(),
                     _ => visitor.with_arg_needs_paren_safe(false),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/ungroupped_query_final_measure.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/ungroupped_query_final_measure.rs
@@ -37,7 +37,7 @@ impl SqlNode for UngroupedQueryFinalMeasureSqlNode {
         let res = match node.as_ref() {
             MemberSymbol::Measure(ev) => {
                 let is_count_like = match ev.kind() {
-                    MeasureKind::Count(_) => true,
+                    MeasureKind::Count(_) | MeasureKind::MultipliedCount(_) => true,
                     MeasureKind::Aggregated(a) => matches!(
                         a.agg_type(),
                         AggregationType::CountDistinct | AggregationType::CountDistinctApprox

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/symbols/measure_kinds/mod.rs
@@ -9,7 +9,7 @@ use cubenativeutils::CubeError;
 impl ToSql for MeasureKind {
     fn to_sql(&self, ctx: &MemberSqlContext) -> Result<String, CubeError> {
         match self {
-            Self::Count(c) => c.to_sql(ctx),
+            Self::Count(c) | Self::MultipliedCount(c) => c.to_sql(ctx),
             Self::Aggregated(a) => a.to_sql(ctx),
             Self::Calculated(c) => c.to_sql(ctx),
             Self::Rank => Err(CubeError::internal(format!(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/aggregate_multiplied_subquery.rs
@@ -188,12 +188,6 @@ impl<'a> LogicalNodeProcessor<'a, AggregateMultipliedSubquery>
             }
         }
         select_builder.set_group_by(group_by);
-        context_factory.set_rendered_as_multiplied_measures(
-            aggregate_multiplied_subquery
-                .schema
-                .multiplied_measures
-                .clone(),
-        );
         Ok(Rc::new(
             select_builder.build(query_tools.clone(), context_factory),
         ))

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/measure_subquery.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/measure_subquery.rs
@@ -30,14 +30,6 @@ impl<'a> LogicalNodeProcessor<'a, MeasureSubquery> for MeasureSubqueryProcessor<
         let references_builder = ReferencesBuilder::new(from.clone());
         let mut select_builder = SelectBuilder::new(from);
 
-        context_factory.set_rendered_as_multiplied_measures(
-            measure_subquery
-                .schema
-                .measures
-                .iter()
-                .map(|m| m.full_name())
-                .collect(),
-        );
         self.builder.resolve_subquery_dimensions_references(
             &measure_subquery.source.dimension_subqueries(),
             &references_builder,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
@@ -199,9 +199,6 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
         select_builder.set_limit(logical_plan.modifers().limit);
         select_builder.set_offset(logical_plan.modifers().offset);
 
-        context_factory
-            .set_rendered_as_multiplied_measures(logical_plan.schema().multiplied_measures.clone());
-
         if is_pre_aggregation {
             context_factory.clear_render_references();
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -1,4 +1,6 @@
-use crate::planner::collectors::{collect_join_hints, has_multi_stage_members};
+use crate::planner::collectors::{
+    collect_join_hints, collect_multiplied_measures, has_multi_stage_members,
+};
 use crate::planner::filter::FilterItem;
 use crate::planner::join_hints::JoinHints;
 use crate::planner::planners::JoinTreeBuilder;
@@ -237,12 +239,22 @@ impl MultiFactJoinGroups {
         self.groups.len() > 1
     }
 
-    /// True when any grouped measure sits on a cube that the join tree
-    /// of its group multiplies (one-to-many join below the measure).
-    pub fn has_multiplied_measures(&self) -> bool {
-        self.groups
-            .iter()
-            .any(|(join, measures)| measures.iter().any(|m| join.is_multiplied(&m.cube_name())))
+    /// True when any grouped measure — or a measure nested inside a
+    /// composite one — sits on a cube that the join tree of its group
+    /// multiplies (a one-to-many join below the measure). Descends the
+    /// compiled measure tree so composite measures are covered.
+    pub fn has_multiplied_measures(&self) -> Result<bool, CubeError> {
+        for (join, measures) in self.groups.iter() {
+            for measure in measures.iter() {
+                if collect_multiplied_measures(measure, join)?
+                    .iter()
+                    .any(|item| item.multiplied)
+                {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
     }
 
     pub fn groups(&self) -> &[(Rc<JoinTree>, Vec<Rc<MemberSymbol>>)] {
@@ -365,6 +377,47 @@ mod tests {
         assert!(!groups.is_multi_fact());
         assert_eq!(groups.num_groups(), 1);
         assert!(groups.single_join().unwrap().is_some());
+    }
+
+    #[test]
+    fn test_has_multiplied_measures_one_side_measure() {
+        // `customers` is the `one` side of a one_to_many join to `orders`.
+        // Selecting an `orders` dimension drags `orders` into the join, so
+        // each customer row is multiplied and `customers.count` is multiplied.
+        let schema = MockSchema::from_yaml_file("common/multi_fact.yaml");
+        let ctx = TestContext::new(schema).unwrap();
+
+        let customers_count = ctx.create_symbol("customers.count").unwrap();
+        let orders_status = ctx.create_symbol("orders.status").unwrap();
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[orders_status])
+            .build(&[customers_count])
+            .unwrap();
+
+        let groups = MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints).unwrap();
+
+        assert!(groups.has_multiplied_measures().unwrap());
+    }
+
+    #[test]
+    fn test_has_multiplied_measures_many_side_measure() {
+        // `orders` is the `many` side, so joining the `customers` dimension
+        // does not multiply order rows: `orders.count` is not multiplied.
+        let schema = MockSchema::from_yaml_file("common/multi_fact.yaml");
+        let ctx = TestContext::new(schema).unwrap();
+
+        let orders_count = ctx.create_symbol("orders.count").unwrap();
+        let customers_name = ctx.create_symbol("customers.name").unwrap();
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[customers_name])
+            .build(&[orders_count])
+            .unwrap();
+
+        let groups = MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints).unwrap();
+
+        assert!(!groups.has_multiplied_measures().unwrap());
     }
 
     #[test]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -237,6 +237,14 @@ impl MultiFactJoinGroups {
         self.groups.len() > 1
     }
 
+    /// True when any grouped measure sits on a cube that the join tree
+    /// of its group multiplies (one-to-many join below the measure).
+    pub fn has_multiplied_measures(&self) -> bool {
+        self.groups
+            .iter()
+            .any(|(join, measures)| measures.iter().any(|m| join.is_multiplied(&m.cube_name())))
+    }
+
     pub fn groups(&self) -> &[(Rc<JoinTree>, Vec<Rc<MemberSymbol>>)] {
         &self.groups
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/full_key_query_aggregate_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/full_key_query_aggregate_planner.rs
@@ -45,16 +45,10 @@ impl FullKeyAggregateQueryPlanner {
         let source = self.plan_logical_source(multi_stage_subqueries)?;
         let source = source.into();
 
-        let multiplied_measures = self
-            .query_properties
-            .full_key_aggregate_measures()?
-            .rendered_as_multiplied_measures
-            .clone();
         let schema = LogicalSchema::default()
             .set_dimensions(self.query_properties.dimensions().clone())
             .set_time_dimensions(self.query_properties.time_dimensions().clone())
-            .set_measures(self.query_properties.measures().clone())
-            .set_multiplied_measures(multiplied_measures)
+            .set_measures(self.query_properties.measures_for_render()?)
             .into_rc();
 
         let logical_filter = Rc::new(LogicalFilter {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/full_key_query_aggregate_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/full_key_query_aggregate_planner.rs
@@ -48,7 +48,7 @@ impl FullKeyAggregateQueryPlanner {
         let schema = LogicalSchema::default()
             .set_dimensions(self.query_properties.dimensions().clone())
             .set_time_dimensions(self.query_properties.time_dimensions().clone())
-            .set_measures(self.query_properties.measures_for_render()?)
+            .set_measures(self.query_properties.select_measures()?)
             .into_rc();
 
         let logical_filter = Rc::new(LogicalFilter {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multiplied_measures_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multiplied_measures_query_planner.rs
@@ -160,11 +160,6 @@ impl MultipliedMeasuresQueryPlanner {
             .set_dimensions(self.query_properties.dimensions().clone())
             .set_time_dimensions(self.query_properties.time_dimensions().clone())
             .set_measures(measures.clone())
-            .set_multiplied_measures(
-                self.full_key_aggregate_measures
-                    .rendered_as_multiplied_measures
-                    .clone(),
-            )
             .into_rc();
         let should_build_join_for_measure_select =
             self.check_should_build_join_for_measure_select(measures, key_cube_name)?;
@@ -281,11 +276,6 @@ impl MultipliedMeasuresQueryPlanner {
             .set_dimensions(self.query_properties.dimensions().clone())
             .set_time_dimensions(self.query_properties.time_dimensions().clone())
             .set_measures(measures.clone())
-            .set_multiplied_measures(
-                self.full_key_aggregate_measures
-                    .rendered_as_multiplied_measures
-                    .clone(),
-            )
             .into_rc();
 
         let logical_filter = Rc::new(LogicalFilter {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/simple_query_planer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/simple_query_planer.rs
@@ -27,16 +27,10 @@ impl SimpleQueryPlanner {
     pub fn plan(&self) -> Result<Rc<Query>, CubeError> {
         let source = self.source_and_subquery_dimensions()?;
 
-        let multiplied_measures = self
-            .query_properties
-            .full_key_aggregate_measures()?
-            .rendered_as_multiplied_measures
-            .clone();
         let schema = LogicalSchema::default()
             .set_dimensions(self.query_properties.dimensions().clone())
-            .set_measures(self.query_properties.measures().clone())
+            .set_measures(self.query_properties.measures_for_render()?)
             .set_time_dimensions(self.query_properties.time_dimensions().clone())
-            .set_multiplied_measures(multiplied_measures)
             .into_rc();
         let logical_filter = Rc::new(LogicalFilter {
             dimensions_filters: self.query_properties.dimensions_filters().clone(),

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/simple_query_planer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/simple_query_planer.rs
@@ -29,7 +29,7 @@ impl SimpleQueryPlanner {
 
         let schema = LogicalSchema::default()
             .set_dimensions(self.query_properties.dimensions().clone())
-            .set_measures(self.query_properties.measures_for_render()?)
+            .set_measures(self.query_properties.select_measures()?)
             .set_time_dimensions(self.query_properties.time_dimensions().clone())
             .into_rc();
         let logical_filter = Rc::new(LogicalFilter {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -21,7 +21,7 @@ use crate::planner::{
 use cubenativeutils::CubeError;
 use itertools::Itertools;
 use std::cell::OnceCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use typed_builder::TypedBuilder;
 
@@ -92,15 +92,14 @@ impl MultipliedMeasure {
 
 /// Measures classified by how the planner must compute them: directly
 /// aggregated alongside the rest of the query, wrapped in a multiplied
-/// subquery, or planned as a multi-stage CTE. `rendered_as_multiplied`
-/// tracks symbols that were originally multiplied even after additivity
-/// reclassification flips them into `regular_measures`.
+/// subquery, or planned as a multi-stage CTE. Measures sitting under a
+/// row-multiplying join already carry their distinct render form
+/// (`MultipliedCount`), so no separate tracking is needed.
 #[derive(Default, Clone, Debug)]
 pub struct FullKeyAggregateMeasures {
     pub multiplied_measures: Vec<Rc<MultipliedMeasure>>,
     pub regular_measures: Vec<Rc<MemberSymbol>>,
     pub multi_stage_measures: Vec<Rc<MemberSymbol>>,
-    pub rendered_as_multiplied_measures: HashSet<String>,
 }
 
 /// The full description of a query: selected members, filters, ordering,
@@ -480,30 +479,24 @@ impl QueryProperties {
                     .single_join()?
                     .expect("No join groups returned for single measure multi-fact join group");
                 for item in collect_multiplied_measures(m, &join)? {
-                    if item.multiplied {
-                        result
-                            .rendered_as_multiplied_measures
-                            .insert(item.measure.full_name());
-                    }
-                    let is_multiplied_measure = if item.multiplied {
-                        if let Ok(measure) = item.measure.as_measure() {
-                            if measure.is_additive_in_multiplied() {
-                                false
-                            } else {
-                                true
-                            }
-                        } else {
-                            true
-                        }
-                    } else {
-                        false
-                    };
-                    if is_multiplied_measure {
-                        result
-                            .multiplied_measures
-                            .push(MultipliedMeasure::new(item.measure.clone(), item.cube_name));
-                    } else {
+                    if !item.multiplied {
                         result.regular_measures.push(item.measure.clone());
+                        continue;
+                    }
+                    let measure = item.measure.as_measure().ok();
+                    match measure
+                        .as_ref()
+                        .and_then(|m| m.convert_multiplied_to_regular())
+                    {
+                        Some(regular) => result.regular_measures.push(regular),
+                        None => {
+                            let rendered = measure
+                                .map(|m| m.into_multiplied())
+                                .unwrap_or_else(|| item.measure.clone());
+                            result
+                                .multiplied_measures
+                                .push(MultipliedMeasure::new(rendered, item.cube_name));
+                        }
                     }
                 }
             }
@@ -525,6 +518,33 @@ impl QueryProperties {
             .collect();
 
         Ok(result)
+    }
+
+    /// The query's selected measures in render form: each measure that
+    /// sits under a row-multiplying join is replaced by its distinct
+    /// `MultipliedCount` form, so it renders correctly without any
+    /// out-of-band "multiplied" flag. Multi-stage and composite measures
+    /// are returned unchanged — their parts are converted where they are
+    /// actually rendered.
+    pub fn measures_for_render(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {
+        let classified = self.full_key_aggregate_measures()?;
+        let mut render_form: HashMap<String, Rc<MemberSymbol>> = HashMap::new();
+        for m in classified.regular_measures.iter() {
+            render_form.insert(m.full_name(), m.clone());
+        }
+        for m in classified.multiplied_measures.iter() {
+            render_form.insert(m.measure().full_name(), m.measure().clone());
+        }
+        Ok(self
+            .measures
+            .iter()
+            .map(|m| {
+                render_form
+                    .get(&m.full_name())
+                    .cloned()
+                    .unwrap_or_else(|| m.clone())
+            })
+            .collect())
     }
 
     fn all_used_measures(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -94,18 +94,32 @@ impl MultipliedMeasure {
 /// aggregated alongside the rest of the query, wrapped in a multiplied
 /// subquery, or planned as a multi-stage CTE.
 ///
-/// `render_forms` maps a selected measure's full name to a copy with
-/// every multiplied `count` (the measure itself or one nested in a
-/// calculated expression) rewritten to its distinct `MultipliedCount`
-/// form. Built during the single classification pass; consumed by
-/// [`QueryProperties::select_measures`]. Only measures that actually
-/// need rewriting get an entry.
+/// `render_forms` maps a leaf measure's full name to its distinct
+/// render form (a `count` rewritten to `MultipliedCount`), recorded
+/// during the single classification pass. Applied via [`Self::render`].
 #[derive(Default, Clone, Debug)]
 pub struct FullKeyAggregateMeasures {
     pub multiplied_measures: Vec<Rc<MultipliedMeasure>>,
     pub regular_measures: Vec<Rc<MemberSymbol>>,
     pub multi_stage_measures: Vec<Rc<MemberSymbol>>,
-    pub render_forms: HashMap<String, Rc<MemberSymbol>>,
+    render_forms: HashMap<String, Rc<MemberSymbol>>,
+}
+
+impl FullKeyAggregateMeasures {
+    /// Rewrite a selected measure into its render form: every multiplied
+    /// `count` in its dependency tree — the measure itself or one nested
+    /// in a calculated expression — is substituted with the distinct
+    /// form recorded during classification. Measures with no multiplied
+    /// count pass through unchanged.
+    pub fn render(&self, measure: &Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError> {
+        measure.apply_recursive(&|node| {
+            Ok(self
+                .render_forms
+                .get(&node.full_name())
+                .cloned()
+                .unwrap_or_else(|| node.clone()))
+        })
+    }
 }
 
 /// The full description of a query: selected members, filters, ordering,
@@ -536,24 +550,11 @@ impl QueryProperties {
         Ok(result)
     }
 
-    /// The query's selected measures with every multiplied `count`
-    /// rewritten to its distinct `MultipliedCount` form — the measure
-    /// itself or any nested inside a calculated expression. Substitutes
-    /// the per-leaf render forms computed in the classification pass into
-    /// each measure's dependency tree; leaves with no rewrite stay as-is.
+    /// The query's selected measures in render form — see
+    /// [`FullKeyAggregateMeasures::render`].
     pub fn select_measures(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {
-        let forms = self.full_key_aggregate_measures()?.render_forms;
-        self.measures
-            .iter()
-            .map(|m| {
-                m.apply_recursive(&|node| {
-                    Ok(forms
-                        .get(&node.full_name())
-                        .cloned()
-                        .unwrap_or_else(|| node.clone()))
-                })
-            })
-            .collect()
+        let classified = self.full_key_aggregate_measures()?;
+        self.measures.iter().map(|m| classified.render(m)).collect()
     }
 
     fn all_used_measures(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -92,14 +92,20 @@ impl MultipliedMeasure {
 
 /// Measures classified by how the planner must compute them: directly
 /// aggregated alongside the rest of the query, wrapped in a multiplied
-/// subquery, or planned as a multi-stage CTE. Measures sitting under a
-/// row-multiplying join already carry their distinct render form
-/// (`MultipliedCount`), so no separate tracking is needed.
+/// subquery, or planned as a multi-stage CTE.
+///
+/// `render_forms` maps a selected measure's full name to a copy with
+/// every multiplied `count` (the measure itself or one nested in a
+/// calculated expression) rewritten to its distinct `MultipliedCount`
+/// form. Built during the single classification pass; consumed by
+/// [`QueryProperties::select_measures`]. Only measures that actually
+/// need rewriting get an entry.
 #[derive(Default, Clone, Debug)]
 pub struct FullKeyAggregateMeasures {
     pub multiplied_measures: Vec<Rc<MultipliedMeasure>>,
     pub regular_measures: Vec<Rc<MemberSymbol>>,
     pub multi_stage_measures: Vec<Rc<MemberSymbol>>,
+    pub render_forms: HashMap<String, Rc<MemberSymbol>>,
 }
 
 /// The full description of a query: selected members, filters, ordering,
@@ -484,20 +490,30 @@ impl QueryProperties {
                         continue;
                     }
                     let measure = item.measure.as_measure().ok();
-                    match measure
+                    // The leaf's render form (a distinct `MultipliedCount`
+                    // for a count) — the same symbol whether it stays in the
+                    // main query or moves to a multiplied subquery.
+                    let rendered = match measure
                         .as_ref()
                         .and_then(|m| m.convert_multiplied_to_regular())
                     {
-                        Some(regular) => result.regular_measures.push(regular),
+                        Some(regular) => {
+                            result.regular_measures.push(regular.clone());
+                            regular
+                        }
                         None => {
                             let rendered = measure
                                 .map(|m| m.into_multiplied())
                                 .unwrap_or_else(|| item.measure.clone());
                             result
                                 .multiplied_measures
-                                .push(MultipliedMeasure::new(rendered, item.cube_name));
+                                .push(MultipliedMeasure::new(rendered.clone(), item.cube_name));
+                            rendered
                         }
-                    }
+                    };
+                    result
+                        .render_forms
+                        .insert(item.measure.full_name(), rendered);
                 }
             }
         }
@@ -520,31 +536,24 @@ impl QueryProperties {
         Ok(result)
     }
 
-    /// The query's selected measures in render form: each measure that
-    /// sits under a row-multiplying join is replaced by its distinct
-    /// `MultipliedCount` form, so it renders correctly without any
-    /// out-of-band "multiplied" flag. Multi-stage and composite measures
-    /// are returned unchanged — their parts are converted where they are
-    /// actually rendered.
-    pub fn measures_for_render(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {
-        let classified = self.full_key_aggregate_measures()?;
-        let mut render_form: HashMap<String, Rc<MemberSymbol>> = HashMap::new();
-        for m in classified.regular_measures.iter() {
-            render_form.insert(m.full_name(), m.clone());
-        }
-        for m in classified.multiplied_measures.iter() {
-            render_form.insert(m.measure().full_name(), m.measure().clone());
-        }
-        Ok(self
-            .measures
+    /// The query's selected measures with every multiplied `count`
+    /// rewritten to its distinct `MultipliedCount` form — the measure
+    /// itself or any nested inside a calculated expression. Substitutes
+    /// the per-leaf render forms computed in the classification pass into
+    /// each measure's dependency tree; leaves with no rewrite stay as-is.
+    pub fn select_measures(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {
+        let forms = self.full_key_aggregate_measures()?.render_forms;
+        self.measures
             .iter()
             .map(|m| {
-                render_form
-                    .get(&m.full_name())
-                    .cloned()
-                    .unwrap_or_else(|| m.clone())
+                m.apply_recursive(&|node| {
+                    Ok(forms
+                        .get(&node.full_name())
+                        .cloned()
+                        .unwrap_or_else(|| node.clone()))
+                })
             })
-            .collect())
+            .collect()
     }
 
     fn all_used_measures(&self) -> Result<Vec<Rc<MemberSymbol>>, CubeError> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/count.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/count.rs
@@ -31,6 +31,13 @@ impl CountMeasure {
         &self.sql
     }
 
+    /// True when this count can be rendered as a key-distinct count to
+    /// survive row multiplication: it falls back to the cube's primary
+    /// keys (`Auto`) and at least one key is available.
+    pub fn convertible_to_distinct(&self) -> bool {
+        matches!(&self.sql, CountSql::Auto(pks) if !pks.is_empty())
+    }
+
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
         let mut deps = vec![];
         match &self.sql {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
@@ -36,6 +36,10 @@ pub enum AggregateWrap<'a> {
 #[derive(Clone)]
 pub enum MeasureKind {
     Count(CountMeasure),
+    /// A `Count` that sits under a row-multiplying join and must be
+    /// rendered as a distinct count to stay correct. Identical to
+    /// `Count` in every respect except the final aggregate wrap.
+    MultipliedCount(CountMeasure),
     Aggregated(AggregatedMeasure),
     Calculated(CalculatedMeasure),
     Rank,
@@ -76,7 +80,7 @@ impl MeasureKind {
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
         match self {
-            Self::Count(c) => c.get_dependencies(),
+            Self::Count(c) | Self::MultipliedCount(c) => c.get_dependencies(),
             Self::Aggregated(a) => a.get_dependencies(),
             Self::Calculated(c) => c.get_dependencies(),
             Self::Rank => vec![],
@@ -89,6 +93,7 @@ impl MeasureKind {
     ) -> Result<Self, CubeError> {
         Ok(match self {
             Self::Count(c) => Self::Count(c.apply_to_deps(f)?),
+            Self::MultipliedCount(c) => Self::MultipliedCount(c.apply_to_deps(f)?),
             Self::Aggregated(a) => Self::Aggregated(a.apply_to_deps(f)?),
             Self::Calculated(c) => Self::Calculated(c.apply_to_deps(f)?),
             Self::Rank => Self::Rank,
@@ -97,7 +102,7 @@ impl MeasureKind {
 
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         match self {
-            Self::Count(c) => c.iter_sql_calls(),
+            Self::Count(c) | Self::MultipliedCount(c) => c.iter_sql_calls(),
             Self::Aggregated(a) => a.iter_sql_calls(),
             Self::Calculated(c) => c.iter_sql_calls(),
             Self::Rank => Box::new(std::iter::empty()),
@@ -106,7 +111,7 @@ impl MeasureKind {
 
     pub fn get_cube_refs(&self) -> Vec<CubeRef> {
         match self {
-            Self::Count(c) => c.get_cube_refs(),
+            Self::Count(c) | Self::MultipliedCount(c) => c.get_cube_refs(),
             Self::Aggregated(a) => a.get_cube_refs(),
             Self::Calculated(c) => c.get_cube_refs(),
             Self::Rank => vec![],
@@ -115,7 +120,7 @@ impl MeasureKind {
 
     pub fn is_owned_by_cube(&self) -> bool {
         match self {
-            Self::Count(c) => c.is_owned_by_cube(),
+            Self::Count(c) | Self::MultipliedCount(c) => c.is_owned_by_cube(),
             Self::Aggregated(a) => a.is_owned_by_cube(),
             Self::Calculated(c) => c.is_owned_by_cube(),
             Self::Rank => false,
@@ -131,7 +136,7 @@ impl MeasureKind {
     /// their `AggregationType`. Calculated and rank are not additive.
     pub fn is_additive(&self) -> bool {
         match self {
-            Self::Count(_) => true,
+            Self::Count(_) | Self::MultipliedCount(_) => true,
             Self::Aggregated(a) => a.agg_type().is_additive(),
             _ => false,
         }
@@ -139,7 +144,7 @@ impl MeasureKind {
 
     pub fn measure_type_str(&self) -> &str {
         match self {
-            Self::Count(_) => "count",
+            Self::Count(_) | Self::MultipliedCount(_) => "count",
             Self::Aggregated(a) => a.agg_type().as_str(),
             Self::Calculated(c) => c.calc_type().as_str(),
             Self::Rank => "rank",
@@ -178,7 +183,7 @@ impl MeasureKind {
     /// `running_total`, calculated and rank measures do not.
     pub fn supports_additional_filters(&self) -> bool {
         match self {
-            Self::Count(_) => true,
+            Self::Count(_) | Self::MultipliedCount(_) => true,
             Self::Aggregated(a) => matches!(
                 a.agg_type(),
                 AggregationType::Sum
@@ -194,7 +199,7 @@ impl MeasureKind {
 
     pub fn member_sql(&self) -> Option<&Rc<SqlCall>> {
         match self {
-            Self::Count(c) => match c.sql() {
+            Self::Count(c) | Self::MultipliedCount(c) => match c.sql() {
                 CountSql::Explicit(sql) => Some(sql),
                 CountSql::Auto(_) => None,
             },
@@ -205,10 +210,9 @@ impl MeasureKind {
     }
 
     /// How the kind wraps its inner SQL when rendered as a top-level
-    /// query measure. `is_multiplied` is true when the join below the
-    /// measure can produce duplicate rows — non-distinct counts then
-    /// switch to `count_distinct` over primary keys to stay correct.
-    pub fn aggregate_wrap(&self, is_multiplied: bool) -> AggregateWrap<'_> {
+    /// query measure. `MultipliedCount` switches to `count_distinct`
+    /// over primary keys to stay correct under row multiplication.
+    pub fn aggregate_wrap(&self) -> AggregateWrap<'_> {
         match self {
             Self::Calculated(_) => AggregateWrap::PassThrough,
             Self::Aggregated(a) => match a.agg_type() {
@@ -218,13 +222,8 @@ impl MeasureKind {
                 AggregationType::RunningTotal => AggregateWrap::Function("sum"),
                 _ => AggregateWrap::Function(a.agg_type().as_str()),
             },
-            Self::Count(_) => {
-                if is_multiplied {
-                    AggregateWrap::CountDistinct
-                } else {
-                    AggregateWrap::Function("count")
-                }
-            }
+            Self::Count(_) => AggregateWrap::Function("count"),
+            Self::MultipliedCount(_) => AggregateWrap::CountDistinct,
             Self::Rank => AggregateWrap::PassThrough,
         }
     }
@@ -235,7 +234,7 @@ impl MeasureKind {
     /// time / boolean values roll up via `max`.
     pub fn pre_aggregate_wrap(&self) -> AggregateWrap<'_> {
         match self {
-            Self::Count(_) => AggregateWrap::Function("sum"),
+            Self::Count(_) | Self::MultipliedCount(_) => AggregateWrap::Function("sum"),
             Self::Aggregated(a) => match a.agg_type() {
                 AggregationType::CountDistinctApprox => AggregateWrap::CountDistinctApprox,
                 AggregationType::Min => AggregateWrap::Function("min"),
@@ -253,12 +252,34 @@ impl MeasureKind {
     pub fn with_new_type(&self, new_type: &str) -> Result<Self, CubeError> {
         let member_sql = self.member_sql().cloned();
         let pk_sqls = match self {
-            Self::Count(c) => match c.sql() {
+            Self::Count(c) | Self::MultipliedCount(c) => match c.sql() {
                 CountSql::Auto(pks) => pks.clone(),
                 _ => vec![],
             },
             _ => vec![],
         };
         Self::from_type_str(new_type, member_sql, pk_sqls)
+    }
+
+    /// Render form when this kind sits under a row-multiplying join:
+    /// a `Count` becomes a distinct `MultipliedCount`; every other
+    /// kind is unchanged (only counts switch wrap under multiplication).
+    pub fn into_multiplied(&self) -> Self {
+        match self {
+            Self::Count(c) => Self::MultipliedCount(c.clone()),
+            other => other.clone(),
+        }
+    }
+
+    /// `Some(render form)` when this kind, under a row-multiplying join,
+    /// is still safe to compute directly in the main query: a key-based
+    /// count rolls up as a distinct `MultipliedCount`, distinct
+    /// aggregations are already immune and stay as-is. `None` otherwise.
+    pub fn regular_in_multiplied(&self) -> Option<Self> {
+        match self {
+            Self::Count(c) if c.convertible_to_distinct() => Some(Self::MultipliedCount(c.clone())),
+            Self::Aggregated(a) if a.agg_type().is_distinct() => Some(self.clone()),
+            _ => None,
+        }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
@@ -368,16 +368,28 @@ impl MeasureSymbol {
         refs
     }
 
-    /// True if the measure stays correct when joined into a context
-    /// that multiplies rows (one-to-many join). Distinct aggregations
-    /// are naturally immune; primary-key-based counts (`type: count`
-    /// without an explicit `sql`) are too.
-    pub fn is_additive_in_multiplied(&self) -> bool {
-        match &self.kind {
-            MeasureKind::Aggregated(agg) => agg.agg_type().is_distinct(),
-            MeasureKind::Count(count) => count.is_owned_by_cube(),
-            _ => false,
-        }
+    /// Render form of this measure when it sits under a row-multiplying
+    /// join: a `count` switches to a distinct `MultipliedCount`, every
+    /// other kind is returned unchanged.
+    pub fn into_multiplied(&self) -> Rc<MemberSymbol> {
+        self.with_kind(self.kind.into_multiplied())
+    }
+
+    /// `Some(render form)` when this measure, under a row-multiplying
+    /// join, can still be computed directly in the main query (it stays
+    /// additive there): a key-based count rolls up as a distinct
+    /// `MultipliedCount`, distinct aggregations are already immune.
+    /// `None` when it must be isolated in a multiplied subquery instead.
+    pub fn convert_multiplied_to_regular(&self) -> Option<Rc<MemberSymbol>> {
+        self.kind
+            .regular_in_multiplied()
+            .map(|kind| self.with_kind(kind))
+    }
+
+    fn with_kind(&self, kind: MeasureKind) -> Rc<MemberSymbol> {
+        let mut new = self.clone();
+        new.kind = kind;
+        MemberSymbol::new_measure(Rc::new(new))
     }
 
     /// True when the cube on the symbol's path is required in the

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_joins.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_joins.yaml
@@ -62,6 +62,9 @@ cubes:
           - name: total_amount
             type: sum
             sql: amount
+          - name: customers_count_x2
+            type: number
+            sql: "{customers.count} * 2"
 
     - name: order_items
       sql: "SELECT * FROM order_items"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/joins.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/joins.rs
@@ -14,6 +14,33 @@ fn create_diamond_context() -> TestContext {
 
 const SEED: &str = "integration_joins_tables.sql";
 
+// A multiplied `count` nested inside a calculated measure from another
+// cube must still render as a distinct count. Here `customers` rows are
+// multiplied by the join to `orders`, so the nested `customers.count`
+// inside `orders.customers_count_x2` (= {customers.count} * 2) must use a
+// distinct count — `customers_count_x2` must equal twice `customers.count`
+// for every row.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multiplied_count_inside_calculated_measure() {
+    let ctx = create_context();
+
+    let query = indoc! {"
+        measures:
+          - customers.count
+          - orders.customers_count_x2
+        dimensions:
+          - orders.status
+        order:
+          - id: orders.status
+    "};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_join_many_to_one() {
     let ctx = create_context();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__joins__multiplied_count_inside_calculated_measure.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/snapshots/cubesqlplanner__tests__integration__joins__multiplied_count_inside_calculated_measure.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/joins.rs
+expression: result
+---
+orders__status | customers__count | orders__customers_count_x2
+---------------+------------------+---------------------------
+cancelled      | 0                | 0                         
+completed      | 3                | 6                         
+pending        | 1                | 2


### PR DESCRIPTION
## Summary

The `count -> count_distinct` switch for measures sitting under a row-multiplying join was driven by a `rendered_as_multiplied_measures` flag threaded from classification all the way down to the `FinalMeasure` render node (and mirrored on `LogicalSchema`). This moves the distinct render form onto the measure symbol itself, so the flag and its plumbing can be removed entirely.

## Changes

- Add `MeasureKind::MultipliedCount`, identical to `Count` except its `aggregate_wrap` (which no longer takes an `is_multiplied` parameter).
- Add `CountMeasure::convertible_to_distinct`, plus `MeasureSymbol::convert_multiplied_to_regular` (the placement gate, replacing `is_additive_in_multiplied`) and `into_multiplied`.
- Collapse the classification ladder in `full_key_aggregate_measures` and expose `measures_for_render`, which substitutes the distinct render form into the selected measures.
- Drop `LogicalSchema::multiplied_measures` and all the setters/plumbing that fed the `FinalMeasure` flag (including a dead set in the ungrouped `measure_subquery` path).
- Derive the pre-aggregation multiplicativity gate from the query's `MultiFactJoinGroups` (`has_multiplied_measures`, descending into composite measures via `collect_multiplied_measures` to stay equivalent to the old classifier). The join groups are now built once and reused for both the gate and join-path matching.

## Testing

- `cargo test -p cubesqlplanner`: 999 unit tests pass, including two new `has_multiplied_measures` cases (one-side measure multiplied / many-side measure not).
- `cargo test -p cubesqlplanner --features integration-postgres`: all 453 integration tests pass against real Postgres (joins, multi-fact, transitive joins, subquery dimensions, views, pre-aggregations incl. partial-match).