### PR TITLE
fix(native): Don't fail deserializing JS numbers above u64/i64 range

### DIFF
--- a/packages/cubejs-backend-native/src/node_obj_deserializer.rs
+++ b/packages/cubejs-backend-native/src/node_obj_deserializer.rs
@@ -102,9 +102,9 @@ impl<'de> Deserializer<'de> for JsValueDeserializer<'_, '_> {
                 return visitor.visit_i64(value as i64);
             }
 
-            Err(JsDeserializationError(
-                "Unsupported number type for deserialization".to_string(),
-            ))
+            // Integer-valued, but too large to fit in any i64/u64 (e.g. 5.18e44).
+            // It originated as an f64 anyway, so keep it as one instead of failing.
+            visitor.visit_f64(value)
         } else if self.value.is_a::<JsBoolean, _>(self.cx) {
             let value = self
                 .value

--- a/rust/cubeorchestrator/Cargo.lock
+++ b/rust/cubeorchestrator/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "cubeshared",
+ "indexmap",
  "itertools",
  "neon",
  "serde",
@@ -131,6 +132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "flatbuffers"
 version = "23.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +152,12 @@ name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "iana-time-zone"
@@ -167,6 +180,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]


### PR DESCRIPTION
A JS number like 5.18e44 is integer-valued (fract() is always 0.0 for |value| >= 2^52, since an f64 has no fractional bits at that magnitude), so it skipped the float path, then failed to fit in any u64/i64 branch and hit "Unsupported number type for deserialization".

Fall back to visit_f64 for such values instead of erroring. The value already arrived as an f64, so nothing is lost beyond JS's own precision.