### PR TITLE
feat(cubestore): unique key filter pushdown below last-row dedup

### DIFF
--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -7386,7 +7386,40 @@ async fn filter_pushdown_unique_key(service: Box<dyn SqlClient>) -> Result<(), C
         "a non-key filter must not reach the parquet pruning predicate:\n{}",
         worker_plan
     );
+
+    // A mixed conjunction splits: the key conjunct goes below the dedup, the non-key one
+    // stays above. The last version of (3, 3) is 50: it fails val <= 25, and the
+    // overwritten (3, 3, 5) must not pass in its place.
+    let query = "SELECT sum(val) FROM s.Versions WHERE a in (2, 3) AND val <= 25";
+    let r = service.exec_query(query).await?;
+    assert_eq!(to_rows(&r), rows(&[(20)]));
+
+    let p = service.plan_query(query).await?;
+    let worker_plan = pp_phys_plan_ext(
+        p.worker.as_ref(),
+        &PPOptions {
+            show_filters: true,
+            ..PPOptions::none()
+        },
+    );
+    assert!(
+        filters_below_scan(&worker_plan) > 0,
+        "the key conjunct must be pushed below the dedup:\n{}",
+        worker_plan
+    );
+    assert!(
+        !below_scan(&worker_plan).contains("val"),
+        "the non-key conjunct must not appear below the dedup:\n{}",
+        worker_plan
+    );
     return Ok(());
+
+    fn below_scan(plan: &str) -> &str {
+        let scan_start = plan
+            .find(scan_line(plan))
+            .expect("scan line is a substring of the plan");
+        &plan[scan_start + scan_line(plan).len()..]
+    }
 
     fn scan_line(plan: &str) -> &str {
         plan.lines()

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -233,6 +233,7 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
             "unique_key_and_multi_partitions_hash_aggregate",
             unique_key_and_multi_partitions_hash_aggregate,
         ),
+        t("filter_pushdown_unique_key", filter_pushdown_unique_key),
         t("divide_by_zero", divide_by_zero),
         t(
             "filter_multiple_in_for_decimal",
@@ -384,6 +385,7 @@ lazy_static::lazy_static! {
         "create_table_with_csv_no_header",
         "create_table_with_csv_no_header_and_delimiter",
         "create_table_with_csv_no_header_and_quotes",
+        "filter_pushdown_unique_key",
     ].into_iter().map(ToOwned::to_owned).collect();
 }
 
