### PR TITLE
fix(clickhouse): use correct Nullable(String) type in CAST expressions

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -176,7 +176,7 @@ export class ClickHouseQuery extends BaseQuery {
   }
 
   public castToString(sql) {
-    return `CAST(${sql} as String)`;
+    return `CAST(${sql} AS Nullable(String))`;
   }
 
   public seriesSql(timeDimension: BaseTimeDimension) {
@@ -273,6 +273,7 @@ export class ClickHouseQuery extends BaseQuery {
     templates.quotes.escape = '\\`';
     templates.types.boolean = 'BOOL';
     templates.types.timestamp = 'DATETIME';
+    templates.types.string = 'Nullable(String)';
     delete templates.types.time;
     // ClickHouse intervals have a distinct type for each granularity
     delete templates.types.interval;


### PR DESCRIPTION
Currently, Cube outputs `CAST(x AS STRING)` which is not valid for Clickhouse.

**Issue Reference this PR resolves**

Partially addresses https://github.com/cube-js/cube/issues/10415