### PR TITLE
feat(cubestore): Introduce HttpQueryResultCompleted for zero-column r…

### DIFF
--- a/rust/cube/cubeshared/src/codegen/http_message.fbs
+++ b/rust/cube/cubeshared/src/codegen/http_message.fbs
@@ -71,8 +71,13 @@ table HttpQueryResultArrow {
     is_last: bool;
 }
 
+// Returned for commands that complete without a result set (zero columns):
+// CREATE TABLE/INSERT, queue/cache writes. A marker — carries no payload.
+table HttpQueryResultCompleted {}
+
 union HttpQueryResultData {
     HttpQueryResultArrow,
+    HttpQueryResultCompleted,
 }
 
 table HttpQueryResult {

--- a/rust/cube/cubeshared/src/codegen/http_message_generated.rs
+++ b/rust/cube/cubeshared/src/codegen/http_message_generated.rs
@@ -324,15 +324,16 @@ pub const ENUM_MIN_HTTP_QUERY_RESULT_DATA: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_HTTP_QUERY_RESULT_DATA: u8 = 1;
+pub const ENUM_MAX_HTTP_QUERY_RESULT_DATA: u8 = 2;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_HTTP_QUERY_RESULT_DATA: [HttpQueryResultData; 2] = [
+pub const ENUM_VALUES_HTTP_QUERY_RESULT_DATA: [HttpQueryResultData; 3] = [
     HttpQueryResultData::NONE,
     HttpQueryResultData::HttpQueryResultArrow,
+    HttpQueryResultData::HttpQueryResultCompleted,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -342,15 +343,21 @@ pub struct HttpQueryResultData(pub u8);
 impl HttpQueryResultData {
     pub const NONE: Self = Self(0);
     pub const HttpQueryResultArrow: Self = Self(1);
+    pub const HttpQueryResultCompleted: Self = Self(2);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 1;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::NONE, Self::HttpQueryResultArrow];
+    pub const ENUM_MAX: u8 = 2;
+    pub const ENUM_VALUES: &'static [Self] = &[
+        Self::NONE,
+        Self::HttpQueryResultArrow,
+        Self::HttpQueryResultCompleted,
+    ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::NONE => Some("NONE"),
             Self::HttpQueryResultArrow => Some("HttpQueryResultArrow"),
+            Self::HttpQueryResultCompleted => Some("HttpQueryResultCompleted"),
             _ => None,
         }
     }
@@ -2792,6 +2799,89 @@ impl ::core::fmt::Debug for HttpQueryResultArrow<'_> {
         ds.finish()
     }
 }
+pub enum HttpQueryResultCompletedOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct HttpQueryResultCompleted<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for HttpQueryResultCompleted<'a> {
+    type Inner = HttpQueryResultCompleted<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> HttpQueryResultCompleted<'a> {
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        HttpQueryResultCompleted { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        _args: &'args HttpQueryResultCompletedArgs,
+    ) -> ::flatbuffers::WIPOffset<HttpQueryResultCompleted<'bldr>> {
+        let mut builder = HttpQueryResultCompletedBuilder::new(_fbb);
+        builder.finish()
+    }
+}
+
+impl ::flatbuffers::Verifiable for HttpQueryResultCompleted<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?.finish();
+        Ok(())
+    }
+}
+pub struct HttpQueryResultCompletedArgs {}
+impl<'a> Default for HttpQueryResultCompletedArgs {
+    #[inline]
+    fn default() -> Self {
+        HttpQueryResultCompletedArgs {}
+    }
+}
+
+pub struct HttpQueryResultCompletedBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> HttpQueryResultCompletedBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> HttpQueryResultCompletedBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        HttpQueryResultCompletedBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<HttpQueryResultCompleted<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for HttpQueryResultCompleted<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("HttpQueryResultCompleted");
+        ds.finish()
+    }
+}
 pub enum HttpQueryResultOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -2876,6 +2966,20 @@ impl<'a> HttpQueryResult<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn data_as_http_query_result_completed(&self) -> Option<HttpQueryResultCompleted<'a>> {
+        if self.data_type() == HttpQueryResultData::HttpQueryResultCompleted {
+            let u = self.data();
+            // Safety:
+            // Created from a valid Table for this object
+            // Which contains a valid union in this slot
+            Some(unsafe { HttpQueryResultCompleted::init_from_table(u) })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for HttpQueryResult<'_> {
@@ -2885,26 +2989,14 @@ impl ::flatbuffers::Verifiable for HttpQueryResult<'_> {
         pos: usize,
     ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
         v.visit_table(pos)?
-            .visit_union::<HttpQueryResultData, _>(
-                "data_type",
-                Self::VT_DATA_TYPE,
-                "data",
-                Self::VT_DATA,
-                true,
-                |key, v, pos| {
-                    match key {
-                        HttpQueryResultData::HttpQueryResultArrow => v
-                            .verify_union_variant::<::flatbuffers::ForwardsUOffset<
-                            HttpQueryResultArrow,
-                        >>(
-                            "HttpQueryResultData::HttpQueryResultArrow",
-                            pos,
-                        ),
-                        _ => Ok(()),
-                    }
-                },
-            )?
-            .finish();
+     .visit_union::<HttpQueryResultData, _>("data_type", Self::VT_DATA_TYPE, "data", Self::VT_DATA, true, |key, v, pos| {
+        match key {
+          HttpQueryResultData::HttpQueryResultArrow => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<HttpQueryResultArrow>>("HttpQueryResultData::HttpQueryResultArrow", pos),
+          HttpQueryResultData::HttpQueryResultCompleted => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<HttpQueryResultCompleted>>("HttpQueryResultData::HttpQueryResultCompleted", pos),
+          _ => Ok(()),
+        }
+     })?
+     .finish();
         Ok(())
     }
 }
