### PR TITLE
docs(oidc): clarify GCP audience is the WIF provider resource path

### DIFF
--- a/docs-mintlify/admin/deployment/oidc/gcp.mdx
+++ b/docs-mintlify/admin/deployment/oidc/gcp.mdx
@@ -109,6 +109,15 @@ GCP_SERVICE_ACCOUNT_EMAIL=cube-deployment@my-project.iam.gserviceaccount.com
 - **`GCP_POOL_AUDIENCE`** — the full resource URI of the WIF provider you
   created in Step 1. This becomes the `aud` claim on the GCP token Cube
   mints.
+
+<Note>
+  The GCP token config under **Admin → OIDC** must carry this **exact same**
+  provider resource path as its audience (unlike AWS/Azure, GCP has no global
+  audience, so it is not auto-filled). If the token config's audience and
+  `GCP_POOL_AUDIENCE` disagree, the STS exchange fails with
+  `invalid_grant: The audience in ID Token ... does not match the expected
+  audience`.
+</Note>
 - **`GCP_SERVICE_ACCOUNT_EMAIL`** — the service account that Cube
   impersonates after federation succeeds. Cube assumes this service account
   by default for every GCP SDK call inside the deployment.

--- a/docs-mintlify/admin/deployment/oidc/index.mdx
+++ b/docs-mintlify/admin/deployment/oidc/index.mdx
@@ -96,8 +96,8 @@ deployments in the tenant.
 
 | Field                     | What it controls                                                                                                       |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Audience type**         | One of `AWS`, `GCP`, `Azure`, or `Custom`. Well-known types pre-fill the audience value.                                |
-| **Audience**              | The JWT `aud` claim value. Pre-set for `AWS`, `GCP`, and `Azure`; user-supplied for `Custom`.                           |
+| **Audience type**         | One of `AWS`, `GCP`, `Azure`, or `Custom`. `AWS` and `Azure` pre-fill the audience value.                               |
+| **Audience**              | The JWT `aud` claim value. Pre-set for `AWS` (`sts.amazonaws.com`) and `Azure` (`api://AzureADTokenExchange`). For `GCP` you supply the **Workload Identity Federation provider resource path** (`//iam.googleapis.com/projects/.../providers/...`) — there is no global GCP audience. User-supplied for `Custom`. |
 | **Name**                  | A short, filesystem-safe slug that becomes part of the token file name (`cube_cloud_token_<name>`).                     |
 | **Subject Claim Format**  | Template for the JWT `sub` claim. Defaults to `cube:deployment:{deployment_id}` if left empty.                          |
 
@@ -204,11 +204,13 @@ config per integration target.
     </Frame>
   </Step>
   <Step title="Add token configs">
-    Click **Add Config** and pick the audience type. For `AWS`, `GCP`, and
-    `Azure`, the audience auto-fills with the standard value; for `Custom`,
-    enter the audience your target system expects in the **Custom Audience**
-    field. Optionally set the **Subject Claim Format** — see
-    [Token configs](#token-configs) for the available templates.
+    Click **Add Config** and pick the audience type. For `AWS` and `Azure`,
+    the audience auto-fills with the standard value. For `GCP`, enter the
+    **Workload Identity Federation provider resource path** (the same
+    `//iam.googleapis.com/projects/.../providers/...` value you use for
+    `GCP_POOL_AUDIENCE`) — GCP has no global audience. For `Custom`, enter the
+    audience your target system expects. Optionally set the **Subject Claim
+    Format** — see [Token configs](#token-configs) for the available templates.
   </Step>
   <Step title="Configure trust on the cloud side">
     Follow the cloud-specific guides below to register Cube as an OIDC


### PR DESCRIPTION
## What

The OIDC token-config docs said the audience "auto-fills with the standard value" for GCP. That's not true: GCP Workload Identity Federation has **no global audience** (unlike AWS's `sts.amazonaws.com` and Azure's `api://AzureADTokenExchange`). The token `aud` must be the **full WIF provider resource path** (`//iam.googleapis.com/projects/.../providers/...`) — the same value as `GCP_POOL_AUDIENCE`.

## Changes

- `admin/deployment/oidc/index.mdx`: token-config table + "Add token configs" step now say AWS/Azure auto-fill, GCP requires the provider resource path, Custom is user-supplied.
- `admin/deployment/oidc/gcp.mdx`: added a `<Note>` that the **Admin → OIDC** GCP token config must carry the same provider path as `GCP_POOL_AUDIENCE`, or the STS exchange fails with `invalid_grant: The audience in ID Token ... does not match the expected audience`.

Pairs with the Cube Cloud change that makes the GCP OIDC audience configurable (the code now matches what these docs describe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)