### PR TITLE
perf(snowflake-driver): Combine session init into a single ALTER SESSION

### DIFF
--- a/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
+++ b/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
@@ -114,6 +114,8 @@ interface SnowflakeDriverOptions {
   exportBucketCsvEscapeSymbol?: string,
 }
 
+type SessionParameterValue = string | number | boolean | undefined;
+
 /**
  * Snowflake driver class.
  *
@@ -456,8 +458,22 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
   }
 
   /**
-   * Initializes and resolves connection to the Snowflake.
+   * Values are interpolated rather than bound because Snowflake does not
+   * support bind variables in `ALTER SESSION SET` (it rejects `?` with
+   * "invalid value [?] for parameter"; see
+   * snowflakedb/snowflake-connector-nodejs#315).
+   *
+   * I've tested it on 04 jun 2026, and it still does not work.
    */
+  protected buildAlterSessionSql(params: Record<string, SessionParameterValue>): string {
+    const assignments = Object.entries(params)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => `${key} = ${typeof value === 'string' ? `'${value}'` : value}`)
+      .join(', ');
+
+    return `ALTER SESSION SET ${assignments}`;
+  }
+
   protected async initConnection() {
     try {
       const connection = await this.createConnection();
@@ -466,9 +482,16 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
         (resolve, reject) => connection.connect((err, conn) => (err ? reject(err) : resolve(conn)))
       );
 
-      await this.execute(connection, 'ALTER SESSION SET TIMEZONE = \'UTC\'', [], false);
-      await this.execute(connection, `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${this.config.executionTimeout}`, [], false);
-      await this.execute(connection, `ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = ${this.config.identIgnoreCase}`, [], false);
+      await this.execute(
+        connection,
+        this.buildAlterSessionSql({
+          TIMEZONE: 'UTC',
+          STATEMENT_TIMEOUT_IN_SECONDS: this.config.executionTimeout,
+          QUOTED_IDENTIFIERS_IGNORE_CASE: this.config.identIgnoreCase,
+        }),
+        [],
+        false,
+      );
       return connection;
     } catch (e) {
       this.connection = null;


### PR DESCRIPTION
initConnection issued three separate `ALTER SESSION SET` statements (TIMEZONE, STATEMENT_TIMEOUT_IN_SECONDS, QUOTED_IDENTIFIERS_IGNORE_CASE), each a blocking network round-trip on every connection (re)establishment.

Collapse them into one statement via a `buildAlterSessionSql` helper, dropping connection init from 4 sequential round-trips (connect + 3 ALTERs) to 2 (connect + 1 ALTER).

Values are interpolated rather than bound: Snowflake does not support bind variables in `ALTER SESSION SET` (verified against a live instance — it rejects `?` with "invalid value [?] for parameter"). The inputs are internal and type-validated, so there is no injection risk.