### PR TITLE
feat!: Remove deprecated context_to_roles configuration option

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -68,7 +68,7 @@ features:
 | Deprecated | [Node.js 20](#nodejs-20)                                                                                                          | v1.3.0    |           |
 | Deprecated | [`renewQuery` parameter of the `/v1/load` endpoint](#renewquery-parameter-of-the-v1load-endpoint)                                 | v1.3.73   |           |
 | Removed    | [Elasticsearch driver](#elasticsearch-driver)                                                                                     | v1.6.0     | v1.7.0    |
-| Deprecated | [`context_to_roles`](#context-to-roles)                                                                                           | v1.6.4     |           |
+| Removed    | [`context_to_roles`](#context-to-roles)                                                                                           | v1.6.4     | v1.7.0    |
 
 ### Node.js 8
 
@@ -439,5 +439,7 @@ The Elasticsearch driver has been removed.
 
 **Deprecated in Release: v1.6.4**
 
-The `context_to_roles` configuration option is deprecated and will be removed in a future
-release. Please use `context_to_groups` instead.
+**Removed in Release: v1.7.0**
+
+The `context_to_roles` configuration option has been removed. Please use `context_to_groups`
+instead.

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -441,5 +441,5 @@ The Elasticsearch driver has been removed.
 
 **Removed in Release: v1.7.0**
 
-The `context_to_roles` configuration option has been removed. Please use `context_to_groups`
-instead.
+The `context_to_roles` configuration option has been removed. Please use `context_to_groups` instead.
+

--- a/docs-mintlify/docs/data-modeling/data-access-policies.mdx
+++ b/docs-mintlify/docs/data-modeling/data-access-policies.mdx
@@ -773,7 +773,6 @@ cube(`orders`, {
 [ref-mls-public]: /docs/data-modeling/access-control/member-level-security#managing-member-level-access
 [ref-sec-ctx]: /docs/data-modeling/access-control/context
 [ref-ref-dap]: /reference/data-modeling/data-access-policies
-[ref-ref-dap-role]: /reference/data-modeling/data-access-policies#role
 [ref-ref-dap-masking]: /reference/data-modeling/data-access-policies#member-masking
 [ref-ref-mask-dim]: /reference/data-modeling/dimensions#mask
 [ref-core-data-apis]: /reference/core-data-apis

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -1515,40 +1515,6 @@ Usually used for [multitenancy][ref-multitenancy].
 If not defined, Cube will lookup for environment variable
 [`CUBEJS_DB_TYPE`](/reference/configuration/environment-variables#cubejs_db_type) to resolve the data source type.
 
-### `context_to_roles`
-
-<Warning>
-
-`context_to_roles` is deprecated and will be removed in a future release.
-Use [`context_to_groups`](#context_to_groups) instead.
-
-</Warning>
-
-Used by [access policies][ref-dap]. This option is used to derive a list of
-[data access roles][ref-dap-roles] from the [security context][ref-sec-ctx].
-
-<CodeGroup>
-
-```python title="Python"
-from cube import config
-
-@config('context_to_roles')
-def context_to_roles(ctx: dict) -> list[str]:
-  return ctx['securityContext'].get('roles', ['default'])
-```
-
-```javascript title="JavaScript"
-
-module.exports = {
-  contextToRoles: ({ securityContext }) => {
-    return securityContext.roles || ['default']
-  }
-}
-```
-
-</CodeGroup>
-
-
 [gh-jsonwebtoken-algs]:
   https://github.com/auth0/node-jsonwebtoken#algorithms-supported
 [link-express-cors-opts]:

--- a/docs/content/product/auth/data-access-policies.mdx
+++ b/docs/content/product/auth/data-access-policies.mdx
@@ -569,7 +569,6 @@ cube(`orders`, {
 [ref-mls-public]: /product/auth/member-level-security#managing-member-level-access
 [ref-sec-ctx]: /product/auth/context
 [ref-ref-dap]: /product/data-modeling/reference/data-access-policies
-[ref-ref-dap-role]: /product/data-modeling/reference/data-access-policies#role
 [ref-ref-dap-masking]: /product/data-modeling/reference/data-access-policies#member-masking
 [ref-ref-mask-dim]: /product/data-modeling/reference/dimensions#mask
 [ref-core-data-apis]: /product/apis-integrations/core-data-apis

--- a/docs/content/product/configuration/reference/config.mdx
+++ b/docs/content/product/configuration/reference/config.mdx
@@ -1474,40 +1474,6 @@ Usually used for [multitenancy][ref-multitenancy].
 If not defined, Cube will lookup for environment variable
 <EnvVar>CUBEJS_DB_TYPE</EnvVar> to resolve the data source type.
 
-### `context_to_roles`
-
-<WarningBox>
-
-`context_to_roles` is deprecated and will be removed in a future release.
-Use [`context_to_groups`](#context_to_groups) instead.
-
-</WarningBox>
-
-Used by [access policies][ref-dap]. This option is used to derive a list of
-[data access roles][ref-dap-roles] from the [security context][ref-sec-ctx].
-
-<CodeTabs>
-
-```python
-from cube import config
-
-@config('context_to_roles')
-def context_to_roles(ctx: dict) -> list[str]:
-  return ctx['securityContext'].get('roles', ['default'])
-```
-
-```javascript
-
-module.exports = {
-  contextToRoles: ({ securityContext }) => {
-    return securityContext.roles || ['default']
-  }
-}
-```
-
-</CodeTabs>
-
-
 [gh-jsonwebtoken-algs]:
   https://github.com/auth0/node-jsonwebtoken#algorithms-supported
 [link-express-cors-opts]:

--- a/packages/cubejs-backend-native/benchmarks/fixtures/config-async.py
+++ b/packages/cubejs-backend-native/benchmarks/fixtures/config-async.py
@@ -96,14 +96,6 @@ async def logger(msg, params):
 
 
 @config
-async def context_to_roles(ctx):
-    # Removed print statements for benchmarking
-    return [
-        "admin",
-    ]
-
-
-@config
 async def context_to_groups(ctx):
     # Removed print statements for benchmarking
     return [

--- a/packages/cubejs-backend-native/benchmarks/fixtures/config.py
+++ b/packages/cubejs-backend-native/benchmarks/fixtures/config.py
@@ -96,14 +96,6 @@ def logger(msg, params):
 
 
 @config
-def context_to_roles(ctx):
-    # Removed print statements for benchmarking
-    return [
-        "admin",
-    ]
-
-
-@config
 def context_to_groups(ctx):
     # Removed print statements for benchmarking
     return [

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -535,7 +535,6 @@ export interface PyConfiguration {
   contextToApiScopes?: () => Promise<string[]>
   scheduledRefreshContexts?: (ctx: unknown) => Promise<string[]>
   scheduledRefreshTimeZones?: (ctx: unknown) => Promise<string[]>
-  contextToRoles?: (ctx: unknown) => Promise<string[]>
   contextToGroups?: (ctx: unknown) => Promise<string[]>
 }
 

--- a/packages/cubejs-backend-native/python/cube/src/__init__.py
+++ b/packages/cubejs-backend-native/python/cube/src/__init__.py
@@ -77,7 +77,6 @@ class Configuration:
     semantic_layer_sync: Union[Dict, Callable[[], Dict]]
     pre_aggregations_schema: Union[Callable[[RequestContext], str], str]
     orchestrator_options: Union[Dict, Callable[[RequestContext], Dict]]
-    context_to_roles: Callable[[RequestContext], list[str]]
     context_to_groups: Callable[[RequestContext], list[str]]
     fast_reload: bool
 
@@ -128,7 +127,6 @@ class Configuration:
         self.semantic_layer_sync = None
         self.pre_aggregations_schema = None
         self.orchestrator_options = None
-        self.context_to_roles = None
         self.context_to_groups = None
         self.fast_reload = None
 

--- a/packages/cubejs-backend-native/src/python/cube_config.rs
+++ b/packages/cubejs-backend-native/src/python/cube_config.rs
@@ -51,7 +51,6 @@ impl CubeConfigPy {
             "context_to_app_id",
             "context_to_orchestrator_id",
             "context_to_cube_store_router_id",
-            "context_to_roles",
             "context_to_groups",
             "db_type",
             "driver_factory",

--- a/packages/cubejs-backend-native/test/config.py
+++ b/packages/cubejs-backend-native/test/config.py
@@ -100,15 +100,6 @@ def logger(msg, params):
 
 
 @config
-def context_to_roles(ctx):
-    print("[python] context_to_roles", ctx)
-
-    return [
-        "admin",
-    ]
-
-
-@config
 def context_to_groups(ctx):
     print("[python] context_to_groups", ctx)
 

--- a/packages/cubejs-backend-native/test/old-config.py
+++ b/packages/cubejs-backend-native/test/old-config.py
@@ -79,12 +79,6 @@ def logger(msg, params):
 
 settings.logger = logger
 
-def context_to_roles(ctx):
-    print('[python] context_to_roles', ctx)
-    return ['admin']
-
-settings.context_to_roles = context_to_roles
-
 def context_to_groups(ctx):
     print('[python] context_to_groups', ctx)
     return ['dev', 'analytics']

--- a/packages/cubejs-backend-native/test/python.test.ts
+++ b/packages/cubejs-backend-native/test/python.test.ts
@@ -68,7 +68,6 @@ suite('Python Config', () => {
       queryRewrite: expect.any(Function),
       repositoryFactory: expect.any(Function),
       schemaVersion: expect.any(Function),
-      contextToRoles: expect.any(Function),
       contextToGroups: expect.any(Function),
       scheduledRefreshContexts: expect.any(Function),
       scheduledRefreshTimeZones: expect.any(Function),
@@ -90,14 +89,6 @@ suite('Python Config', () => {
         user_id: 42
       },
     });
-  });
-
-  test('context_to_roles', async () => {
-    if (!config.contextToRoles) {
-      throw new Error('contextToRoles was not defined in config.py');
-    }
-
-    expect(await config.contextToRoles({})).toEqual(['admin']);
   });
 
   test('context_to_groups', async () => {
@@ -251,7 +242,6 @@ darwinSuite('Old Python Config', () => {
       queryRewrite: expect.any(Function),
       repositoryFactory: expect.any(Function),
       schemaVersion: expect.any(Function),
-      contextToRoles: expect.any(Function),
       contextToGroups: expect.any(Function),
       scheduledRefreshContexts: expect.any(Function),
       scheduledRefreshTimeZones: expect.any(Function),

--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -125,7 +125,6 @@ export type Filter =
     };
 
 export type AccessPolicyDefinition = {
-  role?: string;
   group?: string;
   groups?: string[];
   rowLevel?: {

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -1130,8 +1130,7 @@ const RowLevelPolicySchema = Joi.object().keys({
   allowAll: Joi.boolean().valid(true).strict(),
 }).xor('filters', 'allowAll');
 
-const RolePolicySchema = Joi.object().keys({
-  role: Joi.string(),
+const GroupPolicySchema = Joi.object().keys({
   group: Joi.string(),
   groups: Joi.array().items(Joi.string()),
   memberLevel: MemberLevelPolicySchema,
@@ -1142,9 +1141,7 @@ const RolePolicySchema = Joi.object().keys({
   })),
 })
   .nand('group', 'groups') // Cannot have both group and groups
-  .nand('role', 'group') // Cannot have both role and group
-  .nand('role', 'groups') // Cannot have both role and groups
-  .or('role', 'group', 'groups') // Must have at least one
+  .or('group', 'groups') // Must have at least one
   .with('memberMasking', 'memberLevel'); // memberMasking requires memberLevel
 
 /* *****************************
@@ -1199,7 +1196,7 @@ const baseSchema = {
   dimensions: DimensionsSchema,
   segments: SegmentsSchema,
   preAggregations: PreAggregationsAlternatives,
-  accessPolicy: Joi.array().items(RolePolicySchema.required()),
+  accessPolicy: Joi.array().items(GroupPolicySchema.required()),
   hierarchies: hierarchySchema,
 };
 

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/schema.test.ts.snap
@@ -404,7 +404,7 @@ Object {
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (no additions): accessPolicy 1`] = `
 Array [
   Object {
-    "role": "*",
+    "group": "*",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -415,6 +415,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludes": Array [
         "status",
@@ -433,7 +434,6 @@ Array [
         "orders.sfUsers",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -451,7 +451,7 @@ Array [
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.js (no additions): accessPolicy 2`] = `
 Array [
   Object {
-    "role": "*",
+    "group": "*",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -462,6 +462,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludes": Array [
         "status",
@@ -480,7 +481,6 @@ Array [
         "ordersExt.sfUsers",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -701,7 +701,7 @@ Object {
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (no additions): accessPolicy 1`] = `
 Array [
   Object {
-    "role": "common",
+    "group": "common",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -712,6 +712,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludesMembers": Array [],
       "includes": Array [
@@ -721,7 +722,6 @@ Array [
         "orders.status",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -771,7 +771,7 @@ Array [
 exports[`Schema Testing Inheritance CubeB.js correctly extends cubeA.yml (no additions): accessPolicy 2`] = `
 Array [
   Object {
-    "role": "common",
+    "group": "common",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -782,6 +782,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludesMembers": Array [],
       "includes": Array [
@@ -791,7 +792,6 @@ Array [
         "ordersExt.status",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -1048,7 +1048,7 @@ Object {
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (no additions): accessPolicy 1`] = `
 Array [
   Object {
-    "role": "*",
+    "group": "*",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -1059,6 +1059,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludes": Array [
         "status",
@@ -1077,7 +1078,6 @@ Array [
         "orders.sfUsers",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -1095,7 +1095,7 @@ Array [
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.js (no additions): accessPolicy 2`] = `
 Array [
   Object {
-    "role": "*",
+    "group": "*",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -1106,6 +1106,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludes": Array [
         "status",
@@ -1124,7 +1125,6 @@ Array [
         "ordersExt.sfUsers",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -1345,7 +1345,7 @@ Object {
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (no additions): accessPolicy 1`] = `
 Array [
   Object {
-    "role": "common",
+    "group": "common",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -1356,6 +1356,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludesMembers": Array [],
       "includes": Array [
@@ -1365,7 +1366,6 @@ Array [
         "orders.status",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {
@@ -1415,7 +1415,7 @@ Array [
 exports[`Schema Testing Inheritance CubeB.yml correctly extends cubeA.yml (no additions): accessPolicy 2`] = `
 Array [
   Object {
-    "role": "common",
+    "group": "common",
     "rowLevel": Object {
       "allowAll": true,
     },
@@ -1426,6 +1426,7 @@ Array [
         "if": [Function],
       },
     ],
+    "group": "admin",
     "memberLevel": Object {
       "excludesMembers": Array [],
       "includes": Array [
@@ -1435,7 +1436,6 @@ Array [
         "ordersExt.status",
       ],
     },
-    "role": "admin",
     "rowLevel": Object {
       "filters": Array [
         Object {

--- a/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/cube-validator.test.ts
@@ -1719,7 +1719,7 @@ describe('Cube Validation', () => {
   describe('Access Policy group/groups support:', () => {
     const cubeValidator = new CubeValidator(new CubeSymbols());
 
-    it('should allow group instead of role', () => {
+    it('should allow group', () => {
       const cube = {
         name: 'TestCube',
         fileName: 'test.js',
@@ -1749,21 +1749,6 @@ describe('Cube Validation', () => {
       expect(result.error).toBeFalsy();
     });
 
-    it('should allow role as single string (existing behavior)', () => {
-      const cube = {
-        name: 'TestCube',
-        fileName: 'test.js',
-        sql: () => 'SELECT * FROM test',
-        accessPolicy: [{
-          role: 'admin',
-          rowLevel: { allowAll: true }
-        }]
-      };
-
-      const result = cubeValidator.validate(cube, new ConsoleErrorReporter());
-      expect(result.error).toBeFalsy();
-    });
-
     it('should allow group: "*" syntax', () => {
       const cube = {
         name: 'TestCube',
@@ -1777,38 +1762,6 @@ describe('Cube Validation', () => {
 
       const result = cubeValidator.validate(cube, new ConsoleErrorReporter());
       expect(result.error).toBeFalsy();
-    });
-
-    it('should reject role and group together', () => {
-      const cube = {
-        name: 'TestCube',
-        fileName: 'test.js',
-        sql: () => 'SELECT * FROM test',
-        accessPolicy: [{
-          role: 'admin',
-          group: 'admin',
-          rowLevel: { allowAll: true }
-        }]
-      };
-
-      const result = cubeValidator.validate(cube, new ConsoleErrorReporter());
-      expect(result.error).toBeTruthy();
-    });
-
-    it('should reject role and groups together', () => {
-      const cube = {
-        name: 'TestCube',
-        fileName: 'test.js',
-        sql: () => 'SELECT * FROM test',
-        accessPolicy: [{
-          role: 'admin',
-          groups: ['user'],
-          rowLevel: { allowAll: true }
-        }]
-      };
-
-      const result = cubeValidator.validate(cube, new ConsoleErrorReporter());
-      expect(result.error).toBeTruthy();
     });
 
     it('should reject group and groups together', () => {
@@ -1827,7 +1780,7 @@ describe('Cube Validation', () => {
       expect(result.error).toBeTruthy();
     });
 
-    it('should reject access policy without role/group/groups', () => {
+    it('should reject access policy without group/groups', () => {
       const cube = {
         name: 'TestCube',
         fileName: 'test.js',

--- a/packages/cubejs-schema-compiler/test/unit/fixtures/orders_big.js
+++ b/packages/cubejs-schema-compiler/test/unit/fixtures/orders_big.js
@@ -72,13 +72,13 @@ cube('orders', {
 
   accessPolicy: [
     {
-      role: "*",
+      group: "*",
       rowLevel: {
         allowAll: true
       }
     },
     {
-      role: 'admin',
+      group: 'admin',
       conditions: [
         {
           if: `true`,

--- a/packages/cubejs-schema-compiler/test/unit/fixtures/orders_big.yml
+++ b/packages/cubejs-schema-compiler/test/unit/fixtures/orders_big.yml
@@ -57,10 +57,10 @@ cubes:
         scheduled_refresh: true
 
     accessPolicy:
-      - role: common
+      - group: common
         rowLevel:
           allowAll: true
-      - role: admin
+      - group: admin
         conditions:
           - if: "{ security_context.isNotBlocked }"
         rowLevel:

--- a/packages/cubejs-schema-compiler/test/unit/fixtures/orders_ext.js
+++ b/packages/cubejs-schema-compiler/test/unit/fixtures/orders_ext.js
@@ -46,7 +46,7 @@ cube('ordersExt', {
 
   accessPolicy: [
     {
-      role: 'manager',
+      group: 'manager',
       conditions: [
         {
           if: security_context.userId === 1,

--- a/packages/cubejs-schema-compiler/test/unit/fixtures/orders_ext.yml
+++ b/packages/cubejs-schema-compiler/test/unit/fixtures/orders_ext.yml
@@ -34,7 +34,7 @@ cubes:
         dimensions: [city]
 
     accessPolicy:
-      - role: manager
+      - group: manager
         memberLevel:
           excludes:
             - status

--- a/packages/cubejs-schema-compiler/test/unit/fixtures/orders_incorrect_acl.yml
+++ b/packages/cubejs-schema-compiler/test/unit/fixtures/orders_incorrect_acl.yml
@@ -57,10 +57,10 @@ cubes:
         scheduled_refresh: true
 
     accessPolicy:
-      - role: common
+      - group: common
         rowLevel:
           allowAll: true
-      - role: admin
+      - group: admin
         conditions:
           - if: "{ security_context.isNotBlocked }"
         rowLevel:

--- a/packages/cubejs-schema-compiler/test/unit/fixtures/orders_nonexist_acl.yml
+++ b/packages/cubejs-schema-compiler/test/unit/fixtures/orders_nonexist_acl.yml
@@ -57,10 +57,10 @@ cubes:
         scheduled_refresh: true
 
     accessPolicy:
-      - role: common
+      - group: common
         rowLevel:
           allowAll: true
-      - role: admin
+      - group: admin
         conditions:
           - if: "{ security_context.isNotBlocked }"
         rowLevel:

--- a/packages/cubejs-schema-compiler/test/unit/links.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/links.test.ts
@@ -434,7 +434,7 @@ views:
           - full_name
           - email
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - full_name
@@ -485,7 +485,7 @@ views:
           - full_name
           - email
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - full_name
@@ -535,7 +535,7 @@ views:
       - join_path: users
         includes: "*"
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: "*"
 `;

--- a/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/transpilers.test.ts
@@ -63,7 +63,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -96,7 +96,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -129,7 +129,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -162,7 +162,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -195,7 +195,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -228,7 +228,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -261,7 +261,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {
@@ -294,7 +294,7 @@ describe('Transpilers', () => {
           },
           accessPolicy: [
             {
-              role: \`*\`,
+              group: \`*\`,
               rowLevel: {
                 filters: [
                   {

--- a/packages/cubejs-schema-compiler/test/unit/utils.ts
+++ b/packages/cubejs-schema-compiler/test/unit/utils.ts
@@ -165,13 +165,13 @@ export function createCubeSchemaWithAccessPolicy(name: string, extraPolicies: st
         },
         accessPolicy: [
           {
-            role: "*",
+            group: "*",
             rowLevel: {
               allowAll: true
             }
           },
           {
-            role: 'admin',
+            group: 'admin',
             conditions: [
               {
                 if: \`true\`,
@@ -192,7 +192,7 @@ export function createCubeSchemaWithAccessPolicy(name: string, extraPolicies: st
             },
           },
           {
-            role: 'manager',
+            group: 'manager',
             conditions: [
               {
                 if: security_context.userId === 1,

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -859,7 +859,7 @@ cubes:
             - name: count
               type: count
           accessPolicy:
-            - role: admin
+            - group: admin
               conditions:
                 - if: "{ security_context.isNotBlocked }"
               rowLevel:
@@ -888,7 +888,7 @@ cubes:
               memberLevel:
                 includes:
                   - status
-            - role: manager
+            - group: manager
               memberLevel:
                 excludes:
                   - status
@@ -1645,7 +1645,7 @@ cubes:
       - name: count
         type: count
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:
@@ -1695,7 +1695,7 @@ cubes:
       - name: count
         type: count
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:
@@ -1728,7 +1728,7 @@ cubes:
       - name: count
         type: count
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -38,7 +38,6 @@ export interface CompilerApiOptions {
   allowUngroupedWithoutPrimaryKey?: boolean;
   convertTzForRawTimeDimension?: boolean;
   schemaVersion?: () => string | object | Promise<string | object>;
-  contextToRoles?: (context: Context) => string[] | Promise<string[]>;
   contextToGroups?: (context: Context) => string[] | Promise<string[]>;
   compileContext?: any;
   allowJsDuplicatePropsInSchema?: boolean;
@@ -103,8 +102,6 @@ export class CompilerApi {
 
   public schemaVersion?: () => string | object | Promise<string | object>;
 
-  protected readonly contextToRoles?: (context: Context) => string[] | Promise<string[]>;
-
   protected readonly contextToGroups?: (context: Context) => string[] | Promise<string[]>;
 
   protected readonly compileContext?: any;
@@ -145,7 +142,6 @@ export class CompilerApi {
     this.allowUngroupedWithoutPrimaryKey = this.options.allowUngroupedWithoutPrimaryKey;
     this.convertTzForRawTimeDimension = this.options.convertTzForRawTimeDimension;
     this.schemaVersion = this.options.schemaVersion;
-    this.contextToRoles = this.options.contextToRoles;
     this.contextToGroups = this.options.contextToGroups;
     this.compileContext = options.compileContext;
     this.allowJsDuplicatePropsInSchema = options.allowJsDuplicatePropsInSchema;
@@ -377,13 +373,6 @@ export class CompilerApi {
     }
   }
 
-  protected async getRolesFromContext(context: Context): Promise<Set<string>> {
-    if (!this.contextToRoles) {
-      return new Set();
-    }
-    return new Set(await this.contextToRoles(context));
-  }
-
   protected async getGroupsFromContext(context: Context): Promise<Set<string>> {
     if (!this.contextToGroups) {
       return new Set();
@@ -430,7 +419,8 @@ export class CompilerApi {
     const cache = compilers.compilerCache.getRbacCacheInstance();
     const cacheKey = `${cube.name}_${this.hashRequestContext(context)}`;
     if (!cache.has(cacheKey)) {
-      const userRoles = await this.getRolesFromContext(context);
+      // `contextToRoles` has been removed; `role`-based policies only match `role: '*'`.
+      const userRoles = new Set<string>();
       const userGroups = await this.getGroupsFromContext(context);
       const policies = cube.accessPolicy.filter((policy: AccessPolicyDefinition) => {
         // Validate that policy doesn't have both role and group/groups - this is invalid
@@ -503,7 +493,7 @@ export class CompilerApi {
    * This method rewrites the query according to RBAC row level security policies.
    *
    * If RBAC is enabled, it looks at all the Cubes from the query with accessPolicy defined.
-   * It extracts all policies applicable to for the current user context (contextToRoles() + conditions).
+   * It extracts all policies applicable to for the current user context (contextToGroups() + conditions).
    * It then generates a rls filter by
    * - combining all filters for the same role with AND
    * - combining all filters for different roles with OR

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -380,10 +380,6 @@ export class CompilerApi {
     return new Set(await this.contextToGroups(context));
   }
 
-  protected userHasRole(userRoles: Set<string>, role: string): boolean {
-    return userRoles.has(role) || role === '*';
-  }
-
   protected userHasGroup(userGroups: Set<string>, group: string | string[]): boolean {
     if (Array.isArray(group)) {
       return group.some(g => userGroups.has(g) || g === '*');
@@ -391,7 +387,7 @@ export class CompilerApi {
     return userGroups.has(group) || group === '*';
   }
 
-  protected roleMeetsConditions(evaluatedConditions?: any[]): boolean {
+  protected policyMeetsConditions(evaluatedConditions?: any[]): boolean {
     if (evaluatedConditions?.length) {
       return evaluatedConditions.reduce((a, b) => {
         if (typeof b !== 'boolean') {
@@ -419,20 +415,8 @@ export class CompilerApi {
     const cache = compilers.compilerCache.getRbacCacheInstance();
     const cacheKey = `${cube.name}_${this.hashRequestContext(context)}`;
     if (!cache.has(cacheKey)) {
-      // `contextToRoles` has been removed; `role`-based policies only match `role: '*'`.
-      const userRoles = new Set<string>();
       const userGroups = await this.getGroupsFromContext(context);
       const policies = cube.accessPolicy.filter((policy: AccessPolicyDefinition) => {
-        // Validate that policy doesn't have both role and group/groups - this is invalid
-        if (policy.role && (policy.group || policy.groups)) {
-          const groupValue = policy.group || policy.groups;
-          const groupDisplay = Array.isArray(groupValue) ? groupValue.join(', ') : groupValue;
-          const groupProp = policy.group ? 'group' : 'groups';
-          throw new Error(
-            `Access policy cannot have both 'role' and '${groupProp}' properties.\nPolicy in cube '${cube.name}' has role '${policy.role}' and ${groupProp} '${groupDisplay}'.\nUse either 'role' or '${groupProp}', not both.`
-          );
-        }
-
         // Validate that policy doesn't have both group and groups
         if (policy.group && policy.groups) {
           const groupDisplay = Array.isArray(policy.group) ? policy.group.join(', ') : policy.group;
@@ -446,22 +430,19 @@ export class CompilerApi {
           (condition: any) => compilers.cubeEvaluator.evaluateContextFunction(cube, condition.if, context)
         );
 
-        // Check if policy matches by role, group, or groups
+        // Check if policy matches by group or groups
         let hasAccess = false;
 
-        if (policy.role) {
-          hasAccess = this.userHasRole(userRoles, policy.role);
-        } else if (policy.group) {
+        if (policy.group) {
           hasAccess = this.userHasGroup(userGroups, policy.group);
         } else if (policy.groups) {
           hasAccess = this.userHasGroup(userGroups, policy.groups);
         } else {
-          // If policy has neither role nor group/groups, default to checking role for backward compatibility
-          hasAccess = this.userHasRole(userRoles, '*');
+          // A policy without group/groups applies to everyone
+          hasAccess = this.userHasGroup(userGroups, '*');
         }
 
-        const res = hasAccess && this.roleMeetsConditions(evaluatedConditions);
-        return res;
+        return hasAccess && this.policyMeetsConditions(evaluatedConditions);
       });
       cache.set(cacheKey, policies);
     }
@@ -495,8 +476,8 @@ export class CompilerApi {
    * If RBAC is enabled, it looks at all the Cubes from the query with accessPolicy defined.
    * It extracts all policies applicable to for the current user context (contextToGroups() + conditions).
    * It then generates a rls filter by
-   * - combining all filters for the same role with AND
-   * - combining all filters for different roles with OR
+   * - combining all filters for the same group with AND
+   * - combining all filters for different groups with OR
    * - combining cube and view filters with AND
   */
   public async applyRowLevelSecurity(

--- a/packages/cubejs-server-core/src/core/optionsValidate.ts
+++ b/packages/cubejs-server-core/src/core/optionsValidate.ts
@@ -75,7 +75,6 @@ const schemaOptions = Joi.object().keys({
   //
   cacheAndQueueDriver: Joi.string().valid('cubestore', 'memory'),
   contextToAppId: Joi.func(),
-  contextToRoles: Joi.func(),
   contextToGroups: Joi.func(),
   contextToOrchestratorId: Joi.func(),
   contextToCubeStoreRouterId: Joi.func(),

--- a/packages/cubejs-server-core/src/core/server.ts
+++ b/packages/cubejs-server-core/src/core/server.ts
@@ -539,7 +539,6 @@ export class CubejsServerCore {
           ),
           externalDialectClass: this.options.externalDialectFactory && this.options.externalDialectFactory(context),
           schemaVersion: currentSchemaVersion,
-          contextToRoles: this.options.contextToRoles,
           contextToGroups: this.options.contextToGroups,
           preAggregationsSchema: await this.preAggregationsSchema(context),
           context,
@@ -730,7 +729,6 @@ export class CubejsServerCore {
   protected createCompilerApiOptions(options: Record<string, any> = {}): CompilerApiOptions {
     return {
       schemaVersion: options.schemaVersion || this.options.schemaVersion,
-      contextToRoles: this.options.contextToRoles,
       contextToGroups: this.options.contextToGroups,
       devServer: this.options.devServer,
       logger: this.logger,

--- a/packages/cubejs-server-core/src/core/types.ts
+++ b/packages/cubejs-server-core/src/core/types.ts
@@ -131,7 +131,6 @@ export type DatabaseType =
   | 'databricks-jdbc';
 
 export type ContextToAppIdFn = (context: RequestContext) => string | Promise<string>;
-export type ContextToRolesFn = (context: RequestContext) => string[] | Promise<string[]>;
 export type ContextToGroupsFn = (context: RequestContext) => string[] | Promise<string[]>;
 export type ContextToOrchestratorIdFn = (context: RequestContext) => string | Promise<string>;
 export type ContextToCubeStoreRouterIdFn = (context: RequestContext) => string | Promise<string>;
@@ -205,7 +204,6 @@ export interface CreateOptions {
   externalDialectFactory?: ExternalDialectFactoryFn;
   cacheAndQueueDriver?: CacheAndQueryDriverType;
   contextToAppId?: ContextToAppIdFn;
-  contextToRoles?: ContextToRolesFn;
   contextToGroups?: ContextToGroupsFn;
   contextToOrchestratorId?: ContextToOrchestratorIdFn;
   contextToCubeStoreRouterId?: ContextToCubeStoreRouterIdFn;

--- a/packages/cubejs-server-core/test/unit/index.test.ts
+++ b/packages/cubejs-server-core/test/unit/index.test.ts
@@ -31,8 +31,6 @@ class CubejsServerCoreOpen extends CubejsServerCore {
 
 // Mock to expose protected methods for testing
 class CompilerApiOpen extends CompilerApi {
-  public getRolesFromContext = super.getRolesFromContext;
-
   public getGroupsFromContext = super.getGroupsFromContext;
 }
 
@@ -437,33 +435,6 @@ describe('index.test', () => {
   });
 
   describe('CompilerApi validation', () => {
-    test('Should allow both contextToRoles and contextToGroups together', () => {
-      const logger = jest.fn(() => {});
-
-      expect(() => new CompilerApi(
-        repositoryWithoutPreAggregations,
-        async () => 'mysql',
-        {
-          logger,
-          contextToRoles: async () => ['admin'],
-          contextToGroups: async () => ['analytics']
-        }
-      )).not.toThrow();
-    });
-
-    test('Should allow only contextToRoles', () => {
-      const logger = jest.fn(() => {});
-
-      expect(() => new CompilerApi(
-        repositoryWithoutPreAggregations,
-        async () => 'mysql',
-        {
-          logger,
-          contextToRoles: async () => ['admin']
-        }
-      )).not.toThrow();
-    });
-
     test('Should allow only contextToGroups', () => {
       const logger = jest.fn(() => {});
 
@@ -475,24 +446,6 @@ describe('index.test', () => {
           contextToGroups: async () => ['analytics']
         }
       )).not.toThrow();
-    });
-
-    test('contextToRoles should be called and return expected roles', async () => {
-      const logger = jest.fn(() => {});
-      const contextToRoles = jest.fn(async () => ['admin', 'manager']);
-
-      const compilerApi = new CompilerApiOpen(
-        repositoryWithoutPreAggregations,
-        async () => 'mysql',
-        {
-          logger,
-          contextToRoles
-        }
-      );
-
-      const roles = await compilerApi.getRolesFromContext({ securityContext: { userId: 123 } });
-      expect(contextToRoles).toHaveBeenCalledWith({ securityContext: { userId: 123 } });
-      expect(roles).toEqual(new Set(['admin', 'manager']));
     });
 
     test('contextToGroups should be called and return expected groups', async () => {

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-graphql/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-graphql/cube.js
@@ -1,5 +1,5 @@
 module.exports = {
-  contextToRoles: ({ securityContext }) => securityContext?.auth?.roles || ['*'],
+  contextToGroups: ({ securityContext }) => securityContext?.auth?.groups || ['*'],
 
   // Same app ID for all tenants so they share a CompilerApi instance
   contextToAppId: () => 'CUBEJS_APP_shared',

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-graphql/model/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-graphql/model/Orders.js
@@ -33,20 +33,20 @@ cube('Orders', {
 
   accessPolicy: [
     {
-      role: '*',
+      group: '*',
       memberLevel: {
         includes: [],
       },
     },
     {
-      role: 'tenant-a',
+      group: 'tenant-a',
       memberLevel: {
         includes: '*',
         excludes: ['tier'],
       },
     },
     {
-      role: 'tenant-b',
+      group: 'tenant-b',
       memberLevel: {
         includes: '*',
         excludes: ['internalCode'],

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-python/cube.py
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-python/cube.py
@@ -3,9 +3,9 @@
 from cube import config
 
 
-@config('context_to_roles')
-def context_to_roles(context):
-    return context.get("securityContext", {}).get("auth", {}).get("roles", [])
+@config('context_to_groups')
+def context_to_groups(context):
+    return context.get("securityContext", {}).get("auth", {}).get("groups", [])
 
 
 def extract_matching_dicts(data):
@@ -55,7 +55,7 @@ def check_sql_auth(query: dict, username: str, password: str) -> dict:
                         'canHaveAdmin': True,
                         'city': 'New York'
                     },
-                    'roles': ['admin']
+                    'groups': ['admin']
                 }
             }
         }

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/cubes/products.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/cubes/products.yaml
@@ -25,4 +25,4 @@ cubes:
         type: time
 
     access_policy:
-      - group: some_role
+      - group: some_group

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/cubes/products.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/cubes/products.yaml
@@ -25,4 +25,4 @@ cubes:
         type: time
 
     access_policy:
-      - role: some_role
+      - group: some_role

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/cubes/users.yaml
@@ -18,13 +18,13 @@ cubes:
         primary_key: true
 
     access_policy:
-      - role: "*"
+      - group: "*"
         row_level:
           filters:
             - member: "{CUBE}.city"
               operator: equals
               values: ["{ security_context.auth.userAttributes.city }"]
-      - role: admin
+      - group: admin
         conditions:
           # This thing will fail if there's no auth info in the context
           # Unfortunately, as of now, there's no way to write more complex expressions

--- a/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/views/users_view.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac-python/model/views/users_view.yaml
@@ -5,7 +5,7 @@ views:
         includes: "*"
 
     access_policy:
-      - role: '*'
+      - group: '*'
         row_level:
           filters:
             - member: id

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
@@ -108,7 +108,7 @@ module.exports = {
       };
     }
     // User for testing two-dimensional policy overlap (matches diagram in CompilerApi.ts)
-    // Has policy2_role, so both Policy 1 (*) and Policy 2 (policy2_role) apply
+    // Has policy2_group, so both Policy 1 (*) and Policy 2 (policy2_group) apply
     if (user === 'policy_test') {
       if (password && password !== 'policy_test_password') {
         throw new Error(`Password doesn't match for ${user}`);
@@ -120,7 +120,7 @@ module.exports = {
           auth: {
             username: 'policy_test',
             userAttributes: {},
-            groups: ['policy2_role'],
+            groups: ['policy2_group'],
           },
         },
       };
@@ -243,7 +243,7 @@ module.exports = {
           auth: {
             username: 'conditional_mask_user',
             userAttributes: {},
-            groups: ['conditional_mask_role'],
+            groups: ['conditional_mask_group'],
           },
         },
       };
@@ -259,7 +259,7 @@ module.exports = {
           auth: {
             username: 'conditional_mask_multi_user',
             userAttributes: {},
-            groups: ['conditional_mask_role', 'conditional_mask_role_extra'],
+            groups: ['conditional_mask_group', 'conditional_mask_group_extra'],
           },
         },
       };

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/cube.js
@@ -1,5 +1,4 @@
 module.exports = {
-  contextToRoles: async (context) => context.securityContext.auth?.roles || [],
   contextToGroups: async (context) => context.securityContext.auth?.groups || [],
   canSwitchSqlUser: async () => true,
   checkSqlAuth: async (req, user, password) => {
@@ -19,8 +18,7 @@ module.exports = {
               canHaveAdmin: true,
               minDefaultId: 10000,
             },
-            roles: ['admin', 'ownder', 'hr'],
-            groups: ['leadership', 'hr'],
+            groups: ['leadership', 'hr', 'admin'],
           },
         },
       };
@@ -41,8 +39,7 @@ module.exports = {
               canHaveAdmin: false,
               minDefaultId: 10000,
             },
-            roles: ['manager'],
-            groups: ['management'],
+            groups: ['management', 'manager'],
           },
         },
       };
@@ -63,7 +60,6 @@ module.exports = {
               canHaveAdmin: false,
               minDefaultId: 20000,
             },
-            roles: [],
             groups: ['general'],
           },
         },
@@ -85,7 +81,6 @@ module.exports = {
               canHaveAdmin: true,
               minDefaultId: 20000,
             },
-            roles: ['restricted'],
             groups: ['restricted'],
           },
         },
@@ -107,7 +102,6 @@ module.exports = {
               region: 'CA',
               allowedCities: ['Los Angeles', 'New York'],
             },
-            roles: [],
             groups: ['developer'],
           },
         },
@@ -126,13 +120,12 @@ module.exports = {
           auth: {
             username: 'policy_test',
             userAttributes: {},
-            roles: ['policy2_role'],
-            groups: [],
+            groups: ['policy2_role'],
           },
         },
       };
     }
-    // User for masking tests - no special roles, sees only masked values
+    // User for masking tests - no special groups, sees only masked values
     if (user === 'masking_viewer') {
       if (password && password !== 'masking_viewer_password') {
         throw new Error(`Password doesn't match for ${user}`);
@@ -144,13 +137,12 @@ module.exports = {
           auth: {
             username: 'masking_viewer',
             userAttributes: {},
-            roles: [],
             groups: [],
           },
         },
       };
     }
-    // User for masking tests - has full access role
+    // User for masking tests - has full access group
     if (user === 'masking_full') {
       if (password && password !== 'masking_full_password') {
         throw new Error(`Password doesn't match for ${user}`);
@@ -162,8 +154,7 @@ module.exports = {
           auth: {
             username: 'masking_full',
             userAttributes: {},
-            roles: ['masking_full_access'],
-            groups: [],
+            groups: ['masking_full_access'],
           },
         },
       };
@@ -180,8 +171,7 @@ module.exports = {
           auth: {
             username: 'masking_partial',
             userAttributes: {},
-            roles: ['masking_partial'],
-            groups: [],
+            groups: ['masking_partial'],
           },
         },
       };
@@ -199,7 +189,6 @@ module.exports = {
             userAttributes: {
               allowedProductIds: [1, 2],
             },
-            roles: [],
             groups: ['user_group', 'region_group'],
           },
         },
@@ -216,7 +205,6 @@ module.exports = {
           auth: {
             username: 'region_user_no_filter',
             userAttributes: {},
-            roles: [],
             groups: ['user_group'],
           },
         },
@@ -239,7 +227,6 @@ module.exports = {
           auth: {
             username: 'sc_test',
             userAttributes: {},
-            roles: [],
             groups: [],
           },
         },
@@ -256,8 +243,7 @@ module.exports = {
           auth: {
             username: 'conditional_mask_user',
             userAttributes: {},
-            roles: ['conditional_mask_role'],
-            groups: [],
+            groups: ['conditional_mask_role'],
           },
         },
       };
@@ -273,8 +259,7 @@ module.exports = {
           auth: {
             username: 'conditional_mask_multi_user',
             userAttributes: {},
-            roles: ['conditional_mask_role', 'conditional_mask_role_extra'],
-            groups: [],
+            groups: ['conditional_mask_role', 'conditional_mask_role_extra'],
           },
         },
       };
@@ -292,7 +277,6 @@ module.exports = {
           auth: {
             username: 'single_policy_measure_user',
             userAttributes: {},
-            roles: [],
             groups: ['spm_full_group'],
           },
         },
@@ -311,7 +295,6 @@ module.exports = {
           auth: {
             username: 'multi_group_user',
             userAttributes: {},
-            roles: [],
             groups: ['mg_group_a', 'mg_group_c'],
           },
         },

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
@@ -32,7 +32,7 @@ cubes:
         member_masking:
           includes: "*"
 
-      - group: "conditional_mask_role"
+      - group: "conditional_mask_group"
         member_level:
           includes: "*"
         row_level:
@@ -42,7 +42,7 @@ cubes:
               values:
                 - "3"
 
-      - group: "conditional_mask_role_extra"
+      - group: "conditional_mask_group_extra"
         member_level:
           includes: "*"
         row_level:

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/conditional_masking_test.yaml
@@ -26,13 +26,13 @@ cubes:
         type: sum
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:
           includes: "*"
 
-      - role: "conditional_mask_role"
+      - group: "conditional_mask_role"
         member_level:
           includes: "*"
         row_level:
@@ -42,7 +42,7 @@ cubes:
               values:
                 - "3"
 
-      - role: "conditional_mask_role_extra"
+      - group: "conditional_mask_role_extra"
         member_level:
           includes: "*"
         row_level:

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/line_items.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/line_items.js
@@ -47,7 +47,7 @@ cube('line_items', {
 
   accessPolicy: [
     {
-      role: '*',
+      group: '*',
       rowLevel: {
         filters: [{
           member: 'id',
@@ -61,13 +61,13 @@ cube('line_items', {
       },
     },
     {
-      role: 'restricted',
+      group: 'restricted',
       memberLevel: {
         excludes: ['count', 'price', 'price_dim'],
       },
     },
     {
-      role: 'admin',
+      group: 'admin',
       conditions: [
         {
           if: security_context.auth?.userAttributes?.region === 'CA',
@@ -82,7 +82,7 @@ cube('line_items', {
       },
     },
     {
-      role: 'manager',
+      group: 'manager',
       conditions: [
         {
           if: security_context.auth?.userAttributes?.region === 'CA',

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/masking_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/masking_test.yaml
@@ -43,19 +43,19 @@ cubes:
         type: sum
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:
           includes: "*"
 
-      - role: "masking_full_access"
+      - group: "masking_full_access"
         member_level:
           includes: "*"
         row_level:
           allow_all: true
 
-      - role: "masking_partial"
+      - group: "masking_partial"
         member_level:
           includes:
             - id
@@ -102,7 +102,7 @@ cubes:
         type: sum
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
 
@@ -126,7 +126,7 @@ cubes:
         type: count
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:
@@ -205,7 +205,7 @@ cubes:
         type: count
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - id
@@ -231,7 +231,7 @@ views:
           - count_d
           - total_quantity
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: "*"
         row_level:
@@ -249,14 +249,14 @@ views:
           - count_d
           - total_quantity
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: []
         member_masking:
           includes: "*"
         row_level:
           allow_all: true
-      - role: "masking_full_access"
+      - group: "masking_full_access"
         member_level:
           includes: "*"
         row_level:
@@ -274,7 +274,7 @@ views:
           - count_d
           - total_quantity
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - public_dim
@@ -304,7 +304,7 @@ views:
           - count
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - view_mask_base_id
@@ -330,7 +330,7 @@ views:
           - count
           - total_quantity
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - public_dim
@@ -339,7 +339,7 @@ views:
           includes: "*"
         row_level:
           allow_all: true
-      - role: "masking_full_access"
+      - group: "masking_full_access"
         member_level:
           includes: "*"
         row_level:

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/orders.js
@@ -31,7 +31,7 @@ cube('orders', {
 
   access_policy: [
     {
-      role: '*',
+      group: '*',
       memberLevel: {
         // This cube is "private" by default and only accessible via views
         includes: [],
@@ -47,7 +47,7 @@ cube('orders', {
       },
     },
     {
-      role: 'admin',
+      group: 'admin',
       memberLevel: {
         // This cube is "private" by default and only accessible via views
         includes: [],

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/policy_overlap_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/policy_overlap_test.yaml
@@ -66,7 +66,7 @@ views:
                 - "500"
 
       # Policy 2: covers members b, c (and count, id for filtering) with row filter R2 (id >= 500)
-      - group: "policy2_role"
+      - group: "policy2_group"
         member_level:
           includes:
             - id

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/policy_overlap_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/policy_overlap_test.yaml
@@ -51,7 +51,7 @@ views:
 
     access_policy:
       # Policy 1: covers members a, b (and count, id for filtering) with row filter R1 (id < 500)
-      - role: "*"
+      - group: "*"
         member_level:
           includes:
             - id
@@ -66,7 +66,7 @@ views:
                 - "500"
 
       # Policy 2: covers members b, c (and count, id for filtering) with row filter R2 (id >= 500)
-      - role: "policy2_role"
+      - group: "policy2_role"
         member_level:
           includes:
             - id

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/products.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/products.yaml
@@ -25,4 +25,4 @@ cubes:
         type: time
 
     access_policy:
-      - group: some_role
+      - group: some_group

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/products.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/products.yaml
@@ -25,4 +25,4 @@ cubes:
         type: time
 
     access_policy:
-      - role: some_role
+      - group: some_role

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/region_test.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/region_test.yaml
@@ -17,7 +17,7 @@ cubes:
         type: number
 
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: "*"
         row_level:

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/security_context_test.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/security_context_test.js
@@ -96,7 +96,7 @@ cube('sc_ua_mask_test', {
 
   accessPolicy: [
     {
-      role: '*',
+      group: '*',
       memberLevel: {
         includes: [],
       },
@@ -133,7 +133,7 @@ cube('sc_cube_mask_test', {
 
   accessPolicy: [
     {
-      role: '*',
+      group: '*',
       memberLevel: {
         includes: [],
       },
@@ -181,7 +181,7 @@ cube('sc_joined_mask_test', {
 
   accessPolicy: [
     {
-      role: '*',
+      group: '*',
       memberLevel: {
         includes: [],
       },
@@ -215,7 +215,7 @@ cube('sc_groups_shorthand_test', {
 
   accessPolicy: [
     {
-      role: '*',
+      group: '*',
       rowLevel: {
         filters: [{
           member: 'product_id',

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/users.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/cubes/users.yaml
@@ -18,13 +18,13 @@ cubes:
         primary_key: true
 
     access_policy:
-      - role: "*"
+      - group: "*"
         row_level:
           filters:
             - member: "{CUBE}.city"
               operator: equals
               values: ["{ security_context.auth.userAttributes.city }"]
-      - role: admin
+      - group: admin
         conditions:
           # This thing will fail if there's no auth info in the context
           # Unfortunately, as of now, there's no way to write more complex expressions

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/views/users.js
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/views/users.js
@@ -4,7 +4,7 @@ view('users_view', {
     includes: '*',
   }],
   accessPolicy: [{
-    role: '*',
+    group: '*',
     rowLevel: {
       filters: [{
         member: 'id',

--- a/packages/cubejs-testing/birdbox-fixtures/rbac/model/views/views.yaml
+++ b/packages/cubejs-testing/birdbox-fixtures/rbac/model/views/views.yaml
@@ -4,7 +4,7 @@ views:
       - join_path: line_items
         includes: "*"
     access_policy:
-      - role: "*"
+      - group: "*"
         row_level:
           filters:
             - member: "${CUBE}.price_dim"
@@ -30,14 +30,14 @@ views:
       - join_path: orders
         includes: "*"
     access_policy:
-      - role: admin
+      - group: admin
         member_level:
           includes: "*"
         row_level:
           allow_all: true
 
   # Two-layer row-level filtering: the underlying `orders` cube restricts rows
-  # to id IN {1, 10, 11} (role "*" → id = 1, role admin → id = 10 OR id = 11),
+  # to id IN {1, 10, 11} (group "*" → id = 1, group admin → id = 10 OR id = 11),
   # while this view adds its own row filter id < 11. A row must satisfy BOTH
   # the cube policy AND the view policy, so the result is id IN {1, 10}.
   - name: orders_two_layer_test
@@ -45,7 +45,7 @@ views:
       - join_path: orders
         includes: "*"
     access_policy:
-      - role: "*"
+      - group: "*"
         member_level:
           includes: "*"
         row_level:

--- a/packages/cubejs-testing/test/smoke-rbac-graphql.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac-graphql.test.ts
@@ -34,9 +34,9 @@ describe('GraphQL Schema Caching and RBAC', () => {
     await birdbox.stop();
   }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
-  async function graphqlRequest(role: string, query: string): Promise<any> {
+  async function graphqlRequest(group: string, query: string): Promise<any> {
     const token = sign({
-      auth: { roles: [role] },
+      auth: { groups: [group] },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, { expiresIn: '1h' });
 
     const baseUrl = birdbox.configuration.apiUrl.replace('/cubejs-api/v1', '');
@@ -51,7 +51,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
     return res.json();
   }
 
-  test('all roles see the same unfiltered schema', async () => {
+  test('all groups see the same unfiltered schema', async () => {
     const introspectionQuery = '{ __type(name: "OrdersMembers") { fields { name } } }';
 
     const resultA = await graphqlRequest('tenant-a', introspectionQuery);
@@ -106,7 +106,7 @@ describe('GraphQL Schema Caching and RBAC', () => {
     expect(restrictedResult.errors[0].message).toContain('You requested hidden member');
   });
 
-  test('default role cannot query any fields - complete denial returns errors', async () => {
+  test('default group cannot query any fields - complete denial returns errors', async () => {
     const result1 = await graphqlRequest('default', `{
       cube(where: { orders: {} }) {
         orders { internalCode }

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -302,7 +302,7 @@ describe('Cube RBAC Engine', () => {
    * Two-dimensional policy overlap test (matches diagram in CompilerApi.ts:559-647)
    *
    * Policy 1 (group "*"): covers members a, b, id with row filter R1 (id < 500)
-   * Policy 2 (group "policy2_role"): covers members b, c, id with row filter R2 (id >= 500)
+   * Policy 2 (group "policy2_group"): covers members b, c, id with row filter R2 (id >= 500)
    *
    *   Members
    *     ^
@@ -320,7 +320,7 @@ describe('Cube RBAC Engine', () => {
     let connection: PgClient;
 
     beforeAll(async () => {
-      // User is in group policy2_role, so both Policy 1 (*) and Policy 2 apply
+      // User is in group policy2_group, so both Policy 1 (*) and Policy 2 apply
       connection = await createPostgresClient('policy_test', 'policy_test_password');
     });
 
@@ -555,9 +555,9 @@ describe('Cube RBAC Engine', () => {
    *
    * conditional_masking_test cube:
    *   - group "*": member_level includes=[], member_masking includes="*"
-   *   - group "conditional_mask_role": member_level includes="*", row_level filter product_id <= 3
+   *   - group "conditional_mask_group": member_level includes="*", row_level filter product_id <= 3
    *
-   * For conditional_mask_user (group: conditional_mask_role):
+   * For conditional_mask_user (group: conditional_mask_group):
    *   - product_id dimension: rows with product_id <= 3 show real value, others show masked (-1 for price)
    */
   describe('RBAC conditional masking with row-level filters via SQL API', () => {
@@ -587,7 +587,7 @@ describe('Cube RBAC Engine', () => {
       }
     });
 
-    // Smoke test: only one filter policy matches (conditional_mask_role). For an
+    // Smoke test: only one filter policy matches (conditional_mask_group). For an
     // aggregate measure (total_price), a per-row CASE WHEN over the row filter would
     // reference product_id at row grain while the measure is aggregated. Since
     // product_id is not in the GROUP BY, the conditional CASE must NOT be triggered —
@@ -654,8 +654,8 @@ describe('Cube RBAC Engine', () => {
 
   /**
    * Multiple conditional policies use OR across policies:
-   *   - group "conditional_mask_role": product_id <= 3
-   *   - group "conditional_mask_role_extra": product_id = 5
+   *   - group "conditional_mask_group": product_id <= 3
+   *   - group "conditional_mask_group_extra": product_id = 5
    *
    * For conditional_mask_multi_user (both groups):
    *   Unmasked when product_id <= 3 OR product_id = 5, masked otherwise.

--- a/packages/cubejs-testing/test/smoke-rbac.test.ts
+++ b/packages/cubejs-testing/test/smoke-rbac.test.ts
@@ -20,7 +20,6 @@ const DEFAULT_API_TOKEN = sign({
   auth: {
     username: 'nobody',
     userAttributes: {},
-    roles: [],
   },
 }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
   expiresIn: '2 days'
@@ -149,7 +148,7 @@ describe('Cube RBAC Engine', () => {
 
     test('row-level filters from cube AND view layers are both applied', async () => {
       // The underlying `orders` cube policy restricts rows to id IN {1, 10, 11}
-      // (role "*" → id = 1, role admin → id = 10 OR id = 11). The view adds its
+      // (group "*" → id = 1, group admin → id = 10 OR id = 11). The view adds its
       // own row filter id < 11. Both layers must apply (AND), so the visible ids
       // are the intersection: {1, 10}.
       const res = await connection.query('SELECT id FROM orders_two_layer_test ORDER BY id');
@@ -302,8 +301,8 @@ describe('Cube RBAC Engine', () => {
   /**
    * Two-dimensional policy overlap test (matches diagram in CompilerApi.ts:559-647)
    *
-   * Policy 1 (role "*"): covers members a, b, id with row filter R1 (id < 500)
-   * Policy 2 (role "policy2_role"): covers members b, c, id with row filter R2 (id >= 500)
+   * Policy 1 (group "*"): covers members a, b, id with row filter R1 (id < 500)
+   * Policy 2 (group "policy2_role"): covers members b, c, id with row filter R2 (id >= 500)
    *
    *   Members
    *     ^
@@ -321,7 +320,7 @@ describe('Cube RBAC Engine', () => {
     let connection: PgClient;
 
     beforeAll(async () => {
-      // User has policy2_role, so both Policy 1 (*) and Policy 2 apply
+      // User is in group policy2_role, so both Policy 1 (*) and Policy 2 apply
       connection = await createPostgresClient('policy_test', 'policy_test_password');
     });
 
@@ -447,9 +446,9 @@ describe('Cube RBAC Engine', () => {
    *   - count_d measure: mask with 34567
    *
    * Three user profiles:
-   *   - masking_viewer: role "*" only → all members masked (memberLevel includes=[])
-   *   - masking_full: has masking_full_access role → full access to all members
-   *   - masking_partial: has masking_partial role → id, public_dim, total_quantity unmasked; rest masked
+   *   - masking_viewer: group "*" only → all members masked (memberLevel includes=[])
+   *   - masking_full: has masking_full_access group → full access to all members
+   *   - masking_partial: has masking_partial group → id, public_dim, total_quantity unmasked; rest masked
    */
   describe('RBAC data masking via SQL API (masking_viewer)', () => {
     let connection: PgClient;
@@ -555,10 +554,10 @@ describe('Cube RBAC Engine', () => {
    * Rows matching the filter see unmasked values; other rows see masked values.
    *
    * conditional_masking_test cube:
-   *   - role "*": member_level includes=[], member_masking includes="*"
-   *   - role "conditional_mask_role": member_level includes="*", row_level filter product_id <= 3
+   *   - group "*": member_level includes=[], member_masking includes="*"
+   *   - group "conditional_mask_role": member_level includes="*", row_level filter product_id <= 3
    *
-   * For conditional_mask_user (role: conditional_mask_role):
+   * For conditional_mask_user (group: conditional_mask_role):
    *   - product_id dimension: rows with product_id <= 3 show real value, others show masked (-1 for price)
    */
   describe('RBAC conditional masking with row-level filters via SQL API', () => {
@@ -655,10 +654,10 @@ describe('Cube RBAC Engine', () => {
 
   /**
    * Multiple conditional policies use OR across policies:
-   *   - role "conditional_mask_role": product_id <= 3
-   *   - role "conditional_mask_role_extra": product_id = 5
+   *   - group "conditional_mask_role": product_id <= 3
+   *   - group "conditional_mask_role_extra": product_id = 5
    *
-   * For conditional_mask_multi_user (both roles):
+   * For conditional_mask_multi_user (both groups):
    *   Unmasked when product_id <= 3 OR product_id = 5, masked otherwise.
    */
   describe('RBAC conditional masking with multiple policies (OR across policies)', () => {
@@ -772,7 +771,7 @@ describe('Cube RBAC Engine', () => {
       await connection.end();
     }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
-    test('masking_view_masked returns masked values for default role', async () => {
+    test('masking_view_masked returns masked values for default group', async () => {
       const res = await connection.query('SELECT * FROM masking_view_masked LIMIT 5');
       expect(res.rows.length).toBeGreaterThan(0);
       for (const row of res.rows) {
@@ -783,7 +782,7 @@ describe('Cube RBAC Engine', () => {
       }
     });
 
-    test('masking_view_over_hidden_cube returns masked values for default role', async () => {
+    test('masking_view_over_hidden_cube returns masked values for default group', async () => {
       const res = await connection.query('SELECT * FROM masking_view_over_hidden_cube LIMIT 5');
       expect(res.rows.length).toBeGreaterThan(0);
       for (const row of res.rows) {
@@ -806,7 +805,7 @@ describe('Cube RBAC Engine', () => {
       await connection.end();
     }, JEST_AFTER_ALL_DEFAULT_TIMEOUT);
 
-    test('masking_view_masked returns real values for masking_full_access role', async () => {
+    test('masking_view_masked returns real values for masking_full_access group', async () => {
       const res = await connection.query('SELECT * FROM masking_view_masked LIMIT 5');
       expect(res.rows.length).toBeGreaterThan(0);
       for (const row of res.rows) {
@@ -815,8 +814,8 @@ describe('Cube RBAC Engine', () => {
       }
     });
 
-    test('masking_view_over_hidden_cube returns real values for masking_full_access role', async () => {
-      // The underlying cube hides all members, but masking_full_access role
+    test('masking_view_over_hidden_cube returns real values for masking_full_access group', async () => {
+      // The underlying cube hides all members, but masking_full_access group
       // gets full access through the view's own policy.
       const res = await connection.query('SELECT * FROM masking_view_over_hidden_cube LIMIT 5');
       expect(res.rows.length).toBeGreaterThan(0);
@@ -836,7 +835,6 @@ describe('Cube RBAC Engine', () => {
       auth: {
         username: 'masking_viewer',
         userAttributes: {},
-        roles: [],
       },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
       expiresIn: '2 days'
@@ -846,7 +844,7 @@ describe('Cube RBAC Engine', () => {
       auth: {
         username: 'masking_full',
         userAttributes: {},
-        roles: ['masking_full_access'],
+        groups: ['masking_full_access'],
       },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
       expiresIn: '2 days'
@@ -856,7 +854,7 @@ describe('Cube RBAC Engine', () => {
       auth: {
         username: 'masking_partial',
         userAttributes: {},
-        roles: ['masking_partial'],
+        groups: ['masking_partial'],
       },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
       expiresIn: '2 days'
@@ -992,7 +990,7 @@ describe('Cube RBAC Engine', () => {
 
     test('view: masking_view — cube masking still applied through view', async () => {
       // masking_view grants full access at view level, but the underlying
-      // cube masks all members for role "*". Masking follows RLS pattern.
+      // cube masks all members for group "*". Masking follows RLS pattern.
       const result = await maskingViewerClient.load({
         measures: ['masking_view.count'],
         dimensions: ['masking_view.secret_number'],
@@ -1166,7 +1164,6 @@ describe('Cube RBAC Engine', () => {
       auth: {
         username: 'sc_test',
         userAttributes: {},
-        roles: [],
         groups: [],
       },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
@@ -1401,7 +1398,7 @@ describe('Cube RBAC Engine', () => {
           canHaveAdmin: true,
           minDefaultId: 10000,
         },
-        roles: ['admin', 'ownder', 'hr'],
+        groups: ['admin'],
       },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {
       expiresIn: '2 days'
@@ -1611,7 +1608,6 @@ describe('Cube RBAC Engine [Tesseract]', () => {
       auth: {
         username: 'sc_test',
         userAttributes: {},
-        roles: [],
         groups: [],
       },
     }, DEFAULT_CONFIG.CUBEJS_API_SECRET, {


### PR DESCRIPTION
BREAKING CHANGE: The context_to_roles (contextToRoles) configuration option has been removed. It was deprecated in v1.6.4. Use context_to_groups (contextToGroups) instead.