### PR TITLE
docs: add Cube Cloud public API reference (SCIM + Deployments)

### DIFF
--- a/docs-mintlify/api-reference/authentication.mdx
+++ b/docs-mintlify/api-reference/authentication.mdx
@@ -1,30 +1,41 @@
 ---
 title: Authentication
-description: Authenticate SCIM API requests with a bearer token.
+description: Authenticate REST requests with an API key and SCIM requests with a bearer token.
 ---
 
-The SCIM API authenticates requests with a bearer token issued from your Cube
-Cloud account. Include it in the `Authorization` header on every request:
+How you authenticate depends on which API you call. The REST management API
+(`/api/v1/…`) uses an API key; the SCIM API (`/api/scim/v2/…`) uses a bearer
+token. Both are sent in the `Authorization` header, and only HTTPS is accepted.
+
+## REST API (`/api/v1`)
+
+Authenticate deployment, report, and workbook requests with an API key from your
+Cube Cloud account, sent with the `Api-Key` prefix:
+
+```text
+Authorization: Api-Key <YOUR_API_KEY>
+```
+
+Generate an API key (access token) in your Cube Cloud account settings.
+
+```bash
+curl --request GET \
+  --url 'https://<tenant>.cubecloud.dev/api/v1/deployments' \
+  --header 'Authorization: Api-Key <YOUR_API_KEY>'
+```
+
+## SCIM API (`/api/scim/v2`)
+
+Authenticate user and group provisioning requests with a SCIM bearer token,
+configured in your identity provider's SCIM integration:
 
 ```text
 Authorization: Bearer <YOUR_SCIM_TOKEN>
 ```
 
-## Get a token
-
 Generate a SCIM token in your Cube Cloud account settings, then configure it in
