### PR TITLE
feat(api-gateway)!: Remove deprecated renewQuery parameter

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -66,7 +66,7 @@ features:
 | Removed    | [Node.js 18](#nodejs-18)                                                                                                          | v0.36.0    | v1.3.0    |
 | Removed    | [`CUBEJS_SCHEDULED_REFRESH_CONCURRENCY`](#cubejs_scheduled_refresh_concurrency)                                                   | v1.2.7     | v1.7.0    |
 | Deprecated | [Node.js 20](#nodejs-20)                                                                                                          | v1.3.0    |           |
-| Deprecated | [`renewQuery` parameter of the `/v1/load` endpoint](#renewquery-parameter-of-the-v1load-endpoint)                                 | v1.3.73   |           |
+| Removed    | [`renewQuery` parameter of the `/v1/load` endpoint](#renewquery-parameter-of-the-v1load-endpoint)                                 | v1.3.73   | v1.7.0    |
 | Removed    | [Elasticsearch driver](#elasticsearch-driver)                                                                                     | v1.6.0     | v1.7.0    |
 | Deprecated | [`context_to_roles`](#context-to-roles)                                                                                           | v1.6.4     |           |
 
@@ -424,8 +424,10 @@ no more new features, only security updates. Please upgrade to Node.js 22 or hig
 
 **Deprecated in Release: v1.3.73**
 
-This parameter is deprecated and will be removed in future releases. See [cache control](https://cube.dev/docs/product/apis-integrations/rest-api#cache-control)
-options and use the new `cache` parameter of the `/v1/load` endpoint instead.
+**Removed in Release: v1.7.0**
+
+This parameter has been removed. See [cache control](https://cube.dev/docs/product/apis-integrations/rest-api#cache-control)
+options and use the `cache` parameter of the `/v1/load` endpoint instead.
 
 ### Elasticsearch driver
 

--- a/docs-mintlify/reference/core-data-apis/graphql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/graphql-api/reference.mdx
@@ -30,7 +30,6 @@ query {
 - **`timezone` (`String`):** The [time zone][ref-time-zone] for your query. You can set the
 desired time zone in the [TZ Database Name](https://en.wikipedia.org/wiki/Tz_database)
 format, e.g., `America/Los_Angeles`.
-- **`renewQuery` (`Boolean`):** If `renewQuery` is set to `true`, Cube will renew all `refreshKey` for queries and query results in the foreground. The default value is `false`.
 - **`ungrouped` (`Boolean`):** If set to `true`, Cube will run an
 [ungrouped query][ref-ungrouped-query].
 

--- a/docs-mintlify/reference/core-data-apis/rest-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/query-format.mdx
@@ -45,23 +45,6 @@ The default value is `false`.
 - `timezone`: A [time zone][ref-time-zone] for your query. You can set the
 desired time zone in the [TZ Database Name](https://en.wikipedia.org/wiki/Tz_database)
 format, e.g., `America/Los_Angeles`.
-- `renewQuery`: If `renewQuery` is set to `true`, Cube will renew all
-  [`refreshKey`][ref-schema-ref-preaggs-refreshkey] for queries and query
-  results in the foreground. However, if the
-  [`refreshKey`][ref-schema-ref-preaggs-refreshkey] (or
-  [`refreshKey.every`][ref-schema-ref-preaggs-refreshkey-every]) doesn't
-  indicate that there's a need for an update this setting has no effect. The
-  default value is `false`.
-
-<Info>
-
-Cube provides only eventual consistency guarantee. Using a small
-[`refreshKey.every`][ref-schema-ref-preaggs-refreshkey-every] value together
-with `renewQuery` to achieve immediate consistency can lead to endless
-refresh loops and overall system instability.
-
-</Info>
-
 - `ungrouped`: If set to `true`, Cube will run an [ungrouped
 query][ref-ungrouped-query].
 - `joinHints`: Query-time [join hints][ref-join-hints], provided as an array of
@@ -675,8 +658,6 @@ refer to its documentation for more examples.
 </Info>
 
 [ref-client-core-resultset-drilldown]: /reference/javascript-sdk/reference/cubejs-client-core#drilldown
-[ref-schema-ref-preaggs-refreshkey]: /reference/data-modeling/pre-aggregations#refresh_key
-[ref-schema-ref-preaggs-refreshkey-every]: /reference/data-modeling/pre-aggregations#every
 [ref-schema-ref-preaggs-dimensions]: /reference/data-modeling/pre-aggregations#dimensions
 [ref-schema-ref-preaggs-time-dimension]: /reference/data-modeling/pre-aggregations#time_dimension
 [ref-relative-date-range]: #relative-date-range

--- a/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
+++ b/docs-mintlify/reference/javascript-sdk/reference/cubejs-client-core.mdx
@@ -938,7 +938,6 @@ limit? | number |
 measures? | string[] |
 offset? | number |
 order? | [TQueryOrderObject](#types-t-query-order-object) &#124; [TQueryOrderArray](#types-t-query-order-array) |
-renewQuery? | boolean |
 segments? | string[] |
 timeDimensions? | [TimeDimension](#types-time-dimension)[] |
 timezone? | string |

--- a/docs/content/product/apis-integrations/core-data-apis/graphql-api/reference.mdx
+++ b/docs/content/product/apis-integrations/core-data-apis/graphql-api/reference.mdx
@@ -27,7 +27,6 @@ query {
 - **`timezone` (`String`):** The [time zone][ref-time-zone] for your query. You can set the
 desired time zone in the [TZ Database Name](https://en.wikipedia.org/wiki/Tz_database)
 format, e.g., `America/Los_Angeles`.
-- **`renewQuery` (`Boolean`):** If `renewQuery` is set to `true`, Cube will renew all `refreshKey` for queries and query results in the foreground. The default value is `false`.
 - **`ungrouped` (`Boolean`):** If set to `true`, Cube will run an
 [ungrouped query][ref-ungrouped-query].
 

--- a/docs/content/product/apis-integrations/core-data-apis/rest-api/query-format.mdx
+++ b/docs/content/product/apis-integrations/core-data-apis/rest-api/query-format.mdx
@@ -42,23 +42,6 @@ The default value is `false`.
 - `timezone`: A [time zone][ref-time-zone] for your query. You can set the
 desired time zone in the [TZ Database Name](https://en.wikipedia.org/wiki/Tz_database)
 format, e.g., `America/Los_Angeles`.
-- `renewQuery`: If `renewQuery` is set to `true`, Cube will renew all
-  [`refreshKey`][ref-schema-ref-preaggs-refreshkey] for queries and query
-  results in the foreground. However, if the
-  [`refreshKey`][ref-schema-ref-preaggs-refreshkey] (or
-  [`refreshKey.every`][ref-schema-ref-preaggs-refreshkey-every]) doesn't
-  indicate that there's a need for an update this setting has no effect. The
-  default value is `false`.
-
-<InfoBox>
-
-Cube provides only eventual consistency guarantee. Using a small
-[`refreshKey.every`][ref-schema-ref-preaggs-refreshkey-every] value together
-with `renewQuery` to achieve immediate consistency can lead to endless
-refresh loops and overall system instability.
-
-</InfoBox>
-
 - `ungrouped`: If set to `true`, Cube will run an [ungrouped
 query][ref-ungrouped-query].
 - `joinHints`: Query-time [join hints][ref-join-hints], provided as an array of
@@ -672,10 +655,6 @@ refer to its documentation for more examples.
 </InfoBox>
 
 [ref-client-core-resultset-drilldown]: /product/apis-integrations/javascript-sdk/reference/cubejs-client-core#drilldown
-[ref-schema-ref-preaggs-refreshkey]:
-  /product/data-modeling/reference/pre-aggregations#refresh_key
-[ref-schema-ref-preaggs-refreshkey-every]:
-  /product/data-modeling/reference/pre-aggregations#every
 [ref-schema-ref-preaggs-dimensions]:
   /product/data-modeling/reference/pre-aggregations#dimensions
 [ref-schema-ref-preaggs-time-dimension]:

--- a/packages/cubejs-api-gateway/src/graphql.ts
+++ b/packages/cubejs-api-gateway/src/graphql.ts
@@ -363,7 +363,7 @@ function parseDates(result: any) {
 }
 
 export function getJsonQuery(metaConfig: any, args: Record<string, any>, infos: GraphQLResolveInfo) {
-  const { where, limit, offset, timezone, orderBy, renewQuery, ungrouped, cache } = args;
+  const { where, limit, offset, timezone, orderBy, ungrouped, cache } = args;
 
   const measures: string[] = [];
   const dimensions: string[] = [];
@@ -460,7 +460,6 @@ export function getJsonQuery(metaConfig: any, args: Record<string, any>, infos: 
     ...(offset && { offset }),
     ...(timezone && { timezone }),
     ...(filters.length && { filters }),
-    ...(renewQuery && { renewQuery }),
     ...(cache && { cache }),
     ...(ungrouped && { ungrouped }),
   };
@@ -639,7 +638,6 @@ export function makeSchema(metaConfig: any): GraphQLSchema {
           limit: intArg(),
           offset: intArg(),
           timezone: stringArg(),
-          renewQuery: booleanArg(),
           cache: stringArg(),
           ungrouped: booleanArg(),
           orderBy: arg({

--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -187,8 +187,6 @@ const querySchema = Joi.object().keys({
   limit: Joi.number().integer().strict().min(0),
   offset: Joi.number().integer().strict().min(0),
   total: Joi.boolean(),
-  // @deprecated
-  renewQuery: Joi.boolean(),
   cacheMode: Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache'),
   cache: Joi.valid('stale-if-slow', 'stale-while-revalidate', 'must-revalidate', 'no-cache'),
   ungrouped: Joi.boolean(),
@@ -304,19 +302,12 @@ function parseInputMemberExpression(expression) {
 function normalizeQueryCacheMode(query, cacheMode) {
   if (cacheMode !== undefined) {
     query.cacheMode = cacheMode;
-  } else if (!query.cache && query?.renewQuery !== undefined) {
-    // TODO: Drop this when renewQuery will be removed
-    query.cacheMode = query.renewQuery === true
-      ? 'must-revalidate'
-      : 'stale-if-slow';
   } else if (!query.cache) {
     query.cacheMode = 'stale-if-slow';
   } else {
     query.cacheMode = query.cache;
   }
 
-  // TODO: Drop this when renewQuery will be removed
-  query.renewQuery = undefined;
   query.cache = undefined;
 
   return query;

--- a/packages/cubejs-api-gateway/src/types/query.ts
+++ b/packages/cubejs-api-gateway/src/types/query.ts
@@ -140,8 +140,6 @@ interface Query {
   totalQuery?: boolean;
   order?: any;
   timezone?: string;
-  // @deprecated
-  renewQuery?: boolean;
   cacheMode?: CacheMode; // used after query normalization
   cache?: CacheMode; // Used in public interface
   ungrouped?: boolean;

--- a/packages/cubejs-api-gateway/src/types/request.ts
+++ b/packages/cubejs-api-gateway/src/types/request.ts
@@ -121,7 +121,6 @@ type BaseRequest = {
 };
 
 type RequestQuery = Record<string, any> | Record<string, any>[] & {
-  renewQuery?: boolean;
   cacheMode?: CacheMode;
 };
 

--- a/packages/cubejs-backend-shared/src/shared-types.ts
+++ b/packages/cubejs-backend-shared/src/shared-types.ts
@@ -1,5 +1,5 @@
 /*
-stale-if-slow (default) — equivalent to previously used renewQuery: false
+stale-if-slow (default)
   If refresh keys are up-to-date, returns the value from cache
   If refresh keys are expired, tries to return the value from the database
     Returns fresh value from the database if the query executed in the database until the first “Continue wait” interval is reached
@@ -10,7 +10,7 @@ stale-while-revalidate — AKA “backgroundRefresh”
   If refresh keys are expired, returns stale data from cache
   Updates the cache in background
 
-must-revalidate — equivalent to previously used renewQuery: true
+must-revalidate
   If refresh keys are up-to-date, returns the value from cache
   If refresh keys are expired, tries to return the value from the database
     Returns fresh value from the database even if it takes minutes and many “Continue wait” intervals

--- a/packages/cubejs-client-core/src/types.ts
+++ b/packages/cubejs-client-core/src/types.ts
@@ -162,8 +162,6 @@ export interface Query {
   offset?: number;
   order?: TQueryOrderObject | TQueryOrderArray;
   timezone?: string;
-  // @deprecated
-  renewQuery?: boolean;
   ungrouped?: boolean;
   responseFormat?: 'compact' | 'columnar' | 'default';
   total?: boolean;
@@ -600,7 +598,7 @@ export type ProgressResponse = {
 /**
  * Cache mode options for query execution.
  *
- * - **stale-if-slow** (default): Equivalent to previously used `renewQuery: false`.
+ * - **stale-if-slow** (default):
  *   If refresh keys are up-to-date, returns the value from cache.
  *   If refresh keys are expired, tries to return the value from the database.
  *   Returns fresh value from the database if the query executed until the first "Continue wait" interval is reached.
@@ -611,7 +609,7 @@ export type ProgressResponse = {
  *   If refresh keys are expired, returns stale data from cache.
  *   Updates the cache in background.
  *
- * - **must-revalidate**: Equivalent to previously used `renewQuery: true`.
+ * - **must-revalidate**:
  *   If refresh keys are up-to-date, returns the value from cache.
  *   If refresh keys are expired, tries to return the value from the database.
  *   Returns fresh value from the database even if it takes minutes and many "Continue wait" intervals.

--- a/packages/cubejs-client-dx/index.d.ts
+++ b/packages/cubejs-client-dx/index.d.ts
@@ -19,8 +19,6 @@ declare module "@cubejs-client/core" {
     offset?: number;
     order?: IntrospectedTQueryOrderObject | IntrospectedTQueryOrderArray;
     timezone?: string;
-    // @deprecated
-    renewQuery?: boolean;
     ungrouped?: boolean;
   }
 

--- a/packages/cubejs-client-vue3/src/QueryBuilder.js
+++ b/packages/cubejs-client-vue3/src/QueryBuilder.js
@@ -120,7 +120,6 @@ export default {
       availableSegments: [],
       limit: null,
       offset: null,
-      renewQuery: false,
       order: null,
       prevValidatedQuery: null,
       granularities: GRANULARITIES,
@@ -151,7 +150,6 @@ export default {
       removeLimit,
       setOffset,
       removeOffset,
-      renewQuery,
       order,
       orderMembers,
     } = this;
@@ -180,7 +178,6 @@ export default {
         removeLimit,
         setOffset,
         removeOffset,
-        renewQuery,
         order,
         orderMembers,
         setOrder: this.setOrder,
@@ -349,10 +346,6 @@ export default {
         if (this.order) {
           validatedQuery.order = this.order;
         }
-
-        if (this.renewQuery) {
-          validatedQuery.renewQuery = this.renewQuery;
-        }
       }
 
       if (
@@ -430,7 +423,6 @@ export default {
         filters = [],
         limit,
         offset,
-        renewQuery,
         order,
       } = query || this.initialQuery;
 
@@ -476,7 +468,6 @@ export default {
       this.availableSegments = this.meta.membersForQuery({}, 'segments') || [];
       this.limit = limit || 10000;
       this.offset = offset || null;
-      this.renewQuery = renewQuery || false;
       this.order = order || null;
     },
     addMember(element, member) {

--- a/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
+++ b/packages/cubejs-client-vue3/tests/unit/QueryBuilder.spec.js
@@ -746,34 +746,6 @@ describe('QueryBuilder.vue', () => {
       expect(wrapper.vm.offset).toBe(10);
     });
 
-    it('sets renewQuery', async () => {
-      const cube = createCubeApi();
-      jest
-        .spyOn(cube, 'request')
-        .mockImplementation(fetchMock(load))
-        .mockImplementationOnce(fetchMock(meta));
-
-      const filter = {
-        member: 'Orders.status',
-        operator: 'equals',
-        values: ['invalid'],
-      };
-
-      const wrapper = shallowMount(QueryBuilder, {
-        props: {
-          cubeApi: cube,
-          query: {
-            filters: [filter],
-            renewQuery: true,
-          },
-        },
-      });
-
-      await flushPromises();
-
-      expect(wrapper.vm.renewQuery).toBe(true);
-    });
-
     it('ignore order if empty', async () => {
       const cube = createCubeApi();
       jest

--- a/packages/cubejs-playground/src/QueryBuilderV2/utils/validate-query.ts
+++ b/packages/cubejs-playground/src/QueryBuilderV2/utils/validate-query.ts
@@ -138,11 +138,6 @@ export function validateQuery(query: Record<string, any>): Query {
     sanitizedQuery.timezone = query.timezone;
   }
 
-  // It's not supported yet
-  // if (query.renewQuery === true) {
-  //   sanitizedQuery.renewQuery = query.renewQuery;
-  // }
-
   if (query.ungrouped === true) {
     sanitizedQuery.ungrouped = query.ungrouped;
   }

--- a/packages/cubejs-playground/src/components/CachePane.tsx
+++ b/packages/cubejs-playground/src/components/CachePane.tsx
@@ -9,7 +9,8 @@ import { FatalError } from './Error/FatalError';
 const CachePane = ({ query }) => (
   <QueryRenderer
     loadSql
-    query={{ ...query, renewQuery: true }}
+    cache="must-revalidate"
+    query={query}
     render={({ sqlQuery, resultSet, error }) => {
       if (error) {
         return <FatalError error={error} />;

--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregations.ts
@@ -545,7 +545,7 @@ export class PreAggregations {
             maxPartitions: this.options.maxPartitions,
             maxSourceRowLimit: this.options.maxSourceRowLimit,
             isJob: queryBody.isJob,
-            waitForRenew: queryBody.cacheMode !== undefined ? queryBody.cacheMode === 'must-revalidate' : queryBody.renewQuery,
+            waitForRenew: queryBody.cacheMode === 'must-revalidate',
             // TODO workaround to avoid continuous waiting on building pre-aggregation dependencies
             forceBuild: i === preAggregations.length - 1 ? queryBody.forceBuildPreAggregations : false,
             requestId: queryBody.requestId,
@@ -664,7 +664,7 @@ export class PreAggregations {
         {
           maxPartitions: this.options.maxPartitions,
           maxSourceRowLimit: this.options.maxSourceRowLimit,
-          waitForRenew: queryBody.cacheMode !== undefined ? queryBody.cacheMode === 'must-revalidate' : queryBody.renewQuery,
+          waitForRenew: queryBody.cacheMode === 'must-revalidate',
           requestId: queryBody.requestId,
           externalRefresh: this.externalRefresh,
           compilerCacheFn: queryBody.compilerCacheFn,

--- a/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/QueryCache.ts
@@ -70,8 +70,6 @@ export type Query = {
   preAggregations?: PreAggregationDescription[];
   groupedPartitionPreAggregations?: PreAggregationDescription[][];
   preAggregationsLoadCacheByDataSource?: any;
-  // @deprecated
-  renewQuery?: boolean;
   cacheMode?: CacheMode;
   compilerCacheFn?: <T>(subKey: string[], cacheFn: () => T) => T;
 };
@@ -83,8 +81,6 @@ export type QueryBody = {
   values?: string[];
   loadRefreshKeysOnly?: boolean;
   scheduledRefresh?: boolean;
-  // @deprecated
-  renewQuery?: boolean;
   cacheMode?: CacheMode;
   requestId?: string;
   external?: boolean;
@@ -286,8 +282,7 @@ export class QueryCache {
       }
     }
 
-    // renewQuery has been deprecated, but keeping it for now
-    if (queryBody.cacheMode === 'must-revalidate' || queryBody.renewQuery) {
+    if (queryBody.cacheMode === 'must-revalidate') {
       this.logger('Requested renew', { cacheKey, requestId: queryBody.requestId });
       return this.renewQuery(
         query,

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -147,8 +147,8 @@ describe('PreAggregations', () => {
 
   const basicQuery: any = createBasicQuery();
   const basicQueryExternal = createBasicQuery({ preAggregations: [{ ...basicQuery.preAggregations[0], external: true }] });
-  const basicQueryWithRenew = createBasicQuery({ renewQuery: true });
-  const basicQueryExternalWithRenew = createBasicQuery({ preAggregations: [{ ...basicQuery.preAggregations[0], external: true }], renewQuery: true });
+  const basicQueryWithRenew = createBasicQuery({ cacheMode: 'must-revalidate' });
+  const basicQueryExternalWithRenew = createBasicQuery({ preAggregations: [{ ...basicQuery.preAggregations[0], external: true }], cacheMode: 'must-revalidate' });
 
   beforeEach(() => {
     mockDriver = new MockDriver();

--- a/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
+++ b/packages/cubejs-query-orchestrator/test/unit/QueryOrchestrator.test.js
@@ -357,7 +357,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.orders_number_and_count20191101 AS SELECT\n      date_trunc(\'week\', ("orders".created_at::timestamptz AT TIME ZONE \'UTC\')) "orders__created_at_week", count("orders".id) "orders__count", sum("orders".number) "orders__number"\n    FROM\n      public.orders AS "orders"\n  WHERE ("orders".created_at >= $1::timestamptz AND "orders".created_at <= $2::timestamptz) GROUP BY 1', ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z']],
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'basic'
     };
     const promise = queryOrchestrator.fetchQuery(query);
@@ -386,7 +386,7 @@ describe('QueryOrchestrator', () => {
           indexName: 'orders_number_and_count_week20191101'
         }],
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'indexes'
     };
     const result = await queryOrchestrator.fetchQuery(query);
@@ -413,7 +413,7 @@ describe('QueryOrchestrator', () => {
           indexName: 'orders_number_and_count_week20191102'
         }],
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'index is part of query key'
     });
     await new Promise(resolve => setTimeout(() => resolve(), 400));
@@ -431,7 +431,7 @@ describe('QueryOrchestrator', () => {
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
         indexesSql: [],
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'index is part of query key'
     });
     console.log(result.data[0]);
@@ -457,7 +457,7 @@ describe('QueryOrchestrator', () => {
         }],
         external: true
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'external indexes'
     };
     const result = await queryOrchestrator.fetchQuery(query);
@@ -489,7 +489,7 @@ describe('QueryOrchestrator', () => {
         external: true,
         dataSource: 'bar'
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'external join',
       dataSource: 'foo',
       external: true
@@ -523,7 +523,7 @@ describe('QueryOrchestrator', () => {
         external: true,
         dataSource: 'csv',
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'csv import'
     };
     const result = await queryOrchestrator.fetchQuery(query);
@@ -546,7 +546,7 @@ describe('QueryOrchestrator', () => {
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
         dataSource: 'foo'
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'non default data source pre-aggregation',
       dataSource: 'foo',
     };
@@ -564,7 +564,7 @@ describe('QueryOrchestrator', () => {
         renewalThreshold: 21600,
         queries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]]
       },
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'non default data source query',
       dataSource: 'foo',
     };
@@ -588,7 +588,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.orders_number_and_count_and_very_very_very_very_very_very_long20191101 AS SELECT\n      date_trunc(\'week\', ("orders".created_at::timestamptz AT TIME ZONE \'UTC\')) "orders__created_at_week", count("orders".id) "orders__count", sum("orders".number) "orders__number"\n    FROM\n      public.orders AS "orders"\n  WHERE ("orders".created_at >= $1::timestamptz AND "orders".created_at <= $2::timestamptz) GROUP BY 1', ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z']],
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'silent truncate'
     };
     let thrown = true;
@@ -615,7 +615,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.orders_number_and_count20181101 AS SELECT\n      date_trunc(\'week\', ("orders".created_at::timestamptz AT TIME ZONE \'UTC\')) "orders__created_at_week", count("orders".id) "orders__count", sum("orders".number) "orders__number"\n    FROM\n      public.orders_too_big AS "orders"\n  WHERE ("orders".created_at >= $1::timestamptz AND "orders".created_at <= $2::timestamptz) GROUP BY 1', ['2018-11-01T00:00:00Z', '2018-11-30T23:59:59Z']],
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'cancel pre-aggregation'
     };
     try {
@@ -641,7 +641,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.orders AS SELECT * FROM public.orders', []],
         invalidateKeyQueries: [['SELECT 1', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'save structure versions'
     });
 
@@ -658,7 +658,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.orders AS SELECT * FROM public.orders1', []],
         invalidateKeyQueries: [['SELECT 1', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'save structure versions'
     });
 
@@ -678,7 +678,7 @@ describe('QueryOrchestrator', () => {
           loadSql: ['CREATE TABLE stb_pre_aggregations.orders AS SELECT * FROM public.orders', []],
           invalidateKeyQueries: [['SELECT 2', []]]
         }],
-        renewQuery: true,
+        cacheMode: 'must-revalidate',
         requestId: 'save structure versions'
       });
     }
@@ -777,7 +777,7 @@ describe('QueryOrchestrator', () => {
     // start renew refresh as scheduled refresh does
     const refresh = queryOrchestrator.fetchQuery({
       ...baseQuery,
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: `${requestId}: start refresh`
     });
 
@@ -905,7 +905,7 @@ describe('QueryOrchestrator', () => {
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
         external: true,
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'load cache should respect external flag'
     };
     const internalPreAggregation = {
@@ -922,7 +922,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.internal AS SELECT\n      date_trunc(\'week\', ("orders".created_at::timestamptz AT TIME ZONE \'UTC\')) "orders__created_at_week", count("orders".id) "orders__count", sum("orders".number) "orders__number"\n    FROM\n      public.orders AS "orders"\n  WHERE ("orders".created_at >= $1::timestamptz AND "orders".created_at <= $2::timestamptz) GROUP BY 1', ['2019-11-01T00:00:00Z', '2019-11-30T23:59:59Z']],
         invalidateKeyQueries: [['SELECT date_trunc(\'hour\', (NOW()::timestamptz AT TIME ZONE \'UTC\')) as current_hour', []]],
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'load cache should respect external flag'
     };
     await queryOrchestrator.fetchQuery(internalPreAggregation);
@@ -947,7 +947,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations.orders AS SELECT * FROM public.orders', []],
         invalidateKeyQueries: [['SELECT 2', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'pre-aggregation version entries'
     });
 
@@ -964,7 +964,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE stb_pre_aggregations_2.orders AS SELECT * FROM public.orders', []],
         invalidateKeyQueries: [['SELECT 3', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'pre-aggregation version entries'
     });
 
@@ -1023,7 +1023,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE pre_aggregations_1.orders AS SELECT * FROM public.orders WHERE tenant_id = 1', []],
         invalidateKeyQueries: [['SELECT 1', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'pre-aggregation schema cache'
     });
 
@@ -1040,7 +1040,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE pre_aggregations_2.orders AS SELECT * FROM public.orders WHERE tenant_id = 2', []],
         invalidateKeyQueries: [['SELECT 2', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'pre-aggregation schema cache'
     });
 
@@ -1057,7 +1057,7 @@ describe('QueryOrchestrator', () => {
         loadSql: ['CREATE TABLE pre_aggregations_1.orders AS SELECT * FROM public.orders WHERE tenant_id = 1', []],
         invalidateKeyQueries: [['SELECT 1', []]]
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'pre-aggregation schema cache'
     });
 
@@ -1499,7 +1499,7 @@ describe('QueryOrchestrator', () => {
         ]
       },
       preAggregations: [],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
       requestId: 'loadRefreshKeys should respect external flag'
     };
 
@@ -1562,7 +1562,7 @@ describe('QueryOrchestrator', () => {
         dataSource: 'mockDriverUnloadWithoutTempTableSupport',
         external: true,
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
 
       requestId: 'basic'
     };
@@ -1589,7 +1589,7 @@ describe('QueryOrchestrator', () => {
         dataSource: 'streaming',
         external: true,
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
 
       requestId: 'basic'
     };
@@ -1616,7 +1616,7 @@ describe('QueryOrchestrator', () => {
         external: true,
         streamOffset: 'earliest'
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
 
       requestId: 'basic'
     };
@@ -1646,7 +1646,7 @@ describe('QueryOrchestrator', () => {
         streamOffset: 'earliest',
         readOnly: true
       }],
-      renewQuery: true,
+      cacheMode: 'must-revalidate',
 
       requestId: 'basic'
     };

--- a/packages/cubejs-schema-compiler/test/integration/postgres/views-join-order-2.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/views-join-order-2.test.ts
@@ -158,7 +158,6 @@ cube('D', {
     segments: [],
     filters: [],
     total: true,
-    renewQuery: false,
     limit: 1
   }, [{
     view___a_id: 1,

--- a/rust/cube/cubeorchestrator/benches/transform.rs
+++ b/rust/cube/cubeorchestrator/benches/transform.rs
@@ -126,7 +126,6 @@ fn build_request(
         total: None,
         total_query: None,
         timezone: Some("UTC".to_string()),
-        renew_query: None,
         ungrouped: None,
         response_format: None,
         filters: None,

--- a/rust/cube/cubeorchestrator/src/query_result_transform.rs
+++ b/rust/cube/cubeorchestrator/src/query_result_transform.rs
@@ -3491,7 +3491,6 @@ mod tests {
             total: None,
             total_query: None,
             timezone: None,
-            renew_query: None,
             ungrouped: None,
             response_format: None,
             filters: None,

--- a/rust/cube/cubeorchestrator/src/transport.rs
+++ b/rust/cube/cubeorchestrator/src/transport.rs
@@ -304,8 +304,6 @@ pub struct NormalizedQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub renew_query: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ungrouped: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResultType>,


### PR DESCRIPTION
BREAKING CHANGE: The `renewQuery` parameter of the `/v1/load` REST endpoint and the GraphQL `cube` query has been removed. Use the `cache` parameter instead: `cache: 'must-revalidate'` replaces `renewQuery: true`, and the default `stale-if-slow` replaces `renewQuery: false`.