### PR TITLE
feat(cubeorchestrator): Split numeric query result into typed variants

### DIFF
--- a/packages/cubejs-backend-native/src/orchestrator.rs
+++ b/packages/cubejs-backend-native/src/orchestrator.rs
@@ -132,7 +132,11 @@ impl ResultWrapper {
 fn db_primitive_to_field_value(value: &DBResponsePrimitive) -> FieldValue<'_> {
     match value {
         DBResponsePrimitive::String(s) => FieldValue::String(Cow::Borrowed(s)),
-        DBResponsePrimitive::Number(n) => FieldValue::Number(*n),
+        DBResponsePrimitive::Int64(n) => FieldValue::Int64(*n),
+        DBResponsePrimitive::UInt64(n) => FieldValue::UInt64(*n),
+        DBResponsePrimitive::Float64(n) => FieldValue::Float64(*n),
+        DBResponsePrimitive::Int128(s) => FieldValue::String(Cow::Borrowed(s)),
+        DBResponsePrimitive::UInt128(s) => FieldValue::String(Cow::Borrowed(s)),
         DBResponsePrimitive::Boolean(b) => FieldValue::Bool(*b),
         DBResponsePrimitive::Uncommon(v) => FieldValue::String(Cow::Owned(
             serde_json::to_string(&v).unwrap_or_else(|_| v.to_string()),

--- a/packages/cubejs-backend-native/src/stream.rs
+++ b/packages/cubejs-backend-native/src/stream.rs
@@ -280,7 +280,7 @@ impl ValueObject for JsValueObject<'_> {
         if let Ok(s) = value.downcast::<JsString, _>(&mut self.cx) {
             Ok(FieldValue::String(Cow::Owned(s.value(&mut self.cx))))
         } else if let Ok(n) = value.downcast::<JsNumber, _>(&mut self.cx) {
-            Ok(FieldValue::Number(n.value(&mut self.cx)))
+            Ok(FieldValue::Float64(n.value(&mut self.cx)))
         } else if let Ok(b) = value.downcast::<JsBoolean, _>(&mut self.cx) {
             Ok(FieldValue::Bool(b.value(&mut self.cx)))
         } else if value.downcast::<JsUndefined, _>(&mut self.cx).is_ok()

--- a/rust/cube/cubeorchestrator/benches/common/mod.rs
+++ b/rust/cube/cubeorchestrator/benches/common/mod.rs
@@ -56,7 +56,7 @@ pub fn build_dataset(
         members.push(alias.clone());
         let mut col = ColumnarArray::with_capacity(row_count);
         for i in 0..row_count {
-            col.push(DBResponsePrimitive::Number(((i * (j + 1)) as f64) * 0.5));
+            col.push(DBResponsePrimitive::Float64(((i * (j + 1)) as f64) * 0.5));
         }
         columns.push(col);
     }

--- a/rust/cube/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cube/cubeorchestrator/src/query_result_transform.rs
@@ -1152,14 +1152,38 @@ pub struct RequestResultArray {
     pub results: Vec<RequestResultData>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(untagged)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DBResponsePrimitive {
     Null,
     Boolean(bool),
-    Number(f64),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
+    /// 128-bit integers that don't fit into `i64`/`u64`. Kept as their decimal
+    /// string form to avoid precision loss and to stay safe for JSON/JS consumers
+    /// (which can't represent integers beyond 2^53). Serialized as a JSON string.
+    Int128(String),
+    UInt128(String),
     String(String),
     Uncommon(Value),
+}
+
+// Hand-written `Serialize`. Numeric variants (`Int64`/`UInt64`/`Float64`) are
+// rendered as JSON strings, not numbers.
+impl Serialize for DBResponsePrimitive {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            DBResponsePrimitive::Null => serializer.serialize_none(),
+            DBResponsePrimitive::Boolean(b) => serializer.serialize_bool(*b),
+            DBResponsePrimitive::Int64(n) => serializer.collect_str(n),
+            DBResponsePrimitive::UInt64(n) => serializer.collect_str(n),
+            DBResponsePrimitive::Float64(n) => serializer.collect_str(n),
+            DBResponsePrimitive::Int128(s) => serializer.serialize_str(s),
+            DBResponsePrimitive::UInt128(s) => serializer.serialize_str(s),
+            DBResponsePrimitive::String(s) => serializer.serialize_str(s),
+            DBResponsePrimitive::Uncommon(v) => v.serialize(serializer),
+        }
+    }
 }
 
 // Hand-written `Deserialize` that avoids serde's untagged-enum buffering.
@@ -1182,23 +1206,23 @@ impl<'de> Deserialize<'de> for DBResponsePrimitive {
             }
 
             fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
-                Ok(DBResponsePrimitive::Number(v as f64))
+                Ok(DBResponsePrimitive::Int64(v))
             }
 
             fn visit_i128<E: de::Error>(self, v: i128) -> Result<Self::Value, E> {
-                Ok(DBResponsePrimitive::Number(v as f64))
+                Ok(DBResponsePrimitive::Int128(v.to_string()))
             }
 
             fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
-                Ok(DBResponsePrimitive::Number(v as f64))
+                Ok(DBResponsePrimitive::UInt64(v))
             }
 
             fn visit_u128<E: de::Error>(self, v: u128) -> Result<Self::Value, E> {
-                Ok(DBResponsePrimitive::Number(v as f64))
+                Ok(DBResponsePrimitive::UInt128(v.to_string()))
             }
 
             fn visit_f64<E: de::Error>(self, v: f64) -> Result<Self::Value, E> {
-                Ok(DBResponsePrimitive::Number(v))
+                Ok(DBResponsePrimitive::Float64(v))
             }
 
             fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
@@ -1254,7 +1278,11 @@ impl Display for DBResponsePrimitive {
         let str = match self {
             DBResponsePrimitive::Null => "null".to_string(),
             DBResponsePrimitive::Boolean(b) => b.to_string(),
-            DBResponsePrimitive::Number(n) => n.to_string(),
+            DBResponsePrimitive::Int64(n) => n.to_string(),
+            DBResponsePrimitive::UInt64(n) => n.to_string(),
+            DBResponsePrimitive::Float64(n) => n.to_string(),
+            DBResponsePrimitive::Int128(s) => s.clone(),
+            DBResponsePrimitive::UInt128(s) => s.clone(),
             DBResponsePrimitive::String(s) => s.clone(),
             DBResponsePrimitive::Uncommon(v) => {
                 serde_json::to_string(&v).unwrap_or_else(|_| v.to_string())
@@ -1323,6 +1351,116 @@ mod tests {
     use std::{fmt, sync::LazyLock};
 
     type TestSuiteData = HashMap<String, TestData>;
+
+    /// Guards the in-memory size of the per-cell primitive. It is materialized
+    /// once per cell across every parse/transform path, so an accidental growth
+    /// (e.g. a fat new variant) would regress memory and throughput for large
+    /// result sets. Bump this deliberately if the layout must change.
+    #[test]
+    fn test_db_response_primitive_size() {
+        assert_eq!(std::mem::size_of::<DBResponsePrimitive>(), 32);
+    }
+
+    #[test]
+    fn test_numeric_primitives_serialize_as_json_strings() {
+        use serde_json::{json, to_value, Value as JsonValue};
+
+        assert_eq!(to_value(DBResponsePrimitive::Int64(5)).unwrap(), json!("5"));
+        assert_eq!(
+            to_value(DBResponsePrimitive::UInt64(42)).unwrap(),
+            json!("42")
+        );
+        assert_eq!(
+            to_value(DBResponsePrimitive::Float64(2.0)).unwrap(),
+            json!("2")
+        );
+        assert_eq!(
+            to_value(DBResponsePrimitive::Float64(0.6666666666666666)).unwrap(),
+            json!("0.6666666666666666")
+        );
+        assert_eq!(
+            to_value(DBResponsePrimitive::Int128(
+                "170141183460469231731687303715884105727".to_string()
+            ))
+            .unwrap(),
+            json!("170141183460469231731687303715884105727")
+        );
+
+        assert_eq!(
+            to_value(DBResponsePrimitive::Boolean(true)).unwrap(),
+            json!(true)
+        );
+        assert_eq!(
+            to_value(DBResponsePrimitive::Null).unwrap(),
+            JsonValue::Null
+        );
+        assert_eq!(
+            to_value(DBResponsePrimitive::String("x".to_string())).unwrap(),
+            json!("x")
+        );
+    }
+
+    #[test]
+    fn test_from_js_raw_data_parses_numeric_variants() -> Result<()> {
+        use serde_json::{from_value, json};
+
+        let raw: JsRawColumnarData = from_value(json!({
+            "members": ["nonneg", "neg", "float", "mixed"],
+            "columns": [
+                [0, 1, u64::MAX],
+                [-1, -42, i64::MIN],
+                [1.5, 2.0, 0.6666666666666666],
+                ["text", true, null],
+            ],
+        }))?;
+
+        let result = QueryResult::from_js_raw_data(raw)?;
+
+        assert_eq!(result.row_count(), 3);
+        assert_eq!(
+            result.members().to_vec(),
+            vec!["nonneg", "neg", "float", "mixed"]
+        );
+
+        // Non-negative integers -> UInt64, including u64::MAX.
+        assert_eq!(
+            result.column(0)?.as_slice(),
+            &[
+                DBResponsePrimitive::UInt64(0),
+                DBResponsePrimitive::UInt64(1),
+                DBResponsePrimitive::UInt64(u64::MAX),
+            ]
+        );
+        // Negative integers -> Int64, including i64::MIN.
+        assert_eq!(
+            result.column(1)?.as_slice(),
+            &[
+                DBResponsePrimitive::Int64(-1),
+                DBResponsePrimitive::Int64(-42),
+                DBResponsePrimitive::Int64(i64::MIN),
+            ]
+        );
+        // Fractional values -> Float64 (`2.0` keeps its float token).
+        assert_eq!(
+            result.column(2)?.as_slice(),
+            &[
+                DBResponsePrimitive::Float64(1.5),
+                DBResponsePrimitive::Float64(2.0),
+                DBResponsePrimitive::Float64(0.6666666666666666),
+            ]
+        );
+        // Non-numeric cells pass through.
+        assert_eq!(
+            result.column(3)?.as_slice(),
+            &[
+                DBResponsePrimitive::String("text".to_string()),
+                DBResponsePrimitive::Boolean(true),
+                DBResponsePrimitive::Null,
+            ]
+        );
+
+        Ok(())
+    }
 
     #[derive(Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -305,7 +305,9 @@ pub enum FieldValue<'a> {
     // because V8 uses UTF-16 It allocates/converts a new strings while doing JsString.value()
     // @see v8 WriteUtf8 for more details. Cow::Owned is used for this variant
     String(Cow<'a, str>),
-    Number(f64),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
     Bool(bool),
     Null,
 }
@@ -345,9 +347,28 @@ impl JsonValueObject {
 fn json_value_to_field_value(value: &Value) -> std::result::Result<FieldValue<'_>, CubeError> {
     Ok(match value {
         Value::String(s) => FieldValue::String(Cow::Borrowed(s)),
-        Value::Number(n) => FieldValue::Number(n.as_f64().ok_or_else(|| {
-            DataFusionError::Execution(format!("Can't convert {:?} to float", n))
-        })?),
+        Value::Number(n) => {
+            if n.is_f64() {
+                return n
+                    .as_f64()
+                    .map(|v| FieldValue::Float64(v))
+                    .ok_or(CubeError::user(format!(
+                        "Can't convert number {:?} to FieldValue::Float64",
+                        n
+                    )));
+            };
+
+            if let Some(i) = n.as_i64() {
+                FieldValue::Int64(i)
+            } else if let Some(u) = n.as_u64() {
+                FieldValue::UInt64(u)
+            } else {
+                return Err(CubeError::user(format!(
+                    "Can't convert number: {:?} to FieldValue",
+                    n
+                )));
+            }
+        }
         Value::Bool(b) => FieldValue::Bool(*b),
         Value::Null => FieldValue::Null,
         x => {
@@ -918,7 +939,9 @@ macro_rules! transform_response_body {
                         {
                             (FieldValue::String(v), builder) => builder.append_value(v)?,
                             (FieldValue::Bool(v), builder) => builder.append_value(if v { "true" } else { "false" })?,
-                            (FieldValue::Number(v), builder) => builder.append_value(v.to_string())?,
+                            (FieldValue::Int64(v), builder) => builder.append_value(v.to_string())?,
+                            (FieldValue::UInt64(v), builder) => builder.append_value(v.to_string())?,
+                            (FieldValue::Float64(v), builder) => builder.append_value(v.to_string())?,
                         },
                         {
                             (ScalarValue::Utf8(v), builder) => builder.append_option(v.as_ref())?,
@@ -933,7 +956,9 @@ macro_rules! transform_response_body {
                         $response,
                         field_name,
                         {
-                            (FieldValue::Number(number), builder) => builder.append_value(number.round() as i16)?,
+                            (FieldValue::Int64(number), builder) => builder.append_value(number as i16)?,
+                            (FieldValue::UInt64(number), builder) => builder.append_value(number as i16)?,
+                            (FieldValue::Float64(number), builder) => builder.append_value(number.round() as i16)?,
                             (FieldValue::String(s), builder) => match s.parse::<i16>() {
                                 Ok(v) => builder.append_value(v)?,
                                 Err(error) => {
@@ -959,7 +984,9 @@ macro_rules! transform_response_body {
                         $response,
                         field_name,
                         {
-                            (FieldValue::Number(number), builder) => builder.append_value(number.round() as i32)?,
+                            (FieldValue::Int64(number), builder) => builder.append_value(number as i32)?,
+                            (FieldValue::UInt64(number), builder) => builder.append_value(number as i32)?,
+                            (FieldValue::Float64(number), builder) => builder.append_value(number.round() as i32)?,
                             (FieldValue::String(s), builder) => match s.parse::<i32>() {
                                 Ok(v) => builder.append_value(v)?,
                                 Err(error) => {
@@ -985,7 +1012,9 @@ macro_rules! transform_response_body {
                         $response,
                         field_name,
                         {
-                            (FieldValue::Number(number), builder) => builder.append_value(number.round() as i64)?,
+                            (FieldValue::Int64(number), builder) => builder.append_value(number)?,
+                            (FieldValue::UInt64(number), builder) => builder.append_value(number as i64)?,
+                            (FieldValue::Float64(number), builder) => builder.append_value(number.round() as i64)?,
                             (FieldValue::String(s), builder)  => match s.parse::<i64>() {
                                 Ok(v) => builder.append_value(v)?,
                                 Err(error) => {
@@ -1011,7 +1040,9 @@ macro_rules! transform_response_body {
                         $response,
                         field_name,
                         {
-                            (FieldValue::Number(number), builder) => builder.append_value(number as f32)?,
+                            (FieldValue::Int64(number), builder) => builder.append_value(number as f32)?,
+                            (FieldValue::UInt64(number), builder) => builder.append_value(number as f32)?,
+                            (FieldValue::Float64(number), builder) => builder.append_value(number as f32)?,
                             (FieldValue::String(s), builder) => match s.parse::<f32>() {
                                 Ok(v) => builder.append_value(v)?,
                                 Err(error) => {
@@ -1037,7 +1068,9 @@ macro_rules! transform_response_body {
                         $response,
                         field_name,
                         {
-                            (FieldValue::Number(number), builder) => builder.append_value(number)?,
+                            (FieldValue::Int64(number), builder) => builder.append_value(number as f64)?,
+                            (FieldValue::UInt64(number), builder) => builder.append_value(number as f64)?,
+                            (FieldValue::Float64(number), builder) => builder.append_value(number)?,
                             (FieldValue::String(s), builder) => match s.parse::<f64>() {
                                 Ok(v) => builder.append_value(v)?,
                                 Err(error) => {


### PR DESCRIPTION
Replace the single f64 `DBResponsePrimitive::Number` / `FieldValue::Number` variant with precise `Int64`/`UInt64`/`Float64` variants so integer-vs-float type is preserved through the query result path and large 64-bit integers no longer lose precision via f64.