-your identity provider's SCIM integration alongside the
+your identity provider alongside the
 [base URL](/api-reference/introduction#base-url).
-
-<Warning>
-
-Treat the SCIM token like a password. It grants full access to provision and
-de-provision users and groups. Store it securely and rotate it if it is
-exposed.
-
-</Warning>
-
-## Example request
 
 ```bash
 curl --request GET \
@@ -32,5 +43,12 @@ curl --request GET \
   --header 'Authorization: Bearer <YOUR_SCIM_TOKEN>'
 ```
 
-A `401 Unauthorized` response means the token is missing, malformed, or
+<Warning>
+
+Treat API keys and SCIM tokens like passwords — they grant full access to your
+account's resources. Store them securely and rotate them if they are exposed.
+
+</Warning>
+
+A `401 Unauthorized` response means the credential is missing, malformed, or
 expired.

--- a/docs-mintlify/api-reference/authentication.mdx
+++ b/docs-mintlify/api-reference/authentication.mdx
@@ -1,0 +1,36 @@
+---
+title: Authentication
+description: Authenticate SCIM API requests with a bearer token.
+---
+
+The SCIM API authenticates requests with a bearer token issued from your Cube
+Cloud account. Include it in the `Authorization` header on every request:
+
+```text
+Authorization: Bearer <YOUR_SCIM_TOKEN>
+```
+
+## Get a token
+
+Generate a SCIM token in your Cube Cloud account settings, then configure it in
+your identity provider's SCIM integration alongside the
+[base URL](/api-reference/introduction#base-url).
+
+<Warning>
+
+Treat the SCIM token like a password. It grants full access to provision and
+de-provision users and groups. Store it securely and rotate it if it is
+exposed.
+
+</Warning>
+
+## Example request
+
+```bash
+curl --request GET \
+  --url 'https://<tenant>.cubecloud.dev/api/scim/v2/Users?count=100&startIndex=1' \
+  --header 'Authorization: Bearer <YOUR_SCIM_TOKEN>'
+```
+
+A `401 Unauthorized` response means the token is missing, malformed, or
+expired.

--- a/docs-mintlify/api-reference/deployments.yaml
+++ b/docs-mintlify/api-reference/deployments.yaml
@@ -1,0 +1,2296 @@
+openapi: 3.1.0
+info:
+  title: Cube Cloud Deployments API
+  version: 1.0.0
+  description: |-
+    Manage Cube Cloud deployments and everything scoped to them — environments and
+    API tokens, folders, reports, and workbooks with their dashboards.
+servers:
+  - url: https://{tenant}.cubecloud.dev/api
+    description: Cube Cloud API base URL. Replace the whole host if you use a custom domain.
+    variables:
+      tenant:
+        default: your-tenant
+        description: Your Cube Cloud tenant subdomain
+security:
+  - jwtAuth: []
+tags:
+  - name: Deployments
+  - name: Environments
+  - name: Folders
+  - name: Reports
+  - name: Workbooks
+paths:
+  /v1/deployments/:
+    get:
+      operationId: getDeployments
+      parameters:
+        - in: query
+          name: creationStep
+          required: false
+          schema:
+            oneOf:
+              - items:
+                  enum:
+                    - project
+                    - upload
+                    - schema
+                    - github
+                    - ssh
+                    - databases
+                    - ready
+                    - demo
+                  type: string
+                type: array
+                $ref: '#/components/schemas/CreationStep'
+              - type: array
+                items:
+                  $ref: '#/components/schemas/CreationStep'
+        - in: query
+          name: offset
+          required: false
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+            type: integer
+            minimum: 0
+        - in: query
+          name: limit
+          required: false
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+            type: integer
+            minimum: 0
+        - in: query
+          name: first
+          required: false
+          schema:
+            oneOf:
+              - type: string
+              - type: 'null'
+            type: integer
+            minimum: 1
+          description: Page size for cursor-based pagination
+        - in: query
+          name: after
+          required: false
+          schema:
+            oneOf:
+              - minimum: 1
+                type: integer
+              - type: 'null'
+            type: string
+          description: Cursor for fetching the next page
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentsListResponse'
+          description: ''
+      summary: Get deployments
+      tags:
+        - Deployments
+  /v1/deployments/{deploymentId}:
+    get:
+      operationId: getDeployment
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Deployment'
+          description: ''
+      summary: Get deployment
+      tags:
+        - Deployments
+  /v1/deployments/{deploymentId}/environments:
+    get:
+      operationId: getDeploymentEnvironments
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: type
+          required: false
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/GetDeploymentEnvironmentsQueryType'
+              - type: 'null'
+            type: string
+            enum:
+              - production
+              - staging
+              - development
+        - in: query
+          name: offset
+          required: false
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+            type: integer
+            minimum: 0
+        - in: query
+          name: limit
+          required: false
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentEnvironmentsListResponse'
+          description: ''
+      summary: Get deployment environments
+      tags:
+        - Environments
+  /v1/deployments/{deploymentId}/environments/{environmentId}/tokens:
+    get:
+      operationId: getDeploymentEnvironmentTokens
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: environmentId
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          required: false
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+            type: integer
+            minimum: 0
+        - in: query
+          name: limit
+          required: false
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentEnvironmentTokensListResponse'
+          description: ''
+      summary: Get deployment environment tokens
+      tags:
+        - Environments
+    post:
+      operationId: createDeploymentEnvironmentToken
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: environmentId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeploymentEnvironmentTokenInput'
+        description: CreateDeploymentEnvironmentTokenInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentEnvironmentTokenResponse'
+          description: ''
+      summary: Create deployment environment token
+      tags:
+        - Environments
+  /v1/deployments/{deploymentId}/environments/{environmentId}/tokens-for-meta-sync:
+    post:
+      operationId: createDeploymentEnvironmentTokenForMetaSync
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+        - in: path
+          name: environmentId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeploymentEnvironmentTokenInput'
+        description: CreateDeploymentEnvironmentTokenInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentEnvironmentTokenResponse'
+          description: ''
+      summary: Create deployment environment token for meta sync
+      tags:
+        - Environments
+  /v1/deployments/{deploymentId}/folders:
+    get:
+      operationId: getFolders
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: query
+          name: parentId
+          required: false
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FoldersFindAllResult'
+          description: ''
+      summary: Get folders
+      tags:
+        - Folders
+  /v1/deployments/{deploymentId}/folders/{folderId}/ancestors:
+    get:
+      operationId: getFolderAncestors
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: folderId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/FolderDto'
+                type: array
+          description: ''
+      summary: Get folder ancestors
+      tags:
+        - Folders
+  /v1/deployments/{deploymentId}/report-folders:
+    get:
+      operationId: getReportFolders
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportFoldersFindAllResult'
+          description: ''
+      summary: Get report folders
+      tags:
+        - Reports
+  /v1/deployments/{deploymentId}/reports:
+    get:
+      operationId: getReports
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: query
+          name: workbookId
+          schema:
+            oneOf:
+              - type: integer
+              - type: 'null'
+        - in: query
+          name: limit
+          schema:
+            oneOf:
+              - type: integer
+              - type: 'null'
+        - in: query
+          name: page
+          schema:
+            oneOf:
+              - type: integer
+              - type: 'null'
+        - in: query
+          name: sortBy
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/GetReportsQuerySortBy'
+              - type: 'null'
+        - in: query
+          name: sortDirection
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/GetReportsQuerySortDirection'
+              - type: 'null'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportsFindAllResult'
+          description: ''
+      summary: Get reports
+      tags:
+        - Reports
+    post:
+      operationId: createReport
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReportInput'
+        description: CreateReportInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportDto'
+          description: ''
+      summary: Create report
+      tags:
+        - Reports
+  /v1/deployments/{deploymentId}/reports/{reportId}:
+    delete:
+      operationId: deleteReport
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: reportId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json: {}
+          description: Successful response
+      summary: Delete report
+      tags:
+        - Reports
+    get:
+      operationId: getReport
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: reportId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportDto'
+          description: ''
+      summary: Get report
+      tags:
+        - Reports
+    put:
+      operationId: updateReport
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: reportId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateReportInput'
+        description: UpdateReportInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportDto'
+          description: ''
+      summary: Update report
+      tags:
+        - Reports
+  /v1/deployments/{deploymentId}/reports/{reportId}/refresh:
+    put:
+      operationId: refreshReport
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: reportId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportDto'
+          description: ''
+      summary: Refresh report
+      tags:
+        - Reports
+  /v1/deployments/{deploymentId}/token:
+    post:
+      operationId: deploymentToken
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeploymentTokenResponse'
+          description: ''
+      summary: Deployment token
+      tags:
+        - Deployments
+  /v1/deployments/{deploymentId}/workbooks:
+    get:
+      operationId: getWorkbooks
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: query
+          name: folderId
+          schema:
+            oneOf:
+              - minimum: 0
+                type: integer
+              - type: 'null'
+        - in: query
+          name: after
+          schema:
+            oneOf:
+              - type: string
+              - type: 'null'
+        - in: query
+          name: first
+          schema:
+            oneOf:
+              - minimum: 1
+                type: integer
+              - type: 'null'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkbooksListResponse'
+          description: ''
+      summary: Get workbooks
+      tags:
+        - Workbooks
+    post:
+      operationId: createWorkbook
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWorkbookInput'
+        description: CreateWorkbookInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkbookDto'
+          description: ''
+      summary: Create workbook
+      tags:
+        - Workbooks
+  /v1/deployments/{deploymentId}/workbooks/{workbookId}:
+    delete:
+      operationId: deleteWorkbook
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json: {}
+          description: Successful response
+      summary: Delete workbook
+      tags:
+        - Workbooks
+    get:
+      operationId: getWorkbook
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkbookDto'
+          description: ''
+      summary: Get workbook
+      tags:
+        - Workbooks
+    put:
+      operationId: updateWorkbook
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateWorkbookInput'
+        description: UpdateWorkbookInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json: {}
+          description: Successful response
+      summary: Update workbook
+      tags:
+        - Workbooks
+  /v1/deployments/{deploymentId}/workbooks/{workbookId}/dashboard:
+    put:
+      operationId: updateWorkbookDashboard
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkbookDashboardInput'
+        description: WorkbookDashboardInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkbookDashboardDto'
+          description: ''
+      summary: Update workbook dashboard
+      tags:
+        - Workbooks
+  /v1/deployments/{deploymentId}/workbooks/{workbookId}/publish:
+    post:
+      operationId: publishDashboard
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublishDashboardInput'
+        description: PublishDashboardInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardDto'
+          description: ''
+      summary: Publish dashboard
+      tags:
+        - Workbooks
+components:
+  securitySchemes:
+    jwtAuth:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http
+  schemas:
+    ColumnFormatOverrideDto:
+      properties:
+        decimalPlaces:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/ColumnFormatOverrideDtoType'
+      required:
+        - type
+      type: object
+    ColumnFormatOverrideDtoType:
+      enum:
+        - currency
+        - percent
+        - number
+      type: string
+    ControlThemeBorderSectionInput:
+      properties:
+        color:
+          oneOf:
+            - type: string
+            - type: 'null'
+        radius:
+          oneOf:
+            - type: string
+            - type: 'null'
+        style:
+          oneOf:
+            - type: string
+            - type: 'null'
+        width:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    ControlThemeSectionInput:
+      properties:
+        backgroundColor:
+          oneOf:
+            - type: string
+            - type: 'null'
+        border:
+          oneOf:
+            - $ref: '#/components/schemas/ControlThemeBorderSectionInput'
+            - type: 'null'
+        padding:
+          oneOf:
+            - type: string
+            - type: 'null'
+        title:
+          oneOf:
+            - $ref: '#/components/schemas/ControlThemeTitleSectionInput'
+            - type: 'null'
+      type: object
+    ControlThemeTitleSectionInput:
+      properties:
+        color:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontFamily:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontSize:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontWeight:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    CreateDeploymentEnvironmentTokenInput:
+      properties:
+        expires_in:
+          oneOf:
+            - maximum: 3600
+              type: integer
+              minimum: 1
+            - type: 'null'
+        scopes:
+          oneOf:
+            - items:
+                type: string
+              type: array
+            - type: 'null'
+        security_context:
+          additionalProperties: true
+          not:
+            type: 'null'
+          type: object
+      required:
+        - security_context
+      type: object
+    CreateReportInput:
+      properties:
+        endResultCell:
+          oneOf:
+            - type: string
+            - type: 'null'
+        externalWorkbookId:
+          oneOf:
+            - type: string
+            - type: 'null'
+        folderId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        jsonQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        meta:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+        pivotItems:
+          oneOf:
+            - $ref: '#/components/schemas/PivotItemsInput'
+            - type: 'null'
+        publicId:
+          oneOf:
+            - pattern: ^[0-9A-Za-z]+$
+              type: string
+              minLength: 12
+              maxLength: 12
+            - type: 'null'
+        resultLocation:
+          oneOf:
+            - type: string
+            - type: 'null'
+        source:
+          oneOf:
+            - $ref: '#/components/schemas/CreateReportInputSource'
+            - type: 'null'
+        sqlQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        workbookId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      type: object
+    CreateReportInputSource:
+      enum:
+        - GOOGLE_SHEETS
+        - EXCEL
+        - PLAYGROUND
+        - D3
+      type: string
+    CreateWorkbookInput:
+      properties:
+        folderId:
+          oneOf:
+            - type: number
+            - type: 'null'
+        meta:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    CreationStep:
+      enum:
+        - project
+        - upload
+        - schema
+        - github
+        - ssh
+        - databases
+        - ready
+        - demo
+      type: string
+    DashboardBreakpointColsDto:
+      properties:
+        lg:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        md:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        sm:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xxs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      title: DashboardBreakpointColsDto
+      type: object
+    DashboardBreakpointColsInput:
+      properties:
+        lg:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        md:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        sm:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xxs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      title: DashboardBreakpointColsInput
+      type: object
+    DashboardBreakpointsDto:
+      properties:
+        lg:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        md:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        sm:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xxs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      title: DashboardBreakpointsDto
+      type: object
+    DashboardBreakpointsInput:
+      properties:
+        lg:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        md:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        sm:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        xxs:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      title: DashboardBreakpointsInput
+      type: object
+    DashboardConfigDto:
+      properties:
+        description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        layout:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardLayoutDto'
+            - type: 'null'
+        settings:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        theme:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        widgets:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardWidgetDto'
+              type: array
+            - type: 'null'
+      type: object
+    DashboardConfigInput:
+      properties:
+        description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        layout:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardLayoutInput'
+            - type: 'null'
+        settings:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        theme:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardThemeInput'
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        widgets:
+          items:
+            $ref: '#/components/schemas/DashboardWidgetInput'
+          type: array
+      required:
+        - widgets
+      type: object
+    DashboardDto:
+      properties:
+        allowEmbed:
+          type: boolean
+        config:
+          $ref: '#/components/schemas/DashboardConfigDto'
+        createdBy:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        deploymentId:
+          type: integer
+        description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        id:
+          type: integer
+        publicId:
+          type: string
+        reportSnapshots:
+          items:
+            $ref: '#/components/schemas/ReportSnapshotDto'
+          type: array
+        status:
+          $ref: '#/components/schemas/DashboardDtoStatus'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        versionId:
+          type: integer
+        versionNumber:
+          type: integer
+        workbookId:
+          type: integer
+      required:
+        - id
+        - publicId
+        - deploymentId
+        - workbookId
+        - status
+        - allowEmbed
+        - config
+        - versionNumber
+        - versionId
+        - reportSnapshots
+      type: object
+    DashboardDtoStatus:
+      enum:
+        - draft
+        - published
+        - archived
+      type: string
+    DashboardLayoutDto:
+      properties:
+        breakpoints:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardBreakpointsDto'
+            - type: 'null'
+        cols:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardBreakpointColsDto'
+            - type: 'null'
+        containerPadding:
+          oneOf:
+            - items:
+                type: integer
+              type: array
+            - type: 'null'
+        margin:
+          oneOf:
+            - items:
+                type: integer
+              type: array
+            - type: 'null'
+        rowHeight:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      type: object
+    DashboardLayoutInput:
+      properties:
+        breakpoints:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardBreakpointsInput'
+            - type: 'null'
+        cols:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardBreakpointColsInput'
+            - type: 'null'
+        containerPadding:
+          oneOf:
+            - items:
+                type: integer
+              type: array
+            - type: 'null'
+        margin:
+          oneOf:
+            - items:
+                type: integer
+              type: array
+            - type: 'null'
+        rowHeight:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      type: object
+    DashboardResponsiveLayoutsDto:
+      properties:
+        lg:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionDto'
+            - type: 'null'
+        md:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionDto'
+            - type: 'null'
+        sm:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionDto'
+            - type: 'null'
+        xs:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionDto'
+            - type: 'null'
+        xxs:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionDto'
+            - type: 'null'
+      type: object
+    DashboardResponsiveLayoutsInput:
+      properties:
+        lg:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionInput'
+            - type: 'null'
+        md:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionInput'
+            - type: 'null'
+        sm:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionInput'
+            - type: 'null'
+        xs:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionInput'
+            - type: 'null'
+        xxs:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardWidgetPositionInput'
+            - type: 'null'
+      type: object
+    DashboardThemeInput:
+      properties:
+        backgroundColor:
+          oneOf:
+            - type: string
+            - type: 'null'
+        controls:
+          oneOf:
+            - $ref: '#/components/schemas/ControlThemeSectionInput'
+            - type: 'null'
+        dashboard:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardThemeSectionInput'
+            - type: 'null'
+        fontFamily:
+          oneOf:
+            - type: string
+            - type: 'null'
+        primaryColor:
+          oneOf:
+            - type: string
+            - type: 'null'
+        themeId:
+          oneOf:
+            - type: string
+            - type: 'null'
+        widgets:
+          oneOf:
+            - $ref: '#/components/schemas/WidgetThemeSectionInput'
+            - type: 'null'
+      type: object
+    DashboardThemeSectionInput:
+      properties:
+        backgroundColor:
+          oneOf:
+            - type: string
+            - type: 'null'
+        padding:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    DashboardWidgetDto:
+      properties:
+        config:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        id:
+          type: string
+        position:
+          $ref: '#/components/schemas/DashboardWidgetPositionDto'
+        responsiveLayouts:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardResponsiveLayoutsDto'
+            - type: 'null'
+        style:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/DashboardWidgetDtoType'
+      required:
+        - id
+        - type
+        - position
+      type: object
+    DashboardWidgetDtoType:
+      enum:
+        - CHART
+        - TEXT
+        - FILTER
+        - AI
+        - TABS_CONTAINER
+        - TIME_GRAIN
+      type: string
+    DashboardWidgetInput:
+      properties:
+        config:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        id:
+          type: string
+        position:
+          $ref: '#/components/schemas/DashboardWidgetPositionInput'
+        responsiveLayouts:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardResponsiveLayoutsInput'
+            - type: 'null'
+        style:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/DashboardWidgetInputType'
+      required:
+        - id
+        - type
+        - position
+      type: object
+    DashboardWidgetInputType:
+      enum:
+        - CHART
+        - TEXT
+        - FILTER
+        - AI
+        - TABS_CONTAINER
+        - TIME_GRAIN
+      type: string
+    DashboardWidgetPositionDto:
+      properties:
+        h:
+          type: integer
+        w:
+          type: integer
+        x:
+          type: integer
+        'y':
+          type: integer
+      required:
+        - x
+        - 'y'
+        - w
+        - h
+      type: object
+    DashboardWidgetPositionInput:
+      properties:
+        h:
+          type: integer
+        w:
+          type: integer
+        x:
+          type: integer
+        'y':
+          type: integer
+      required:
+        - x
+        - 'y'
+        - w
+        - h
+      type: object
+    Deployment:
+      properties:
+        creationStep:
+          $ref: '#/components/schemas/CreationStep'
+        deploymentUrl:
+          type: string
+        id:
+          type: integer
+        name:
+          type: string
+      required:
+        - id
+        - name
+        - deploymentUrl
+        - creationStep
+      type: object
+    DeploymentEnvironment:
+      properties:
+        api_credentials:
+          items:
+            $ref: '#/components/schemas/DeploymentEnvironmentApiCredential'
+          type: array
+        branch:
+          oneOf:
+            - type: string
+            - type: 'null'
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/DeploymentEnvironmentType'
+        user:
+          oneOf:
+            - type: string
+            - type: 'null'
+      required:
+        - id
+        - type
+        - api_credentials
+      type: object
+    DeploymentEnvironmentApiCredential:
+      properties:
+        database:
+          oneOf:
+            - type: string
+            - type: 'null'
+        host:
+          oneOf:
+            - type: string
+            - type: 'null'
+        port:
+          oneOf:
+            - minimum: 1
+              type: integer
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/DeploymentEnvironmentApiCredentialType'
+        url:
+          oneOf:
+            - type: string
+            - type: 'null'
+        version:
+          minimum: 1
+          type: integer
+      required:
+        - type
+        - version
+      type: object
+    DeploymentEnvironmentApiCredentialType:
+      enum:
+        - rest
+        - sql
+      type: string
+    DeploymentEnvironmentToken:
+      properties:
+        created_at:
+          type: string
+        expires_at:
+          type: string
+        security_context:
+          additionalProperties: true
+          type: object
+        token:
+          type: string
+      required:
+        - token
+        - security_context
+        - created_at
+        - expires_at
+      type: object
+    DeploymentEnvironmentTokenResponse:
+      properties:
+        data:
+          $ref: '#/components/schemas/DeploymentEnvironmentToken'
+      required:
+        - data
+      type: object
+    DeploymentEnvironmentTokensListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/DeploymentEnvironmentToken'
+          type: array
+        pagination:
+          $ref: '#/components/schemas/DeploymentsPagination'
+      required:
+        - data
+        - pagination
+      type: object
+    DeploymentEnvironmentType:
+      enum:
+        - production
+        - staging
+        - development
+      type: string
+    DeploymentEnvironmentsListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/DeploymentEnvironment'
+          type: array
+        pagination:
+          $ref: '#/components/schemas/DeploymentsPagination'
+      required:
+        - data
+        - pagination
+      type: object
+    DeploymentTokenResponse:
+      properties:
+        cubeApiToken:
+          type: string
+      required:
+        - cubeApiToken
+      type: object
+    DeploymentsListResponse:
+      properties:
+        count:
+          oneOf:
+            - minimum: 0
+              type: integer
+            - type: 'null'
+        data:
+          items:
+            $ref: '#/components/schemas/Deployment'
+          type: array
+        items:
+          items:
+            $ref: '#/components/schemas/Deployment'
+          type: array
+        pageInfo:
+          oneOf:
+            - $ref: '#/components/schemas/PageInfoDto'
+            - type: 'null'
+        pagination:
+          $ref: '#/components/schemas/DeploymentsPagination'
+        totalCount:
+          oneOf:
+            - minimum: 0
+              type: integer
+            - type: 'null'
+      required:
+        - data
+        - items
+        - pagination
+      type: object
+    DeploymentsPagination:
+      properties:
+        limit:
+          minimum: 0
+          type: integer
+        offset:
+          minimum: 0
+          type: integer
+        total:
+          minimum: 0
+          type: integer
+      required:
+        - total
+        - offset
+        - limit
+      type: object
+    FolderDto:
+      properties:
+        createdAt:
+          oneOf:
+            - format: date
+              type: string
+            - format: date-time
+              type: string
+        createdBy:
+          type: integer
+        deploymentId:
+          type: integer
+        id:
+          type: integer
+        name:
+          type: string
+        parentId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        position:
+          type: integer
+        type:
+          $ref: '#/components/schemas/FolderDtoType'
+        updatedAt:
+          oneOf:
+            - format: date
+              type: string
+            - format: date-time
+              type: string
+        updatedBy:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      required:
+        - name
+        - position
+        - id
+        - deploymentId
+        - createdAt
+        - updatedAt
+        - type
+      type: object
+    FolderDtoType:
+      enum:
+        - FOLDER
+        - WORKBOOK
+        - REPORT
+      type: string
+    FoldersFindAllResult:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/FolderDto'
+          type: array
+      required:
+        - data
+      type: object
+    GetDeploymentEnvironmentsQueryType:
+      enum:
+        - production
+        - staging
+        - development
+      type: string
+    GetReportsQuerySortBy:
+      enum:
+        - createdAt
+        - updatedAt
+        - lastViewedAt
+      type: string
+    GetReportsQuerySortDirection:
+      enum:
+        - ASC
+        - DESC
+      type: string
+    PageInfoDto:
+      properties:
+        endCursor:
+          oneOf:
+            - type: string
+            - type: 'null'
+        hasNextPage:
+          type: boolean
+        hasPreviousPage:
+          type: boolean
+        startCursor:
+          oneOf:
+            - type: string
+            - type: 'null'
+      required:
+        - hasNextPage
+        - hasPreviousPage
+      type: object
+    PivotItemsDto:
+      properties:
+        columns:
+          items:
+            type: string
+          type: array
+        filters:
+          items:
+            type: string
+          type: array
+        measures:
+          items:
+            type: string
+          type: array
+        rows:
+          items:
+            type: string
+          type: array
+      required:
+        - columns
+        - measures
+        - rows
+        - filters
+      type: object
+    PivotItemsInput:
+      properties:
+        columns:
+          items:
+            type: string
+          type: array
+        filters:
+          items:
+            type: string
+          type: array
+        measures:
+          items:
+            type: string
+          type: array
+        rows:
+          items:
+            type: string
+          type: array
+      required:
+        - columns
+        - measures
+        - rows
+        - filters
+      type: object
+    PublishDashboardInput:
+      properties:
+        config:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardConfigInput'
+            - type: 'null'
+        dashboardId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        workbookId:
+          type: integer
+      required:
+        - workbookId
+      type: object
+    ReportDto:
+      properties:
+        createdAt:
+          oneOf:
+            - format: date
+              type: string
+            - format: date-time
+              type: string
+        createdBy:
+          type: integer
+        deploymentId:
+          type: integer
+        description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        endResultCell:
+          oneOf:
+            - type: string
+            - type: 'null'
+        externalWorkbookId:
+          oneOf:
+            - type: string
+            - type: 'null'
+        folderId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        id:
+          type: integer
+        jsonQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        meta:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        name:
+          type: string
+        pivotItems:
+          oneOf:
+            - $ref: '#/components/schemas/PivotItemsDto'
+            - type: 'null'
+        publicId:
+          maxLength: 12
+          minLength: 12
+          pattern: ^[0-9A-Za-z]+$
+          type: string
+        refreshedBy:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        refreshedByUser:
+          $ref: '#/components/schemas/ResourceOwnerDto'
+        resultLocation:
+          oneOf:
+            - type: string
+            - type: 'null'
+        rolesWithAccess:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/RoleWithAccess'
+              type: array
+            - type: 'null'
+        source:
+          oneOf:
+            - $ref: '#/components/schemas/ReportDtoSource'
+            - type: 'null'
+        sqlQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/ReportDtoType'
+        updatedAt:
+          oneOf:
+            - format: date
+              type: string
+            - format: date-time
+              type: string
+        user:
+          $ref: '#/components/schemas/ResourceOwnerDto'
+        userId:
+          type: integer
+        version:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        workbookId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      required:
+        - publicId
+        - userId
+        - user
+        - name
+        - refreshedByUser
+        - id
+        - deploymentId
+        - createdAt
+        - updatedAt
+        - type
+      type: object
+    ReportDtoSource:
+      enum:
+        - GOOGLE_SHEETS
+        - EXCEL
+        - PLAYGROUND
+        - D3
+      type: string
+    ReportDtoType:
+      enum:
+        - FOLDER
+        - WORKBOOK
+        - REPORT
+      type: string
+    ReportFolderDto:
+      properties:
+        createdBy:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        id:
+          type: integer
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+        reportsCount:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      required:
+        - id
+      type: object
+    ReportFoldersFindAllResult:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/ReportFolderDto'
+          type: array
+      required:
+        - data
+      type: object
+    ReportSnapshotDto:
+      properties:
+        description:
+          oneOf:
+            - type: string
+            - type: 'null'
+        id:
+          type: integer
+        kind:
+          oneOf:
+            - $ref: '#/components/schemas/ReportSnapshotDtoKind'
+            - type: 'null'
+        meta:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+        preferences:
+          oneOf:
+            - $ref: '#/components/schemas/ReportSnapshotPreferencesDto'
+            - type: 'null'
+        reportId:
+          type: integer
+        spec:
+          oneOf:
+            - oneOf:
+                - type: string
+                - type: object
+            - type: 'null'
+        sqlQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        versionNumber:
+          type: integer
+      required:
+        - id
+        - reportId
+        - versionNumber
+      type: object
+    ReportSnapshotDtoKind:
+      enum:
+        - vega
+        - table
+        - kpi
+        - html
+        - map
+      type: string
+    ReportSnapshotPreferencesDto:
+      properties:
+        columnFormats:
+          oneOf:
+            - type: object
+              additionalProperties:
+                $ref: '#/components/schemas/ColumnFormatOverrideDto'
+            - type: 'null'
+      type: object
+    ReportsFindAllResult:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/ReportDto'
+          type: array
+      required:
+        - data
+      type: object
+    ResourceOwnerDto:
+      properties:
+        email:
+          type: string
+        firstName:
+          oneOf:
+            - type: string
+            - type: 'null'
+        id:
+          type: integer
+        picture:
+          oneOf:
+            - type: string
+            - type: 'null'
+      required:
+        - id
+        - email
+      type: object
+    RoleWithAccess:
+      properties:
+        actions:
+          items:
+            enum:
+              - All
+              - DeploymentsManage
+              - DeploymentCreate
+              - DeploymentRead
+              - DeploymentUpdate
+              - DeploymentDelete
+              - PlaygroundRead
+              - SchemaRead
+              - SchemaUpdate
+              - SchemaUpdateDevBranches
+              - APMRead
+              - PreAggregationBuild
+              - AlertsCreate
+              - AlertsRead
+              - AlertsUpdate
+              - AlertsDelete
+              - AuditLogManage
+              - BillingRead
+              - SqlRunnerRead
+              - DataAssetsRead
+              - DataAssetsManage
+              - CubeNetworkConnect
+              - ReportRead
+              - ReportEdit
+              - ReportManage
+              - WorkbookManage
+              - WorkbookRead
+              - WorkbookEdit
+              - ChatThreadRead
+              - AgentManage
+              - AgentRead
+              - AgentSpaceManage
+              - AgentAdmin
+              - DeploymentAgentRead
+              - OAuthIntegrationsManage
+              - OAuthIntegrationsIssueTokens
+              - AIBIDevelop
+              - AIBIExplore
+              - AIBIView
+              - ChartPalettesManage
+              - DashboardThemesManage
+              - AIBIDeveloper
+              - AIBIUser
+              - AIBIViewer
+              - EmbedDeploymentRead
+              - EmbedDashboardRead
+              - FolderRead
+              - FolderEdit
+              - FolderManage
+            type: string
+          type: array
+        id:
+          type: integer
+        name:
+          type: string
+      required:
+        - id
+        - name
+        - actions
+      type: object
+    UpdateReportInput:
+      properties:
+        endResultCell:
+          oneOf:
+            - type: string
+            - type: 'null'
+        externalWorkbookId:
+          oneOf:
+            - type: string
+            - type: 'null'
+        folderId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+        jsonQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        meta:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+        pivotItems:
+          oneOf:
+            - $ref: '#/components/schemas/PivotItemsDto'
+            - type: 'null'
+        resultLocation:
+          oneOf:
+            - type: string
+            - type: 'null'
+        sqlQuery:
+          oneOf:
+            - type: string
+            - type: 'null'
+        title:
+          oneOf:
+            - type: string
+            - type: 'null'
+        workbookId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      type: object
+    UpdateWorkbookInput:
+      properties:
+        folderId:
+          oneOf:
+            - type: number
+            - type: 'null'
+        meta:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: 'null'
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    WidgetThemeBorderSectionInput:
+      properties:
+        color:
+          oneOf:
+            - type: string
+            - type: 'null'
+        radius:
+          oneOf:
+            - type: string
+            - type: 'null'
+        style:
+          oneOf:
+            - type: string
+            - type: 'null'
+        width:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    WidgetThemeSectionInput:
+      properties:
+        backgroundColor:
+          oneOf:
+            - type: string
+            - type: 'null'
+        border:
+          oneOf:
+            - $ref: '#/components/schemas/WidgetThemeBorderSectionInput'
+            - type: 'null'
+        margin:
+          oneOf:
+            - type: string
+            - type: 'null'
+        padding:
+          oneOf:
+            - type: string
+            - type: 'null'
+        text:
+          oneOf:
+            - $ref: '#/components/schemas/WidgetThemeTextSectionInput'
+            - type: 'null'
+        title:
+          oneOf:
+            - $ref: '#/components/schemas/WidgetThemeTitleSectionInput'
+            - type: 'null'
+      type: object
+    WidgetThemeTextSectionInput:
+      properties:
+        codeFontFamily:
+          oneOf:
+            - type: string
+            - type: 'null'
+        color:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontFamily:
+          oneOf:
+            - type: string
+            - type: 'null'
+        secondaryColor:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    WidgetThemeTitleSectionInput:
+      properties:
+        color:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontFamily:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontSize:
+          oneOf:
+            - type: string
+            - type: 'null'
+        fontWeight:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    WorkbookDashboardDto:
+      properties:
+        dashboardDraft:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardConfigDto'
+            - type: 'null'
+        dashboardPublished:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardConfigDto'
+            - type: 'null'
+      type: object
+    WorkbookDashboardInput:
+      properties:
+        dashboardDraft:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardConfigInput'
+            - type: 'null'
+      type: object
+    WorkbookDto:
+      properties:
+        calculatedFields:
+          type: object
+        createdAt:
+          oneOf:
+            - format: date
+              type: string
+            - format: date-time
+              type: string
+        createdBy:
+          type: integer
+        dashboardDraft:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardConfigDto'
+            - type: 'null'
+        dashboardPublished:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardConfigDto'
+            - type: 'null'
+        deploymentId:
+          type: integer
+        folderId:
+          oneOf:
+            - type: number
+            - type: 'null'
+        id:
+          type: integer
+        isFavorite:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        meta:
+          additionalProperties: true
+          type: object
+        name:
+          type: string
+        publishedDashboard:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardDto'
+            - type: 'null'
+        type:
+          $ref: '#/components/schemas/WorkbookDtoType'
+        updatedAt:
+          oneOf:
+            - format: date
+              type: string
+            - format: date-time
+              type: string
+        userId:
+          oneOf:
+            - type: number
+            - type: 'null'
+      required:
+        - name
+        - meta
+        - calculatedFields
+        - id
+        - deploymentId
+        - createdAt
+        - updatedAt
+        - type
+      type: object
+    WorkbookDtoType:
+      enum:
+        - FOLDER
+        - WORKBOOK
+        - REPORT
+      type: string
+    WorkbooksListResponse:
+      properties:
+        count:
+          oneOf:
+            - minimum: 0
+              type: integer
+            - type: 'null'
+        data:
+          items:
+            $ref: '#/components/schemas/WorkbookDto'
+          type: array
+        items:
+          items:
+            $ref: '#/components/schemas/WorkbookDto'
+          type: array
+        pageInfo:
+          oneOf:
+            - $ref: '#/components/schemas/PageInfoDto'
+            - type: 'null'
+      required:
+        - items
+        - data
+      type: object

--- a/docs-mintlify/api-reference/deployments.yaml
+++ b/docs-mintlify/api-reference/deployments.yaml
@@ -13,7 +13,7 @@ servers:
         default: your-tenant
         description: Your Cube Cloud tenant subdomain
 security:
-  - jwtAuth: []
+  - apiKey: []
 tags:
   - name: Deployments
   - name: Environments
@@ -733,10 +733,11 @@ paths:
         - Workbooks
 components:
   securitySchemes:
-    jwtAuth:
-      bearerFormat: JWT
-      scheme: bearer
-      type: http
+    apiKey:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: 'API key authentication. Send `Authorization: Api-Key <YOUR_API_KEY>`.'
   schemas:
     ColumnFormatOverrideDto:
       properties:

--- a/docs-mintlify/api-reference/introduction.mdx
+++ b/docs-mintlify/api-reference/introduction.mdx
@@ -1,28 +1,37 @@
 ---
 title: Introduction
-description: Programmatically provision users and groups in Cube Cloud with the SCIM 2.0 API.
+description: Programmatically manage Cube Cloud — deployments, reports, and workbooks over REST, plus user and group provisioning via SCIM 2.0.
 ---
+
+Programmatically manage your Cube Cloud account: work with deployments and the
+resources scoped to them (environments, folders, reports, and workbooks) over a
+REST API, and provision users and groups from your identity provider via SCIM
+2.0.
 
 ## Base URL
 
-The API base URL is your Cube Cloud tenant host with the `/api/scim/v2`
-namespace:
+Both APIs are served from your Cube Cloud tenant host under `/api`:
 
 ```text
-https://<tenant>.cubecloud.dev/api/scim/v2
+https://<tenant>.cubecloud.dev/api
 ```
 
-Only HTTPS calls are accepted. Authenticate every request with a bearer token —
-see [Authentication](/api-reference/authentication).
+Endpoints live under two namespaces:
+
+- `/api/v1/…` — the REST management API (deployments and nested resources)
+- `/api/scim/v2/…` — the SCIM 2.0 user and group provisioning API
+
+Only HTTPS calls are accepted. Authenticate every request — see
+[Authentication](/api-reference/authentication).
 
 ## Available endpoints
 
 | Entity | Resource | Version |
 | --- | --- | --- |
-| [Users](/api-reference/users/list-users) | `/scim/v2/Users` | SCIM 2.0 |
-| [Groups](/api-reference/groups/list-groups) | `/scim/v2/Groups` | SCIM 2.0 |
 | [Deployments](/api-reference/deployments/get-deployments) | `/v1/deployments` | v1 |
 | [Environments](/api-reference/environments/get-deployment-environments) | `/v1/deployments/{deploymentId}/environments` | v1 |
 | [Folders](/api-reference/folders/get-folders) | `/v1/deployments/{deploymentId}/folders` | v1 |
 | [Reports](/api-reference/reports/get-reports) | `/v1/deployments/{deploymentId}/reports` | v1 |
 | [Workbooks](/api-reference/workbooks/get-workbooks) | `/v1/deployments/{deploymentId}/workbooks` | v1 |
+| [Users](/api-reference/users/list-users) | `/scim/v2/Users` | SCIM 2.0 |
+| [Groups](/api-reference/groups/list-groups) | `/scim/v2/Groups` | SCIM 2.0 |

--- a/docs-mintlify/api-reference/introduction.mdx
+++ b/docs-mintlify/api-reference/introduction.mdx
@@ -1,0 +1,28 @@
+---
+title: Introduction
+description: Programmatically provision users and groups in Cube Cloud with the SCIM 2.0 API.
+---
+
+## Base URL
+
+The API base URL is your Cube Cloud tenant host with the `/api/scim/v2`
+namespace:
+
+```text
+https://<tenant>.cubecloud.dev/api/scim/v2
+```
+
+Only HTTPS calls are accepted. Authenticate every request with a bearer token —
+see [Authentication](/api-reference/authentication).
+
+## Available endpoints
+
+| Entity | Resource | Version |
+| --- | --- | --- |
+| [Users](/api-reference/users/list-users) | `/scim/v2/Users` | SCIM 2.0 |
+| [Groups](/api-reference/groups/list-groups) | `/scim/v2/Groups` | SCIM 2.0 |
+| [Deployments](/api-reference/deployments/get-deployments) | `/v1/deployments` | v1 |
+| [Environments](/api-reference/environments/get-deployment-environments) | `/v1/deployments/{deploymentId}/environments` | v1 |
+| [Folders](/api-reference/folders/get-folders) | `/v1/deployments/{deploymentId}/folders` | v1 |
+| [Reports](/api-reference/reports/get-reports) | `/v1/deployments/{deploymentId}/reports` | v1 |
+| [Workbooks](/api-reference/workbooks/get-workbooks) | `/v1/deployments/{deploymentId}/workbooks` | v1 |

--- a/docs-mintlify/api-reference/scim.yaml
+++ b/docs-mintlify/api-reference/scim.yaml
@@ -1,0 +1,559 @@
+openapi: 3.1.0
+info:
+  title: Cube Cloud SCIM API
+  version: "1.0.0"
+  description: |
+    The SCIM 2.0 API lets identity providers (Okta, Azure AD/Entra ID, OneLogin,
+    and others) provision and de-provision users and groups in Cube Cloud
+    automatically. It implements the System for Cross-domain Identity Management
+    protocol as defined in [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643)
+    and [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644).
+
+    ## Base URL
+
+    All SCIM endpoints live under the `/scim/v2` namespace on your Cube Cloud
+    tenant's API host:
+
+    ```text
+    https://<tenant>.cubecloud.dev/api/scim/v2
+    ```
+
+    Replace `<tenant>` with your Cube Cloud subdomain, or swap the whole host
+    if your account uses a custom domain.
+
+    ## Authentication
+
+    SCIM requests are authenticated with a bearer token issued from your Cube
+    Cloud account settings. Include it in the `Authorization` header:
+
+    ```text
+    Authorization: Bearer <YOUR_SCIM_TOKEN>
+    ```
+
+    ## Content type
+
+    Requests and responses use `application/json`. The SCIM media type
+    `application/scim+json` is also accepted.
+servers:
+  - url: https://{tenant}.cubecloud.dev/api
+    description: Cube Cloud API base URL. Replace the whole host if you use a custom domain.
+    variables:
+      tenant:
+        default: your-tenant
+        description: Your Cube Cloud tenant subdomain
+security:
+  - bearerAuth: []
+tags:
+  - name: Users
+    description: Provision, read, update, and de-provision users.
+  - name: Groups
+    description: Provision, read, update, and de-provision groups and their memberships.
+paths:
+  /scim/v2/Users:
+    get:
+      operationId: listUsers
+      summary: List users
+      description: |
+        Returns a paginated [ListResponse](https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2)
+        of users. Use the `filter` parameter to look a user up by `userName`,
+        for example `userName eq "jane@example.com"`.
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/components/parameters/Filter'
+        - $ref: '#/components/parameters/StartIndex'
+        - $ref: '#/components/parameters/Count'
+      responses:
+        '200':
+          description: A list of users.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserListResponse'
+              example:
+                schemas:
+                  - urn:ietf:params:scim:api:messages:2.0:ListResponse
+                totalResults: 1
+                startIndex: 1
+                itemsPerPage: 20
+                Resources:
+                  - schemas:
+                      - urn:ietf:params:scim:schemas:core:2.0:User
+                    id: "2819c223-7f76-453a-919d-413861904646"
+                    userName: jane@example.com
+                    name:
+                      givenName: Jane
+                      familyName: Doe
+                    emails:
+                      - value: jane@example.com
+                        primary: true
+                    active: true
+    post:
+      operationId: createUser
+      summary: Create user
+      description: Provisions a new user.
+      tags:
+        - Users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            example:
+              schemas:
+                - urn:ietf:params:scim:schemas:core:2.0:User
+              userName: jane@example.com
+              name:
+                givenName: Jane
+                familyName: Doe
+              emails:
+                - value: jane@example.com
+                  primary: true
+              active: true
+      responses:
+        '201':
+          description: The created user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /scim/v2/Users/{id}:
+    get:
+      operationId: getUser
+      summary: Get user
+      description: Returns a single user by their SCIM `id`.
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        '200':
+          description: The requested user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: replaceUser
+      summary: Replace user
+      description: Replaces all attributes of an existing user with the supplied representation.
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: The updated user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      operationId: patchUser
+      summary: Patch user
+      description: |
+        Applies a partial update to a user using a SCIM
+        [PatchOp](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2).
+        Commonly used to deactivate a user by setting `active` to `false`.
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchOp'
+            example:
+              schemas:
+                - urn:ietf:params:scim:api:messages:2.0:PatchOp
+              Operations:
+                - op: replace
+                  path: active
+                  value: false
+      responses:
+        '200':
+          description: The updated user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: deleteUser
+      summary: Delete user
+      description: De-provisions (deletes) a user by their SCIM `id`.
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        '204':
+          description: The user was deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /scim/v2/Groups:
+    get:
+      operationId: listGroups
+      summary: List groups
+      description: Returns a paginated ListResponse of groups.
+      tags:
+        - Groups
+      parameters:
+        - $ref: '#/components/parameters/Filter'
+        - $ref: '#/components/parameters/StartIndex'
+        - $ref: '#/components/parameters/Count'
+        - $ref: '#/components/parameters/ExcludedAttributes'
+      responses:
+        '200':
+          description: A list of groups.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupListResponse'
+    post:
+      operationId: createGroup
+      summary: Create group
+      description: Provisions a new group.
+      tags:
+        - Groups
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+            example:
+              schemas:
+                - urn:ietf:params:scim:schemas:core:2.0:Group
+              displayName: Analysts
+      responses:
+        '201':
+          description: The created group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+  /scim/v2/Groups/{id}:
+    get:
+      operationId: getGroup
+      summary: Get group
+      description: Returns a single group by its SCIM `id`.
+      tags:
+        - Groups
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+        - $ref: '#/components/parameters/ExcludedAttributes'
+      responses:
+        '200':
+          description: The requested group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      operationId: replaceGroup
+      summary: Replace group
+      description: Replaces all attributes of an existing group, including its full membership list.
+      tags:
+        - Groups
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+      responses:
+        '200':
+          description: The updated group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      operationId: patchGroup
+      summary: Patch group
+      description: |
+        Applies a partial update to a group using a SCIM PatchOp. Commonly used
+        to add or remove members without resending the entire membership list.
+      tags:
+        - Groups
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchOp'
+            example:
+              schemas:
+                - urn:ietf:params:scim:api:messages:2.0:PatchOp
+              Operations:
+                - op: add
+                  path: members
+                  value:
+                    - value: "2819c223-7f76-453a-919d-413861904646"
+      responses:
+        '200':
+          description: The updated group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      operationId: deleteGroup
+      summary: Delete group
+      description: Deletes a group by its SCIM `id`. Member users are not deleted.
+      tags:
+        - Groups
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        '204':
+          description: The group was deleted.
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: SCIM bearer token issued from your Cube Cloud account settings.
+  parameters:
+    ResourceId:
+      name: id
+      in: path
+      required: true
+      description: The unique SCIM identifier of the resource.
+      schema:
+        type: string
+    Filter:
+      name: filter
+      in: query
+      required: false
+      description: |
+        SCIM filter expression used to narrow results, for example
+        `userName eq "jane@example.com"`.
+      schema:
+        type: string
+    StartIndex:
+      name: startIndex
+      in: query
+      required: false
+      description: 1-based index of the first result to return. Defaults to `1`.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    Count:
+      name: count
+      in: query
+      required: false
+      description: Maximum number of results to return per page.
+      schema:
+        type: integer
+        minimum: 0
+    ExcludedAttributes:
+      name: excludedAttributes
+      in: query
+      required: false
+      description: Comma-separated list of attributes to omit from the response.
+      schema:
+        type: string
+  responses:
+    NotFound:
+      description: The requested resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            schemas:
+              - urn:ietf:params:scim:api:messages:2.0:Error
+            status: "404"
+            detail: Resource not found.
+  schemas:
+    User:
+      type: object
+      description: A SCIM 2.0 core User resource.
+      required:
+        - userName
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          example:
+            - urn:ietf:params:scim:schemas:core:2.0:User
+        id:
+          type: string
+          description: Unique identifier assigned by Cube Cloud. Read-only.
+          readOnly: true
+        userName:
+          type: string
+          description: Unique identifier for the user, typically their email address.
+        name:
+          type: object
+          properties:
+            givenName:
+              type: string
+            familyName:
+              type: string
+        emails:
+          type: array
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+              primary:
+                type: boolean
+        active:
+          type: boolean
+          description: Whether the user is active. Set to `false` to deactivate.
+        externalId:
+          type: string
+          description: Identifier of the user as defined by the provisioning client.
+        meta:
+          $ref: '#/components/schemas/Meta'
+    Group:
+      type: object
+      description: A SCIM 2.0 core Group resource.
+      required:
+        - displayName
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          example:
+            - urn:ietf:params:scim:schemas:core:2.0:Group
+        id:
+          type: string
+          readOnly: true
+        displayName:
+          type: string
+          description: Human-readable name of the group.
+        members:
+          type: array
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+                description: The `id` of a member user.
+              display:
+                type: string
+        meta:
+          $ref: '#/components/schemas/Meta'
+    PatchOp:
+      type: object
+      description: A SCIM 2.0 PatchOp request.
+      required:
+        - schemas
+        - Operations
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          example:
+            - urn:ietf:params:scim:api:messages:2.0:PatchOp
+        Operations:
+          type: array
+          items:
+            type: object
+            required:
+              - op
+            properties:
+              op:
+                type: string
+                enum:
+                  - add
+                  - remove
+                  - replace
+              path:
+                type: string
+              value: {}
+    UserListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ListResponse'
+        - type: object
+          properties:
+            Resources:
+              type: array
+              items:
+                $ref: '#/components/schemas/User'
+    GroupListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ListResponse'
+        - type: object
+          properties:
+            Resources:
+              type: array
+              items:
+                $ref: '#/components/schemas/Group'
+    ListResponse:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          example:
+            - urn:ietf:params:scim:api:messages:2.0:ListResponse
+        totalResults:
+          type: integer
+        startIndex:
+          type: integer
+        itemsPerPage:
+          type: integer
+    Meta:
+      type: object
+      readOnly: true
+      properties:
+        resourceType:
+          type: string
+        created:
+          type: string
+          format: date-time
+        lastModified:
+          type: string
+          format: date-time
+        location:
+          type: string
+    Error:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          example:
+            - urn:ietf:params:scim:api:messages:2.0:Error
+        status:
+          type: string
+        detail:
+          type: string

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -667,6 +667,100 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "API",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "api-reference/introduction",
+              "api-reference/authentication"
+            ]
+          },
+          {
+            "group": "Endpoints",
+            "pages": [
+              {
+                "group": "Users",
+                "openapi": "/api-reference/scim.yaml",
+                "pages": [
+                  "GET /scim/v2/Users",
+                  "POST /scim/v2/Users",
+                  "GET /scim/v2/Users/{id}",
+                  "PUT /scim/v2/Users/{id}",
+                  "PATCH /scim/v2/Users/{id}",
+                  "DELETE /scim/v2/Users/{id}"
+                ]
+              },
+              {
+                "group": "Groups",
+                "openapi": "/api-reference/scim.yaml",
+                "pages": [
+                  "GET /scim/v2/Groups",
+                  "POST /scim/v2/Groups",
+                  "GET /scim/v2/Groups/{id}",
+                  "PUT /scim/v2/Groups/{id}",
+                  "PATCH /scim/v2/Groups/{id}",
+                  "DELETE /scim/v2/Groups/{id}"
+                ]
+              },
+              {
+                "group": "Deployments",
+                "openapi": "/api-reference/deployments.yaml",
+                "pages": [
+                  "GET /v1/deployments/",
+                  "GET /v1/deployments/{deploymentId}",
+                  "POST /v1/deployments/{deploymentId}/token"
+                ]
+              },
+              {
+                "group": "Environments",
+                "openapi": "/api-reference/deployments.yaml",
+                "pages": [
+                  "GET /v1/deployments/{deploymentId}/environments",
+                  "GET /v1/deployments/{deploymentId}/environments/{environmentId}/tokens",
+                  "POST /v1/deployments/{deploymentId}/environments/{environmentId}/tokens",
+                  "POST /v1/deployments/{deploymentId}/environments/{environmentId}/tokens-for-meta-sync"
+                ]
+              },
+              {
+                "group": "Folders",
+                "openapi": "/api-reference/deployments.yaml",
+                "pages": [
+                  "GET /v1/deployments/{deploymentId}/folders",
+                  "GET /v1/deployments/{deploymentId}/folders/{folderId}/ancestors"
+                ]
+              },
+              {
+                "group": "Reports",
+                "openapi": "/api-reference/deployments.yaml",
+                "pages": [
+                  "GET /v1/deployments/{deploymentId}/report-folders",
+                  "GET /v1/deployments/{deploymentId}/reports",
+                  "POST /v1/deployments/{deploymentId}/reports",
+                  "GET /v1/deployments/{deploymentId}/reports/{reportId}",
+                  "PUT /v1/deployments/{deploymentId}/reports/{reportId}",
+                  "DELETE /v1/deployments/{deploymentId}/reports/{reportId}",
+                  "PUT /v1/deployments/{deploymentId}/reports/{reportId}/refresh"
+                ]
+              },
+              {
+                "group": "Workbooks",
+                "openapi": "/api-reference/deployments.yaml",
+                "pages": [
+                  "GET /v1/deployments/{deploymentId}/workbooks",
+                  "POST /v1/deployments/{deploymentId}/workbooks",
+                  "GET /v1/deployments/{deploymentId}/workbooks/{workbookId}",
+                  "PUT /v1/deployments/{deploymentId}/workbooks/{workbookId}",
+                  "DELETE /v1/deployments/{deploymentId}/workbooks/{workbookId}",
+                  "PUT /v1/deployments/{deploymentId}/workbooks/{workbookId}/dashboard",
+                  "POST /v1/deployments/{deploymentId}/workbooks/{workbookId}/publish"
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   },

--- a/docs-mintlify/scripts/extract-deployments.js
+++ b/docs-mintlify/scripts/extract-deployments.js
@@ -1,0 +1,134 @@
+/* eslint-disable */
+// One-off extractor: pulls the /api/v1/deployments subtree (paths + transitive
+// schema closure) out of the enterprise public OpenAPI spec into a standalone
+// deployments.yaml for the Mintlify API docs.
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const SRC = path.join(
+  process.env.HOME,
+  'code/cubejs-enterprise/packages/console-server/open-api-spec-public-v3.1.yaml'
+);
+const OUT = path.join(__dirname, '..', 'api-reference', 'deployments.yaml');
+
+const TAG_MAP = {
+  'Deployments Public': 'Deployments',
+  'Deployment Environment Public': 'Environments',
+  'Agents Public': 'Agents',
+  'Folders Public': 'Folders',
+  'Reports Public': 'Reports',
+  'Workbooks Public': 'Workbooks',
+  'Workspace Public': 'Workspace',
+};
+// Allowlist of areas to include (also controls tag + nav order).
+const TAG_ORDER = ['Deployments', 'Environments', 'Folders', 'Reports', 'Workbooks'];
+const METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+
+const src = yaml.load(fs.readFileSync(SRC, 'utf8'));
+
+// 1. Filter + rewrite deployments paths (strip leading /api -> server holds it).
+const paths = {};
+for (const [key, val] of Object.entries(src.paths)) {
+  if (!key.startsWith('/api/v1/deployments')) continue;
+  // skip whole paths whose area is not in the allowlist (e.g. Agents, Workspace)
+  const firstOp = METHODS.map((m) => val[m]).find(Boolean);
+  const cleanTag = firstOp && firstOp.tags && (TAG_MAP[firstOp.tags[0]] || firstOp.tags[0]);
+  if (!TAG_ORDER.includes(cleanTag)) continue;
+  const newKey = key.replace(/^\/api/, '');
+  for (const m of METHODS) {
+    if (!val[m]) continue;
+    // retag operations to clean names
+    if (Array.isArray(val[m].tags)) {
+      val[m].tags = val[m].tags.map((t) => TAG_MAP[t] || t);
+    }
+    // strip "XxxController." prefix from operationId for clean page slugs
+    if (typeof val[m].operationId === 'string') {
+      val[m].operationId = val[m].operationId.replace(/^[^.]*\./, '');
+    }
+  }
+  paths[newKey] = val;
+}
+
+// 2. Transitive $ref schema closure.
+function collectRefs(node, acc) {
+  if (Array.isArray(node)) { node.forEach((n) => collectRefs(n, acc)); return; }
+  if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      if (k === '$ref' && typeof v === 'string') {
+        const m = v.match(/^#\/components\/schemas\/(.+)$/);
+        if (m) acc.add(m[1]);
+      } else collectRefs(v, acc);
+    }
+  }
+}
+const wanted = new Set();
+collectRefs(paths, wanted);
+const schemas = {};
+const queue = [...wanted];
+while (queue.length) {
+  const name = queue.shift();
+  if (schemas[name]) continue;
+  const def = src.components.schemas[name];
+  if (!def) { console.warn('MISSING schema:', name); continue; }
+  schemas[name] = def;
+  const sub = new Set();
+  collectRefs(def, sub);
+  for (const s of sub) if (!schemas[s]) queue.push(s);
+}
+
+// 3. Assemble output doc (sorted schemas for stable diff).
+const sortedSchemas = {};
+Object.keys(schemas).sort().forEach((k) => { sortedSchemas[k] = schemas[k]; });
+
+const out = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Cube Cloud Deployments API',
+    version: '1.0.0',
+    description:
+      'Manage Cube Cloud deployments and everything scoped to them — environments and\n' +
+      'API tokens, folders, reports, and workbooks with their dashboards.',
+  },
+  servers: [
+    {
+      url: 'https://{tenant}.cubecloud.dev/api',
+      description: 'Cube Cloud API base URL. Replace the whole host if you use a custom domain.',
+      variables: { tenant: { default: 'your-tenant', description: 'Your Cube Cloud tenant subdomain' } },
+    },
+  ],
+  security: [{ jwtAuth: [] }],
+  tags: TAG_ORDER.map((t) => ({ name: t })),
+  paths,
+  components: {
+    securitySchemes: { jwtAuth: src.components.securitySchemes.jwtAuth },
+    schemas: sortedSchemas,
+  },
+};
+
+fs.writeFileSync(OUT, yaml.dump(out, { lineWidth: 100, noRefs: true }));
+console.log('Wrote', OUT);
+console.log('paths:', Object.keys(paths).length, '| schemas:', Object.keys(schemas).length);
+
+// 4. Emit nav fragment (pages grouped by clean tag, in file order) + index rows.
+const byTag = {};
+const firstPathForTag = {};
+for (const [p, val] of Object.entries(paths)) {
+  for (const m of METHODS) {
+    if (!val[m]) continue;
+    const tag = (val[m].tags && val[m].tags[0]) || 'Other';
+    (byTag[tag] = byTag[tag] || []).push(`${m.toUpperCase()} ${p}`);
+    if (!firstPathForTag[tag]) firstPathForTag[tag] = p;
+  }
+}
+const groups = TAG_ORDER.filter((t) => byTag[t]).map((t) => ({
+  group: t,
+  openapi: '/api-reference/deployments.yaml',
+  pages: byTag[t],
+}));
+console.log('\n=== NAV GROUPS ===');
+console.log(JSON.stringify(groups, null, 2));
+console.log('\n=== INDEX ROWS (entity | resource | version) ===');
+for (const t of TAG_ORDER) {
+  if (firstPathForTag[t]) console.log(`${t} | ${firstPathForTag[t]} | v1`);
+}

