### PR TITLE
docs: fix legacy redirect destinations 404ing on docs.cube.dev

### DIFF
--- a/docs-mintlify/scripts/build_old_site_redirects.py
+++ b/docs-mintlify/scripts/build_old_site_redirects.py
@@ -1,144 +1,346 @@
 #!/usr/bin/env python3
 """
 Build the cross-domain redirect table for the OLD docs site (Next.js/Nextra,
-served at cube.dev/docs) so that every legacy URL 301s to the NEW Mintlify
-docs at docs.cube.dev.
+served at cube.dev/docs) so that every legacy URL 301s to the NEW Mintlify docs
+at docs.cube.dev.
 
-The old site already performs server-side redirects via `next.config.mjs` ->
-`redirects()`. This script emits a JSON array of Next.js redirect objects with
-ABSOLUTE destinations (https://docs.cube.dev/...), which `next.config.mjs` reads
-and appends to its `redirects()` return value.
+Why this is content-driven (and not a simple prefix rewrite)
+------------------------------------------------------------
+An earlier version of this script reused ``rewrite_links.PATH_REWRITES`` to map
+old ``/product/...`` paths to new ones. That table described an INTERMEDIATE
+migration layout (``/access-security``, ``/api-reference``, ``/analytics`` tabs
+and ``/docs/data-modeling/reference/...`` pages) that no longer exists — the
+content was later consolidated into the live tabs (``admin``, ``reference``,
+``docs``, ``recipes``, ``embedding``, ``configuration``, ``cube-core``). As a
+result ~76% of the generated destinations 404'd (e.g.
+``/docs/data-modeling/reference/pre-aggregations`` instead of the real
+``/reference/data-modeling/pre-aggregations``).
 
-`basePath: false` is intentionally omitted. Next.js prefixes a redirect's
-`source` with the configured `basePath` (e.g. /docs) only when `basePath` is not
-set to false, while absolute (http/https) destinations are treated as external
-and never get the basePath prepended. Omitting it therefore matches legacy URLs
-under /docs and keeps the cross-domain destination intact.
+To stay correct as the layout evolves, destinations are derived by MATCHING the
+old page's body text against the new Mintlify pages (the new files were copied
+from the old ones during migration, so the prose is preserved even though
+front matter and links were rewritten). Pages that cannot be matched reliably
+(short/list pages, or pages consolidated/removed during migration) are pinned
+explicitly in ``OVERRIDES``.
 
-Two layers are produced, in first-match-wins order:
+Every emitted destination is validated against the on-disk Mintlify tree; the
+script exits non-zero if any destination would 404, so a broken table can never
+be committed silently.
 
-  1. Specific page redirects — every entry from the old `redirects.json`, with
-     its destination rewritten to the new path structure (PATH_REWRITES). These
-     come first so consolidated/renamed pages reach their exact new home.
+Layers produced, in first-match-wins order:
 
-  2. Wildcard prefix redirects — one `/old/prefix/:path*` -> `/new/prefix/:path*`
-     per PATH_REWRITES entry, plus a final `/product/:path*` -> `/docs/:path*`
-     catch-all. These cover the bulk of pages that never needed an explicit
-     redirect before. Next.js supports true wildcards, so subpaths are handled.
+  1. Specific redirects — every entry from the old ``redirects.json`` (legacy
+     aliases) plus one direct redirect per canonical old ``/product/...`` page,
+     each pointing at its verified new home.
+
+  2. A final ``/product/:path*`` catch-all so any legacy ``/product`` URL that
+     isn't enumerated still lands on the new docs instead of 404ing.
+
+``basePath: false`` is intentionally omitted in next.config.mjs. Next.js
+prefixes a redirect's ``source`` with the configured ``basePath`` (``/docs``)
+only when ``basePath`` is not false, while absolute (http/https) destinations
+are treated as external and never get the basePath prepended. Omitting it
+therefore matches legacy URLs under ``/docs`` and keeps the cross-domain
+destination intact.
 
 Usage:
     python build_old_site_redirects.py \
         --redirects ../docs/redirects.json \
+        --old-content ../docs/content/product \
+        --new-root .. \
         -o ../docs/redirects-new-docs.json
 """
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
-from rewrite_links import rewrite_path, PATH_REWRITES
-
 NEW_DOCS_ORIGIN = "https://docs.cube.dev"
 
+# Tabs/dirs that hold real Mintlify pages. Anything else under docs-mintlify/
+# (scripts, images, node_modules, ...) is ignored when indexing/validating.
+NEW_CONTENT_DIRS = {
+    "admin", "configuration", "cube-core", "docs",
+    "embedding", "recipes", "reference",
+}
+
+# Content-match tuning. Shingle = sliding window of N normalized words; the
+# match score is Jaccard overlap of the old and new shingle sets.
+SHINGLE_N = 4
+
+# Pages whose new home cannot be recovered reliably by content matching:
+#   - short/list pages with little distinctive prose, or
+#   - pages consolidated into another page or removed during migration.
+# Keys are old (legacy) URLs; values are root-relative new Mintlify paths that
+# are verified to exist. These take precedence over the content match.
+OVERRIDES = {
+    # AI admin pages renamed/consolidated (mirrors docs.json internal redirects).
+    "/product/administration/ai": "/admin/ai",
+    "/product/administration/ai/agent-rules": "/admin/ai/rules",
+    "/product/administration/ai/spaces-agents-models": "/admin/ai/multi-agent",
+    "/product/administration/ai/yaml-config": "/admin/ai",
+
+    # Monitoring landing (no standalone monitoring index in the new tree).
+    "/product/administration/monitoring": "/admin/monitoring/query-history",
+
+    # Dedicated-infrastructure (old "vpc"/"byoc") networking pages.
+    "/product/administration/deployment/byoc/aws/privatelink": "/admin/deployment/dedicated/aws/private-link",
+    "/product/administration/deployment/vpc": "/admin/deployment/dedicated",
+    "/product/administration/deployment/vpc/aws": "/admin/deployment/dedicated/aws",
+    "/product/administration/deployment/vpc/azure": "/admin/deployment/dedicated/azure",
+    "/product/administration/deployment/vpc/gcp": "/admin/deployment/dedicated/gcp",
+
+    # Okta SSO landing -> SAML page (no standalone Okta index in the new tree).
+    "/product/administration/sso/okta": "/admin/sso/okta/saml",
+
+    # Workspace pages consolidated/removed; fall back to the closest live home.
+    "/product/administration/workspace": "/admin",
+    "/product/administration/workspace/cli": "/admin",
+    "/product/administration/workspace/cli/reference": "/admin",
+    "/product/administration/workspace/preferences": "/admin",
+    "/product/administration/workspace/maintenance-window": "/admin",
+    "/product/administration/workspace/semantic-catalog": "/admin",
+    "/product/administration/workspace/integrations": "/admin/connect-to-data/visualization-tools",
+    "/product/administration/workspace/saved-reports": "/docs/explore-analyze/workbooks",
+
+    # Auth methods moved under the Embedding tab's authentication section;
+    # provider-specific pages without a dedicated new page go to the SSO/auth
+    # landing rather than 404.
+    "/product/auth/methods": "/embedding/authentication/jwt",
+    "/product/auth/methods/identity-provider": "/admin/sso",
+    "/product/auth/methods/name-password": "/embedding/authentication/jwt",
+
+    # Data-modeling concepts landing/short pages.
+    "/product/data-modeling/concepts": "/docs/data-modeling/overview",
+    "/product/data-modeling/concepts/calculated-members": "/docs/data-modeling/measures",
+    "/product/data-modeling/dynamic": "/docs/data-modeling/dynamic",
+    "/product/data-modeling/advanced/code-reusability-export-and-import": "/docs/data-modeling/dynamic/code-reusability-export-and-import",
+    "/product/data-modeling/advanced/polymorphic-cubes": "/recipes/data-modeling/polymorphic-cubes",
+
+    # Data-model reference landing and the removed types-and-formats page.
+    "/product/data-modeling/reference": "/reference",
+    "/product/data-modeling/reference/types-and-formats": "/reference/data-modeling/dimensions",
+
+    # FAQ section removed; send to the docs entry point.
+    "/product/faqs/general": "/docs/introduction",
+    "/product/faqs/tips-and-tricks": "/docs/introduction",
+    "/product/faqs/troubleshooting": "/docs/introduction",
+
+    # Legacy guide alias whose canonical page no longer exists under /product.
+    "/guides/recipes/code-reusability/using-dynamic-measures": "/recipes/data-modeling/using-dynamic-measures",
+
+    # Migrate-from-Core landing (no index; point at the most common path).
+    "/product/getting-started/migrate-from-core": "/docs/getting-started/migrate-from-core/import-github-repository",
+
+    # Metabase semantic-layer sync was removed; send to the sync overview.
+    "/product/apis-integrations/semantic-layer-sync/metabase": "/docs/integrations/semantic-layer-sync",
+}
+
+# Where to send any /product/* URL that matches nothing else.
+PRODUCT_CATCH_ALL = "/docs/introduction"
+
+
+# --------------------------------------------------------------------------- #
+# Content matching
+# --------------------------------------------------------------------------- #
+
+def normalize(text: str) -> str:
+    """Reduce MDX to a bag of prose words, ignoring front matter/markup/links."""
+    text = re.sub(r"^---\n.*?\n---\n", "", text, flags=re.S)      # front matter
+    text = re.sub(r"^(import|export)\s.*$", "", text, flags=re.M)  # JS imports
+    text = re.sub(r"<[^>]+>", " ", text)                           # JSX tags
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)           # [t](url)->t
+    text = re.sub(r"^\[[^\]]+\]:\s*\S+\s*$", "", text, flags=re.M)  # ref links
+    text = text.replace("`", "")
+    text = re.sub(r"[#>*_\-]", " ", text)
+    return re.sub(r"\s+", " ", text).lower().strip()
+
+
+def shingles(text: str) -> set:
+    words = normalize(text).split()
+    if len(words) < SHINGLE_N:
+        return set(words)
+    return {" ".join(words[i:i + SHINGLE_N]) for i in range(len(words) - SHINGLE_N + 1)}
+
+
+def file_to_url(path: Path, root: Path) -> str:
+    """Map a Mintlify .mdx file to its served URL path (root-relative)."""
+    rel = str(path.relative_to(root)).removesuffix(".mdx")
+    rel = re.sub(r"/index$", "", rel)
+    return "/" + rel
+
+
+def index_new_pages(new_root: Path) -> list:
+    """Return [(url, shingle_set, valid_path_set_entry)] for every new page."""
+    pages = []
+    for d in sorted(NEW_CONTENT_DIRS):
+        base = new_root / d
+        if not base.is_dir():
+            continue
+        for f in sorted(base.rglob("*.mdx")):
+            text = f.read_text(encoding="utf-8", errors="ignore")
+            pages.append((file_to_url(f, new_root), shingles(text)))
+    return pages
+
+
+def build_page_map(old_content: Path, new_root: Path, new_pages: list) -> dict:
+    """Map each canonical old /product/... URL to its verified new URL."""
+    page_map = {}
+    for f in sorted(old_content.rglob("*.mdx")):
+        rel = str(f.relative_to(old_content)).removesuffix(".mdx")
+        rel = re.sub(r"/index$", "", rel)
+        old_url = "/product/" + rel if rel else "/product"
+
+        if old_url in OVERRIDES:
+            page_map[old_url] = OVERRIDES[old_url]
+            continue
+
+        osh = shingles(f.read_text(encoding="utf-8", errors="ignore"))
+        best_url, best_score = None, 0.0
+        for nurl, nsh in new_pages:
+            if not osh or not nsh:
+                continue
+            inter = len(osh & nsh)
+            if not inter:
+                continue
+            score = inter / len(osh | nsh)
+            if score > best_score:
+                best_score, best_url = score, nurl
+        if best_url is not None:
+            page_map[old_url] = best_url
+    return page_map
+
+
+# --------------------------------------------------------------------------- #
+# Redirect table assembly
+# --------------------------------------------------------------------------- #
 
 def to_absolute(path: str) -> str:
-    """Turn a root-relative new-site path into an absolute new-docs URL."""
     if path.startswith(("http://", "https://")):
         return path
     return NEW_DOCS_ORIGIN + path
 
 
-def build_specific_redirects(old_redirects: list[dict]) -> list[dict]:
-    """Rewrite each legacy redirect's destination and make it cross-domain."""
-    out = []
+def split_fragment(url: str):
+    if "#" in url:
+        base, frag = url.split("#", 1)
+        return base, "#" + frag
+    return url, ""
+
+
+def resolve_destination(old_dest: str, page_map: dict) -> str:
+    """Resolve a legacy redirect destination to a new (absolute) URL."""
+    if old_dest.startswith(("http://", "https://")):
+        return old_dest  # already external (e.g. blog links)
+
+    base, frag = split_fragment(old_dest)
+    if base in OVERRIDES:
+        new_base = OVERRIDES[base]
+    elif base in page_map:
+        new_base = page_map[base]
+    elif base.startswith("/product/"):
+        new_base = PRODUCT_CATCH_ALL
+    else:
+        new_base = PRODUCT_CATCH_ALL
+    return to_absolute(new_base + frag)
+
+
+def build_redirects(old_redirects: list, page_map: dict) -> list:
+    out, seen = [], set()
+
+    def add(source: str, dest: str):
+        if source in seen:
+            return
+        seen.add(source)
+        out.append({"source": source, "destination": dest, "permanent": True})
+
+    # 1. Legacy aliases from the old redirects.json.
     for r in old_redirects:
