### PR TITLE
docs: add Demos link to navbar

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -681,6 +681,10 @@
   "navbar": {
     "links": [
       {
+        "label": "Demos",
+        "href": "https://cube.dev/demos"
+      },
+      {
         "label": "Changelog",
         "href": "https://cube.dev/changelog"
       },


### PR DESCRIPTION
## Summary

Adds a **Demos** link pointing to https://cube.dev/demos in the docs top navbar, alongside Changelog and Community. Placing it in `navbar.links` keeps it always visible across every documentation page.

## Changes

- `docs-mintlify/docs.json` — new entry in `navbar.links` for Demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)