### PR TITLE
docs(oidc): add Azure Blob Storage CSPS section

### DIFF
--- a/docs-mintlify/admin/deployment/oidc/azure.mdx
+++ b/docs-mintlify/admin/deployment/oidc/azure.mdx
@@ -246,6 +246,79 @@ unloaded objects from the bucket.
 
 </Warning>
 
+## Azure Blob Storage CSPS bucket
+
+Cube Store CSPS lets you store pre-aggregations in your own Azure Blob
+Storage container. Cube Store gets a separate OIDC token whose `sub` claim
+ends in `component:cube_store`, so the federated credential can be locked
+down to that component — even if the same app registration were shared with
+the rest of the deployment, only Cube Store would match.
+
+Every Cube Store worker emits a `sub` of the form
+`cube:deployment:<deployment-id>:component:cube_store`. Unlike AWS IAM —
+which matches `sub` with a `StringLike` wildcard, so one role can cover the
+whole tenant — **Azure pins the federated credential's `subject` literally**
+and has no tenant-wide `*`. So CSPS on Azure is **per deployment**: each
+deployment that writes pre-aggregations to the container needs its own
+federated credential carrying that deployment's exact `sub`. If you expect
+many deployments, mind the 20-credential limit and see [Scaling past 20
+federated credentials](#scaling-past-20-federated-credentials).
+
+<Steps>
+  <Step title="Create the Cube Store federated credential">
+    Add a federated credential on the app registration, pinning the subject
+    to the deployment's Cube Store component:
+
+    ```bash
+    az ad app federated-credential create \
+      --id <APP_OBJECT_ID> \
+      --parameters '{
+        "name": "cube-<tenant-name>-deployment-<deployment-id>-cube-store",
+        "issuer": "https://<tenant-name>.cubecloud.dev",
+        "subject": "cube:deployment:<deployment-id>:component:cube_store",
+        "audiences": ["api://AzureADTokenExchange"]
+      }'
+    ```
+
+    Make sure the Azure token config's **Subject Claim Format** includes the
+    `:component:` segment
+    (`cube:deployment:{deployment_id}:component:{component}`) — see
+    [Step 2](#step-2-add-a-federated-credential) — otherwise the Cube Store
+    `sub` won't match this credential.
+  </Step>
+  <Step title="Grant the container permissions">
+    Grant the app registration **Storage Blob Data Contributor** so Cube
+    Store can read, write, and list pre-aggregation blobs. Scope it to the
+    container for tightest isolation:
+
+    ```bash
+    az role assignment create \
+      --assignee <APP_CLIENT_ID> \
+      --role "Storage Blob Data Contributor" \
+      --scope "/subscriptions/<SUB_ID>/resourceGroups/<RG>/providers/Microsoft.Storage/storageAccounts/<ACCOUNT>/blobServices/default/containers/<container>"
+    ```
+
+    Use the storage account scope (drop the
+    `/blobServices/default/containers/<container>` suffix) if you'd rather
+    one assignment cover multiple containers.
+  </Step>
+  <Step title="Enable CSPS on each deployment">
+    For each deployment that should use this container, go to **Settings →
+    Pre-Aggregation Storage** on the deployment and:
+
+    - Toggle **Enable CSPS** on.
+    - **Storage Provider**: Azure Blob Storage.
+    - **Storage Account**: `<account>`.
+    - **Container**: `<container>`.
+    - **Client ID**: the app registration's Application (client) ID.
+    - **Tenant ID**: the Microsoft Entra ID (Azure AD) directory ID.
+
+    Click **Test Connection** to verify Cube Store can exchange its OIDC
+    token with Azure AD and access the container, then **Apply**. Cube Store
+    starts writing pre-aggregations to your container on the next refresh.
+  </Step>
+</Steps>
+
 ## Scaling past 20 federated credentials
 
 A single app registration accepts at most **20 federated credentials**.

--- a/docs-mintlify/admin/deployment/oidc/index.mdx
+++ b/docs-mintlify/admin/deployment/oidc/index.mdx
@@ -27,8 +27,9 @@ You can use OIDC workload identity to authenticate to:
   unloads. OIDC covers Cube's download of the unloaded objects; the warehouse's
   `UNLOAD` write still needs its own credentials configured on the client side
   — see the per-cloud guides for details.
-- **Cube Store CSPS** — a per-deployment S3 / GCS bucket that holds your
-  Cube Store pre-aggregations (Customer-Supplied Pre-aggregation Storage).
+- **Cube Store CSPS** — a per-deployment S3, GCS, or Azure Blob Storage
+  bucket that holds your Cube Store pre-aggregations (Customer-Supplied
+  Pre-aggregation Storage).
 - **Bring-your-own LLM providers** — AWS Bedrock, Google Vertex AI, and Azure
   OpenAI behind your own cloud account.
 - **Other cloud services** — any cloud service that supports OIDC federation
@@ -283,17 +284,20 @@ deployment's default role is simpler and easier to reason about.
 
 ## Cube Store CSPS
 
-Cube Store can store its pre-aggregations in a **per-deployment** S3 or GCS
-bucket that you own — Customer-Supplied Pre-aggregation Storage (CSPS). When
-you enable CSPS for a deployment, Cube Store authenticates to your bucket
-with the same OIDC machinery as the rest of the deployment. The trust policy
-on your IAM role pins the `sub` claim to `cube:deployment:<deployment-id>:component:cube_store`,
+Cube Store can store its pre-aggregations in a **per-deployment** S3, GCS, or
+Azure Blob Storage bucket that you own — Customer-Supplied Pre-aggregation
+Storage (CSPS). When you enable CSPS for a deployment, Cube Store
+authenticates to your bucket with the same OIDC machinery as the rest of the
+deployment. The trust policy (AWS IAM role / Azure federated credential) pins
+the `sub` claim to `cube:deployment:<deployment-id>:component:cube_store`,
 giving Cube Store its own identity that's distinct from the Cube API.
 
 CSPS is configured under **Settings → Pre-Aggregation Storage** on the
 deployment. See
-[AWS](/admin/deployment/oidc/aws#cube-store-csps-bucket) and
-[GCP](/admin/deployment/oidc/gcp) for the trust policy shape on each cloud.
+[AWS](/admin/deployment/oidc/aws#cube-store-csps-bucket),
+[GCP](/admin/deployment/oidc/gcp), and
+[Azure](/admin/deployment/oidc/azure#azure-blob-storage-csps-bucket) for the
+trust policy shape on each cloud.
 
 ## Audit trail
 


### PR DESCRIPTION
## What

The OIDC docs' `azure.mdx` covered Azure SQL and the Blob **export bucket**, but was missing the **Cube Store CSPS** (Customer-Supplied Pre-aggregation Storage) section that `aws.mdx` has — an inconsistency across the per-cloud guides.

This adds an **"Azure Blob Storage CSPS bucket"** section to `azure.mdx`, mirroring the AWS one:
1. Create a per-deployment federated credential pinned to `cube:deployment:<id>:component:cube_store`.
2. Grant **Storage Blob Data Contributor** on the container.
3. Enable CSPS under **Settings → Pre-Aggregation Storage** (Storage Provider: Azure Blob Storage; Storage Account; Container; Client ID; Tenant ID; **Test Connection**).

It also calls out the Azure-specific difference from AWS: Azure pins the federated credential `subject` **literally** (no `StringLike` wildcard), so CSPS on Azure is **per-deployment** and subject to the 20-credential-per-app limit (cross-links the existing scaling section).

`index.mdx` is updated to list Azure alongside S3/GCS for CSPS and link the new section.

## Consistency check
- `aws.mdx`: `## Cube Store CSPS bucket` ✅ (existing)
- `azure.mdx`: `## Azure Blob Storage CSPS bucket` ✅ (this PR)
- `index.mdx`: CSPS section now links AWS, GCP, and Azure ✅

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)