### PR TITLE
docs: document contextToCubeStoreRouterId config option

### DIFF
--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -360,6 +360,40 @@ module.exports = {
 
 </CodeGroup>
 
+### `context_to_cube_store_router_id`
+
+`context_to_cube_store_router_id` is a function used to determine which Cube Store
+router a request is routed to. It returns a string id that is used as a routing
+key: requests that resolve to the same id share the same Cube Store router, while
+distinct ids are routed to separate routers.
+
+This is only relevant for deployments running multiple Cube Store routers (for
+example, when [tenants][ref-multitenancy] are partitioned across routers to
+isolate their pre-aggregation storage and query load). By default this function
+is not set, and all requests use the same Cube Store router.
+
+Called on each request.
+
+<CodeGroup>
+
+```python title="Python"
+from cube import config
+
+@config('context_to_cube_store_router_id')
+def context_to_cube_store_router_id(ctx: dict) -> str:
+  return f"CUBE_ROUTER_{ctx['securityContext']['tenant_id']}"
+```
+
+```javascript title="JavaScript"
+module.exports = {
+  contextToCubeStoreRouterId: ({ securityContext }) => {
+    return `CUBE_ROUTER_${securityContext.tenant_id}`
+  }
+}
+```
+
+</CodeGroup>
+
 ### `driver_factory`
 
 A function to provide a custom configuration for the data source driver.

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -372,6 +372,13 @@ example, when [tenants][ref-multitenancy] are partitioned across routers to
 isolate their pre-aggregation storage and query load). By default this function
 is not set, and all requests use the same Cube Store router.
 
+<Warning>
+
+`context_to_cube_store_router_id` requires
+[`context_to_orchestrator_id`][self-orchestrator-id] to also be defined.
+
+</Warning>
+
 Called on each request.
 
 <CodeGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Documents the `contextToCubeStoreRouterId` (`context_to_cube_store_router_id`) configuration option, which was added in [#9197](https://github.com/cube-js/cube/pull/9197) but never documented.

The new section is added to the configuration reference (`docs-mintlify/reference/configuration/config.mdx`), placed right after `context_to_orchestrator_id` since the two are closely related routing/caching-key options. It includes:

- A description of what the function does — returns a string id used as a routing key to select which Cube Store router a request is routed to.
- A note that it only matters for deployments running multiple Cube Store routers, and that all requests share one router by default.
- A warning that `context_to_cube_store_router_id` requires `context_to_orchestrator_id` to also be defined.
- JavaScript and Python examples (both `contextToCubeStoreRouterId` and `context_to_cube_store_router_id` are exposed in the respective config interfaces).

## Checklist

- [x] Docs added/updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4781c25-8ed1-4ada-91de-05f4a1d88fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4781c25-8ed1-4ada-91de-05f4a1d88fa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