-        source = r.get("source", "")
-        destination = rewrite_path(r.get("destination", ""))
-        out.append({
-            "source": source,
-            "destination": to_absolute(destination),
-            "permanent": True,
-        })
+        add(r.get("source", ""), resolve_destination(r.get("destination", ""), page_map))
+
+    # 2. Direct redirects for every canonical old /product page.
+    for old_url, new_url in sorted(page_map.items()):
+        add(old_url, to_absolute(new_url))
+
+    # 3. Catch-all so unmatched /product URLs never 404.
+    add("/product/:path*", to_absolute(PRODUCT_CATCH_ALL))
+
     return out
 
 
-def build_wildcard_redirects() -> list[dict]:
-    """One wildcard per PATH_REWRITES prefix, plus a /product catch-all.
+def valid_url_set(new_root: Path) -> set:
+    urls = set()
+    for d in sorted(NEW_CONTENT_DIRS):
+        base = new_root / d
+        if not base.is_dir():
+            continue
+        for f in base.rglob("*.mdx"):
+            urls.add(file_to_url(f, new_root))
+    return urls
 
-    PATH_REWRITES is already ordered most-specific-first, which is the order
-    Next.js needs for first-match-wins among the wildcards.
-    """
-    out = []
-    for old_prefix, new_prefix in PATH_REWRITES:
-        # Exact prefix (e.g. /product/configuration itself).
-        out.append({
-            "source": old_prefix,
-            "destination": to_absolute(new_prefix),
-            "permanent": True,
-        })
-        # All subpaths under the prefix.
-        out.append({
-            "source": f"{old_prefix}/:path*",
-            "destination": to_absolute(f"{new_prefix}/:path*"),
-            "permanent": True,
-        })
-    # Final catch-all: any remaining /product/* mirrors rewrite_path's default.
-    out.append({
-        "source": "/product",
-        "destination": to_absolute("/docs"),
-        "permanent": True,
-    })
-    out.append({
-        "source": "/product/:path*",
-        "destination": to_absolute("/docs/:path*"),
-        "permanent": True,
-    })
-    return out
+
+def validate(redirects: list, valid: set) -> list:
+    """Return a list of redirects whose destination would 404."""
+    broken = []
+    for r in redirects:
+        dest = r["destination"]
+        if not dest.startswith(NEW_DOCS_ORIGIN):
+            continue  # external destination, not ours to validate
+        path = dest[len(NEW_DOCS_ORIGIN):]
+        base = split_fragment(path)[0]
+        if base.endswith("/:path*"):
+            base = base[:-len("/:path*")]
+        if base in ("", "/"):
+            continue
+        if base not in valid:
+            broken.append((r["source"], path))
+    return broken
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--redirects",
-        default="../docs/redirects.json",
-        help="Path to the old site's redirects.json (default: ../docs/redirects.json)",
-    )
-    parser.add_argument(
-        "-o", "--output",
-        default="../docs/redirects-new-docs.json",
-        help="Output path (default: ../docs/redirects-new-docs.json)",
-    )
+    parser.add_argument("--redirects", default="../docs/redirects.json")
+    parser.add_argument("--old-content", default="../docs/content/product")
+    parser.add_argument("--new-root", default="..")
+    parser.add_argument("-o", "--output", default="../docs/redirects-new-docs.json")
     args = parser.parse_args()
 
     redirects_path = Path(args.redirects)
-    if not redirects_path.exists():
-        print(f"Error: {redirects_path} not found", file=sys.stderr)
-        sys.exit(1)
+    old_content = Path(args.old_content)
+    new_root = Path(args.new_root)
+
+    for p in (redirects_path, old_content, new_root):
+        if not p.exists():
+            print(f"Error: {p} not found", file=sys.stderr)
+            sys.exit(1)
 
     old_redirects = json.loads(redirects_path.read_text(encoding="utf-8"))
-    specific = build_specific_redirects(old_redirects)
-    wildcard = build_wildcard_redirects()
 
