### PR TITLE
feat(schema-compiler): capitalize ID acronyms in default meta titles

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -473,7 +473,10 @@ export class CubeToMetaTransformer implements CompilerInterface {
   }
 
   private titleize(name: string): string {
-    return inflection.titleize(inflection.underscore(camelCase(name, { pascalCase: true })));
+    const titleized = inflection.titleize(inflection.underscore(camelCase(name, { pascalCase: true })));
+    // Capitalize common identifier acronyms so e.g. `userId` reads as "User ID"
+    // rather than "User Id" and an `id` member becomes "ID" instead of "Id".
+    return titleized.replace(/\bId(s?)\b/g, (_match, plural) => `ID${plural}`);
   }
 
   private transformDimensionFormat({ format: formatOrName, type }: ExtendedCubeSymbolDefinition): DimensionFormat | undefined {


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Default member titles in the meta are generated via `titleize()` in `CubeToMetaTransformer`, which used `inflection.titleize`. That rendered the identifier suffix as `"Id"`:

- `userId` → `"User Id"`
- an `id` member → `"Id"`

This post-processes the titleized string to uppercase the `Id`/`Ids` token at word boundaries, so default titles read naturally:

| member | before | after |
|---|---|---|
| `id` | Id | **ID** |
| `userId` | User Id | **User ID** |
| `userIds` | User Ids | **User IDs** |
| `orderId` | Order Id | **Order ID** |
| `identityProvider` | Identity Provider | Identity Provider (unchanged) |
| `idaho` | Idaho | Idaho (unchanged) |

The word-boundary regex only touches the standalone `Id`/`Ids` token, so words like "Identity" or "Idaho" are unaffected. Explicit `title:` overrides in the data model are unaffected since `titleize` is only the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)