--- a/docs-mintlify/scripts/extract-deployments.js
+++ b/docs-mintlify/scripts/extract-deployments.js
@@ -37,11 +37,9 @@ const OUT = path.join(__dirname, '..', 'api-reference', 'deployments.yaml');
 const TAG_MAP = {
   'Deployments Public': 'Deployments',
   'Deployment Environment Public': 'Environments',
-  'Agents Public': 'Agents',
   'Folders Public': 'Folders',
   'Reports Public': 'Reports',
   'Workbooks Public': 'Workbooks',
-  'Workspace Public': 'Workspace',
 };
 // Allowlist of areas to include (also controls tag + nav order).
 const TAG_ORDER = ['Deployments', 'Environments', 'Folders', 'Reports', 'Workbooks'];

--- a/docs-mintlify/scripts/extract-deployments.js
+++ b/docs-mintlify/scripts/extract-deployments.js
@@ -92,16 +92,27 @@ function collectRefs(node, acc) {
 const wanted = new Set();
 collectRefs(paths, wanted);
 const schemas = {};
+const missing = [];
 const queue = [...wanted];
 while (queue.length) {
   const name = queue.shift();
   if (schemas[name]) continue;
   const def = src.components.schemas[name];
-  if (!def) { console.warn('MISSING schema:', name); continue; }
+  if (!def) { missing.push(name); continue; }
   schemas[name] = def;
   const sub = new Set();
   collectRefs(def, sub);
   for (const s of sub) if (!schemas[s]) queue.push(s);
+}
+// Hard-fail rather than shipping deployments.yaml with dangling $refs (broken
+// docs). A missing schema usually means an upstream rename/removal to handle.
+if (missing.length) {
+  console.error(
+    'Aborting: referenced schemas not found in the source spec (broken $refs):\n  ' +
+      missing.sort().join('\n  ') +
+      '\nThe upstream spec likely renamed or removed these. Fix the mapping and re-run.'
+  );
+  process.exit(1);
 }
 
 // 3. Assemble output doc (sorted schemas for stable diff).
@@ -124,11 +135,21 @@ const out = {
       variables: { tenant: { default: 'your-tenant', description: 'Your Cube Cloud tenant subdomain' } },
     },
   ],