-    # Specifics first (exact pages win), wildcards last (catch-all fallbacks).
-    # Drop later duplicate sources so a specific page redirect always wins over
-    # the wildcard prefix's exact-match entry for the same source.
-    combined = []
-    seen = set()
-    for r in specific + wildcard:
-        if r["source"] in seen:
-            continue
-        seen.add(r["source"])
-        combined.append(r)
+    print("Indexing new Mintlify pages...", file=sys.stderr)
+    new_pages = index_new_pages(new_root)
+    print(f"  {len(new_pages)} new pages", file=sys.stderr)
+
+    print("Content-matching old pages to new pages...", file=sys.stderr)
+    page_map = build_page_map(old_content, new_root, new_pages)
+    print(f"  mapped {len(page_map)} old pages", file=sys.stderr)
+
+    redirects = build_redirects(old_redirects, page_map)
+
+    valid = valid_url_set(new_root)
+    broken = validate(redirects, valid)
+    if broken:
+        print(f"\nERROR: {len(broken)} redirect destinations do not resolve:",
+              file=sys.stderr)
+        for s, d in broken[:50]:
+            print(f"  {s}  ->  {d}", file=sys.stderr)
+        sys.exit(2)
 
     Path(args.output).write_text(
-        json.dumps(combined, indent=2) + "\n", encoding="utf-8"
-    )
-    print(
-        f"Wrote {len(combined)} redirects "
-        f"({len(specific)} specific + {len(wildcard)} wildcard) to {args.output}",
-        file=sys.stderr,
-    )
+        json.dumps(redirects, indent=2) + "\n", encoding="utf-8")
+    print(f"\nWrote {len(redirects)} redirects to {args.output} "
+          f"(all destinations validated against the live tree).", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/docs/redirects-new-docs.json
+++ b/docs/redirects-new-docs.json
@@ -1,27 +1,27 @@
 [
   {
     "source": "/product/administration/sso/okta",
-    "destination": "https://docs.cube.dev/access-security/sso/okta/saml",
+    "destination": "https://docs.cube.dev/admin/sso/okta/saml",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/saved-reports",
-    "destination": "https://docs.cube.dev/admin/workspace",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/access-control",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions/custom-roles",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/custom-roles",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/byoc/aws",
-    "destination": "https://docs.cube.dev/admin/deployment/byoc/aws/deployment",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/byoc",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/rest-api/real-time-data-fetch",
-    "destination": "https://docs.cube.dev/api-reference/recipes/real-time-data-fetch",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/real-time-data-fetch",
     "permanent": true
   },
   {
@@ -36,22 +36,22 @@
   },
   {
     "source": "/guides/data-store-cost-saving-guide",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/data-store-cost-saving-guide",
+    "destination": "https://docs.cube.dev/recipes/configuration/data-store-cost-saving-guide",
     "permanent": true
   },
   {
     "source": "/guides/style-guide",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/style-guide",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/style-guide",
     "permanent": true
   },
   {
     "source": "/guides/designing-metrics",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/designing-metrics",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/designing-metrics",
     "permanent": true
   },
   {
     "source": "/guides/dbt",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/dbt",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dbt",
     "permanent": true
   },
   {
@@ -61,12 +61,12 @@
   },
   {
     "source": "/guides/recipes/data-exploration/drilldowns",
-    "destination": "https://docs.cube.dev/api-reference/recipes/drilldowns",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/drilldowns",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-exploration/cast-numerics",
-    "destination": "https://docs.cube.dev/api-reference/recipes/cast-numerics",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/cast-numerics",
     "permanent": true
   },
   {
@@ -76,237 +76,237 @@
   },
   {
     "source": "/guides/recipes/query-acceleration/non-additivity",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/non-additivity",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/non-additivity",
     "permanent": true
   },
   {
     "source": "/guides/recipes/query-acceleration/incrementally-building-pre-aggregations-for-a-date-range",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/incrementally-building-pre-aggregations-for-a-date-range",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/incrementally-building-pre-aggregations-for-a-date-range",
     "permanent": true
   },
   {
     "source": "/guides/recipes/query-acceleration/disabling-pre-aggregations",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/disabling-pre-aggregations",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/disabling-pre-aggregations",
     "permanent": true
   },
   {
     "source": "/guides/recipes/query-acceleration/using-originalsql-and-rollups-effectively",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/using-originalsql-and-rollups-effectively",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/using-originalsql-and-rollups-effectively",
     "permanent": true
   },
   {
     "source": "/guides/recipes/query-acceleration/refreshing-select-partitions",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/refreshing-select-partitions",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/refreshing-select-partitions",
     "permanent": true
   },
   {
     "source": "/guides/recipes/query-acceleration/joining-multiple-data-sources",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/joining-multiple-data-sources",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/joining-multiple-data-sources",
     "permanent": true
   },
   {
     "source": "/guides/recipes/queries/getting-unique-values-for-a-field",
-    "destination": "https://docs.cube.dev/api-reference/recipes/getting-unique-values-for-a-field",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/getting-unique-values-for-a-field",
     "permanent": true
   },
   {
     "source": "/guides/recipes/queries/sorting",
-    "destination": "https://docs.cube.dev/api-reference/recipes/sorting",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/sorting",
     "permanent": true
   },
   {
     "source": "/guides/recipes/queries/pagination",
-    "destination": "https://docs.cube.dev/api-reference/recipes/pagination",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/pagination",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-sources/multiple-sources-same-schema",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/multiple-sources-same-schema",
+    "destination": "https://docs.cube.dev/recipes/configuration/multiple-sources-same-schema",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-sources/using-ssl-connections-to-data-source",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/using-ssl-connections-to-data-source",
+    "destination": "https://docs.cube.dev/recipes/configuration/using-ssl-connections-to-data-source",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/recipes/environment-variables",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/environment-variables",
+    "destination": "https://docs.cube.dev/recipes/configuration/environment-variables",
     "permanent": true
   },
   {
     "source": "/guides/recipes/multitenancy/custom-data-model-per-tenant",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/custom-data-model-per-tenant",
+    "destination": "https://docs.cube.dev/recipes/configuration/custom-data-model-per-tenant",
     "permanent": true
   },
   {
     "source": "/guides/recipes/code-reusability/environment-variables",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/environment-variables",
+    "destination": "https://docs.cube.dev/recipes/configuration/environment-variables",
     "permanent": true
   },
   {
     "source": "/guides/recipes/code-reusability/schema-generation",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/using-dynamic-measures",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/using-dynamic-measures",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/percentiles",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/percentiles",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/percentiles",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/nested-aggregates",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/nested-aggregates",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/nested-aggregates",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/filtered-aggregates",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/filtered-aggregates",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/filtered-aggregates",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/period-over-period",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/period-over-period",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/period-over-period",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/custom-granularity",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/custom-granularity",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/custom-granularity",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/custom-calendar",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/custom-calendar",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/custom-calendar",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/snapshots",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/snapshots",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/snapshots",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/entity-attribute-value",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/entity-attribute-value",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/entity-attribute-value",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/passing-dynamic-parameters-in-a-query",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/passing-dynamic-parameters-in-a-query",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/passing-dynamic-parameters-in-a-query",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/using-dynamic-measures",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/using-dynamic-measures",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/using-dynamic-measures",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/dynamic-union-tables",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/dynamic-union-tables",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dynamic-union-tables",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/string-time-dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/string-time-dimensions",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/string-time-dimensions",
     "permanent": true
   },
   {
     "source": "/guides/recipes/auth/aws-cognito",
-    "destination": "https://docs.cube.dev/access-security/authentication/aws-cognito",
+    "destination": "https://docs.cube.dev/embedding/authentication/aws-cognito",
     "permanent": true
   },
   {
     "source": "/guides/recipes/auth/auth0-guide",
-    "destination": "https://docs.cube.dev/access-security/authentication/auth0",
+    "destination": "https://docs.cube.dev/embedding/authentication/auth0",
     "permanent": true
   },
   {
     "source": "/guides/recipes/auth/sql-api-ldap",
-    "destination": "https://docs.cube.dev/access-security/authentication",
+    "destination": "https://docs.cube.dev/embedding/authentication/jwt",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/aws-cognito",
-    "destination": "https://docs.cube.dev/access-security/authentication/aws-cognito",
+    "destination": "https://docs.cube.dev/embedding/authentication/aws-cognito",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/auth0-guide",
-    "destination": "https://docs.cube.dev/access-security/authentication/auth0",
+    "destination": "https://docs.cube.dev/embedding/authentication/auth0",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/sql-api-ldap",
-    "destination": "https://docs.cube.dev/access-security/authentication",
+    "destination": "https://docs.cube.dev/embedding/authentication/jwt",
     "permanent": true
   },
   {
     "source": "/guides/recipes/access-control/using-different-schemas-for-tenants",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/custom-data-model-per-tenant#loading-from-disk",
+    "destination": "https://docs.cube.dev/recipes/configuration/custom-data-model-per-tenant#loading-from-disk",
     "permanent": true
   },
   {
     "source": "/guides/recipes/access-control/controlling-access-to-cubes-and-views",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#controlling-access-to-cubes-and-views",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#controlling-access-to-cubes-and-views",
     "permanent": true
   },
   {
     "source": "/guides/recipes/access-control/role-based-access",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-role-based-access",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-role-based-access",
     "permanent": true
   },
   {
     "source": "/guides/recipes/access-control/column-based-access",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-column-based-access",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-column-based-access",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/controlling-access-to-cubes-and-views",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#controlling-access-to-cubes-and-views",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#controlling-access-to-cubes-and-views",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/role-based-access",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-role-based-access",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-role-based-access",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/column-based-access",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-column-based-access",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-column-based-access",
     "permanent": true
   },
   {
     "source": "/guides/recipes/access-control/enforcing-mandatory-filters",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-mandatory-filters",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-mandatory-filters",
     "permanent": true
   },
   {
     "source": "/product/auth/recipes/enforcing-mandatory-filters",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-mandatory-filters",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-mandatory-filters",
     "permanent": true
   },
   {
     "source": "/guides/recipes/analytics/xirr",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/xirr",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/xirr",
     "permanent": true
   },
   {
     "source": "/guides/recipes/analytics/funnels",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/funnels",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/funnels",
     "permanent": true
   },
   {
     "source": "/guides/recipes/analytics/cohort-retention",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/cohort-retention",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/cohort-retention",
     "permanent": true
   },
   {
     "source": "/guides/recipes/analytics/event-analytics",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/event-analytics",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/event-analytics",
     "permanent": true
   },
   {
     "source": "/guides/recipes/analytics/active-users",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/active-users",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/active-users",
     "permanent": true
   },
   {
@@ -316,92 +316,92 @@
   },
   {
     "source": "/reference/python/cube",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/cube-package",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube-package",
     "permanent": true
   },
   {
     "source": "/reference/python/lkml2cube",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/lkml2cube",
+    "destination": "https://docs.cube.dev/reference/data-modeling/lkml2cube",
     "permanent": true
   },
   {
     "source": "/reference/python/cube_dbt",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/cube_dbt",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube_dbt",
     "permanent": true
   },
   {
     "source": "/reference/data-model",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference",
+    "destination": "https://docs.cube.dev/reference",
     "permanent": true
   },
   {
     "source": "/reference/data-model/cube",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/cube",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube",
     "permanent": true
   },
   {
     "source": "/reference/data-model/dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/dimensions",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
     "permanent": true
   },
   {
     "source": "/reference/data-model/measures",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/measures",
+    "destination": "https://docs.cube.dev/reference/data-modeling/measures",
     "permanent": true
   },
   {
     "source": "/reference/data-model/joins",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/joins",
+    "destination": "https://docs.cube.dev/reference/data-modeling/joins",
     "permanent": true
   },
   {
     "source": "/reference/data-model/segments",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/segments",
+    "destination": "https://docs.cube.dev/reference/data-modeling/segments",
     "permanent": true
   },
   {
     "source": "/reference/data-model/types-and-formats",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/types-and-formats",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
     "permanent": true
   },
   {
     "source": "/reference/data-model/view",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/view",
+    "destination": "https://docs.cube.dev/reference/data-modeling/view",
     "permanent": true
   },
   {
     "source": "/reference/data-model/hierarchies",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/hierarchies",
+    "destination": "https://docs.cube.dev/reference/data-modeling/hierarchies",
     "permanent": true
   },
   {
     "source": "/reference/data-model/context-variables",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/context-variables",
+    "destination": "https://docs.cube.dev/reference/data-modeling/context-variables",
     "permanent": true
   },
   {
     "source": "/reference/data-model/data-access-policies",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/data-access-policies",
+    "destination": "https://docs.cube.dev/reference/data-modeling/data-access-policies",
     "permanent": true
   },
   {
     "source": "/reference/data-model/pre-aggregations",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/pre-aggregations",
+    "destination": "https://docs.cube.dev/reference/data-modeling/pre-aggregations",
     "permanent": true
   },
   {
     "source": "/reference/configuration/environment-variables",
-    "destination": "https://docs.cube.dev/docs/configuration/reference/environment-variables",
+    "destination": "https://docs.cube.dev/reference/configuration/environment-variables",
     "permanent": true
   },
   {
     "source": "/product/configuration/advanced/multiple-data-sources",
-    "destination": "https://docs.cube.dev/docs/configuration/multiple-data-sources",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/multiple-data-sources",
     "permanent": true
   },
   {
     "source": "/product/configuration/advanced/multitenancy",
-    "destination": "https://docs.cube.dev/docs/configuration/multitenancy",
+    "destination": "https://docs.cube.dev/embedding/multitenancy",
     "permanent": true
   },
   {
@@ -416,62 +416,62 @@
   },
   {
     "source": "/product/apis-integrations/semantic-layer-sync/power-bi",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/powerbi",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/powerbi",
     "permanent": true
   },
   {
     "source": "/reference/frontend/cubejs-client-core",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-core",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-core",
     "permanent": true
   },
   {
     "source": "/reference/frontend/cubejs-client-react",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-react",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-react",
     "permanent": true
   },
   {
     "source": "/reference/frontend/cubejs-client-ngx",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-ngx",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-ngx",
     "permanent": true
   },
   {
     "source": "/reference/frontend/cubejs-client-vue",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-vue",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-vue",
     "permanent": true
   },
   {
     "source": "/reference/frontend/cubejs-client-ws-transport",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-ws-transport",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-ws-transport",
     "permanent": true
   },
   {
     "source": "/reference/cli",
-    "destination": "https://docs.cube.dev/admin/workspace/cli/reference",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/reference/graphql-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/graphql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api/reference",
     "permanent": true
   },
   {
     "source": "/reference/rest-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/reference",
     "permanent": true
   },
   {
     "source": "/reference/sql-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/reference",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/concepts/publicity",
-    "destination": "https://docs.cube.dev/access-security/access-control/member-level-security",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/member-level-security",
     "permanent": true
   },
   {
     "source": "/guides/recipes/data-modeling/fiscal-year-quarter-dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/custom-granularity",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/custom-granularity",
     "permanent": true
   },
   {
@@ -481,42 +481,42 @@
   },
   {
     "source": "/product/monitoring/integrations/cloudwatch",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/cloudwatch",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/cloudwatch",
     "permanent": true
   },
   {
     "source": "/product/monitoring/integrations/s3",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/s3",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/s3",
     "permanent": true
   },
   {
     "source": "/product/monitoring/integrations/datadog",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/datadog",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/datadog",
     "permanent": true
   },
   {
     "source": "/product/monitoring/integrations/grafana-cloud",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/grafana-cloud",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/grafana-cloud",
     "permanent": true
   },
   {
     "source": "/product/monitoring/integrations",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/concepts/subquery-dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calculated-members#subquery-dimensions",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures#subquery-dimensions",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/fundamentals/additional-concepts",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calculated-members#subquery-dimensions",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures#subquery-dimensions",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/advanced/using-dbt",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/dbt",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dbt",
     "permanent": true
   },
   {
@@ -536,7 +536,7 @@
   },
   {
     "source": "/product/data-modeling/fundamentals/syntax",
-    "destination": "https://docs.cube.dev/docs/data-modeling/syntax",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/syntax",
     "permanent": true
   },
   {
@@ -546,17 +546,17 @@
   },
   {
     "source": "/product/data-modeling/fundamentals/concepts",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts",
+    "destination": "https://docs.cube.dev/docs/data-modeling/overview",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/advanced/code-reusability-extending-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/code-reusability-extending-cubes",
+    "destination": "https://docs.cube.dev/docs/data-modeling/extending-cubes",
     "permanent": true
   },
   {
     "source": "/product/data-modeling/fundamentals/working-with-joins",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/working-with-joins",
+    "destination": "https://docs.cube.dev/docs/data-modeling/joins",
     "permanent": true
   },
   {
@@ -586,7 +586,7 @@
   },
   {
     "source": "/workspace/preferences",
-    "destination": "https://docs.cube.dev/admin/workspace/preferences",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
@@ -606,12 +606,12 @@
   },
   {
     "source": "/dev-tools/dev-playground",
-    "destination": "https://docs.cube.dev/analytics/playground",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/playground",
     "permanent": true
   },
   {
     "source": "/cloud/dev-tools/dev-playground",
-    "destination": "https://docs.cube.dev/analytics/playground",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/playground",
     "permanent": true
   },
   {
@@ -631,12 +631,12 @@
   },
   {
     "source": "/using-the-cubejs-cli",
-    "destination": "https://docs.cube.dev/admin/workspace/cli",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/cloud/access-control/",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions/custom-roles",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/custom-roles",
     "permanent": true
   },
   {
@@ -646,17 +646,17 @@
   },
   {
     "source": "/cloud/workspace/alerts",
-    "destination": "https://docs.cube.dev/docs/monitoring",
+    "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   },
   {
     "source": "/cloud/dev-tools/alerts/",
-    "destination": "https://docs.cube.dev/docs/monitoring",
+    "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   },
   {
     "source": "/style-guide",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/style-guide",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/style-guide",
     "permanent": true
   },
   {
@@ -676,72 +676,72 @@
   },
   {
     "source": "/configuration/overview",
-    "destination": "https://docs.cube.dev/docs/configuration",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/config/databases",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources",
     "permanent": true
   },
   {
     "source": "/connecting-to-the-database",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources",
     "permanent": true
   },
   {
     "source": "/config/downstream",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools",
     "permanent": true
   },
   {
     "source": "/caching/using-pre-aggregations",
-    "destination": "https://docs.cube.dev/docs/caching/using-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/using-pre-aggregations",
     "permanent": true
   },
   {
     "source": "/caching/running-in-production",
-    "destination": "https://docs.cube.dev/docs/caching/running-in-production",
+    "destination": "https://docs.cube.dev/cube-core/running-in-production",
     "permanent": true
   },
   {
     "source": "/caching",
-    "destination": "https://docs.cube.dev/docs/caching",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations",
     "permanent": true
   },
   {
     "source": "/caching/pre-aggregations/lambda-pre-aggregations",
-    "destination": "https://docs.cube.dev/docs/caching/lambda-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/lambda-pre-aggregations",
     "permanent": true
   },
   {
     "source": "/caching/pre-aggregations/getting-started",
-    "destination": "https://docs.cube.dev/docs/caching/getting-started-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/getting-started-pre-aggregations",
     "permanent": true
   },
   {
     "source": "/security/context",
-    "destination": "https://docs.cube.dev/access-security/access-control/context",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context",
     "permanent": true
   },
   {
     "source": "/security",
-    "destination": "https://docs.cube.dev/access-security/access-control",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control",
     "permanent": true
   },
   {
     "source": "/apis-integrations",
-    "destination": "https://docs.cube.dev/api-reference",
+    "destination": "https://docs.cube.dev/reference",
     "permanent": true
   },
   {
     "source": "/workspace/sso/",
-    "destination": "https://docs.cube.dev/access-security/sso",
+    "destination": "https://docs.cube.dev/admin/sso",
     "permanent": true
   },
   {
     "source": "/workspace/sso/okta",
-    "destination": "https://docs.cube.dev/access-security/sso/okta",
+    "destination": "https://docs.cube.dev/admin/sso/okta/saml",
     "permanent": true
   },
   {
@@ -751,92 +751,92 @@
   },
   {
     "source": "/deployment/overview",
-    "destination": "https://docs.cube.dev/admin/deployment",
+    "destination": "https://docs.cube.dev/cube-core/architecture",
     "permanent": true
   },
   {
     "source": "/deployment",
-    "destination": "https://docs.cube.dev/admin/deployment",
+    "destination": "https://docs.cube.dev/cube-core/architecture",
     "permanent": true
   },
   {
     "source": "/deployment/guide",
-    "destination": "https://docs.cube.dev/admin/deployment",
+    "destination": "https://docs.cube.dev/cube-core/architecture",
     "permanent": true
   },
   {
     "source": "/schema/reference/view",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/view",
+    "destination": "https://docs.cube.dev/reference/data-modeling/view",
     "permanent": true
   },
   {
     "source": "/schema/reference/types-and-formats",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/types-and-formats",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
     "permanent": true
   },
   {
     "source": "/types-and-formats",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/types-and-formats",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
     "permanent": true
   },
   {
     "source": "/schema/reference/segments",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/segments",
+    "destination": "https://docs.cube.dev/reference/data-modeling/segments",
     "permanent": true
   },
   {
     "source": "/segments",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/segments",
+    "destination": "https://docs.cube.dev/reference/data-modeling/segments",
     "permanent": true
   },
   {
     "source": "/schema/reference/pre-aggregations",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/pre-aggregations",
+    "destination": "https://docs.cube.dev/reference/data-modeling/pre-aggregations",
     "permanent": true
   },
   {
     "source": "/pre-aggregations",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/pre-aggregations",
+    "destination": "https://docs.cube.dev/reference/data-modeling/pre-aggregations",
     "permanent": true
   },
   {
     "source": "/schema/reference/measures",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/measures",
+    "destination": "https://docs.cube.dev/reference/data-modeling/measures",
     "permanent": true
   },
   {
     "source": "/measures",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/measures",
+    "destination": "https://docs.cube.dev/reference/data-modeling/measures",
     "permanent": true
   },
   {
     "source": "/schema/reference/joins",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/joins",
+    "destination": "https://docs.cube.dev/reference/data-modeling/joins",
     "permanent": true
   },
   {
     "source": "/joins",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/joins",
+    "destination": "https://docs.cube.dev/reference/data-modeling/joins",
     "permanent": true
   },
   {
     "source": "/schema/reference/dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/dimensions",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
     "permanent": true
   },
   {
     "source": "/dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/dimensions",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
     "permanent": true
   },
   {
     "source": "/schema/reference/cube",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/cube",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube",
     "permanent": true
   },
   {
     "source": "/cube",
-    "destination": "https://docs.cube.dev/docs/data-modeling/reference/cube",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube",
     "permanent": true
   },
   {
@@ -846,17 +846,17 @@
   },
   {
     "source": "/faqs/troubleshooting",
-    "destination": "https://docs.cube.dev/docs/faqs/troubleshooting",
+    "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   },
   {
     "source": "/faqs/tips-and-tricks",
-    "destination": "https://docs.cube.dev/docs/faqs/tips-and-tricks",
+    "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   },
   {
     "source": "/faqs/general",
-    "destination": "https://docs.cube.dev/docs/faqs/general",
+    "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   },
   {
@@ -871,22 +871,22 @@
   },
   {
     "source": "/schema/advanced/using-dbt",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/dbt",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dbt",
     "permanent": true
   },
   {
     "source": "/schema/advanced/polymorphic-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/advanced/polymorphic-cubes",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/polymorphic-cubes",
     "permanent": true
   },
   {
     "source": "/polymorphic-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/advanced/polymorphic-cubes",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/polymorphic-cubes",
     "permanent": true
   },
   {
     "source": "/recipes/polymorphic-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/advanced/polymorphic-cubes",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/polymorphic-cubes",
     "permanent": true
   },
   {
@@ -916,437 +916,437 @@
   },
   {
     "source": "/schema/advanced/extending-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/code-reusability-extending-cubes",
+    "destination": "https://docs.cube.dev/docs/data-modeling/extending-cubes",
     "permanent": true
   },
   {
     "source": "/extending-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/code-reusability-extending-cubes",
+    "destination": "https://docs.cube.dev/docs/data-modeling/extending-cubes",
     "permanent": true
   },
   {
     "source": "/recipes/extending-cubes",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/code-reusability-extending-cubes",
+    "destination": "https://docs.cube.dev/docs/data-modeling/extending-cubes",
     "permanent": true
   },
   {
     "source": "/schema/advanced/export-import",
-    "destination": "https://docs.cube.dev/docs/data-modeling/advanced/code-reusability-export-and-import",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/code-reusability-export-and-import",
     "permanent": true
   },
   {
     "source": "/export-import",
-    "destination": "https://docs.cube.dev/docs/data-modeling/advanced/code-reusability-export-and-import",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/code-reusability-export-and-import",
     "permanent": true
   },
   {
     "source": "/recipes/export-import",
-    "destination": "https://docs.cube.dev/docs/data-modeling/advanced/code-reusability-export-and-import",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/code-reusability-export-and-import",
     "permanent": true
   },
   {
     "source": "/backend/sql/reference/functions-operators",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/reference#sql-functions-and-operators",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/reference#sql-functions-and-operators",
     "permanent": true
   },
   {
     "source": "/backend/sql/reference/commands",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/reference#sql-commands",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/reference#sql-commands",
     "permanent": true
   },
   {
     "source": "/schema/fundamentals/joins",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/working-with-joins",
+    "destination": "https://docs.cube.dev/docs/data-modeling/joins",
     "permanent": true
   },
   {
     "source": "/direction-of-joins",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/working-with-joins",
+    "destination": "https://docs.cube.dev/docs/data-modeling/joins",
     "permanent": true
   },
   {
     "source": "/many-to-many-relationship",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/working-with-joins",
+    "destination": "https://docs.cube.dev/docs/data-modeling/joins",
     "permanent": true
   },
   {
     "source": "/data-modeling/syntax",
-    "destination": "https://docs.cube.dev/docs/data-modeling/syntax",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/syntax",
     "permanent": true
   },
   {
     "source": "/schema/fundamentals/working-with-yaml",
-    "destination": "https://docs.cube.dev/docs/data-modeling/syntax",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/syntax",
     "permanent": true
   },
   {
     "source": "/schema/getting-started/yaml",
-    "destination": "https://docs.cube.dev/docs/data-modeling/syntax",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/syntax",
     "permanent": true
   },
   {
     "source": "/schema/fundamentals/concepts",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts",
+    "destination": "https://docs.cube.dev/docs/data-modeling/overview",
     "permanent": true
   },
   {
     "source": "/schema/fundamentals/additional-concepts",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calculated-members#subquery-dimensions",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures#subquery-dimensions",
     "permanent": true
   },
   {
     "source": "/drill-downs",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calculated-members#subquery-dimensions",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures#subquery-dimensions",
     "permanent": true
   },
   {
     "source": "/subquery",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calculated-members#subquery-dimensions",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures#subquery-dimensions",
     "permanent": true
   },
   {
     "source": "/working-with-string-time-dimensions",
-    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calculated-members#subquery-dimensions",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures#subquery-dimensions",
     "permanent": true
   },
   {
     "source": "/rest-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/reference",
     "permanent": true
   },
   {
     "source": "/backend/graphql",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/graphql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api/reference",
     "permanent": true
   },
   {
     "source": "/@cubejs-client-vue",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-vue",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-vue",
     "permanent": true
   },
   {
     "source": "/@cubejs-client-ngx",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/reference/cubejs-client-ngx",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-ngx",
     "permanent": true
   },
   {
     "source": "/reference/environment-variables",
-    "destination": "https://docs.cube.dev/docs/configuration/reference/environment-variables",
+    "destination": "https://docs.cube.dev/reference/configuration/environment-variables",
     "permanent": true
   },
   {
     "source": "/config",
-    "destination": "https://docs.cube.dev/docs/configuration/reference/config",
+    "destination": "https://docs.cube.dev/reference/configuration/config",
     "permanent": true
   },
   {
     "source": "/monitoring/integrations",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations",
     "permanent": true
   },
   {
     "source": "/cloud/workspace/logs",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations",
     "permanent": true
   },
   {
     "source": "/monitoring/grafana-cloud",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/grafana-cloud",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/grafana-cloud",
     "permanent": true
   },
   {
     "source": "/monitoring/datadog",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/datadog",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/datadog",
     "permanent": true
   },
   {
     "source": "/cloud/configuration/connecting-with-a-vpc",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated",
     "permanent": true
   },
   {
     "source": "/cloud/configuration/connecting-with-a-vpc/gcp",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/gcp",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/gcp",
     "permanent": true
   },
   {
     "source": "/cloud/configuration/connecting-with-a-vpc/azure",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/azure/vpc-peering",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/vpc-peering",
     "permanent": true
   },
   {
     "source": "/cloud/configuration/connecting-with-a-vpc/aws",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/aws",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws",
     "permanent": true
   },
   {
     "source": "/config/downstream/thoughtspot",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/thoughtspot",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/thoughtspot",
     "permanent": true
   },
   {
     "source": "/config/downstream/tableau",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/tableau",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/tableau",
     "permanent": true
   },
   {
     "source": "/config/downstream/superset",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/superset",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/superset",
     "permanent": true
   },
   {
     "source": "/recipes/using-apache-superset-with-cube-sql",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/superset",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/superset",
     "permanent": true
   },
   {
     "source": "/config/downstream/streamlit",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/streamlit",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/streamlit",
     "permanent": true
   },
   {
     "source": "/config/downstream/retool",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/retool",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/retool",
     "permanent": true
   },
   {
     "source": "/config/downstream/powerbi",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/powerbi",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/powerbi",
     "permanent": true
   },
   {
     "source": "/config/downstream/observable",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/observable",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/observable",
     "permanent": true
   },
   {
     "source": "/config/downstream/metabase",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/metabase",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/metabase",
     "permanent": true
   },
   {
     "source": "/config/downstream/jupyter",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/jupyter",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/jupyter",
     "permanent": true
   },
   {
     "source": "/config/downstream/hex",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/hex",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/hex",
     "permanent": true
   },
   {
     "source": "/config/downstream/deepnote",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/deepnote",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/deepnote",
     "permanent": true
   },
   {
     "source": "/config/downstream/budibase",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/budibase",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/budibase",
     "permanent": true
   },
   {
     "source": "/config/downstream/bubble",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/bubble",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/bubble",
     "permanent": true
   },
   {
     "source": "/config/downstream/appsmith",
-    "destination": "https://docs.cube.dev/docs/configuration/visualization-tools/appsmith",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/appsmith",
     "permanent": true
   },
   {
     "source": "/config/databases/ksqldb",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/ksqldb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/ksqldb",
     "permanent": true
   },
   {
     "source": "/config/databases/trino",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/trino",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/trino",
     "permanent": true
   },
   {
     "source": "/config/databases/snowflake",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/snowflake",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/snowflake",
     "permanent": true
   },
   {
     "source": "/config/databases/sqlite",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/sqlite",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/sqlite",
     "permanent": true
   },
   {
     "source": "/config/databases/questdb",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/questdb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/questdb",
     "permanent": true
   },
   {
     "source": "/config/databases/presto",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/presto",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/presto",
     "permanent": true
   },
   {
     "source": "/config/databases/prestodb",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/presto",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/presto",
     "permanent": true
   },
   {
     "source": "/config/databases/postgres",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/postgres",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/postgres",
     "permanent": true
   },
   {
     "source": "/config/databases/oracle",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/oracle",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/oracle",
     "permanent": true
   },
   {
     "source": "/config/databases/mysql",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/mysql",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/mysql",
     "permanent": true
   },
   {
     "source": "/config/databases/mongodb",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/mongodb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/mongodb",
     "permanent": true
   },
   {
     "source": "/config/databases/materialize",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/materialize",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/materialize",
     "permanent": true
   },
   {
     "source": "/config/databases/mssql",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/ms-sql",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/ms-sql",
     "permanent": true
   },
   {
     "source": "/config/databases/hive-sparksql",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/hive",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/hive",
     "permanent": true
   },
   {
     "source": "/config/databases/google-bigquery",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/google-bigquery",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/google-bigquery",
     "permanent": true
   },
   {
     "source": "/config/databases/firebolt",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/firebolt",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/firebolt",
     "permanent": true
   },
   {
     "source": "/config/databases/elasticsearch",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/elasticsearch",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/elasticsearch",
     "permanent": true
   },
   {
     "source": "/config/databases/druid",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/druid",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/druid",
     "permanent": true
   },
   {
     "source": "/config/databases/databricks/jdbc",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/databricks-jdbc",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/databricks-jdbc",
     "permanent": true
   },
   {
     "source": "/config/databases/clickhouse",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/clickhouse",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/clickhouse",
     "permanent": true
   },
   {
     "source": "/config/databases/aws-redshift",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/aws-redshift",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/aws-redshift",
     "permanent": true
   },
   {
     "source": "/config/databases/aws-athena",
-    "destination": "https://docs.cube.dev/docs/configuration/data-sources/aws-athena",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/aws-athena",
     "permanent": true
   },
   {
     "source": "/config/multitenancy",
-    "destination": "https://docs.cube.dev/docs/configuration/multitenancy",
+    "destination": "https://docs.cube.dev/embedding/multitenancy",
     "permanent": true
   },
   {
     "source": "/config/multiple-data-sources",
-    "destination": "https://docs.cube.dev/docs/configuration/multiple-data-sources",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/multiple-data-sources",
     "permanent": true
   },
   {
     "source": "/backend/sql",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api",
     "permanent": true
   },
   {
     "source": "/backend/sql/reference/joins",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/joins",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/joins",
     "permanent": true
   },
   {
     "source": "/backend/sql/security",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/security",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/security",
     "permanent": true
   },
   {
     "source": "/real-time-data-fetch",
-    "destination": "https://docs.cube.dev/api-reference/recipes/real-time-data-fetch",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/real-time-data-fetch",
     "permanent": true
   },
   {
     "source": "/query-format",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api/query-format",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/query-format",
     "permanent": true
   },
   {
     "source": "/http-api/rest",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api",
     "permanent": true
   },
   {
     "source": "/orchestration-api/prefect",
-    "destination": "https://docs.cube.dev/api-reference/orchestration-api/prefect",
+    "destination": "https://docs.cube.dev/reference/orchestration-api/prefect",
     "permanent": true
   },
   {
     "source": "/orchestration-api",
-    "destination": "https://docs.cube.dev/api-reference/orchestration-api",
+    "destination": "https://docs.cube.dev/reference/orchestration-api",
     "permanent": true
   },
   {
     "source": "/orchestration-api/dagster",
-    "destination": "https://docs.cube.dev/api-reference/orchestration-api/dagster",
+    "destination": "https://docs.cube.dev/reference/orchestration-api/dagster",
     "permanent": true
   },
   {
     "source": "/orchestration-api/airflow",
-    "destination": "https://docs.cube.dev/api-reference/orchestration-api/airflow",
+    "destination": "https://docs.cube.dev/reference/orchestration-api/airflow",
     "permanent": true
   },
   {
     "source": "/http-api/graphql",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/graphql-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api",
     "permanent": true
   },
   {
     "source": "/frontend-introduction",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk",
     "permanent": true
   },
   {
     "source": "/frontend-introduction/vue",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/vue",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/vue",
     "permanent": true
   },
   {
     "source": "/frontend-introduction/react",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/react",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/react",
     "permanent": true
   },
   {
     "source": "/frontend-introduction/angular",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/angular",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/angular",
     "permanent": true
   },
   {
@@ -1356,7 +1356,7 @@
   },
   {
     "source": "/cloud/pricing",
-    "destination": "https://docs.cube.dev/admin/pricing",
+    "destination": "https://docs.cube.dev/admin/account-billing/pricing",
     "permanent": true
   },
   {
@@ -1391,37 +1391,37 @@
   },
   {
     "source": "/getting-started/core/learn-more",
-    "destination": "https://docs.cube.dev/docs/getting-started/core/learn-more",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/learn-more",
     "permanent": true
   },
   {
     "source": "/getting-started/core/add-a-pre-aggregation",
-    "destination": "https://docs.cube.dev/docs/getting-started/core/add-a-pre-aggregation",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/add-a-pre-aggregation",
     "permanent": true
   },
   {
     "source": "/getting-started/core/query-data",
-    "destination": "https://docs.cube.dev/docs/getting-started/core/query-data",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/query-data",
     "permanent": true
   },
   {
     "source": "/getting-started/core/create-a-project",
-    "destination": "https://docs.cube.dev/docs/getting-started/core/create-a-project",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/create-a-project",
     "permanent": true
   },
   {
     "source": "/getting-started/core/overview",
-    "destination": "https://docs.cube.dev/docs/getting-started/core",
+    "destination": "https://docs.cube.dev/cube-core/getting-started",
     "permanent": true
   },
   {
     "source": "/getting-started-docker",
-    "destination": "https://docs.cube.dev/docs/getting-started/core",
+    "destination": "https://docs.cube.dev/cube-core/getting-started",
     "permanent": true
   },
   {
     "source": "/getting-started/docker",
-    "destination": "https://docs.cube.dev/docs/getting-started/core",
+    "destination": "https://docs.cube.dev/cube-core/getting-started",
     "permanent": true
   },
   {
@@ -1456,27 +1456,27 @@
   },
   {
     "source": "/cloud/getting-started/cli",
-    "destination": "https://docs.cube.dev/docs/getting-started/migrate-from-core/upload-with-cli",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/upload-with-cli",
     "permanent": true
   },
   {
     "source": "/cloud/getting-started/ssh/gitlab",
-    "destination": "https://docs.cube.dev/docs/getting-started/migrate-from-core/import-gitlab-repository-via-ssh",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-gitlab-repository-via-ssh",
     "permanent": true
   },
   {
     "source": "/cloud/getting-started/github",
-    "destination": "https://docs.cube.dev/docs/getting-started/migrate-from-core/import-github-repository",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-github-repository",
     "permanent": true
   },
   {
     "source": "/cloud/getting-started/ssh/git",
-    "destination": "https://docs.cube.dev/docs/getting-started/migrate-from-core/import-git-repository-via-ssh",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-git-repository-via-ssh",
     "permanent": true
   },
   {
     "source": "/cloud/getting-started/ssh/bitbucket",
-    "destination": "https://docs.cube.dev/docs/getting-started/migrate-from-core/import-bitbucket-repository-via-ssh",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-bitbucket-repository-via-ssh",
     "permanent": true
   },
   {
@@ -1486,207 +1486,207 @@
   },
   {
     "source": "/recipes/using-originalsql-and-rollups-effectively",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/using-originalsql-and-rollups-effectively",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/using-originalsql-and-rollups-effectively",
     "permanent": true
   },
   {
     "source": "/recipes/non-additivity",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/non-additivity",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/non-additivity",
     "permanent": true
   },
   {
     "source": "/recipes/joining-multiple-data-sources",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/joining-multiple-data-sources",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/joining-multiple-data-sources",
     "permanent": true
   },
   {
     "source": "/recipes/incrementally-building-pre-aggregations-for-a-date-range",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/incrementally-building-pre-aggregations-for-a-date-range",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/incrementally-building-pre-aggregations-for-a-date-range",
     "permanent": true
   },
   {
     "source": "/recipes/refreshing-select-partitions",
-    "destination": "https://docs.cube.dev/docs/caching/recipes/refreshing-select-partitions",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/refreshing-select-partitions",
     "permanent": true
   },
   {
     "source": "/recipes/pagination",
-    "destination": "https://docs.cube.dev/api-reference/recipes/pagination",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/pagination",
     "permanent": true
   },
   {
     "source": "/recipes/getting-unique-values-for-a-field",
-    "destination": "https://docs.cube.dev/api-reference/recipes/getting-unique-values-for-a-field",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/getting-unique-values-for-a-field",
     "permanent": true
   },
   {
     "source": "/recipes/enforcing-mandatory-filters",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-mandatory-filters",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-mandatory-filters",
     "permanent": true
   },
   {
     "source": "/recipes/enable-ssl-connections-to-database",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/using-ssl-connections-to-data-source",
+    "destination": "https://docs.cube.dev/recipes/configuration/using-ssl-connections-to-data-source",
     "permanent": true
   },
   {
     "source": "/recipes/multiple-sources-same-schema",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/multiple-sources-same-schema",
+    "destination": "https://docs.cube.dev/recipes/configuration/multiple-sources-same-schema",
     "permanent": true
   },
   {
     "source": "/recipes/authn-with-auth0",
-    "destination": "https://docs.cube.dev/access-security/authentication/auth0",
+    "destination": "https://docs.cube.dev/embedding/authentication/auth0",
     "permanent": true
   },
   {
     "source": "/security/jwt/auth0",
-    "destination": "https://docs.cube.dev/access-security/authentication/auth0",
+    "destination": "https://docs.cube.dev/embedding/authentication/auth0",
     "permanent": true
   },
   {
     "source": "/recipes/authn-with-aws-cognito",
-    "destination": "https://docs.cube.dev/access-security/authentication/aws-cognito",
+    "destination": "https://docs.cube.dev/embedding/authentication/aws-cognito",
     "permanent": true
   },
   {
     "source": "/security/jwt/aws-cognito",
-    "destination": "https://docs.cube.dev/access-security/authentication/aws-cognito",
+    "destination": "https://docs.cube.dev/embedding/authentication/aws-cognito",
     "permanent": true
   },
   {
     "source": "/recipes/referencing-dynamic-measures",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/using-dynamic-measures",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/using-dynamic-measures",
     "permanent": true
   },
   {
     "source": "/recipes/snapshots",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/snapshots",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/snapshots",
     "permanent": true
   },
   {
     "source": "/recipes/percentiles",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/percentiles",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/percentiles",
     "permanent": true
   },
   {
     "source": "/recipes/passing-dynamic-parameters-in-a-query",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/passing-dynamic-parameters-in-a-query",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/passing-dynamic-parameters-in-a-query",
     "permanent": true
   },
   {
     "source": "/recipes/entity-attribute-value",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/entity-attribute-value",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/entity-attribute-value",
     "permanent": true
   },
   {
     "source": "/recipes/dynamically-union-tables",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/dynamic-union-tables",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dynamic-union-tables",
     "permanent": true
   },
   {
     "source": "/dynamically-union-tables",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/dynamic-union-tables",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dynamic-union-tables",
     "permanent": true
   },
   {
     "source": "/recipes/schema-generation",
-    "destination": "https://docs.cube.dev/guides/recipes/code-reusability/using-dynamic-measures",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/using-dynamic-measures",
     "permanent": true
   },
   {
     "source": "/schema-generation",
-    "destination": "https://docs.cube.dev/guides/recipes/code-reusability/using-dynamic-measures",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/using-dynamic-measures",
     "permanent": true
   },
   {
     "source": "/recipes/funnels",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/funnels",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/funnels",
     "permanent": true
   },
   {
     "source": "/funnels",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/funnels",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/funnels",
     "permanent": true
   },
   {
     "source": "/recipes/event-analytics",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/event-analytics",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/event-analytics",
     "permanent": true
   },
   {
     "source": "/event-analytics",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/event-analytics",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/event-analytics",
     "permanent": true
   },
   {
     "source": "/recipes/cohort-retention",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/cohort-retention",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/cohort-retention",
     "permanent": true
   },
   {
     "source": "/cohort-retention",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/cohort-retention",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/cohort-retention",
     "permanent": true
   },
   {
     "source": "/recipes/active-users",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/active-users",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/active-users",
     "permanent": true
   },
   {
     "source": "/active-users",
-    "destination": "https://docs.cube.dev/docs/data-modeling/recipes/active-users",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/active-users",
     "permanent": true
   },
   {
     "source": "/recipes/using-different-schemas-for-tenants",
-    "destination": "https://docs.cube.dev/docs/configuration/recipes/custom-data-model-per-tenant#loading-from-disk",
+    "destination": "https://docs.cube.dev/recipes/configuration/custom-data-model-per-tenant#loading-from-disk",
     "permanent": true
   },
   {
     "source": "/recipes/role-based-access",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-role-based-access",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-role-based-access",
     "permanent": true
   },
   {
     "source": "/recipes/controlling-access-to-cubes-and-views",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#controlling-access-to-cubes-and-views",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#controlling-access-to-cubes-and-views",
     "permanent": true
   },
   {
     "source": "/recipes/column-based-access",
-    "destination": "https://docs.cube.dev/access-security/access-control/context#enforcing-column-based-access",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context#enforcing-column-based-access",
     "permanent": true
   },
   {
     "source": "/reference/configuration/config",
-    "destination": "https://docs.cube.dev/docs/configuration/reference/config",
+    "destination": "https://docs.cube.dev/reference/configuration/config",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/azure",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/azure/vpc-peering",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/vpc-peering",
     "permanent": true
   },
   {
     "source": "/product/workspace",
-    "destination": "https://docs.cube.dev/admin/workspace",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/product/workspace/access-control",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions/custom-roles",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/custom-roles",
     "permanent": true
   },
   {
     "source": "/product/workspace/api-keys",
-    "destination": "https://docs.cube.dev/admin/api-keys",
+    "destination": "https://docs.cube.dev/admin/account-billing/api-keys",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/api-keys",
-    "destination": "https://docs.cube.dev/admin/api-keys",
+    "destination": "https://docs.cube.dev/admin/account-billing/api-keys",
     "permanent": true
   },
   {
@@ -1721,12 +1721,12 @@
   },
   {
     "source": "/product/workspace/budgets",
-    "destination": "https://docs.cube.dev/admin/budgets",
+    "destination": "https://docs.cube.dev/admin/account-billing/budgets",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/budgets",
-    "destination": "https://docs.cube.dev/admin/budgets",
+    "destination": "https://docs.cube.dev/admin/account-billing/budgets",
     "permanent": true
   },
   {
@@ -1736,12 +1736,12 @@
   },
   {
     "source": "/product/workspace/cli",
-    "destination": "https://docs.cube.dev/admin/workspace/cli",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/product/workspace/cli/reference",
-    "destination": "https://docs.cube.dev/admin/workspace/cli/reference",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
@@ -1786,67 +1786,67 @@
   },
   {
     "source": "/product/workspace/integrations",
-    "destination": "https://docs.cube.dev/admin/workspace/integrations",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools",
     "permanent": true
   },
   {
     "source": "/product/workspace/monitoring",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/monitoring",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/monitoring/cloudwatch",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/cloudwatch",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/cloudwatch",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/monitoring/s3",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/s3",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/s3",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/monitoring/datadog",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/datadog",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/datadog",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/monitoring/grafana-cloud",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/grafana-cloud",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/grafana-cloud",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/monitoring/new-relic",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/new-relic",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/new-relic",
     "permanent": true
   },
   {
     "source": "/product/workspace/monitoring/cloudwatch",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/cloudwatch",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/cloudwatch",
     "permanent": true
   },
   {
     "source": "/product/workspace/monitoring/datadog",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/datadog",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/datadog",
     "permanent": true
   },
   {
     "source": "/product/workspace/monitoring/grafana-cloud",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/grafana-cloud",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/grafana-cloud",
     "permanent": true
   },
   {
     "source": "/product/workspace/monitoring/new-relic",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/new-relic",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/new-relic",
     "permanent": true
   },
   {
     "source": "/product/workspace/monitoring/s3",
-    "destination": "https://docs.cube.dev/admin/deployment/monitoring/s3",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/s3",
     "permanent": true
   },
   {
@@ -1856,12 +1856,12 @@
   },
   {
     "source": "/product/workspace/playground",
-    "destination": "https://docs.cube.dev/analytics/playground",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/playground",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/playground",
-    "destination": "https://docs.cube.dev/analytics/playground",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/playground",
     "permanent": true
   },
   {
@@ -1871,7 +1871,7 @@
   },
   {
     "source": "/product/workspace/preferences",
-    "destination": "https://docs.cube.dev/admin/workspace/preferences",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
@@ -1901,12 +1901,12 @@
   },
   {
     "source": "/product/workspace/saved-reports",
-    "destination": "https://docs.cube.dev/admin/workspace/saved-reports",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/workbooks",
     "permanent": true
   },
   {
     "source": "/product/workspace/semantic-catalog",
-    "destination": "https://docs.cube.dev/admin/workspace/semantic-catalog",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
@@ -1921,42 +1921,42 @@
   },
   {
     "source": "/product/workspace/sso",
-    "destination": "https://docs.cube.dev/access-security/sso",
+    "destination": "https://docs.cube.dev/admin/sso",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/sso",
-    "destination": "https://docs.cube.dev/access-security/sso",
+    "destination": "https://docs.cube.dev/admin/sso",
     "permanent": true
   },
   {
     "source": "/product/workspace/sso/google-workspace",
-    "destination": "https://docs.cube.dev/access-security/sso/google-workspace",
+    "destination": "https://docs.cube.dev/admin/sso/google-workspace",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/sso/google-workspace",
-    "destination": "https://docs.cube.dev/access-security/sso/google-workspace",
+    "destination": "https://docs.cube.dev/admin/sso/google-workspace",
     "permanent": true
   },
   {
     "source": "/product/workspace/sso/microsoft-entra-id",
-    "destination": "https://docs.cube.dev/access-security/sso/microsoft-entra-id",
+    "destination": "https://docs.cube.dev/admin/sso/microsoft-entra-id",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/sso/microsoft-entra-id",
-    "destination": "https://docs.cube.dev/access-security/sso/microsoft-entra-id",
+    "destination": "https://docs.cube.dev/admin/sso/microsoft-entra-id",
     "permanent": true
   },
   {
     "source": "/product/workspace/sso/okta",
-    "destination": "https://docs.cube.dev/access-security/sso/okta",
+    "destination": "https://docs.cube.dev/admin/sso/okta/saml",
     "permanent": true
   },
   {
     "source": "/product/administration/workspace/sso/okta",
-    "destination": "https://docs.cube.dev/access-security/sso/okta",
+    "destination": "https://docs.cube.dev/admin/sso/okta/saml",
     "permanent": true
   },
   {
@@ -1976,7 +1976,7 @@
   },
   {
     "source": "/product/deployment",
-    "destination": "https://docs.cube.dev/admin/deployment",
+    "destination": "https://docs.cube.dev/cube-core/architecture",
     "permanent": true
   },
   {
@@ -1991,27 +1991,27 @@
   },
   {
     "source": "/product/deployment/cloud/byoc",
-    "destination": "https://docs.cube.dev/admin/deployment/byoc",
+    "destination": "https://docs.cube.dev/admin/deployment/infrastructure",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/byoc/aws/deployment",
-    "destination": "https://docs.cube.dev/admin/deployment/byoc/aws/deployment",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/byoc",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/byoc/aws/privatelink",
-    "destination": "https://docs.cube.dev/admin/deployment/byoc/aws/privatelink",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/private-link",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/byoc/azure",
-    "destination": "https://docs.cube.dev/admin/deployment/byoc/azure",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/byoc",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/byoc/gcp/deployment",
-    "destination": "https://docs.cube.dev/admin/deployment/byoc/gcp/deployment",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/gcp/byoc",
     "permanent": true
   },
   {
@@ -2031,7 +2031,7 @@
   },
   {
     "source": "/product/deployment/cloud/deployments",
-    "destination": "https://docs.cube.dev/admin/deployment/deployments",
+    "destination": "https://docs.cube.dev/admin/deployment",
     "permanent": true
   },
   {
@@ -2046,12 +2046,12 @@
   },
   {
     "source": "/product/deployment/cloud/pricing",
-    "destination": "https://docs.cube.dev/admin/pricing",
+    "destination": "https://docs.cube.dev/admin/account-billing/pricing",
     "permanent": true
   },
   {
     "source": "/product/administration/deployment/pricing",
-    "destination": "https://docs.cube.dev/admin/pricing",
+    "destination": "https://docs.cube.dev/admin/account-billing/pricing",
     "permanent": true
   },
   {
@@ -2081,42 +2081,42 @@
   },
   {
     "source": "/product/deployment/cloud/support",
-    "destination": "https://docs.cube.dev/admin/deployment/support",
+    "destination": "https://docs.cube.dev/admin/account-billing/support",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/aws",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/aws",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/aws/private-link",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/aws/private-link",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/private-link",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/aws/vpc-peering",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/aws/vpc-peering",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/vpc-peering",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/azure/private-link",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/azure/private-link",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/private-link",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/azure/vpc-peering",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/azure/vpc-peering",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/vpc-peering",
     "permanent": true
   },
   {
     "source": "/product/deployment/cloud/vpc/gcp",
-    "destination": "https://docs.cube.dev/admin/deployment/vpc/gcp",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/gcp",
     "permanent": true
   },
   {
@@ -2141,12 +2141,12 @@
   },
   {
     "source": "/product/administration",
-    "destination": "https://docs.cube.dev/admin/workspace",
+    "destination": "https://docs.cube.dev/admin",
     "permanent": true
   },
   {
     "source": "/product/presentation",
-    "destination": "https://docs.cube.dev/analytics/dashboards",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/dashboards",
     "permanent": true
   },
   {
@@ -2156,32 +2156,32 @@
   },
   {
     "source": "/product/presentation/embedding/private-embedding",
-    "destination": "https://docs.cube.dev/embedding/private-embedding",
+    "destination": "https://docs.cube.dev/embedding/iframe/auth/private",
     "permanent": true
   },
   {
     "source": "/product/presentation/embedding/signed-embedding",
-    "destination": "https://docs.cube.dev/embedding/signed-embedding",
+    "destination": "https://docs.cube.dev/embedding/iframe/auth/signed",
     "permanent": true
   },
   {
     "source": "/product/presentation/embedding/creator-mode",
-    "destination": "https://docs.cube.dev/embedding/creator-mode",
+    "destination": "https://docs.cube.dev/embedding/iframe/creator-mode",
     "permanent": true
   },
   {
     "source": "/product/distribution",
-    "destination": "https://docs.cube.dev/admin/distribution",
+    "destination": "https://docs.cube.dev/admin/account-billing/distribution",
     "permanent": true
   },
   {
     "source": "/product/agentic-analytics/spaces-agents-models",
-    "destination": "https://docs.cube.dev/admin/ai/spaces-agents-models",
+    "destination": "https://docs.cube.dev/admin/ai/multi-agent",
     "permanent": true
   },
   {
     "source": "/product/agentic-analytics/agent-rules",
-    "destination": "https://docs.cube.dev/admin/ai/agent-rules",
+    "destination": "https://docs.cube.dev/admin/ai/rules",
     "permanent": true
   },
   {
@@ -2191,167 +2191,557 @@
   },
   {
     "source": "/product/agentic-analytics/user-attributes",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions/user-attributes",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/user-attributes",
     "permanent": true
   },
   {
     "source": "/product/agentic-analytics/roles-and-permissions",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions/roles-and-permissions",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/roles-and-permissions",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/queries",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/queries",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/queries",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/sql-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/sql-api/joins",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/joins",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/joins",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/sql-api/query-format",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/query-format",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/query-format",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/sql-api/reference",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/reference",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/sql-api/security",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/sql-api/security",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/security",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/dax-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/dax-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/dax-api",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/dax-api/reference",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/dax-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/dax-api/reference",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/mdx-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/mdx-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/mdx-api",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/rest-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/rest-api/query-format",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api/query-format",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/query-format",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/rest-api/reference",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/rest-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/reference",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/graphql-api",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/graphql-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/graphql-api/reference",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/graphql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api/reference",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/chat-api",
-    "destination": "https://docs.cube.dev/api-reference/embed-apis/chat-api",
+    "destination": "https://docs.cube.dev/reference/embed-apis/chat-api",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/core-data-apis",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis",
+    "source": "/product/administration/ai",
+    "destination": "https://docs.cube.dev/admin/ai",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/core-data-apis/:path*",
-    "destination": "https://docs.cube.dev/api-reference/core-data-apis/:path*",
+    "source": "/product/administration/ai/agent-rules",
+    "destination": "https://docs.cube.dev/admin/ai/rules",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/embed-apis",
-    "destination": "https://docs.cube.dev/api-reference/embed-apis",
+    "source": "/product/administration/ai/memory-isolation",
+    "destination": "https://docs.cube.dev/admin/ai/memory-isolation",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/embed-apis/:path*",
-    "destination": "https://docs.cube.dev/api-reference/embed-apis/:path*",
+    "source": "/product/administration/ai/spaces-agents-models",
+    "destination": "https://docs.cube.dev/admin/ai/multi-agent",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/ai/yaml-config",
+    "destination": "https://docs.cube.dev/admin/ai",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/api-keys",
+    "destination": "https://docs.cube.dev/admin/account-billing/api-keys",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/budgets",
+    "destination": "https://docs.cube.dev/admin/account-billing/budgets",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment",
+    "destination": "https://docs.cube.dev/cube-core/architecture",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/auto-suspension",
+    "destination": "https://docs.cube.dev/admin/deployment/auto-suspension",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/byoc",
+    "destination": "https://docs.cube.dev/admin/deployment/infrastructure",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/byoc/aws",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/byoc",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/byoc/aws/deployment",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/byoc",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/byoc/aws/privatelink",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/private-link",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/byoc/azure",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/byoc",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/byoc/gcp/deployment",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/gcp/byoc",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/continuous-deployment",
+    "destination": "https://docs.cube.dev/admin/deployment/continuous-deployment",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/core",
+    "destination": "https://docs.cube.dev/admin/deployment/core",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/custom-domains",
+    "destination": "https://docs.cube.dev/admin/deployment/custom-domains",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/deployment-types",
+    "destination": "https://docs.cube.dev/admin/deployment/deployment-types",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/deployments",
+    "destination": "https://docs.cube.dev/admin/deployment",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/encryption-keys",
+    "destination": "https://docs.cube.dev/admin/deployment/encryption-keys",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/environments",
+    "destination": "https://docs.cube.dev/admin/deployment/environments",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/infrastructure",
+    "destination": "https://docs.cube.dev/admin/deployment/infrastructure",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/limits",
+    "destination": "https://docs.cube.dev/admin/deployment/limits",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/monitoring/cloudwatch",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/cloudwatch",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/monitoring/datadog",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/datadog",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/monitoring/grafana-cloud",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/grafana-cloud",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/monitoring/new-relic",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/new-relic",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/monitoring/s3",
+    "destination": "https://docs.cube.dev/admin/monitoring/monitoring-integrations/s3",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/providers",
+    "destination": "https://docs.cube.dev/admin/deployment/providers",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/providers/aws",
+    "destination": "https://docs.cube.dev/admin/deployment/providers/aws",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/providers/azure",
+    "destination": "https://docs.cube.dev/admin/deployment/providers/azure",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/providers/gcp",
+    "destination": "https://docs.cube.dev/admin/deployment/providers/gcp",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/scalability",
+    "destination": "https://docs.cube.dev/admin/deployment/scalability",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/support",
+    "destination": "https://docs.cube.dev/admin/account-billing/support",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/aws",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/aws/private-link",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/private-link",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/aws/vpc-peering",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/aws/vpc-peering",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/azure",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/azure/private-link",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/private-link",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/azure/vpc-peering",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/azure/vpc-peering",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/vpc/gcp",
+    "destination": "https://docs.cube.dev/admin/deployment/dedicated/gcp",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/deployment/warm-up",
+    "destination": "https://docs.cube.dev/admin/deployment/warm-up",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/distribution",
+    "destination": "https://docs.cube.dev/admin/account-billing/distribution",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring",
+    "destination": "https://docs.cube.dev/admin/monitoring/query-history",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring/audit-log",
+    "destination": "https://docs.cube.dev/admin/monitoring/audit-log",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring/chats-history",
+    "destination": "https://docs.cube.dev/admin/monitoring/chats-history",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring/performance",
+    "destination": "https://docs.cube.dev/admin/monitoring/performance",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring/pre-aggregations",
+    "destination": "https://docs.cube.dev/admin/monitoring/pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring/query-history",
+    "destination": "https://docs.cube.dev/admin/monitoring/query-history",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/monitoring/query-history-export",
+    "destination": "https://docs.cube.dev/admin/monitoring/query-history-export",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/pricing",
+    "destination": "https://docs.cube.dev/admin/account-billing/pricing",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso",
+    "destination": "https://docs.cube.dev/admin/sso",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso/google-workspace",
+    "destination": "https://docs.cube.dev/admin/sso/google-workspace",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso/microsoft-entra-id",
+    "destination": "https://docs.cube.dev/admin/sso/microsoft-entra-id",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso/microsoft-entra-id/saml",
+    "destination": "https://docs.cube.dev/admin/sso/microsoft-entra-id/saml",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso/microsoft-entra-id/scim",
+    "destination": "https://docs.cube.dev/admin/sso/microsoft-entra-id/scim",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso/okta/saml",
+    "destination": "https://docs.cube.dev/admin/sso/okta/saml",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/sso/okta/scim",
+    "destination": "https://docs.cube.dev/admin/sso/okta/scim",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/users-and-permissions",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/manage-users",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/users-and-permissions/custom-roles",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/custom-roles",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/users-and-permissions/roles-and-permissions",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/roles-and-permissions",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/users-and-permissions/user-attributes",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/user-attributes",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/users-and-permissions/user-groups",
+    "destination": "https://docs.cube.dev/admin/users-and-permissions/user-groups",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace/cli",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace/cli/reference",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace/integrations",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace/maintenance-window",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace/preferences",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/administration/workspace/semantic-catalog",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations",
+    "destination": "https://docs.cube.dev/reference",
     "permanent": true
   },
   {
     "source": "/product/apis-integrations/control-plane-api",
-    "destination": "https://docs.cube.dev/api-reference/control-plane-api",
+    "destination": "https://docs.cube.dev/reference/control-plane-api",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/control-plane-api/:path*",
-    "destination": "https://docs.cube.dev/api-reference/control-plane-api/:path*",
+    "source": "/product/apis-integrations/core-data-apis",
+    "destination": "https://docs.cube.dev/reference/core-data-apis",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/orchestration-api",
-    "destination": "https://docs.cube.dev/api-reference/orchestration-api",
+    "source": "/product/apis-integrations/core-data-apis/dax-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/dax-api",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/orchestration-api/:path*",
-    "destination": "https://docs.cube.dev/api-reference/orchestration-api/:path*",
+    "source": "/product/apis-integrations/core-data-apis/dax-api/cross-view-filter",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/dax-api/cross-view-filter",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/javascript-sdk",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk",
+    "source": "/product/apis-integrations/core-data-apis/dax-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/dax-api/reference",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/javascript-sdk/:path*",
-    "destination": "https://docs.cube.dev/api-reference/javascript-sdk/:path*",
+    "source": "/product/apis-integrations/core-data-apis/graphql-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/mcp-server",
-    "destination": "https://docs.cube.dev/api-reference/mcp-server",
+    "source": "/product/apis-integrations/core-data-apis/graphql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/graphql-api/reference",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/mcp-server/:path*",
-    "destination": "https://docs.cube.dev/api-reference/mcp-server/:path*",
+    "source": "/product/apis-integrations/core-data-apis/mdx-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/mdx-api",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/recipes",
-    "destination": "https://docs.cube.dev/api-reference/recipes",
+    "source": "/product/apis-integrations/core-data-apis/queries",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/queries",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/recipes/:path*",
-    "destination": "https://docs.cube.dev/api-reference/recipes/:path*",
+    "source": "/product/apis-integrations/core-data-apis/rest-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/microsoft-excel",
-    "destination": "https://docs.cube.dev/docs/integrations/microsoft-excel",
+    "source": "/product/apis-integrations/core-data-apis/rest-api/query-format",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/query-format",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/microsoft-excel/:path*",
-    "destination": "https://docs.cube.dev/docs/integrations/microsoft-excel/:path*",
+    "source": "/product/apis-integrations/core-data-apis/rest-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/rest-api/reference",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/core-data-apis/sql-api",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/core-data-apis/sql-api/joins",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/joins",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/core-data-apis/sql-api/query-format",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/query-format",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/core-data-apis/sql-api/reference",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/reference",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/core-data-apis/sql-api/security",
+    "destination": "https://docs.cube.dev/reference/core-data-apis/sql-api/security",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/embed-apis",
+    "destination": "https://docs.cube.dev/reference/embed-apis",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/embed-apis/chat-api",
+    "destination": "https://docs.cube.dev/reference/embed-apis/chat-api",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/embed-apis/generate-session",
+    "destination": "https://docs.cube.dev/reference/embed-apis/generate-session",
     "permanent": true
   },
   {
@@ -2360,18 +2750,78 @@
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/google-sheets/:path*",
-    "destination": "https://docs.cube.dev/docs/integrations/google-sheets/:path*",
+    "source": "/product/apis-integrations/javascript-sdk",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/tableau",
-    "destination": "https://docs.cube.dev/docs/integrations/tableau",
+    "source": "/product/apis-integrations/javascript-sdk/angular",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/angular",
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/tableau/:path*",
-    "destination": "https://docs.cube.dev/docs/integrations/tableau/:path*",
+    "source": "/product/apis-integrations/javascript-sdk/react",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/react",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/javascript-sdk/reference/cubejs-client-core",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-core",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/javascript-sdk/reference/cubejs-client-ngx",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-ngx",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/javascript-sdk/reference/cubejs-client-react",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-react",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/javascript-sdk/reference/cubejs-client-vue",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-vue",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/javascript-sdk/reference/cubejs-client-ws-transport",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/reference/cubejs-client-ws-transport",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/javascript-sdk/vue",
+    "destination": "https://docs.cube.dev/reference/javascript-sdk/vue",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/mcp-server",
+    "destination": "https://docs.cube.dev/docs/integrations/mcp-server",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/microsoft-excel",
+    "destination": "https://docs.cube.dev/docs/integrations/microsoft-excel",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/orchestration-api",
+    "destination": "https://docs.cube.dev/reference/orchestration-api",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/orchestration-api/airflow",
+    "destination": "https://docs.cube.dev/reference/orchestration-api/airflow",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/orchestration-api/dagster",
+    "destination": "https://docs.cube.dev/reference/orchestration-api/dagster",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/orchestration-api/prefect",
+    "destination": "https://docs.cube.dev/reference/orchestration-api/prefect",
     "permanent": true
   },
   {
@@ -2380,8 +2830,33 @@
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/power-bi/:path*",
-    "destination": "https://docs.cube.dev/docs/integrations/power-bi/:path*",
+    "source": "/product/apis-integrations/recipes/cast-numerics",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/cast-numerics",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/recipes/drilldowns",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/drilldowns",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/recipes/getting-unique-values-for-a-field",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/getting-unique-values-for-a-field",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/recipes/pagination",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/pagination",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/recipes/real-time-data-fetch",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/real-time-data-fetch",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/recipes/sorting",
+    "destination": "https://docs.cube.dev/recipes/core-data-api/sorting",
     "permanent": true
   },
   {
@@ -2390,8 +2865,23 @@
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/semantic-layer-sync/:path*",
-    "destination": "https://docs.cube.dev/docs/integrations/semantic-layer-sync/:path*",
+    "source": "/product/apis-integrations/semantic-layer-sync/metabase",
+    "destination": "https://docs.cube.dev/docs/integrations/semantic-layer-sync",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/semantic-layer-sync/preset",
+    "destination": "https://docs.cube.dev/docs/integrations/semantic-layer-sync/preset",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/semantic-layer-sync/superset",
+    "destination": "https://docs.cube.dev/docs/integrations/semantic-layer-sync/superset",
+    "permanent": true
+  },
+  {
+    "source": "/product/apis-integrations/semantic-layer-sync/tableau",
+    "destination": "https://docs.cube.dev/docs/integrations/tableau",
     "permanent": true
   },
   {
@@ -2400,78 +2890,748 @@
     "permanent": true
   },
   {
-    "source": "/product/apis-integrations/snowflake-semantic-views/:path*",
-    "destination": "https://docs.cube.dev/docs/integrations/snowflake-semantic-views/:path*",
-    "permanent": true
-  },
-  {
-    "source": "/product/apis-integrations",
-    "destination": "https://docs.cube.dev/api-reference",
-    "permanent": true
-  },
-  {
-    "source": "/product/apis-integrations/:path*",
-    "destination": "https://docs.cube.dev/api-reference/:path*",
-    "permanent": true
-  },
-  {
-    "source": "/product/auth/methods",
-    "destination": "https://docs.cube.dev/access-security/authentication",
-    "permanent": true
-  },
-  {
-    "source": "/product/auth/methods/:path*",
-    "destination": "https://docs.cube.dev/access-security/authentication/:path*",
+    "source": "/product/apis-integrations/tableau",
+    "destination": "https://docs.cube.dev/docs/integrations/tableau",
     "permanent": true
   },
   {
     "source": "/product/auth",
-    "destination": "https://docs.cube.dev/access-security/access-control",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control",
     "permanent": true
   },
   {
-    "source": "/product/auth/:path*",
-    "destination": "https://docs.cube.dev/access-security/access-control/:path*",
+    "source": "/product/auth/context",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/context",
     "permanent": true
   },
   {
-    "source": "/product/administration/sso",
-    "destination": "https://docs.cube.dev/access-security/sso",
+    "source": "/product/auth/data-access-policies",
+    "destination": "https://docs.cube.dev/docs/data-modeling/data-access-policies",
     "permanent": true
   },
   {
-    "source": "/product/administration/sso/:path*",
-    "destination": "https://docs.cube.dev/access-security/sso/:path*",
+    "source": "/product/auth/member-level-security",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/member-level-security",
     "permanent": true
   },
   {
-    "source": "/product/administration/users-and-permissions",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions",
+    "source": "/product/auth/methods",
+    "destination": "https://docs.cube.dev/embedding/authentication/jwt",
     "permanent": true
   },
   {
-    "source": "/product/administration/users-and-permissions/:path*",
-    "destination": "https://docs.cube.dev/access-security/users-and-permissions/:path*",
+    "source": "/product/auth/methods/auth0",
+    "destination": "https://docs.cube.dev/embedding/authentication/auth0",
     "permanent": true
   },
   {
-    "source": "/product/administration/:path*",
-    "destination": "https://docs.cube.dev/admin/:path*",
+    "source": "/product/auth/methods/aws-cognito",
+    "destination": "https://docs.cube.dev/embedding/authentication/aws-cognito",
     "permanent": true
   },
   {
-    "source": "/product/exploration",
-    "destination": "https://docs.cube.dev/analytics",
+    "source": "/product/auth/methods/identity-provider",
+    "destination": "https://docs.cube.dev/admin/sso",
     "permanent": true
   },
   {
-    "source": "/product/exploration/:path*",
-    "destination": "https://docs.cube.dev/analytics/:path*",
+    "source": "/product/auth/methods/jwt",
+    "destination": "https://docs.cube.dev/embedding/authentication/jwt",
     "permanent": true
   },
   {
-    "source": "/product/presentation/:path*",
-    "destination": "https://docs.cube.dev/analytics/:path*",
+    "source": "/product/auth/methods/kerberos",
+    "destination": "https://docs.cube.dev/docs/integrations/power-bi/kerberos",
+    "permanent": true
+  },
+  {
+    "source": "/product/auth/methods/name-password",
+    "destination": "https://docs.cube.dev/embedding/authentication/jwt",
+    "permanent": true
+  },
+  {
+    "source": "/product/auth/methods/ntlm",
+    "destination": "https://docs.cube.dev/docs/integrations/power-bi/ntlm",
+    "permanent": true
+  },
+  {
+    "source": "/product/auth/row-level-security",
+    "destination": "https://docs.cube.dev/docs/data-modeling/access-control/row-level-security",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/getting-started-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/getting-started-pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/lambda-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/lambda-pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/matching-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/matching-pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/recipes/disabling-pre-aggregations",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/disabling-pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/recipes/incrementally-building-pre-aggregations-for-a-date-range",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/incrementally-building-pre-aggregations-for-a-date-range",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/recipes/joining-multiple-data-sources",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/joining-multiple-data-sources",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/recipes/non-additivity",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/non-additivity",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/recipes/refreshing-select-partitions",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/refreshing-select-partitions",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/recipes/using-originalsql-and-rollups-effectively",
+    "destination": "https://docs.cube.dev/recipes/pre-aggregations/using-originalsql-and-rollups-effectively",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/refreshing-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/refreshing-pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/running-in-production",
+    "destination": "https://docs.cube.dev/cube-core/running-in-production",
+    "permanent": true
+  },
+  {
+    "source": "/product/caching/using-pre-aggregations",
+    "destination": "https://docs.cube.dev/docs/pre-aggregations/using-pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration",
+    "destination": "https://docs.cube.dev/admin",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/concurrency",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/concurrency",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/aws-athena",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/aws-athena",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/aws-redshift",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/aws-redshift",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/clickhouse",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/clickhouse",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/databricks-jdbc",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/databricks-jdbc",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/druid",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/druid",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/duckdb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/duckdb",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/elasticsearch",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/elasticsearch",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/firebolt",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/firebolt",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/google-bigquery",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/google-bigquery",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/hive",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/hive",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/ksqldb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/ksqldb",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/materialize",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/materialize",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/mongodb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/mongodb",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/ms-fabric",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/ms-fabric",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/ms-sql",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/ms-sql",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/mysql",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/mysql",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/oracle",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/oracle",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/pinot",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/pinot",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/postgres",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/postgres",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/presto",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/presto",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/questdb",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/questdb",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/risingwave",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/risingwave",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/singlestore",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/singlestore",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/snowflake",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/snowflake",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/sqlite",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/sqlite",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/trino",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/trino",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/data-sources/vertica",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/data-sources/vertica",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/multiple-data-sources",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/multiple-data-sources",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/multitenancy",
+    "destination": "https://docs.cube.dev/embedding/multitenancy",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/recipes/custom-data-model-per-tenant",
+    "destination": "https://docs.cube.dev/recipes/configuration/custom-data-model-per-tenant",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/recipes/data-store-cost-saving-guide",
+    "destination": "https://docs.cube.dev/recipes/configuration/data-store-cost-saving-guide",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/recipes/environment-variables",
+    "destination": "https://docs.cube.dev/recipes/configuration/environment-variables",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/recipes/multiple-sources-same-schema",
+    "destination": "https://docs.cube.dev/recipes/configuration/multiple-sources-same-schema",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/recipes/using-ssl-connections-to-data-source",
+    "destination": "https://docs.cube.dev/recipes/configuration/using-ssl-connections-to-data-source",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/reference/config",
+    "destination": "https://docs.cube.dev/reference/configuration/config",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/reference/environment-variables",
+    "destination": "https://docs.cube.dev/reference/configuration/environment-variables",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/appsmith",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/appsmith",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/bubble",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/bubble",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/budibase",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/budibase",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/deepnote",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/deepnote",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/excel",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/excel",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/google-sheets",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/google-sheets",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/hashboard",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/hashboard",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/hex",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/hex",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/hightouch",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/hightouch",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/jupyter",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/jupyter",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/klipfolio",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/klipfolio",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/langchain",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/langchain",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/looker-studio",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/looker-studio",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/metabase",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/metabase",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/observable",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/observable",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/powerbi",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/powerbi",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/push-ai",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/push-ai",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/qlik-sense",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/qlik-sense",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/quicksight",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/quicksight",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/retool",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/retool",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/rudderstack",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/rudderstack",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/sigma",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/sigma",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/steep",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/steep",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/streamlit",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/streamlit",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/superset",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/superset",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/tableau",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/tableau",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/thoughtspot",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/thoughtspot",
+    "permanent": true
+  },
+  {
+    "source": "/product/configuration/visualization-tools/unity-catalog",
+    "destination": "https://docs.cube.dev/admin/connect-to-data/visualization-tools/unity-catalog",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts",
+    "destination": "https://docs.cube.dev/docs/data-modeling/overview",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/calculated-members",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/calendar-cubes",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/calendar-cubes",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/code-reusability-extending-cubes",
+    "destination": "https://docs.cube.dev/docs/data-modeling/extending-cubes",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/data-blending",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/data-blending",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/multi-fact-queries",
+    "destination": "https://docs.cube.dev/docs/data-modeling/multi-fact-views",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/multi-stage-calculations",
+    "destination": "https://docs.cube.dev/docs/data-modeling/measures",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/polymorphic-cubes",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/polymorphic-cubes",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/concepts/working-with-joins",
+    "destination": "https://docs.cube.dev/docs/data-modeling/joins",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/data-model-ide",
+    "destination": "https://docs.cube.dev/docs/data-modeling/data-model-ide",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/dev-mode",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dev-mode",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/dynamic",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/dynamic/code-reusability-export-and-import",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/code-reusability-export-and-import",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/dynamic/javascript",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/javascript",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/dynamic/jinja",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/jinja",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/dynamic/schema-execution-environment",
+    "destination": "https://docs.cube.dev/docs/data-modeling/dynamic/schema-execution-environment",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/overview",
+    "destination": "https://docs.cube.dev/docs/data-modeling/overview",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/active-users",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/active-users",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/cohort-retention",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/cohort-retention",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/custom-calendar",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/custom-calendar",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/custom-granularity",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/custom-granularity",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/dbt",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dbt",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/designing-metrics",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/designing-metrics",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/dynamic-union-tables",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/dynamic-union-tables",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/entity-attribute-value",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/entity-attribute-value",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/event-analytics",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/event-analytics",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/filtered-aggregates",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/filtered-aggregates",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/funnels",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/funnels",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/nested-aggregates",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/nested-aggregates",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/passing-dynamic-parameters-in-a-query",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/passing-dynamic-parameters-in-a-query",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/percentiles",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/percentiles",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/period-over-period",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/period-over-period",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/snapshots",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/snapshots",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/string-time-dimensions",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/string-time-dimensions",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/style-guide",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/style-guide",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/using-dynamic-measures",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/using-dynamic-measures",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/recipes/xirr",
+    "destination": "https://docs.cube.dev/recipes/data-modeling/xirr",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/context-variables",
+    "destination": "https://docs.cube.dev/reference/data-modeling/context-variables",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/cube",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/cube-package",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube-package",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/cube_dbt",
+    "destination": "https://docs.cube.dev/reference/data-modeling/cube_dbt",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/data-access-policies",
+    "destination": "https://docs.cube.dev/reference/data-modeling/data-access-policies",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/dimensions",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/hierarchies",
+    "destination": "https://docs.cube.dev/reference/data-modeling/hierarchies",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/joins",
+    "destination": "https://docs.cube.dev/reference/data-modeling/joins",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/lkml2cube",
+    "destination": "https://docs.cube.dev/reference/data-modeling/lkml2cube",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/measures",
+    "destination": "https://docs.cube.dev/reference/data-modeling/measures",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/pre-aggregations",
+    "destination": "https://docs.cube.dev/reference/data-modeling/pre-aggregations",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/segments",
+    "destination": "https://docs.cube.dev/reference/data-modeling/segments",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/types-and-formats",
+    "destination": "https://docs.cube.dev/reference/data-modeling/dimensions",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/reference/view",
+    "destination": "https://docs.cube.dev/reference/data-modeling/view",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/sql-runner",
+    "destination": "https://docs.cube.dev/docs/data-modeling/sql-runner",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/syntax",
+    "destination": "https://docs.cube.dev/docs/data-modeling/concepts/syntax",
+    "permanent": true
+  },
+  {
+    "source": "/product/data-modeling/visual-modeler",
+    "destination": "https://docs.cube.dev/docs/data-modeling/visual-modeler",
     "permanent": true
   },
   {
@@ -2480,8 +3640,63 @@
     "permanent": true
   },
   {
-    "source": "/product/embedding/:path*",
-    "destination": "https://docs.cube.dev/embedding/:path*",
+    "source": "/product/embedding/creator-mode",
+    "destination": "https://docs.cube.dev/embedding/iframe/creator-mode",
+    "permanent": true
+  },
+  {
+    "source": "/product/embedding/private-embedding",
+    "destination": "https://docs.cube.dev/embedding/iframe/auth/private",
+    "permanent": true
+  },
+  {
+    "source": "/product/embedding/react-embed-sdk",
+    "destination": "https://docs.cube.dev/embedding/react-embed-sdk",
+    "permanent": true
+  },
+  {
+    "source": "/product/embedding/signed-embedding",
+    "destination": "https://docs.cube.dev/embedding/iframe/auth/signed",
+    "permanent": true
+  },
+  {
+    "source": "/product/embedding/vizard",
+    "destination": "https://docs.cube.dev/embedding/vizard",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/analytics-chat",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/analytics-chat",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/explore",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/explore",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/playground",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/playground",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/workbooks",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/workbooks",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/workbooks/charts",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/charts",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/workbooks/querying-data",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/workbooks/querying-data",
+    "permanent": true
+  },
+  {
+    "source": "/product/exploration/workbooks/source-sql-tabs",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/workbooks/source-sql-tabs",
     "permanent": true
   },
   {
@@ -2490,38 +3705,143 @@
     "permanent": true
   },
   {
-    "source": "/product/getting-started/:path*",
-    "destination": "https://docs.cube.dev/docs/getting-started/:path*",
+    "source": "/product/getting-started/cloud",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud",
     "permanent": true
   },
   {
-    "source": "/product/configuration",
-    "destination": "https://docs.cube.dev/docs/configuration",
+    "source": "/product/getting-started/cloud/connect-to-snowflake",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud/connect-to-snowflake",
     "permanent": true
   },
   {
-    "source": "/product/configuration/:path*",
-    "destination": "https://docs.cube.dev/docs/configuration/:path*",
+    "source": "/product/getting-started/cloud/create-data-model",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud/create-data-model",
     "permanent": true
   },
   {
-    "source": "/product/data-modeling",
-    "destination": "https://docs.cube.dev/docs/data-modeling",
+    "source": "/product/getting-started/cloud/load-data",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud/load-data",
     "permanent": true
   },
   {
-    "source": "/product/data-modeling/:path*",
-    "destination": "https://docs.cube.dev/docs/data-modeling/:path*",
+    "source": "/product/getting-started/cloud/query-from-bi",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud/query-from-bi",
     "permanent": true
   },
   {
-    "source": "/product/caching",
-    "destination": "https://docs.cube.dev/docs/caching",
+    "source": "/product/getting-started/cloud/query-from-react-app",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud/query-from-react-app",
     "permanent": true
   },
   {
-    "source": "/product/caching/:path*",
-    "destination": "https://docs.cube.dev/docs/caching/:path*",
+    "source": "/product/getting-started/connect-your-data",
+    "destination": "https://docs.cube.dev/docs/getting-started/connect-your-data",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/core",
+    "destination": "https://docs.cube.dev/cube-core/getting-started",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/core/add-a-pre-aggregation",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/add-a-pre-aggregation",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/core/create-a-project",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/create-a-project",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/core/learn-more",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/learn-more",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/core/query-data",
+    "destination": "https://docs.cube.dev/cube-core/getting-started/query-data",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/create-workbooks-and-dashboards",
+    "destination": "https://docs.cube.dev/docs/getting-started/create-workbooks-and-dashboards",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/databricks",
+    "destination": "https://docs.cube.dev/docs/getting-started/databricks",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/databricks/connect-to-databricks",
+    "destination": "https://docs.cube.dev/docs/getting-started/databricks/connect-to-databricks",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/databricks/create-data-model",
+    "destination": "https://docs.cube.dev/docs/getting-started/databricks/create-data-model",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/databricks/load-data",
+    "destination": "https://docs.cube.dev/docs/getting-started/databricks/load-data",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/databricks/query-from-bi",
+    "destination": "https://docs.cube.dev/docs/getting-started/databricks/query-from-bi",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/databricks/query-from-react-app",
+    "destination": "https://docs.cube.dev/docs/getting-started/cloud/query-from-react-app",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/develop-in-ide",
+    "destination": "https://docs.cube.dev/docs/getting-started/develop-in-ide",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/embed-analytics",
+    "destination": "https://docs.cube.dev/docs/getting-started/embed-analytics",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/migrate-from-core",
+    "destination": "https://docs.cube.dev/docs/getting-started/migrate-from-core/import-github-repository",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/migrate-from-core/import-bitbucket-repository-via-ssh",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-bitbucket-repository-via-ssh",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/migrate-from-core/import-git-repository-via-ssh",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-git-repository-via-ssh",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/migrate-from-core/import-github-repository",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-github-repository",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/migrate-from-core/import-gitlab-repository-via-ssh",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/import-gitlab-repository-via-ssh",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/migrate-from-core/upload-with-cli",
+    "destination": "https://docs.cube.dev/cube-core/migrate-from-core/upload-with-cli",
+    "permanent": true
+  },
+  {
+    "source": "/product/getting-started/use-analytics-chat",
+    "destination": "https://docs.cube.dev/docs/getting-started/use-analytics-chat",
     "permanent": true
   },
   {
@@ -2530,18 +3850,23 @@
     "permanent": true
   },
   {
-    "source": "/product/introduction/:path*",
-    "destination": "https://docs.cube.dev/docs/introduction/:path*",
+    "source": "/product/presentation/dashboards",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/dashboards",
     "permanent": true
   },
   {
-    "source": "/product",
-    "destination": "https://docs.cube.dev/docs",
+    "source": "/product/presentation/notifications",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/notifications",
+    "permanent": true
+  },
+  {
+    "source": "/product/presentation/scheduled-refreshes",
+    "destination": "https://docs.cube.dev/docs/explore-analyze/scheduled-refreshes",
     "permanent": true
   },
   {
     "source": "/product/:path*",
-    "destination": "https://docs.cube.dev/docs/:path*",
+    "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   }
 ]


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

The cross-domain redirect table from #11002 sent most legacy `cube.dev/docs` URLs to **non-existent** `docs.cube.dev` pages — **386 of 509 destinations (76%) returned 404**, including the pre-aggregations reference page reported internally (`/product/data-modeling/reference/pre-aggregations` → dead `/docs/data-modeling/reference/pre-aggregations` instead of the real `/reference/data-modeling/pre-aggregations`).

**Root cause:** `build_old_site_redirects.py` reused `rewrite_links.PATH_REWRITES`, which describes an *intermediate* migration layout (`/access-security`, `/api-reference`, `/analytics` tabs and `/docs/data-modeling/reference/...` pages) that never shipped. Content was later consolidated into the live tabs (`admin`, `reference`, `docs`, `recipes`, `embedding`, `configuration`, `cube-core`), so the prefix rewrites produced dead URLs.

**Fix — rewrote the generator to be content-driven and self-validating:**
- Derives each destination by **matching the old page's body text against the live Mintlify pages** (new files were copied from the old ones during migration, so prose is preserved). 319 old pages mapped.
- Pins ambiguous / consolidated / removed pages in an explicit `OVERRIDES` table, verified by hand against the real tree.
- Emits a redirect for every legacy alias **and** every canonical `/product/*` page, plus a `/product/:path*` catch-all so nothing 404s.
- **Validates every destination against the on-disk Mintlify tree and exits non-zero if any would 404**, so a broken table can't be committed silently.

**Result:** regenerated `redirects-new-docs.json` (509 → 774 entries, all validated). All 455 original alias sources remain covered.

**Verification:**
- All 774 generated destinations resolve to existing pages (local tree).
- Live production check: the reported pre-aggregations page now returns **200** (was **404**); a 30-destination random sample returned **200** across all section types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)