### PR TITLE
docs: fix spacing in data access policies diagram

### DIFF
--- a/docs-mintlify/docs/data-modeling/data-access-policies.mdx
+++ b/docs-mintlify/docs/data-modeling/data-access-policies.mdx
@@ -129,16 +129,16 @@ by only one policy:
 
 ```text
   members
-     ▲
-     │        ┌──────────────────────────────────┐
- revenue      │           finance policy          │
-     │   ┌────┼──────────────┐                    │
-   count │    │   overlap     │                    │
-     │   │    └──────────────┼────────────────────┘
-  status │     support policy │
-     │   └────────────────────┘
-     └────────────────────────────────────────────▶ rows
-              US region            EU region
+         ▲
+         │          ┌───────────────────────────────────────┐
+ revenue │          │            finance policy             │
+         │ ┌────────┼──────────────┐                        │
+   count │ │        │   overlap    │                        │
+         │ │        └──────────────┼────────────────────────┘
+  status │ │    support policy     │
+         │ └───────────────────────┘
+         └───────────────────────────────────────────────────▶ rows
+                   US region                EU region
 ```
 
 For a user in **both** groups, the readable cells (✓) of the permission space are:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the misaligned ASCII diagram in the data access policies documentation (`docs-mintlify/docs/data-modeling/data-access-policies.mdx`).

The original `members`/`rows` permission-space diagram had inconsistent column positions: the y-axis line dropped out on member-label rows, box borders didn't line up vertically, and the `┼` crossings and closing borders were offset, making the figure render skewed in a monospaced font.

## Changes

- Re-aligned all box borders to fixed columns so the `finance policy` and `support policy` boxes, their `overlap` crossing, the y-axis, and the x-axis labels all line up cleanly.
- The semantics are unchanged — same members (`revenue`, `count`, `status`), same regions (`US`/`EU`), same overlap.

Before:

```
  members
     ▲
     │        ┌──────────────────────────────────┐
 revenue      │           finance policy          │
     │   ┌────┼──────────────┐                    │
   count │    │   overlap     │                    │
     │   │    └──────────────┼────────────────────┘
  status │     support policy │
     │   └────────────────────┘
     └────────────────────────────────────────────▶ rows
              US region            EU region
```

After:

```
  members
         ▲
         │          ┌───────────────────────────────────────┐
 revenue │          │            finance policy             │
         │ ┌────────┼──────────────┐                        │
   count │ │        │   overlap    │                        │
         │ │        └──────────────┼────────────────────────┘
  status │ │    support policy     │
         │ └───────────────────────┘
         └───────────────────────────────────────────────────▶ rows
                   US region                EU region
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54222ee9-6cff-48eb-8a1b-e532af7b0d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54222ee9-6cff-48eb-8a1b-e532af7b0d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

