### PR TITLE
fix(prestodb-driver): Send custom headers on nextUri poll requests

### DIFF
--- a/packages/cubejs-prestodb-driver/package.json
+++ b/packages/cubejs-prestodb-driver/package.json
@@ -21,15 +21,16 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
-    "integration": "jest dist/test",
-    "integration:presto": "jest dist/test",
+    "unit": "jest dist/test/unit",
+    "integration": "jest dist/test/integration",
+    "integration:presto": "jest dist/test/integration",
     "lint": "eslint src/* --ext .ts",
     "lint:fix": "eslint --fix src/* --ext .ts"
   },
   "dependencies": {
     "@cubejs-backend/base-driver": "1.6.55",
     "@cubejs-backend/shared": "1.6.55",
-    "presto-client": "^1.2.0",
+    "presto-client": "1.2.0",
     "ramda": "^0.27.0",
     "sqlstring": "^2.3.1"
   },

--- a/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
+++ b/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
@@ -132,6 +132,61 @@ export class PrestoDriver extends BaseDriver implements DriverInterface {
       engine: 'presto',
       ...this.config,
     });
+
+    this.applyCustomHeadersToAllRequests(this.client);
+  }
+
+  /**
+   * https://github.com/tagomoris/presto-client-node/pull/97
+   *
+   * Reason for monkey patching:
+   *
+   * The underlying `presto-client` only applies custom headers to the initial
+   * `POST /v1/statement` request. The follow-up `nextUri` GET polls (and the
+   * cancel/kill/node requests) are issued with a fresh, empty header set.
+   */
+  protected applyCustomHeadersToAllRequests(client: any) {
+    const customHeaders = this.config.headers;
+    if (!customHeaders || Object.keys(customHeaders).length === 0) {
+      return;
+    }
+
+    // `request` lives on the prototype; capture it before shadowing it on the instance.
+    const originalRequest = client.request;
+
+    client.request = function patchedRequest(opts: any, callback: any) {
+      if (typeof opts === 'string') {
+        // `opts` is a `nextUri` URL string. The upstream client rebuilds GET
+        // options from it with empty headers, dropping our custom headers. We
+        // recreate those options ourselves (seeded with the custom headers) and
+        // invoke the original `request` with a client "view" whose host/port/
+        // protocol point at the `nextUri` target. The original object branch
+        // otherwise forces the client's configured host, so the view preserves
+        // upstream's host-following behaviour.
+        let href;
+        try {
+          href = new URL(opts);
+        } catch (error) {
+          return callback(error);
+        }
+
+        const view = Object.create(this);
+        view.host = href.hostname;
+        view.port = href.port || (href.protocol === 'https:' ? '443' : '80');
+        view.protocol = href.protocol;
+
+        return originalRequest.call(view, {
+          method: 'GET',
+          path: href.pathname + href.search,
+          headers: { ...customHeaders },
+        }, callback);
+      }
+
+      // Object form (POST /v1/statement, DELETE cancel/kill, node list, ...).
+      // Merge in the custom headers, letting any explicitly-provided headers win.
+      opts.headers = { ...customHeaders, ...(opts.headers || {}) };
+      return originalRequest.call(this, opts, callback);
+    };
   }
 
   public async testConnection(): Promise<void> {

--- a/packages/cubejs-prestodb-driver/test/integration/presto-driver.test.ts
+++ b/packages/cubejs-prestodb-driver/test/integration/presto-driver.test.ts
@@ -1,4 +1,4 @@
-import { PrestoDriver } from '../src/PrestoDriver';
+import { PrestoDriver } from '../../src/PrestoDriver';
 
 const path = require('path');
 const { DockerComposeEnvironment, Wait } = require('testcontainers');
@@ -37,7 +37,7 @@ describe('PrestoHouseDriver', () => {
     }
 
     const dc = new DockerComposeEnvironment(
-      path.resolve(path.dirname(__filename), '../../'),
+      path.resolve(path.dirname(__filename), '../../../'),
       'docker-compose.yml'
     );
 

--- a/packages/cubejs-prestodb-driver/test/unit/headers.test.ts
+++ b/packages/cubejs-prestodb-driver/test/unit/headers.test.ts
@@ -1,0 +1,132 @@
+import { EventEmitter } from 'events';
+
+import { PrestoDriver } from '../../src/PrestoDriver';
+
+/**
+ * Regression test for custom headers being dropped on `nextUri` poll requests.
+ *
+ * The upstream `presto-client` only applies custom headers to the initial
+ * `POST /v1/statement` request. The `nextUri` GET polls were issued with empty
+ * headers, so proxy/gateway auth headers were lost after the first request and
+ * the query failed with "User authentication failed".
+ *
+ * Rather than standing up a real Presto/Trino server, we mock the HTTP
+ * transport that `presto-client` uses (`follow-redirects/http`) and let the
+ * real client + driver logic run on top of it. The mock records the headers it
+ * sees on every request, so we can assert the custom headers reach the
+ * `nextUri` poll — not just the initial POST.
+ */
+
+type RecordedRequest = {
+  protocol: string;
+  method: string;
+  host: string;
+  port: string | number;
+  path: string;
+  headers: Record<string, string>;
+};
+
+const mockRecorded: RecordedRequest[] = [];
+
+// Drives a single fake HTTP round-trip the way `presto-client` expects:
+// `request(options, onResponse)` returns a writable request emitter; once it is
+// `end()`ed we invoke `onResponse(res)` and stream a JSON body back.
+const mockHttpRequest = jest.fn((protocol: string, opts: any, onResponse: (res: any) => void) => {
+  mockRecorded.push({
+    protocol,
+    method: opts.method,
+    host: opts.host,
+    port: opts.port,
+    path: opts.path,
+    headers: { ...opts.headers },
+  });
+
+  const res: any = new EventEmitter();
+  res.statusCode = 200;
+  res.setEncoding = () => res;
+
+  const req: any = new EventEmitter();
+  req.write = () => true;
+  req.destroy = () => req;
+  req.end = () => {
+    process.nextTick(() => {
+      onResponse(res);
+
+      const body = opts.method === 'POST'
+        ? JSON.stringify({
+          id: 'q1',
+          infoUri: 'http://coordinator.local:8080/v1/query/q1',
+          // Point the poll at a different host to also assert that the
+          // upstream nextUri host-following behaviour is preserved.
+          nextUri: 'http://worker.internal:8081/v1/statement/q1/1',
+          stats: { state: 'QUEUED' },
+        })
+        : JSON.stringify({
+          id: 'q1',
+          infoUri: 'http://coordinator.local:8080/v1/query/q1',
+          stats: { state: 'FINISHED' },
+          columns: [{ name: 'one', type: 'integer' }],
+          data: [[1]],
+        });
+
+      res.emit('data', body);
+      res.emit('end');
+    });
+  };
+
+  return req;
+});
+
+jest.mock('follow-redirects/http', () => ({
+  Agent: class {},
+  request: (opts: any, onResponse: any) => mockHttpRequest('http:', opts, onResponse),
+}));
+
+jest.mock('follow-redirects/https', () => ({
+  Agent: class {},
+  request: (opts: any, onResponse: any) => mockHttpRequest('https:', opts, onResponse),
+}));
+
+describe('PrestoDriver custom headers', () => {
+  beforeEach(() => {
+    mockRecorded.length = 0;
+    mockHttpRequest.mockClear();
+  });
+
+  it('sends custom headers on every request, including nextUri polls', async () => {
+    const driver = new PrestoDriver({
+      host: 'coordinator.local',
+      port: '8080',
+      catalog: 'test',
+      schema: 'default',
+      dataSource: 'default',
+      // Poll fast so the test doesn't wait on the default 800ms interval.
+      checkInterval: 1,
+      headers: {
+        'X-Custom-Header': 'custom-value',
+        'Proxy-Authorization': 'Basic dGVzdA==',
+      },
+    } as any);
+
+    const rows = await driver.query('SELECT 1', []);
+    expect(rows).toEqual([{ one: 1 }]);
+
+    const post = mockRecorded.find((r) => r.method === 'POST');
+    const poll = mockRecorded.find((r) => r.method === 'GET');
+
+    expect(post).toBeDefined();
+    expect(poll).toBeDefined();
+
+    // The initial POST goes to the configured coordinator with the headers.
+    expect(post!.host).toBe('coordinator.local');
+    expect(post!.headers['X-Custom-Header']).toBe('custom-value');
+    expect(post!.headers['Proxy-Authorization']).toBe('Basic dGVzdA==');
+
+    // The nextUri poll must follow the nextUri host *and* carry the custom
+    // headers — the header drop is what regressed.
+    expect(poll!.host).toBe('worker.internal');
+    expect(poll!.port).toBe('8081');
+    expect(poll!.headers['X-Custom-Header']).toBe('custom-value');
+    expect(poll!.headers['Proxy-Authorization']).toBe('Basic dGVzdA==');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -21528,7 +21528,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-presto-client@^1.2.0:
+presto-client@1.2.0, presto-client@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/presto-client/-/presto-client-1.2.0.tgz#7f6c4d78092298fa4b107775f8a2fabe008772e9"
   integrity sha512-mBwc6nZMGWbo9tRkDLxE6eZ4pyGlS08TeNJnF5zpRww02l6ASxQ14jdVNk+AcFrxNdI7yEDOBQXr+gK2KPiTOw==


### PR DESCRIPTION
The upstream presto-client only applies custom headers to the initial POST /v1/statement request. The follow-up nextUri GET polls (and the cancel/kill/node requests) were issued with an empty header set, so custom headers required by a proxy/gateway in front of Presto/Trino (e.g. Proxy-Authorization) were dropped after the first request, causing the query to fail with "User authentication failed".

Wrap client.request so the configured custom headers are applied to every request, while preserving the upstream nextUri host-following behaviour.

Also split the driver tests into test/unit and test/integration folders and add a `unit` script, matching the trino-driver convention.