### PR TITLE
docs: update workbook default query row limit to 10,000

### DIFF
--- a/docs/content/product/exploration/workbooks/querying-data.mdx
+++ b/docs/content/product/exploration/workbooks/querying-data.mdx
@@ -18,7 +18,7 @@ Note that chart tables are different from results tables. You can configure pivo
 
 ## Limiting
 
-By default, queries are limited to 5,000 rows of data, but the limit can be adjusted up to 50,000.
+By default, queries are limited to 10,000 rows of data, but the limit can be adjusted up to 50,000.
 
 ## Sorting
 


### PR DESCRIPTION
## What changed

Updates the documented default row limit for workbook semantic queries from **5,000** to **10,000** in `docs/content/product/exploration/workbooks/querying-data.mdx`.

## Why

The default row limit for workbook queries is 10,000; the docs lagged at 5,000. This brings the documentation in line with the current product default.

## Notes for reviewers

- Only the default value changed. The adjustable maximum (50,000) on the same line is unchanged.
- This is the workbook UI limit, distinct from the Core Data API default (`CUBEJS_DB_QUERY_DEFAULT_LIMIT`, documented separately as 10,000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)