### PR TITLE
feat!: Remove deprecated CUBEJS_SCHEDULED_REFRESH_CONCURRENCY env var…

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -64,7 +64,7 @@ features:
 | Removed    | [`initApp` hook](#initapp-hook)                                                                                                   | v0.35.0    | v0.35.0   |
 | Removed    | [`/v1/run-scheduled-refresh` REST API endpoint](#v1run-scheduled-refresh-rest-api-endpoint)                                       | v0.35.0    | v0.36.0   |
 | Removed    | [Node.js 18](#nodejs-18)                                                                                                          | v0.36.0    | v1.3.0    |
-| Deprecated | [`CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`](#cubejs_scheduled_refresh_concurrency)                                                   | v1.2.7    |           |
+| Removed    | [`CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`](#cubejs_scheduled_refresh_concurrency)                                                   | v1.2.7     | v1.7.0    |
 | Deprecated | [Node.js 20](#nodejs-20)                                                                                                          | v1.3.0    |           |
 | Deprecated | [`renewQuery` parameter of the `/v1/load` endpoint](#renewquery-parameter-of-the-v1load-endpoint)                                 | v1.3.73   |           |
 | Removed    | [Elasticsearch driver](#elasticsearch-driver)                                                                                     | v1.6.0     | v1.7.0    |
@@ -400,6 +400,8 @@ no more updates. Please upgrade to Node.js 20 or higher.
 ### `CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`
 
 **Deprecated in Release: v1.2.7**
+
+**Removed in Release: v1.7.0**
 
 This environment variable was renamed to [`CUBEJS_SCHEDULED_REFRESH_QUERIES_PER_APP_ID`](https://cube.dev/docs/reference/configuration/environment-variables#cubejs_scheduled_refresh_queries_per_app_id). Please use the new name.
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -137,12 +137,6 @@ it should be adjusted accordingly.
 | ------------------------------------ | ---------------------- | --------------------- |
 | A valid number of concurrent queries | 10                     | 10                    |
 
-<Info>
-
-Previously, this environment variable was named [`CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`](/reference/configuration/environment-variables#cubejs_scheduled_refresh_concurrency).
-
-</Info>
-
 ## `CUBEJS_CUBESTORE_HOST`
 
 The hostname of the Cube Store deployment

--- a/docs/content/product/configuration/reference/environment-variables.mdx
+++ b/docs/content/product/configuration/reference/environment-variables.mdx
@@ -151,12 +151,6 @@ it should be adjusted accordingly.
 | ------------------------------------ | ---------------------- | --------------------- |
 | A valid number of concurrent queries | 10                     | 10                    |
 
-<InfoBox>
-
-Previously, this environment variable was named <EnvVar>CUBEJS_SCHEDULED_REFRESH_CONCURRENCY</EnvVar>.
-
-</InfoBox>
-
 ## `CUBEJS_CUBESTORE_HOST`
 
 The hostname of the Cube Store deployment

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -266,23 +266,7 @@ const variables: Record<string, (...args: any) => any> = {
     // It's true by default for development
     return process.env.NODE_ENV !== 'production';
   },
-  scheduledRefreshQueriesPerAppId: () => {
-    const refreshQueries = get('CUBEJS_SCHEDULED_REFRESH_QUERIES_PER_APP_ID').asIntPositive();
-
-    if (refreshQueries) {
-      return refreshQueries;
-    }
-
-    const refreshConcurrency = get('CUBEJS_SCHEDULED_REFRESH_CONCURRENCY').asIntPositive();
-
-    if (refreshConcurrency) {
-      console.warn(
-        'The CUBEJS_SCHEDULED_REFRESH_CONCURRENCY is deprecated. Please, use the CUBEJS_SCHEDULED_REFRESH_QUERIES_PER_APP_ID instead.'
-      );
-    }
-
-    return refreshConcurrency;
-  },
+  scheduledRefreshQueriesPerAppId: () => get('CUBEJS_SCHEDULED_REFRESH_QUERIES_PER_APP_ID').asIntPositive(),
   refreshWorkerConcurrency: () => get('CUBEJS_REFRESH_WORKER_CONCURRENCY')
     .asIntPositive(),
   // eslint-disable-next-line consistent-return


### PR DESCRIPTION
…iable

BREAKING CHANGE: The CUBEJS_SCHEDULED_REFRESH_CONCURRENCY environment variable has been removed. It was deprecated in v1.2.7. Use CUBEJS_SCHEDULED_REFRESH_QUERIES_PER_APP_ID instead.