### PR TITLE
fix(tesseract): pre-aggregation table name corruption when one name is a prefix of another

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -426,10 +426,24 @@ export class QueryCache {
     const [keyQuery, params, queryOptions] = Array.isArray(queryAndParams)
       ? queryAndParams
       : [queryAndParams, []];
-    const replacedKeyQuery: string = preAggregationsTablesToTempTables.reduce(
-      (query, [tableName, { targetTableName }]) => QueryCache.replaceAll(tableName, targetTableName, query),
-      keyQuery
+    // Single-pass replacement with longest-first alternation: sequential
+    // per-name replacement would corrupt names that are prefixes of other
+    // names (e.g. `name1` vs `name10`) and rescan already inserted target
+    // names, which contain the source name as a prefix
+    const sorted = [...preAggregationsTablesToTempTables]
+      .sort(([a], [b]) => b.length - a.length);
+    const replacements = new Map(
+      sorted.map(([tableName, { targetTableName }]) => [tableName, targetTableName])
     );
+    const replaceRegex = new RegExp(
+      sorted
+        .map(([tableName]) => tableName.replace(/([/,!\\^${}[\]().*+?|<>\-&])/g, '\\$&'))
+        .join('|'),
+      'g'
+    );
+    const replacedKeyQuery: string = sorted.length
+      ? keyQuery.replace(replaceRegex, (match) => replacements.get(match) as string)
+      : keyQuery;
     return Array.isArray(queryAndParams)
       ? [replacedKeyQuery, params, queryOptions]
       : replacedKeyQuery;

--- a/packages/cubejs-query-orchestrator/test/unit/ReplacePreAggregationTableNames.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/ReplacePreAggregationTableNames.test.ts
@@ -1,0 +1,83 @@
+import { QueryCache } from '../../src';
+import type { PreAggTableToTempTableNames } from '../../src';
+
+describe('QueryCache.replacePreAggregationTableNames', () => {
+  test('replaces a single table name', () => {
+    const result = QueryCache.replacePreAggregationTableNames(
+      'SELECT * FROM dev_pre_aggregations.orders_rollup',
+      [['dev_pre_aggregations.orders_rollup', { targetTableName: 'dev_pre_aggregations.orders_rollup_20250401_abc' }]],
+    );
+    expect(result).toBe('SELECT * FROM dev_pre_aggregations.orders_rollup_20250401_abc');
+  });
+
+  test('does not corrupt names that are prefixes of other names (name1 vs name10)', () => {
+    const baseName = 'dev_pre_aggregations.orders_rollup';
+    const entries: PreAggTableToTempTableNames[] = Array.from(
+      { length: 12 },
+      (_, i): PreAggTableToTempTableNames => [
+        `${baseName}${i}`,
+        { targetTableName: `(SELECT * FROM ${baseName}_20250401_part${i})` },
+      ],
+    );
+    const query = entries
+      .map(([tableName], i) => `SELECT * FROM ${tableName} AS "alias${i}"`)
+      .join(' UNION ALL ');
+
+    const result = QueryCache.replacePreAggregationTableNames(query, entries) as string;
+
+    entries.forEach(([, { targetTableName }], i) => {
+      expect(result).toContain(`${targetTableName} AS "alias${i}"`);
+    });
+    // No stray suffix digits left behind, e.g. `...)0 AS "alias10"`
+    expect(result).not.toMatch(/\)\d+ AS/);
+    expect(result).not.toContain(`${baseName}10`);
+  });
+
+  test('does not match source names inside already inserted target names', () => {
+    // Real-world target shape: tableName + '_' + versions, so the target
+    // of `rollup10` contains `rollup1` as a substring
+    const entries: PreAggTableToTempTableNames[] = [
+      ['pa.rollup1', { targetTableName: 'pa.rollup1_aaa_bbb_111' }],
+      ['pa.rollup10', { targetTableName: 'pa.rollup10_ccc_ddd_222' }],
+    ];
+    const result = QueryCache.replacePreAggregationTableNames(
+      'SELECT * FROM pa.rollup10 JOIN pa.rollup1',
+      entries,
+    );
+    expect(result).toBe('SELECT * FROM pa.rollup10_ccc_ddd_222 JOIN pa.rollup1_aaa_bbb_111');
+  });
+
+  test('keeps params and query options for QueryWithParams input', () => {
+    const result = QueryCache.replacePreAggregationTableNames(
+      ['SELECT * FROM dev_pre_aggregations.orders_rollup WHERE id = ?', ['1'], { external: true }],
+      [['dev_pre_aggregations.orders_rollup', { targetTableName: 'dev_pre_aggregations.orders_rollup_20250401_abc' }]],
+    );
+    expect(result).toEqual([
+      'SELECT * FROM dev_pre_aggregations.orders_rollup_20250401_abc WHERE id = ?',
+      ['1'],
+      { external: true },
+    ]);
+  });
+
+  test('returns query as is for empty replacements', () => {
+    const result = QueryCache.replacePreAggregationTableNames('SELECT 1', []);
+    expect(result).toBe('SELECT 1');
+  });
+
+  test('treats $ in target names literally', () => {
+    const result = QueryCache.replacePreAggregationTableNames(
+      'SELECT * FROM pa.rollup',
+      [['pa.rollup', { targetTableName: 'pa.rollup_$&_$1' }]],
+    );
+    expect(result).toBe('SELECT * FROM pa.rollup_$&_$1');
+  });
+
+  test('does not mutate the incoming array order', () => {
+    const entries: PreAggTableToTempTableNames[] = [
+      ['name1', { targetTableName: 'target1' }],
+      ['name10', { targetTableName: 'target10' }],
+    ];
+    QueryCache.replacePreAggregationTableNames('SELECT * FROM name1, name10', entries);
+    expect(entries.map(([tableName]) => tableName)).toEqual(['name1', 'name10']);
+  });
+});


### PR DESCRIPTION
## Summary

`QueryCache.replacePreAggregationTableNames` replaced pre-aggregation placeholder table names sequentially with a global string replace per entry, which corrupts the SQL when one placeholder name is a prefix of another. With per-usage partition pruning (Tesseract), entries are suffixed `name0`..`name10`..., so 11+ usages of the same rollup in one query deterministically produce broken SQL like `(SELECT ...)0 AS "alias"` and fail on CubeStore with `ParserError("Expected: ), found: 0")`.

Sequential replacement is broken in any order: real target names are built as `tableName + '_' + versions` (see `PreAggregations.targetTableName`), so a source name also matches inside already inserted target names of other entries.

## Changes

- Replace all placeholder names in a single pass using one regex alternation (longest names first, since JS alternation matches left-to-right) with a `Map`-based replacement callback — inserted text is never rescanned
- Add unit tests: prefix collision with 11+ suffixed entries, source name inside an inserted target name, `QueryWithParams` passthrough, empty replacements, literal `$` in target names, input array immutability

## Testing

- `yarn jest test/unit/ReplacePreAggregationTableNames.test.ts` — 7 passed; the two collision tests fail against the previous implementation
- Reproduced live with Tesseract (`CUBEJS_TESSERACT_SQL_PLANNER=true`, `CUBEJS_TESSERACT_PRE_AGGREGATIONS=true`) on a query with 10+ multi-stage measures from one view (11 usages of the same rollup); fix verified against that setup