### PR TITLE
fix(pinot): support tesseract select template

### DIFF
--- a/packages/cubejs-pinot-driver/src/PinotQuery.ts
+++ b/packages/cubejs-pinot-driver/src/PinotQuery.ts
@@ -145,12 +145,23 @@ export class PinotQuery extends BaseQuery {
     // epoch-millis representation produced by the timestamp_literal template
     templates.functions.UTCTIMESTAMP = 'NOW()';
     templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
-    templates.statements.select = 'SELECT {{ select_concat | map(attribute=\'aliased\') | join(\', \') }} \n' +
-      'FROM (\n  {{ from }}\n) AS {{ from_alias }} \n' +
-      '{% if group_by %} GROUP BY {{ group_by }}{% endif %}' +
-      '{% if order_by %} ORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}{% endif %}' +
-      '{% if offset %}\nOFFSET {{ offset }}{% endif %}' +
-      '{% if limit %}\nLIMIT {{ limit }}{% endif %}';
+    templates.statements.select = '{% if ctes %} WITH \n' +
+      '{{ ctes | join(\',\n\') }}\n' +
+      '{% endif %}' +
+      'SELECT {% if distinct %}DISTINCT {% endif %}' +
+      '{{ select_concat | map(attribute=\'aliased\') | join(\', \') }} {% if from %}\n' +
+      'FROM (\n' +
+      '{{ from | indent(2, true) }}\n' +
+      ') AS {{ from_alias }}{% elif from_prepared %}\n' +
+      'FROM {{ from_prepared }}' +
+      '{% endif %}' +
+      '{% for join in joins %}\n{{ join }}{% endfor %}' +
+      '{% if filter %}\nWHERE {{ filter }}{% endif %}' +
+      '{% if group_by %}\nGROUP BY {{ group_by }}{% endif %}' +
+      '{% if having %}\nHAVING {{ having }}{% endif %}' +
+      '{% if order_by %}\nORDER BY {{ order_by | map(attribute=\'expr\') | join(\', \') }}{% endif %}' +
+      '{% if offset is not none %}\nOFFSET {{ offset }}{% endif %}' +
+      '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
     templates.expressions.timestamp_literal = `fromDateTime('{{ value }}', ${DATE_TIME_FORMAT})`;
     // NOTE: this template contains a comma; two order expressions are being generated

--- a/packages/cubejs-pinot-driver/test/PinotQueryTemplates.test.ts
+++ b/packages/cubejs-pinot-driver/test/PinotQueryTemplates.test.ts
@@ -1,16 +1,51 @@
+import { prepareCompiler as originalPrepareCompiler } from '@cubejs-backend/schema-compiler';
 import { PinotQuery } from '../src/PinotQuery';
 
-describe('PinotQuery SQL templates', () => {
-  it('supports Tesseract select template variables', () => {
-    const templates = PinotQuery.prototype.sqlTemplates.call({} as PinotQuery);
-    const selectTemplate = templates.statements.select;
+const prepareCompiler = (content: string) => originalPrepareCompiler({
+  localPath: () => __dirname,
+  dataSchemaFiles: () => Promise.resolve([
+    { fileName: 'main.js', content }
+  ])
+}, { adapter: 'postgres' });
 
-    expect(selectTemplate).toContain('from_prepared');
-    expect(selectTemplate).toContain('ctes');
-    expect(selectTemplate).toContain('distinct');
-    expect(selectTemplate).toContain('joins');
-    expect(selectTemplate).toContain('filter');
-    expect(selectTemplate).toContain('having');
-    expect(selectTemplate.indexOf('OFFSET')).toBeLessThan(selectTemplate.indexOf('LIMIT'));
+describe('PinotQuery SQL templates', () => {
+  it('renders Tesseract sql_table queries with a prepared FROM source', async () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareCompiler(`
+      cube('orders', {
+        sql_table: 'orders',
+
+        measures: {
+          count: {
+            type: 'count',
+          },
+        },
+
+        dimensions: {
+          id: {
+            sql: 'id',
+            type: 'number',
+            primary_key: true,
+          },
+        },
+      });
+    `);
+
+    await compiler.compile();
+
+    const query = new PinotQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['orders.count'],
+      timeDimensions: [],
+      filters: [],
+      limit: 10,
+      offset: 5,
+      useNativeSqlPlanner: true,
+    });
+
+    const [sql] = query.buildSqlAndParams();
+
+    expect(sql).toMatch(/FROM\s+orders\b/);
+    expect(sql).not.toMatch(/FROM\s*\(\s*\)\s+AS\b/);
+    expect(sql.indexOf('OFFSET 5')).toBeGreaterThan(-1);
+    expect(sql.indexOf('OFFSET 5')).toBeLessThan(sql.indexOf('LIMIT 10'));
   });
 });

--- a/packages/cubejs-pinot-driver/test/PinotQueryTemplates.test.ts
+++ b/packages/cubejs-pinot-driver/test/PinotQueryTemplates.test.ts
@@ -1,0 +1,16 @@
+import { PinotQuery } from '../src/PinotQuery';
+
+describe('PinotQuery SQL templates', () => {
+  it('supports Tesseract select template variables', () => {
+    const templates = PinotQuery.prototype.sqlTemplates.call({} as PinotQuery);
+    const selectTemplate = templates.statements.select;
+
+    expect(selectTemplate).toContain('from_prepared');
+    expect(selectTemplate).toContain('ctes');
+    expect(selectTemplate).toContain('distinct');
+    expect(selectTemplate).toContain('joins');
+    expect(selectTemplate).toContain('filter');
+    expect(selectTemplate).toContain('having');
+    expect(selectTemplate.indexOf('OFFSET')).toBeLessThan(selectTemplate.indexOf('LIMIT'));
+  });
+});


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #10988

**Description of Changes Made (if issue reference is not provided)**

This updates the Pinot `statements.select` SQL template to support Tesseract planner inputs such as `from_prepared`.

Previously, Pinot overrode the base select template with an older template that only rendered `{{ from }}` and `{{ from_alias }}`. When `CUBEJS_TESSERACT_SQL_PLANNER=true`, Tesseract can pass the source table through `from_prepared`, which caused Pinot SQL for `sql_table` cubes to render an empty subquery:

```sql
FROM (

) AS
```

The Pinot template now preserves the base select template behavior for Tesseract-facing variables, including from_prepared, while *keeping Pinot’s dialect-specific OFFSET before LIMIT ordering* (which is why we can't just use BaseQuery)

This also adds regression coverage for a Pinot sql_table cube using the native SQL planner to verify that generated SQL renders the table source and does not emit an empty FROM () AS clause.