### PR TITLE
fix(cubesql): ensure numeric measure filters are cast correctly

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
@@ -144,11 +144,32 @@ impl TypedFilterBuilder {
         self
     }
 
+    fn measure_filter_param_type(measure_type: &str) -> &str {
+        match measure_type {
+            "count"
+            | "sum"
+            | "avg"
+            | "min"
+            | "max"
+            | "countDistinct"
+            | "countDistinctApprox"
+            | "count_distinct"
+            | "count_distinct_approx"
+            | "numberAgg"
+            | "number_agg"
+            | "runningTotal"
+            | "running_total" => "number",
+            _ => measure_type,
+        }
+    }
+
     fn resolve_member_type(member_evaluator: &Rc<MemberSymbol>) -> Option<String> {
         let symbol = resolve_base_symbol(member_evaluator);
         match symbol.as_ref() {
             MemberSymbol::Dimension(d) => Some(d.dimension_type().to_string()),
-            MemberSymbol::Measure(m) => Some(m.measure_type().to_string()),
+            MemberSymbol::Measure(m) => {
+                Some(Self::measure_filter_param_type(m.measure_type()).to_string())
+            }
             _ => None,
         }
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/filter/to_sql.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/filter/to_sql.rs
@@ -325,6 +325,34 @@ fn test_lte_string_no_cast() {
 }
 
 #[test]
+fn test_sum_measure_filter_casts_numeric() {
+    let result = build(indoc! {"
+        filters:
+          - member: visitors.total_revenue
+            operator: lt
+            values:
+              - \"100\"
+    "});
+    assert_filter(
+        &result,
+        r#"(sum("visitors".revenue) < $_0_$::numeric)"#,
+        &["100"],
+    );
+}
+
+#[test]
+fn test_count_measure_filter_casts_numeric() {
+    let result = build(indoc! {"
+        filters:
+          - member: visitors.count
+            operator: equals
+            values:
+              - \"4\"
+    "});
+    assert_filter(&result, r#"(count(COUNT(*)) = $_0_$::numeric)"#, &["4"]);
+}
+
+#[test]
 fn test_contains_filter() {
     let result = build(indoc! {"
         filters:


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

Closes #11031 

Would be great to get this merged as it's blocking our migration to Tesseract, and we'd love multi-fact views!