@@ -2965,6 +3057,16 @@ impl ::core::fmt::Debug for HttpQueryResult<'_> {
         match self.data_type() {
             HttpQueryResultData::HttpQueryResultArrow => {
                 if let Some(x) = self.data_as_http_query_result_arrow() {
+                    ds.field("data", &x)
+                } else {
+                    ds.field(
+                        "data",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            HttpQueryResultData::HttpQueryResultCompleted => {
+                if let Some(x) = self.data_as_http_query_result_completed() {
                     ds.field("data", &x)
                 } else {
                     ds.field(

--- a/rust/cube/cubestore-cli/src/format.rs
+++ b/rust/cube/cubestore-cli/src/format.rs
@@ -17,6 +17,8 @@ pub fn render_table(result: &QueryResult) -> Result<Option<String>, CliError> {
     let table = match &result.data {
         ResultData::Legacy { rows, .. } => render_legacy_rows(&columns, rows),
         ResultData::Arrow { batches, .. } => render_arrow_batches(&columns, batches)?,
+        // Completed carries no columns, so the guard above already returned.
+        ResultData::Completed => return Ok(None),
     };
     Ok(Some(table))
 }

--- a/rust/cube/cubestore-ws-transport/src/codec.rs
+++ b/rust/cube/cubestore-ws-transport/src/codec.rs
@@ -5,7 +5,7 @@ use arrow::ipc::reader::StreamReader;
 use bytes::Bytes;
 use cubeshared::codegen::{
     root_as_http_message, HttpCommand, HttpMessage, HttpMessageArgs, HttpQuery, HttpQueryArgs,
-    QueryResultFormat,
+    HttpQueryResultData, QueryResultFormat,
 };
 use flatbuffers::FlatBufferBuilder;
 
@@ -105,20 +105,38 @@ pub fn decode_frame(bytes: &[u8]) -> Result<DecodedFrame, TransportError> {
             let qr = msg.command_as_http_query_result().ok_or_else(|| {
                 TransportError::Protocol("HttpQueryResult union variant missing".into())
             })?;
-            let arrow = qr.data_as_http_query_result_arrow().ok_or_else(|| {
-                TransportError::Protocol(
-                    "HttpQueryResult.data variant is not HttpQueryResultArrow".into(),
-                )
-            })?;
 
-            let result = decode_arrow_ipc(arrow.data().bytes())?;
-            log::debug!(
-                "decoded HttpQueryResult (Arrow IPC): {} columns, {} rows",
-                result.get_columns().len(),
-                result.row_count()
-            );
+            match qr.data_type() {
+                HttpQueryResultData::HttpQueryResultArrow => {
+                    let arrow = qr.data_as_http_query_result_arrow().ok_or_else(|| {
+                        TransportError::Protocol(
+                            "HttpQueryResult.data variant is not HttpQueryResultArrow".into(),
+                        )
+                    })?;
 
-            DecodedResponse::Ok(result)
+                    let result = decode_arrow_ipc(arrow.data().bytes())?;
+                    log::debug!(
+                        "decoded HttpQueryResult (Arrow IPC): {} columns, {} rows",
+                        result.get_columns().len(),
+                        result.row_count()
+                    );
+
+                    DecodedResponse::Ok(result)
+                }
+                HttpQueryResultData::HttpQueryResultCompleted => {
+                    // Command completed without a result set (zero columns).
+                    log::debug!("decoded HttpQueryResult (Completed): no result set");
+                    DecodedResponse::Ok(QueryResult {
+                        data: ResultData::Completed,
+                    })
+                }
+                other => {
+                    return Err(TransportError::Protocol(format!(
+                        "unsupported HttpQueryResult.data variant: {:?}",
+                        other.variant_name()
+                    )));
+                }
+            }
         }
         other => {
             return Err(TransportError::Protocol(format!(

--- a/rust/cube/cubestore-ws-transport/src/result.rs
+++ b/rust/cube/cubestore-ws-transport/src/result.rs
@@ -9,6 +9,9 @@ pub enum ResponseFormat {
     #[default]
     Legacy,
     Arrow,
+    /// The command completed without a result set (zero columns). This is a
+    /// decoded-from-the-wire descriptor only — clients can never request it.
+    Completed,
 }
 
 impl std::fmt::Display for ResponseFormat {
@@ -16,6 +19,7 @@ impl std::fmt::Display for ResponseFormat {
         match self {
             ResponseFormat::Legacy => f.write_str("Legacy"),
             ResponseFormat::Arrow => f.write_str("Arrow"),
+            ResponseFormat::Completed => f.write_str("Completed"),
         }
     }
 }
@@ -38,6 +42,9 @@ pub enum ResultData {
         schema: SchemaRef,
         batches: Vec<RecordBatch>,
     },
+    /// The command completed without a result set (zero columns) — e.g. CREATE
+    /// TABLE/INSERT or queue/cache writes. Carries no columns and no rows.
+    Completed,
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +61,7 @@ impl QueryResult {
         match &self.data {
             ResultData::Legacy { rows, .. } => rows.len(),
             ResultData::Arrow { batches, .. } => batches.iter().map(|b| b.num_rows()).sum(),
+            ResultData::Completed => 0,
         }
     }
 
@@ -62,6 +70,7 @@ impl QueryResult {
         match &self.data {
             ResultData::Legacy { .. } => ResponseFormat::Legacy,
             ResultData::Arrow { .. } => ResponseFormat::Arrow,
+            ResultData::Completed => ResponseFormat::Completed,
         }
     }
 
@@ -73,6 +82,7 @@ impl QueryResult {
             ResultData::Arrow { schema, .. } => {
                 schema.fields().iter().map(|f| f.name().clone()).collect()
             }
+            ResultData::Completed => Vec::new(),
         }
     }
 }

--- a/rust/cube/cubestore-ws-transport/tests/mock_server.rs
+++ b/rust/cube/cubestore-ws-transport/tests/mock_server.rs
@@ -19,6 +19,7 @@ fn legacy_rows(r: &QueryResult) -> &Vec<Vec<Option<String>>> {
     match &r.data {
         ResultData::Legacy { rows, .. } => rows,
         ResultData::Arrow { .. } => panic!("expected ResultData::Legacy, got Arrow"),
+        ResultData::Completed => panic!("expected ResultData::Legacy, got Completed"),
     }
 }
 

--- a/rust/cube/cubestore-ws-transport/tests/wire_roundtrip.rs
+++ b/rust/cube/cubestore-ws-transport/tests/wire_roundtrip.rs
@@ -8,8 +8,8 @@ use arrow::ipc::writer::StreamWriter;
 use cubeshared::codegen::{
     root_as_http_message, HttpColumnValue, HttpColumnValueArgs, HttpCommand, HttpMessage,
     HttpMessageArgs, HttpQueryResult, HttpQueryResultArgs, HttpQueryResultArrow,
-    HttpQueryResultArrowArgs, HttpQueryResultData, HttpResultSet, HttpResultSetArgs, HttpRow,
-    HttpRowArgs, QueryResultFormat,
+    HttpQueryResultArrowArgs, HttpQueryResultCompleted, HttpQueryResultCompletedArgs,
+    HttpQueryResultData, HttpResultSet, HttpResultSetArgs, HttpRow, HttpRowArgs, QueryResultFormat,
 };
 use cubestore_ws_transport::codec::{decode_frame, encode_query, DecodedResponse};
 use cubestore_ws_transport::{ResponseFormat, ResultData, TransportError};
@@ -279,6 +279,49 @@ fn decode_arrow_ipc_result_with_nulls() -> Result<(), TransportError> {
     assert_eq!(name_col.value(0), "alice");
     assert!(name_col.is_null(1), "row 1 name should be NULL");
     assert_eq!(name_col.value(2), "carol");
+
+    Ok(())
+}
+
+#[test]
+fn decode_query_result_completed() -> Result<(), TransportError> {
+    // Commands that complete without a result set (CREATE TABLE/INSERT,
+    // queue/cache writes) come back as HttpQueryResult carrying the
+    // HttpQueryResultCompleted marker instead of an Arrow IPC payload.
+    let mut b = FlatBufferBuilder::with_capacity(1024);
+    let completed = HttpQueryResultCompleted::create(&mut b, &HttpQueryResultCompletedArgs {});
+    let qr = HttpQueryResult::create(
+        &mut b,
+        &HttpQueryResultArgs {
+            data_type: HttpQueryResultData::HttpQueryResultCompleted,
+            data: Some(completed.as_union_value()),
+        },
+    );
+    let conn = b.create_string("c");
+    let msg = HttpMessage::create(
+        &mut b,
+        &HttpMessageArgs {
+            message_id: 7,
+            command_type: HttpCommand::HttpQueryResult,
+            command: Some(qr.as_union_value()),
+            connection_id: Some(conn),
+        },
+    );
+    b.finish(msg, None);
+    let bytes = b.finished_data().to_vec();
+
+    let decoded = decode_frame(&bytes)?;
+    assert_eq!(decoded.message_id, 7);
+    let result = match decoded.response {
+        DecodedResponse::Ok(r) => r,
+        DecodedResponse::Error(e) => panic!("unexpected error: {e}"),
+    };
+
+    assert!(matches!(result.data, ResultData::Completed));
+    assert!(result.is_empty());
+    assert_eq!(result.row_count(), 0);
+    assert_eq!(result.get_columns(), Vec::<String>::new());
+    assert_eq!(result.get_format(), ResponseFormat::Completed);
 
     Ok(())
 }

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -1090,6 +1090,45 @@ mod tests {
     use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
     use url::Url;
 
+    /// Minimal SqlService that always replies with a fixed DataFrame, used to
+    /// drive process_command in unit tests.
+    struct StubService(Arc<DataFrame>);
+    crate::di_service!(StubService, [SqlService]);
+    #[async_trait]
+    impl SqlService for StubService {
+        async fn exec_query(&self, _q: &str) -> Result<QueryResult, CubeError> {
+            unimplemented!("Mock")
+        }
+        async fn exec_query_with_context(
+            &self,
+            _ctx: SqlQueryContext,
+            _q: &str,
+        ) -> Result<QueryResult, CubeError> {
+            Ok(QueryResult::Frame(self.0.clone()))
+        }
+        async fn plan_query(&self, _q: &str) -> Result<QueryPlans, CubeError> {
+            unimplemented!("Mock")
+        }
+        async fn plan_query_with_context(
+            &self,
+            _ctx: SqlQueryContext,
+            _q: &str,
+        ) -> Result<QueryPlans, CubeError> {
+            unimplemented!("Mock")
+        }
+        async fn upload_temp_file(
+            &self,
+            _ctx: SqlQueryContext,
+            _name: String,
+            _path: &Path,
+        ) -> Result<(), CubeError> {
+            unimplemented!("Mock")
+        }
+        async fn temp_uploads_dir(&self, _ctx: SqlQueryContext) -> Result<String, CubeError> {
+            unimplemented!("Mock")
+        }
+    }
+
     fn build_types<'a: 'ma, 'ma>(
         builder: &'ma mut FlatBufferBuilder<'a>,
         columns: &Vec<Column>,
@@ -1219,7 +1258,7 @@ mod tests {
     #[tokio::test]
     async fn arrow_response_format_round_trip() -> Result<(), CubeError> {
         use crate::queryplanner::query_executor::batches_to_dataframe;
-        use crate::sql::{timestamp_from_string, QueryResult};
+        use crate::sql::timestamp_from_string;
         use crate::util::decimal::{Decimal, Decimal96};
         use crate::util::int96::Int96;
         use cubeshared::codegen::{root_as_http_message, HttpQueryResultData};
@@ -1279,43 +1318,6 @@ mod tests {
         let original_df = Arc::new(DataFrame::new(columns.clone(), rows));
 
         // 2. Drive process_command with response_format = Arrow.
-        struct StubService(Arc<DataFrame>);
-        crate::di_service!(StubService, [SqlService]);
-        #[async_trait]
-        impl SqlService for StubService {
-            async fn exec_query(&self, _q: &str) -> Result<QueryResult, CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn exec_query_with_context(
-                &self,
-                _ctx: SqlQueryContext,
-                _q: &str,
-            ) -> Result<QueryResult, CubeError> {
-                Ok(QueryResult::Frame(self.0.clone()))
-            }
-            async fn plan_query(&self, _q: &str) -> Result<QueryPlans, CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn plan_query_with_context(
-                &self,
-                _ctx: SqlQueryContext,
-                _q: &str,
-            ) -> Result<QueryPlans, CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn upload_temp_file(
-                &self,
-                _ctx: SqlQueryContext,
-                _name: String,
-                _path: &Path,
-            ) -> Result<(), CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn temp_uploads_dir(&self, _ctx: SqlQueryContext) -> Result<String, CubeError> {
-                unimplemented!("Mock")
-            }
-        }
-
         let svc = Arc::new(StubService(original_df.clone()));
         let resp = HttpServer::process_command(
             svc,
@@ -1373,50 +1375,12 @@ mod tests {
 
     #[tokio::test]
     async fn arrow_response_format_zero_columns_completed() -> Result<(), CubeError> {
-        use crate::sql::QueryResult;
         use cubeshared::codegen::{root_as_http_message, HttpQueryResultData};
 
         // Write commands (CREATE TABLE/INSERT, queue/cache writes) produce a
         // result with zero columns. For Arrow-format requests there's no Arrow
         // stream to build, so the server answers with QueryResultCompleted.
         let empty_df = Arc::new(DataFrame::new(vec![], vec![]));
-
-        struct StubService(Arc<DataFrame>);
-        crate::di_service!(StubService, [SqlService]);
-        #[async_trait]
-        impl SqlService for StubService {
-            async fn exec_query(&self, _q: &str) -> Result<QueryResult, CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn exec_query_with_context(
-                &self,
-                _ctx: SqlQueryContext,
-                _q: &str,
-            ) -> Result<QueryResult, CubeError> {
-                Ok(QueryResult::Frame(self.0.clone()))
-            }
-            async fn plan_query(&self, _q: &str) -> Result<QueryPlans, CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn plan_query_with_context(
-                &self,
-                _ctx: SqlQueryContext,
-                _q: &str,
-            ) -> Result<QueryPlans, CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn upload_temp_file(
-                &self,
-                _ctx: SqlQueryContext,
-                _name: String,
-                _path: &Path,
-            ) -> Result<(), CubeError> {
-                unimplemented!("Mock")
-            }
-            async fn temp_uploads_dir(&self, _ctx: SqlQueryContext) -> Result<String, CubeError> {
-                unimplemented!("Mock")
-            }
-        }
 
         let svc = Arc::new(StubService(empty_df));
         let resp = HttpServer::process_command(

--- a/rust/cubestore/cubestore/src/http/mod.rs
+++ b/rust/cubestore/cubestore/src/http/mod.rs
@@ -17,8 +17,9 @@ use async_std::fs::File;
 use cubeshared::codegen::{
     root_as_http_message, HttpColumnValue, HttpColumnValueArgs, HttpError, HttpErrorArgs,
     HttpMessageArgs, HttpParameterValue, HttpQuery, HttpQueryArgs, HttpQueryResult,
-    HttpQueryResultArgs, HttpQueryResultArrow, HttpQueryResultArrowArgs, HttpQueryResultData,
-    HttpResultSet, HttpResultSetArgs, HttpRow, HttpRowArgs, QueryResultFormat,
+    HttpQueryResultArgs, HttpQueryResultArrow, HttpQueryResultArrowArgs, HttpQueryResultCompleted,
+    HttpQueryResultCompletedArgs, HttpQueryResultData, HttpResultSet, HttpResultSetArgs, HttpRow,
+    HttpRowArgs, QueryResultFormat,
 };
 use cubeshared::flatbuffers::{FlatBufferBuilder, ForwardsUOffset, Vector, WIPOffset};
 use datafusion::cube_ext;
@@ -328,6 +329,7 @@ impl HttpServer {
                                     HttpCommand::CloseConnection { error } => format!("HttpCommand::CloseConnection {{ error: {:?} }}", error),
                                     HttpCommand::ResultSet { .. } => format!("HttpCommand::ResultSet {{}}"),
                                     HttpCommand::QueryResultArrow { .. } => format!("HttpCommand::QueryResultArrow {{}}"),
+                                    HttpCommand::QueryResultCompleted => format!("HttpCommand::QueryResultCompleted"),
                                 };
                                 log::error!(
                                     "Error processing HTTP command (connection_id={}): {}\nThe command: {}",
@@ -409,6 +411,7 @@ impl HttpServer {
                             HttpCommand::CloseConnection { error } => format!("HttpCommand::CloseConnection {{ error: {:?} }}", error),
                             HttpCommand::ResultSet { .. } => format!("HttpCommand::ResultSet {{}}"),
                             HttpCommand::QueryResultArrow { .. } => format!("HttpCommand::QueryResultArrow {{}}"),
+                            HttpCommand::QueryResultCompleted => format!("HttpCommand::QueryResultCompleted"),
                         };
                         let res = HttpServer::process_command(
                             sql_service.clone(),
@@ -599,8 +602,16 @@ impl HttpServer {
                         data_frame: query_result.collect().await?,
                     }),
                     QueryResultFormat::Arrow => {
-                        let data = query_result.to_arrow_ipc_stream().await?;
-                        Ok(HttpCommand::QueryResultArrow { data })
+                        // Commands that complete without a result set (CREATE
+                        // TABLE/INSERT, queue/cache writes) carry zero columns.
+                        // There's no Arrow stream to build for them, so signal
+                        // completion with a dedicated result instead.
+                        if query_result.schema().fields().is_empty() {
+                            Ok(HttpCommand::QueryResultCompleted)
+                        } else {
+                            let data = query_result.to_arrow_ipc_stream().await?;
+                            Ok(HttpCommand::QueryResultArrow { data })
+                        }
                     }
                     other => Err(CubeError::user(format!(
                         "Unsupported response_format: {:?}",
@@ -668,6 +679,10 @@ pub enum HttpCommand {
         /// decode it with a streaming IPC reader.
         data: Vec<u8>,
     },
+    /// Command completed without a result set (zero columns) — e.g. CREATE
+    /// TABLE/INSERT or queue/cache writes. Only produced for Arrow-format
+    /// requests; the legacy path returns an empty `ResultSet` instead.
+    QueryResultCompleted,
     CloseConnection {
         error: String,
     },
@@ -685,7 +700,7 @@ impl HttpMessage {
             command_type: match self.command {
                 HttpCommand::Query { .. } => cubeshared::codegen::HttpCommand::HttpQuery,
                 HttpCommand::ResultSet { .. } => cubeshared::codegen::HttpCommand::HttpResultSet,
-                HttpCommand::QueryResultArrow { .. } => {
+                HttpCommand::QueryResultArrow { .. } | HttpCommand::QueryResultCompleted => {
                     cubeshared::codegen::HttpCommand::HttpQueryResult
                 }
                 HttpCommand::CloseConnection { .. } | HttpCommand::Error { .. } => {
@@ -742,6 +757,22 @@ impl HttpMessage {
                             &HttpQueryResultArgs {
                                 data_type: HttpQueryResultData::HttpQueryResultArrow,
                                 data: Some(arrow_table.as_union_value()),
+                            },
+                        )
+                        .as_union_value(),
+                    )
+                }
+                HttpCommand::QueryResultCompleted => {
+                    let completed_table = HttpQueryResultCompleted::create(
+                        &mut builder,
+                        &HttpQueryResultCompletedArgs {},
+                    );
+                    Some(
+                        HttpQueryResult::create(
+                            &mut builder,
+                            &HttpQueryResultArgs {
+                                data_type: HttpQueryResultData::HttpQueryResultCompleted,
+                                data: Some(completed_table.as_union_value()),
                             },
                         )
                         .as_union_value(),
@@ -1336,6 +1367,94 @@ mod tests {
         assert_eq!(decoded.get_rows().len(), original_df.get_rows().len());
 
         insta::assert_snapshot!("arrow_response_format_round_trip", decoded.print());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn arrow_response_format_zero_columns_completed() -> Result<(), CubeError> {
+        use crate::sql::QueryResult;
+        use cubeshared::codegen::{root_as_http_message, HttpQueryResultData};
+
+        // Write commands (CREATE TABLE/INSERT, queue/cache writes) produce a
+        // result with zero columns. For Arrow-format requests there's no Arrow
+        // stream to build, so the server answers with QueryResultCompleted.
+        let empty_df = Arc::new(DataFrame::new(vec![], vec![]));
+
+        struct StubService(Arc<DataFrame>);
+        crate::di_service!(StubService, [SqlService]);
+        #[async_trait]
+        impl SqlService for StubService {
+            async fn exec_query(&self, _q: &str) -> Result<QueryResult, CubeError> {
+                unimplemented!("Mock")
+            }
+            async fn exec_query_with_context(
+                &self,
+                _ctx: SqlQueryContext,
+                _q: &str,
+            ) -> Result<QueryResult, CubeError> {
+                Ok(QueryResult::Frame(self.0.clone()))
+            }
+            async fn plan_query(&self, _q: &str) -> Result<QueryPlans, CubeError> {
+                unimplemented!("Mock")
+            }
+            async fn plan_query_with_context(
+                &self,
+                _ctx: SqlQueryContext,
+                _q: &str,
+            ) -> Result<QueryPlans, CubeError> {
+                unimplemented!("Mock")
+            }
+            async fn upload_temp_file(
+                &self,
+                _ctx: SqlQueryContext,
+                _name: String,
+                _path: &Path,
+            ) -> Result<(), CubeError> {
+                unimplemented!("Mock")
+            }
+            async fn temp_uploads_dir(&self, _ctx: SqlQueryContext) -> Result<String, CubeError> {
+                unimplemented!("Mock")
+            }
+        }
+
+        let svc = Arc::new(StubService(empty_df));
+        let resp = HttpServer::process_command(
+            svc,
+            SqlQueryContext::default(),
+            HttpCommand::Query {
+                query: "CREATE TABLE s.t (id int)".to_string(),
+                inline_tables: vec![],
+                trace_obj: None,
+                parameters: None,
+                response_format: QueryResultFormat::Arrow,
+            },
+        )
+        .await?;
+        assert!(
+            matches!(resp, HttpCommand::QueryResultCompleted),
+            "expected QueryResultCompleted, got: {:?}",
+            resp
+        );
+
+        // Round-trip through HttpMessage::bytes() and verify the wire shape.
+        let wire = HttpMessage {
+            message_id: 7,
+            command: HttpCommand::QueryResultCompleted,
+            connection_id: None,
+        }
+        .bytes();
+        let parsed = root_as_http_message(&wire)?;
+        assert_eq!(
+            parsed.command_type(),
+            cubeshared::codegen::HttpCommand::HttpQueryResult
+        );
+        let result = parsed.command_as_http_query_result().unwrap();
+        assert_eq!(
+            result.data_type(),
+            HttpQueryResultData::HttpQueryResultCompleted
+        );
+        assert!(result.data_as_http_query_result_completed().is_some());
 
         Ok(())
     }


### PR DESCRIPTION
…esults

Write commands (CREATE TABLE/INSERT, queue/cache writes) return zero columns. When such a result was requested in Arrow format, building the Arrow IPC stream failed with "must either specify a row count or at least one column" because RecordBatch::try_new can't infer the row count from an empty column set.

Instead of forcing an empty Arrow stream onto the wire, extend the protocol with a dedicated result type. HttpQueryResult already carries the HttpQueryResultData union; add an HttpQueryResultCompleted marker to it. When an Arrow-format query produces no columns, the server now answers with QueryResultCompleted rather than an Arrow payload. QueryResultFormat (the request enum) is left untouched, so Completed is a server-chosen result shape that clients can never request.

The JS driver uses the legacy format, so the only Arrow consumer is the cubestore-ws-transport crate, which decodes the marker into the new ResultData::Completed / ResponseFormat::Completed.