-  security: [{ jwtAuth: [] }],
+  security: [{ apiKey: [] }],
   tags: TAG_ORDER.map((t) => ({ name: t })),
   paths,
   components: {
-    securitySchemes: { jwtAuth: src.components.securitySchemes.jwtAuth },
+    // The public API authenticates REST clients with an API key sent as
+    // `Authorization: Api-Key <token>`. The source spec hardcodes a bearer/JWT
+    // scheme that does not reflect the primary runtime auth, so we override it.
+    securitySchemes: {
+      apiKey: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'Authorization',
+        description: 'API key authentication. Send `Authorization: Api-Key <YOUR_API_KEY>`.',
+      },
+    },
     schemas: sortedSchemas,
   },
 };

--- a/docs-mintlify/scripts/extract-deployments.js
+++ b/docs-mintlify/scripts/extract-deployments.js
@@ -4,37 +4,32 @@
 // deployments.yaml for the Mintlify API docs.
 //
 // The source spec lives in the (private) cubejs-enterprise repo and is NOT in
-// this repo. To regenerate:
+// this repo, so there is no hardcoded path — point the script at the spec via
+// the SRC_SPEC env var (a CLI path arg is also accepted):
 //
-//   1. Clone cubejs-enterprise as a sibling of this repo (default assumption:
-//      ../../../cubejs-enterprise relative to this script), or generate the
-//      spec there with `yarn generate:open-api:spec-public` in
-//      packages/console-server.
-//   2. Run, pointing at the spec:
-//        node scripts/extract-deployments.js [path/to/open-api-spec-public-v3.1.yaml]
-//      or:
-//        SRC_SPEC=path/to/spec.yaml node scripts/extract-deployments.js
+//   SRC_SPEC=/path/to/open-api-spec-public-v3.1.yaml node scripts/extract-deployments.js
+//   node scripts/extract-deployments.js /path/to/open-api-spec-public-v3.1.yaml
 //
