### PR TITLE
fix(native): Don't fail deserializing JS numbers above u64/i64 range

### DIFF
--- a/packages/cubejs-backend-native/src/node_obj_deserializer.rs
+++ b/packages/cubejs-backend-native/src/node_obj_deserializer.rs
@@ -109,9 +109,9 @@ impl<'de> Deserializer<'de> for JsValueDeserializer<'_, '_> {
                 return visitor.visit_i64(value as i64);
             }
 
-            Err(JsDeserializationError(
-                "Unsupported number type for deserialization".to_string(),
-            ))
+            // Integer-valued, but too large to fit in any i64/u64 (e.g. 5.18e44).
+            // It originated as an f64 anyway, so keep it as one instead of failing.
+            visitor.visit_f64(value)
         } else if self.value.is_a::<JsBoolean, _>(self.cx) {
             let value = self
                 .value


### PR DESCRIPTION
A JS number like 5.18e44 is integer-valued (fract() is always 0.0 for |value| >= 2^52, since an f64 has no fractional bits at that magnitude), so it skipped the float path, then failed to fit in any u64/i64 branch and hit "Unsupported number type for deserialization".

Fall back to visit_f64 for such values instead of erroring. The value already arrived as an f64, so nothing is lost beyond JS's own precision.