@@ -7312,6 +7314,63 @@ async fn unique_key_and_multi_partitions_hash_aggregate(
         .await?;
     assert_eq!(to_rows(&r), rows(&[(1, 190), (2, 240)]));
     Ok(())
+}
+
+/// Filters referencing only unique key columns commute with the last-row deduplication
+/// and get pushed below it onto every scan stream. Filters on non-key columns must stay
+/// above the dedup: they apply to the last version of a row, pushing them down would
+/// resurrect overwritten versions.
+async fn filter_pushdown_unique_key(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA s").await?;
+    service
+        .exec_query("CREATE TABLE s.Versions (a int, b int, val int) unique key (a, b)")
+        .await?;
+
+    service
+        .exec_query(
+            "INSERT INTO s.Versions (a, b, val, __seq) VALUES (1, 1, 10, 1), (2, 2, 20, 2), (3, 3, 5, 3)",
+        )
+        .await?;
+    // Newer versions of (1, 1) and (3, 3) in another chunk
+    service
+        .exec_query("INSERT INTO s.Versions (a, b, val, __seq) VALUES (1, 1, 30, 4), (3, 3, 50, 5)")
+        .await?;
+
+    // A key filter selects whole version groups: only the last version of (1, 1) counts.
+    let query = "SELECT sum(val) FROM s.Versions WHERE a = 1";
+    let r = service.exec_query(query).await?;
+    assert_eq!(to_rows(&r), rows(&[(30)]));
+
+    let p = service.plan_query(query).await?;
+    let worker_plan = pp_phys_plan(p.worker.as_ref());
+    assert!(
+        filters_below_scan(&worker_plan) > 0,
+        "the unique key filter must be pushed below the dedup onto scan streams:\n{}",
+        worker_plan
+    );
+
+    // A non-key filter: the overwritten versions (1, 1, 10) and (3, 3, 5) match val < 25
+    // while their last versions don't. They must not be resurrected.
+    let query = "SELECT sum(val) FROM s.Versions WHERE val < 25";
+    let r = service.exec_query(query).await?;
+    assert_eq!(to_rows(&r), rows(&[(20)]));
+
+    let p = service.plan_query(query).await?;
+    let worker_plan = pp_phys_plan(p.worker.as_ref());
+    assert_eq!(
+        filters_below_scan(&worker_plan),
+        0,
+        "a non-key filter must not be pushed below the dedup:\n{}",
+        worker_plan
+    );
+    return Ok(());
+
+    fn filters_below_scan(plan: &str) -> usize {
+        plan.lines()
+            .skip_while(|l| !l.trim_start().starts_with("Scan"))
+            .filter(|l| l.trim() == "Filter")
+            .count()
+    }
 }
 
 async fn divide_by_zero(service: Box<dyn SqlClient>) -> Result<(), CubeError> {

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -7317,9 +7317,10 @@ async fn unique_key_and_multi_partitions_hash_aggregate(
 }
 
 /// Filters referencing only unique key columns commute with the last-row deduplication
-/// and get pushed below it onto every scan stream. Filters on non-key columns must stay
-/// above the dedup: they apply to the last version of a row, pushing them down would
-/// resurrect overwritten versions.
+/// and get pushed below it: onto every scan stream and into the parquet pruning
+/// predicate. Filters on non-key columns must stay above the dedup and out of pruning:
+/// they apply to the last version of a row, acting on individual versions below the
+/// dedup would resurrect overwritten ones.
 async fn filter_pushdown_unique_key(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
     service.exec_query("CREATE SCHEMA s").await?;
     service
@@ -7342,10 +7343,21 @@ async fn filter_pushdown_unique_key(service: Box<dyn SqlClient>) -> Result<(), C
     assert_eq!(to_rows(&r), rows(&[(30)]));
 
     let p = service.plan_query(query).await?;
-    let worker_plan = pp_phys_plan(p.worker.as_ref());
+    let worker_plan = pp_phys_plan_ext(
+        p.worker.as_ref(),
+        &PPOptions {
+            show_filters: true,
+            ..PPOptions::none()
+        },
+    );
     assert!(
         filters_below_scan(&worker_plan) > 0,
         "the unique key filter must be pushed below the dedup onto scan streams:\n{}",
+        worker_plan
+    );
+    assert!(
+        scan_line(&worker_plan).contains("predicate:"),
+        "the unique key filter must reach the parquet pruning predicate:\n{}",
         worker_plan
     );
 
@@ -7356,19 +7368,39 @@ async fn filter_pushdown_unique_key(service: Box<dyn SqlClient>) -> Result<(), C
     assert_eq!(to_rows(&r), rows(&[(20)]));
 
     let p = service.plan_query(query).await?;
-    let worker_plan = pp_phys_plan(p.worker.as_ref());
+    let worker_plan = pp_phys_plan_ext(
+        p.worker.as_ref(),
+        &PPOptions {
+            show_filters: true,
+            ..PPOptions::none()
+        },
+    );
     assert_eq!(
         filters_below_scan(&worker_plan),
         0,
         "a non-key filter must not be pushed below the dedup:\n{}",
         worker_plan
     );
+    assert!(
+        !scan_line(&worker_plan).contains("predicate:"),
+        "a non-key filter must not reach the parquet pruning predicate:\n{}",
+        worker_plan
+    );
     return Ok(());
+
+    fn scan_line(plan: &str) -> &str {
+        plan.lines()
+            .find(|l| l.trim_start().starts_with("Scan"))
+            .expect("no Scan in the worker plan")
+    }
 
     fn filters_below_scan(plan: &str) -> usize {
         plan.lines()
             .skip_while(|l| !l.trim_start().starts_with("Scan"))
-            .filter(|l| l.trim() == "Filter")
+            .filter(|l| {
+                let l = l.trim_start();
+                l.starts_with("Filter") && !l.starts_with("FilterByKeyRange")
+            })
             .count()
     }
 }

--- a/rust/cubestore/cubestore/src/cluster/message.rs
+++ b/rust/cubestore/cubestore/src/cluster/message.rs
@@ -20,7 +20,8 @@ pub enum NetworkMessage {
     SelectResult(Result<(SchemaRef, Vec<SerializedRecordBatchStream>), CubeError>),
 
     //Perform explain analyze of worker query part and return it pretty printed physical plan
-    ExplainAnalyze(SerializedPlan, WorkerPlanningParams),
+    /// The boolean flag is whether to execute the plan to collect runtime metrics.
+    ExplainAnalyze(SerializedPlan, WorkerPlanningParams, bool),
     ExplainAnalyzeResult(Result<String, CubeError>),
 
     /// Select that sends results in batches. The immediate response is [SelectResultSchema],

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -106,12 +106,13 @@ pub trait Cluster: DIService + Send + Sync {
     ) -> Result<Vec<RecordBatch>, CubeError>;
 
     /// Runs explain analyze on a single worker node to get pretty printed physical plan
-    /// from that worker.
+    /// from that worker. `execute` runs the plan to report runtime metrics.
     async fn run_explain_analyze(
         &self,
         node_name: &str,
         plan: SerializedPlan,
         worker_planning_params: WorkerPlanningParams,
+        execute: bool,
     ) -> Result<String, CubeError>;
 
     /// Like [run_select], but streams results as they are requested.
@@ -523,11 +524,12 @@ impl Cluster for ClusterImpl {
         node_name: &str,
         plan: SerializedPlan,
         worker_planning_params: WorkerPlanningParams,
+        execute: bool,
     ) -> Result<String, CubeError> {
         let response = self
             .send_or_process_locally(
                 node_name,
-                NetworkMessage::ExplainAnalyze(plan, worker_planning_params),
+                NetworkMessage::ExplainAnalyze(plan, worker_planning_params, execute),
             )
             .await?;
         match response {
@@ -723,9 +725,9 @@ impl Cluster for ClusterImpl {
                 let res = self.run_local_select_worker(plan, planning_params).await;
                 NetworkMessage::SelectResult(res)
             }
-            NetworkMessage::ExplainAnalyze(plan, planning_params) => {
+            NetworkMessage::ExplainAnalyze(plan, planning_params, execute) => {
                 let res = self
-                    .run_local_explain_analyze_worker(plan, planning_params)
+                    .run_local_explain_analyze_worker(plan, planning_params, execute)
                     .await;
                 NetworkMessage::ExplainAnalyzeResult(res)
             }
@@ -1312,39 +1314,7 @@ impl ClusterImpl {
             warn!("Warmup download for select ({:?})", warmup);
         }
 
-        let chunk_store = self
-            .injector
-            .upgrade()
-            .unwrap()
-            .get_service_typed::<dyn ChunkDataStore>()
-            .await;
-
-        let in_memory_chunks_to_load = plan_node.in_memory_chunks_to_load();
-        let in_memory_chunks_futures = in_memory_chunks_to_load
-            .iter()
-            .map(|(c, p, i)| {
-                chunk_store
-                    .get_chunk_columns_with_preloaded_meta(c.clone(), p.clone(), i.clone())
-                    .instrument(tracing::span!(
-                        tracing::Level::TRACE,
-                        "get in memory chunk columns",
-                        row_count = c.get_row().get_row_count()
-                    ))
-            })
-            .collect::<Vec<_>>();
-
-        let chunk_id_to_record_batches = in_memory_chunks_to_load
-            .clone()
-            .into_iter()
-            .map(|(c, _, _)| c.get_id())
-            .zip(
-                join_all(in_memory_chunks_futures)
-                    .await
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter(),
-            )
-            .collect::<HashMap<_, _>>();
+        let chunk_id_to_record_batches = self.load_in_memory_chunks(&plan_node).await?;
 
         let mut res = None;
         #[cfg(not(target_os = "windows"))]
@@ -1419,14 +1389,18 @@ impl ClusterImpl {
         &self,
         plan_node: SerializedPlan,
         worker_planning_params: WorkerPlanningParams,
+        execute: bool,
     ) -> Result<String, CubeError> {
         let remote_to_local_names = self.warmup_select_worker_files(&plan_node).await?;
-        let in_memory_chunks_to_load = plan_node.in_memory_chunks_to_load();
-        let chunk_id_to_record_batches = in_memory_chunks_to_load
-            .clone()
-            .into_iter()
-            .map(|(c, _, _)| (c.get_id(), Vec::new()))
-            .collect();
+        let chunk_id_to_record_batches = if execute {
+            self.load_in_memory_chunks(&plan_node).await?
+        } else {
+            plan_node
+                .in_memory_chunks_to_load()
+                .into_iter()
+                .map(|(c, _, _)| (c.get_id(), Vec::new()))
+                .collect()
+        };
 
         let res = self
             .query_executor
@@ -1435,10 +1409,49 @@ impl ClusterImpl {
                 worker_planning_params,
                 remote_to_local_names,
                 chunk_id_to_record_batches,
+                execute,
             )
             .await;
 
         res
+    }
+
+    async fn load_in_memory_chunks(
+        &self,
+        plan_node: &SerializedPlan,
+    ) -> Result<HashMap<u64, Vec<RecordBatch>>, CubeError> {
+        let chunk_store = self
+            .injector
+            .upgrade()
+            .unwrap()
+            .get_service_typed::<dyn ChunkDataStore>()
+            .await;
+
+        let in_memory_chunks_to_load = plan_node.in_memory_chunks_to_load();
+        let in_memory_chunks_futures = in_memory_chunks_to_load
+            .iter()
+            .map(|(c, p, i)| {
+                chunk_store
+                    .get_chunk_columns_with_preloaded_meta(c.clone(), p.clone(), i.clone())
+                    .instrument(tracing::span!(
+                        tracing::Level::TRACE,
+                        "get in memory chunk columns",
+                        row_count = c.get_row().get_row_count()
+                    ))
+            })
+            .collect::<Vec<_>>();
+
+        Ok(in_memory_chunks_to_load
+            .iter()
+            .map(|(c, _, _)| c.get_id())
+            .zip(
+                join_all(in_memory_chunks_futures)
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter(),
+            )
+            .collect::<HashMap<_, _>>())
     }
 
     async fn warmup_select_worker_files(

--- a/rust/cubestore/cubestore/src/queryplanner/pretty_printers.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/pretty_printers.rs
@@ -850,7 +850,12 @@ fn pp_phys_plan_indented(p: &dyn ExecutionPlan, indent: usize, o: &PPOptions, ou
 
         if o.show_metrics {
             if let Some(m) = p.metrics() {
-                *out += &format!(", metrics: {}", m);
+                *out += &format!(
+                    ", metrics: {}",
+                    m.aggregate_by_name()
+                        .sorted_for_display()
+                        .timestamps_removed()
+                );
             }
         }
     }

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -74,8 +74,8 @@ use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    collect, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PhysicalExpr,
-    PlanProperties, SendableRecordBatchStream,
+    collect, execute_stream, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    PhysicalExpr, PlanProperties, SendableRecordBatchStream,
 };
 use datafusion::prelude::{and, SessionConfig, SessionContext};
 use datafusion_datasource::memory::MemorySourceConfig;
@@ -399,14 +399,21 @@ impl QueryExecutor for QueryExecutorImpl {
             return Ok(pp_phys_plan(worker_plan.as_ref()));
         }
 
-        // Execute the plan to populate the metrics, the results are discarded.
+        // Execute the plan to populate the metrics. The results are discarded batch by
+        // batch to avoid holding the full result set in memory.
         let session_context = self.execution_context()?;
-        collect(worker_plan.clone(), session_context.task_ctx())
-            .instrument(tracing::span!(
-                tracing::Level::TRACE,
-                "collect_physical_plan_for_explain_analyze"
-            ))
-            .await?;
+        let mut stream = execute_stream(worker_plan.clone(), session_context.task_ctx())?;
+        async {
+            while let Some(batch) = stream.next().await {
+                batch?;
+            }
+            Ok::<_, DataFusionError>(())
+        }
+        .instrument(tracing::span!(
+            tracing::Level::TRACE,
+            "execute_physical_plan_for_explain_analyze"
+        ))
+        .await?;
 
         Ok(pp_phys_plan_ext(
             worker_plan.as_ref(),
@@ -716,6 +723,8 @@ impl CubeTable {
         // pruning or row filtering — could drop the last version while older ones
         // survive elsewhere and get resurrected.
         let predicate = if let Some(key_columns) = &unique_key_columns {
+            // Filters passed to a scan reference only this table's columns, so matching
+            // by bare column name is enough.
             let pushable = filters
                 .iter()
                 .filter(|f| {

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -68,6 +68,7 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
@@ -856,6 +857,40 @@ impl CubeTable {
             }
         }
 
+        let unique_key_columns = self
+            .index_snapshot
+            .table_path
+            .table
+            .get_row()
+            .unique_key_columns();
+
+        // Filters referencing only unique key columns commute with the last-row
+        // deduplication: the key is immutable within a version group, so such filters
+        // select whole groups. Apply them to every stream to cut the merge and dedup
+        // input. Filters on other columns must stay above the dedup: they apply to the
+        // last version of a row, pushing them down would resurrect overwritten versions.
+        if let Some(key_columns) = &unique_key_columns {
+            let pushable = filters
+                .iter()
+                .filter(|f| {
+                    !f.is_volatile()
+                        && f.column_refs()
+                            .iter()
+                            .all(|c| key_columns.iter().any(|k| k.get_name() == &c.name))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if let Some(predicate) = combine_filters(&pushable) {
+                for p in &mut partition_execs {
+                    let phys_predicate = state.create_physical_expr(
+                        predicate.clone(),
+                        &p.schema().as_ref().clone().to_dfschema()?,
+                    )?;
+                    *p = Arc::new(FilterExec::try_new(phys_predicate, p.clone())?);
+                }
+            }
+        }
+
         // Schema for scan output and input to MergeSort and LastRowByUniqueKey
         let table_projected_schema = {
             Arc::new(Schema::new(
@@ -900,13 +935,6 @@ impl CubeTable {
                 Boundedness::Bounded,
             ),
         });
-        let unique_key_columns = self
-            .index_snapshot()
-            .table_path
-            .table
-            .get_row()
-            .unique_key_columns();
-
         let plan: Arc<dyn ExecutionPlan> = if let Some(key_columns) = unique_key_columns {
             let sort_columns = self
                 .index_snapshot()

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -681,7 +681,34 @@ impl CubeTable {
             None
         };
 
-        let predicate = combine_filters(filters);
+        let unique_key_columns = self
+            .index_snapshot
+            .table_path
+            .table
+            .get_row()
+            .unique_key_columns();
+
+        // Only filters referencing unique key columns commute with the last-row
+        // deduplication: the key is immutable within a version group, so such filters
+        // select whole groups. Filters on other columns apply to the last version of a
+        // row; acting on individual versions below the dedup — be it parquet row-group
+        // pruning or row filtering — could drop the last version while older ones
+        // survive elsewhere and get resurrected.
+        let predicate = if let Some(key_columns) = &unique_key_columns {
+            let pushable = filters
+                .iter()
+                .filter(|f| {
+                    !f.is_volatile()
+                        && f.column_refs()
+                            .iter()
+                            .all(|c| key_columns.iter().any(|k| k.get_name() == &c.name))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            combine_filters(&pushable)
+        } else {
+            combine_filters(filters)
+        };
         let physical_predicate = if let Some(pred) = &predicate {
             Some(state.create_physical_expr(
                 pred.clone(),
@@ -857,30 +884,11 @@ impl CubeTable {
             }
         }
 
-        let unique_key_columns = self
-            .index_snapshot
-            .table_path
-            .table
-            .get_row()
-            .unique_key_columns();
-
-        // Filters referencing only unique key columns commute with the last-row
-        // deduplication: the key is immutable within a version group, so such filters
-        // select whole groups. Apply them to every stream to cut the merge and dedup
-        // input. Filters on other columns must stay above the dedup: they apply to the
-        // last version of a row, pushing them down would resurrect overwritten versions.
-        if let Some(key_columns) = &unique_key_columns {
-            let pushable = filters
-                .iter()
-                .filter(|f| {
-                    !f.is_volatile()
-                        && f.column_refs()
-                            .iter()
-                            .all(|c| key_columns.iter().any(|k| k.get_name() == &c.name))
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            if let Some(predicate) = combine_filters(&pushable) {
+        // Apply the dedup-safe predicate to every stream of a unique key table to cut
+        // the merge and dedup input: parquet pruning above only skips whole row groups
+        // and does nothing for in-memory chunks.
+        if unique_key_columns.is_some() {
+            if let Some(predicate) = &predicate {
                 for p in &mut partition_execs {
                     let phys_predicate = state.create_physical_expr(
                         predicate.clone(),

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -136,6 +136,7 @@ pub trait QueryExecutor: DIService + Send + Sync {
         worker_planning_params: WorkerPlanningParams,
         remote_to_local_names: HashMap<String, String>,
         chunk_id_to_record_batches: HashMap<u64, Vec<RecordBatch>>,
+        execute: bool,
     ) -> Result<String, CubeError>;
 }
 
@@ -372,6 +373,7 @@ impl QueryExecutor for QueryExecutorImpl {
         worker_planning_params: WorkerPlanningParams,
         remote_to_local_names: HashMap<String, String>,
         chunk_id_to_record_batches: HashMap<u64, Vec<RecordBatch>>,
+        execute: bool,
     ) -> Result<String, CubeError> {
         let (physical_plan, _) = self
             .worker_plan(
@@ -393,7 +395,26 @@ impl QueryExecutor for QueryExecutorImpl {
             ));
         }
 
-        Ok(pp_phys_plan(worker_plan.as_ref()))
+        if !execute {
+            return Ok(pp_phys_plan(worker_plan.as_ref()));
+        }
+
+        // Execute the plan to populate the metrics, the results are discarded.
+        let session_context = self.execution_context()?;
+        collect(worker_plan.clone(), session_context.task_ctx())
+            .instrument(tracing::span!(
+                tracing::Level::TRACE,
+                "collect_physical_plan_for_explain_analyze"
+            ))
+            .await?;
+
+        Ok(pp_phys_plan_ext(
+            worker_plan.as_ref(),
+            &PPOptions {
+                show_metrics: true,
+                ..PPOptions::default()
+            },
+        ))
     }
 }
 

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -544,10 +544,13 @@ impl SqlServiceImpl {
         )))
     }
 
+    /// `analyze` builds and shows the physical plans on the router and the workers.
+    /// `execute` additionally runs the worker plans to report runtime metrics.
     async fn explain(
         &self,
         statement: Statement,
         analyze: bool,
+        execute: bool,
     ) -> Result<Arc<DataFrame>, CubeError> {
         fn extract_worker_plans(
             p: &Arc<dyn ExecutionPlan>,
@@ -612,6 +615,7 @@ impl SqlServiceImpl {
                                         &name,
                                         plan.to_serialized_plan()?,
                                         worker_planning_params,
+                                        execute,
                                     )
                                     .await
                                     .map(|p| (name, p))
@@ -1376,7 +1380,7 @@ impl SqlService for SqlServiceImpl {
                 ..
             }) => match *statement {
                 Statement::Query(q) => Ok(self
-                    .explain(Statement::Query(q.clone()), analyze)
+                    .explain(Statement::Query(q.clone()), analyze, false)
                     .await?
                     .into()),
                 _ => Err(CubeError::user(format!(
@@ -1384,6 +1388,9 @@ impl SqlService for SqlServiceImpl {
                     query
                 ))),
             },
+            CubeStoreStatement::ExplainAnalyzeExtended(q) => {
+                Ok(self.explain(Statement::Query(q), true, true).await?.into())
+            }
 
             CubeStoreStatement::Dump(q) => Ok(self.dump_select_inputs(query, q).await?.into()),
 
@@ -5160,6 +5167,37 @@ mod tests {
                             ).unwrap();
                             let matches = regex.captures_iter(&pp_plan).count();
                             assert_eq!(matches, 1, "pp_plan = {}", pp_plan);
+                            // EXPLAIN ANALYZE only shows the plan, it doesn't execute it.
+                            assert!(!pp_plan.contains("metrics:"), "pp_plan = {}", pp_plan);
+                        },
+                        _ => {assert!(false);}
+                    };
+
+                let result = service.exec_query(
+                    "EXPLAIN ANALYZE EXTENDED SELECT platform, sum(amount) from foo.orders where age > 15 group by platform"
+                    ).await?.collect().await?;
+
+                assert_eq!(result.len(), 2);
+                let worker_row = &result.get_rows()[1];
+                match &worker_row
+                    .values()[2] {
+                        TableValue::String(pp_plan) => {
+                            let regex = Regex::new(
+                                r"LinearPartialAggregate[^\n]*\s+Filter[^\n]*\s+Scan, index: default:1:\[1\], fields: \[platform, age, amount\][^\n]*\s+ParquetScan, files: \S*\.chunk\.parquet"
+                            ).unwrap();
+                            let matches = regex.captures_iter(&pp_plan).count();
+                            assert_eq!(matches, 1, "pp_plan = {}", pp_plan);
+                            // The plan is executed, so the nodes carry runtime metrics.
+                            assert!(
+                                pp_plan.contains("metrics:") && pp_plan.contains("output_rows="),
+                                "pp_plan = {}",
+                                pp_plan
+                            );
+                            assert!(
+                                pp_plan.contains("row_groups_pruned_statistics="),
+                                "parquet scans must report pruning metrics, pp_plan = {}",
+                                pp_plan
+                            );
                         },
                         _ => {assert!(false);}
                     };

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -304,18 +304,31 @@ impl<'a> CubeStoreParser<'a> {
                     Ok(Statement::Dump(q))
                 }
                 // Plain EXPLAIN and EXPLAIN ANALYZE fall through to the generic parser.
+                // A bare identifier after EXPLAIN ANALYZE is intercepted: it is either
+                // EXTENDED or a parse error. Otherwise the generic parser would treat it
+                // as an EXPLAIN <table_name> and silently drop the rest of the statement.
                 Keyword::EXPLAIN
                     if matches!(
                         &self.parser.peek_nth_token(1).token,
                         Token::Word(w) if w.keyword == Keyword::ANALYZE
                     ) && matches!(
                         &self.parser.peek_nth_token(2).token,
-                        Token::Word(w) if w.value.eq_ignore_ascii_case("extended")
+                        Token::Word(w) if w.keyword == Keyword::NoKeyword
+                            || w.value.eq_ignore_ascii_case("extended")
                     ) =>
                 {
                     self.parser.next_token();
                     self.parser.next_token();
-                    self.parser.next_token();
+                    let word = self.parser.next_token();
+                    if !matches!(
+                        &word.token,
+                        Token::Word(w) if w.value.eq_ignore_ascii_case("extended")
+                    ) {
+                        return Err(ParserError::ParserError(format!(
+                            "Expected EXTENDED or a query after EXPLAIN ANALYZE, found: {}",
+                            word
+                        )));
+                    }
                     let s = self.parser.parse_statement()?;
                     let q = match s {
                         SQLStatement::Query(q) => q,
@@ -1058,6 +1071,26 @@ mod tests {
     fn parse_stmt(query: &str) -> Result<Statement, CubeError> {
         let mut parser = CubeStoreParser::new(query, None)?;
         Ok(parser.parse_statement()?)
+    }
+
+    #[test]
+    fn parse_explain_analyze_extended() -> Result<(), CubeError> {
+        match parse_stmt("EXPLAIN ANALYZE EXTENDED SELECT 1")? {
+            Statement::ExplainAnalyzeExtended(_) => {}
+            s => panic!("Expected ExplainAnalyzeExtended, got {:?}", s),
+        }
+        match parse_stmt("EXPLAIN ANALYZE SELECT 1")? {
+            Statement::Statement(SQLStatement::Explain { analyze: true, .. }) => {}
+            s => panic!("Expected Explain with analyze, got {:?}", s),
+        }
+        match parse_stmt("EXPLAIN SELECT 1")? {
+            Statement::Statement(SQLStatement::Explain { analyze: false, .. }) => {}
+            s => panic!("Expected Explain without analyze, got {:?}", s),
+        }
+        // A misspelled EXTENDED is a parse error, not an EXPLAIN of the "EXTANDED" table
+        // silently dropping the rest of the statement.
+        assert!(parse_stmt("EXPLAIN ANALYZE EXTANDED SELECT 1").is_err());
+        Ok(())
     }
 
     #[test]

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -66,6 +66,8 @@ pub enum Statement {
     Queue(QueueCommand),
     System(SystemCommand),
     Dump(Box<Query>),
+    /// Like EXPLAIN ANALYZE, but executes worker plans to report runtime metrics.
+    ExplainAnalyzeExtended(Box<Query>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -300,6 +302,31 @@ impl<'a> CubeStoreParser<'a> {
                         }
                     };
                     Ok(Statement::Dump(q))
+                }
+                // Plain EXPLAIN and EXPLAIN ANALYZE fall through to the generic parser.
+                Keyword::EXPLAIN
+                    if matches!(
+                        &self.parser.peek_nth_token(1).token,
+                        Token::Word(w) if w.keyword == Keyword::ANALYZE
+                    ) && matches!(
+                        &self.parser.peek_nth_token(2).token,
+                        Token::Word(w) if w.value.eq_ignore_ascii_case("extended")
+                    ) =>
+                {
+                    self.parser.next_token();
+                    self.parser.next_token();
+                    self.parser.next_token();
+                    let s = self.parser.parse_statement()?;
+                    let q = match s {
+                        SQLStatement::Query(q) => q,
+                        _ => {
+                            return Err(ParserError::ParserError(
+                                "Expected select query after 'explain analyze extended'"
+                                    .to_string(),
+                            ))
+                        }
+                    };
+                    Ok(Statement::ExplainAnalyzeExtended(q))
                 }
                 _ => Ok(Statement::Statement(self.parser.parse_statement()?)),
             },


### PR DESCRIPTION
## Summary

Queries over unique-key (streaming) tables filter rows only after the sort-preserving merge and last-row deduplication have processed every row that survives row-group pruning. This PR pushes the dedup-safe part of the predicate below the dedup, fixes a latent resurrection hazard in parquet pruning, and adds `EXPLAIN ANALYZE EXTENDED` to observe runtime metrics.

## Changes

- **Unique key filter pushdown** (`CubeTable::async_scan`): conjuncts referencing only unique key columns are applied as a `FilterExec` on every scan stream, below the merge and `LastRowByUniqueKey`. Such filters commute with the deduplication — the key is immutable within a version group, so they select whole groups. Filters on non-key columns stay above the dedup: they apply to the last version of a row, pushing them down would resurrect overwritten versions.
- **Parquet pruning predicate restricted to the same dedup-safe set** for unique-key tables (pre-existing issue): row-group pruning by a non-key filter could drop a row group holding the last version of a row while older versions survive in other files and get resurrected — e.g. an overwritten row in the main partition file outliving its newer version stored in a chunk. Non-unique tables keep the full predicate.
- **`EXPLAIN ANALYZE EXTENDED`**: workers execute their plans (results discarded, in-memory chunks loaded via the path shared with select) and report per-node metrics — `output_rows`, `elapsed_compute`, row-group pruning counters and bytes scanned on parquet scans. `EXPLAIN` and `EXPLAIN ANALYZE` behave exactly as before (plan only, no execution).

## Testing

- New SQL test `filter_pushdown_unique_key`: key versions split across chunks; key filter pushed below the dedup (plan + result), non-key filter kept above with no resurrection of overwritten versions (result), pruning predicate present/absent on the scan accordingly.
- `explain_physical_plan` extended: `EXPLAIN ANALYZE` asserts no metrics (unchanged behavior), `EXPLAIN ANALYZE EXTENDED` asserts `output_rows=` and `row_groups_pruned_statistics=` are reported.
- Full runs green on every commit: cubestore unit tests, in-process / cluster / migration / multi-process suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)