-// Resolution order for the source path: CLI arg > SRC_SPEC env > sibling repo
-// default. The script errors out with this guidance if the file is missing.
+// The spec is generated in cubejs-enterprise/packages/console-server via
+// `yarn generate:open-api:spec-public`.
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-const DEFAULT_SRC = path.resolve(
-  __dirname,
-  '../../../cubejs-enterprise/packages/console-server/open-api-spec-public-v3.1.yaml'
-);
-const SRC = path.resolve(process.argv[2] || process.env.SRC_SPEC || DEFAULT_SRC);
-if (!fs.existsSync(SRC)) {
+const srcArg = process.argv[2] || process.env.SRC_SPEC;
+if (!srcArg) {
   console.error(
-    `Source spec not found: ${SRC}\n\n` +
-      'Pass the path to the Console Server public OpenAPI spec, e.g.:\n' +
-      '  node scripts/extract-deployments.js /path/to/open-api-spec-public-v3.1.yaml\n' +
-      '  SRC_SPEC=/path/to/spec.yaml node scripts/extract-deployments.js\n\n' +
+    'No source spec provided. Set the SRC_SPEC env var (or pass a path arg):\n' +
+      '  SRC_SPEC=/path/to/open-api-spec-public-v3.1.yaml node scripts/extract-deployments.js\n' +
+      '  node scripts/extract-deployments.js /path/to/open-api-spec-public-v3.1.yaml\n\n' +
       'The spec is generated in cubejs-enterprise/packages/console-server via\n' +
       '`yarn generate:open-api:spec-public` and is not committed to this repo.'
   );
+  process.exit(1);
+}
+const SRC = path.resolve(srcArg);
+if (!fs.existsSync(SRC)) {
+  console.error(`Source spec not found: ${SRC}`);
   process.exit(1);
 }
 const OUT = path.join(__dirname, '..', 'api-reference', 'deployments.yaml');

--- a/docs-mintlify/scripts/extract-deployments.js
+++ b/docs-mintlify/scripts/extract-deployments.js
@@ -1,15 +1,42 @@
 /* eslint-disable */
-// One-off extractor: pulls the /api/v1/deployments subtree (paths + transitive
-// schema closure) out of the enterprise public OpenAPI spec into a standalone
+// Extractor: pulls the /api/v1/deployments subtree (paths + transitive schema
+// closure) out of the Console Server public OpenAPI spec into a standalone
 // deployments.yaml for the Mintlify API docs.
+//
+// The source spec lives in the (private) cubejs-enterprise repo and is NOT in
+// this repo. To regenerate:
+//
+//   1. Clone cubejs-enterprise as a sibling of this repo (default assumption:
+//      ../../../cubejs-enterprise relative to this script), or generate the
+//      spec there with `yarn generate:open-api:spec-public` in
+//      packages/console-server.
+//   2. Run, pointing at the spec:
+//        node scripts/extract-deployments.js [path/to/open-api-spec-public-v3.1.yaml]
+//      or:
+//        SRC_SPEC=path/to/spec.yaml node scripts/extract-deployments.js
+//
+// Resolution order for the source path: CLI arg > SRC_SPEC env > sibling repo
+// default. The script errors out with this guidance if the file is missing.
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-const SRC = path.join(
-  process.env.HOME,
-  'code/cubejs-enterprise/packages/console-server/open-api-spec-public-v3.1.yaml'
+const DEFAULT_SRC = path.resolve(
+  __dirname,
+  '../../../cubejs-enterprise/packages/console-server/open-api-spec-public-v3.1.yaml'
 );
+const SRC = path.resolve(process.argv[2] || process.env.SRC_SPEC || DEFAULT_SRC);
+if (!fs.existsSync(SRC)) {
+  console.error(
+    `Source spec not found: ${SRC}\n\n` +
+      'Pass the path to the Console Server public OpenAPI spec, e.g.:\n' +
+      '  node scripts/extract-deployments.js /path/to/open-api-spec-public-v3.1.yaml\n' +
+      '  SRC_SPEC=/path/to/spec.yaml node scripts/extract-deployments.js\n\n' +
+      'The spec is generated in cubejs-enterprise/packages/console-server via\n' +
+      '`yarn generate:open-api:spec-public` and is not committed to this repo.'
+  );
+  process.exit(1);
+}
 const OUT = path.join(__dirname, '..', 'api-reference', 'deployments.yaml');
 
 const TAG_MAP = {


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Adds a new **API** tab to the Mintlify docs (`docs-mintlify`) with interactive, OpenAPI-driven reference pages for the **Cube Cloud Console Server Public API**, styled after the Omni API docs — a landing index plus per-endpoint pages with parameters, request/response schemas, code samples, and a Try-it playground.

### Scope
Cherry-picked from the enterprise public spec (`cubejs-enterprise/packages/console-server/open-api-spec-public-v3.1.yaml`):
- **SCIM 2.0** — Users and Groups under `/api/scim/v2`
- **Deployments** and nested resources under `/api/v1/deployments` — deployments, environments + tokens, folders, reports, workbooks/dashboards

### What's included
- `docs-mintlify/api-reference/scim.yaml` — hand-authored SCIM 2.0 spec. The source spec ships empty SCIM request/response bodies, so these were filled in per RFC 7643/7644 with examples. Uses `application/json` and a `{tenant}` server variable.
- `docs-mintlify/api-reference/deployments.yaml` — **generated** from the enterprise public spec (20→16 paths, ~74 schemas after trimming Agents/Workspace).
- `docs-mintlify/scripts/extract-deployments.js` — reproducible extractor: pulls the `/api/v1/deployments` subtree (paths + transitive schema closure), rewrites paths to sit under the `/api` base URL, retags to clean group names, and strips `Controller.` prefixes from operationIds for clean page slugs. Re-run to regenerate `deployments.yaml` when the source spec changes.
- `docs-mintlify/api-reference/introduction.mdx` + `authentication.mdx` — Getting Started pages (base URL, auth, and an "Available endpoints" index table).
- `docs-mintlify/docs.json` — registers the new **API** tab (Getting Started + grouped Endpoints).

### Notes for reviewers
- All specs validate with `mintlify openapi-check`; every generated page was verified to render locally.
- **Auth discrepancy to confirm:** the generated deployments spec declares **bearer JWT** (`Authorization: Bearer <token>`), while the existing hand-written `docs-mintlify/reference/control-plane-api.mdx` documents the same endpoints with `Authorization: Api-Key <key>`. The OpenAPI spec is code-generated, but please confirm which is current — and whether `control-plane-api.mdx` should eventually be folded into this reference.
- Local preview requires the latest Mintlify renderer (Node ≥ 20.17); the version pinned in `docs-mintlify/package.json` showed an older cached renderer that dropped OpenAPI bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)