### PR TITLE
docs(oidc): document OIDC auth on Redshift, Athena, and BigQuery driver pages

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
@@ -58,12 +58,30 @@ Configuration** in your deployment.
 
 </Info>
 
-In Cube Cloud, select AWS Athena** when creating a new deployment and fill in
+In Cube Cloud, select **AWS Athena** when creating a new deployment and fill in
 the required fields:
 
 <Frame>
   <img src="https://ucarecdn.com/d30fa31d-e6ea-4a73-9950-1786634a1e32/" alt="Cube Cloud AWS Athena Configuration Screen" />
 </Frame>
+
+#### OIDC workload identity
+
+Instead of static credentials, Cube Cloud deployments can authenticate to
+Athena with [OIDC workload identity][ref-oidc-aws-athena]: an IAM role in
+your account trusts Cube's OIDC issuer, and the driver assumes it through
+the AWS SDK's default credential chain — no access keys to provision or
+rotate.
+
+```dotenv
+CUBEJS_DB_TYPE=athena
+AWS_ROLE_ARN=arn:aws:iam::123456789012:role/cube-deployment-acme
+CUBEJS_AWS_REGION=us-east-1
+CUBEJS_AWS_S3_OUTPUT_LOCATION=s3://my-athena-output-bucket
+```
+
+See the [AWS OIDC guide][ref-oidc-aws-athena] for the IAM role, trust
+policy, and permissions setup.
 
 Cube Cloud also supports connecting to data sources within private VPCs
 if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
@@ -87,7 +105,7 @@ if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 | [`CUBEJS_DB_SCHEMA`](/reference/configuration/environment-variables#cubejs_db_schema)                              | The name of the schema to use as `information_schema` filter. Reduces count of tables loaded during schema generation. | A valid schema name                              |    ❌    |
 | [`CUBEJS_CONCURRENCY`](/reference/configuration/environment-variables#cubejs_concurrency)                            | The number of [concurrent queries][ref-data-source-concurrency] to the data source                                     | A valid number                                   |    ❌    |
 
-<sup>1</sup> Either provide [`CUBEJS_AWS_KEY`](/reference/configuration/environment-variables#cubejs_aws_key) and [`CUBEJS_AWS_SECRET`](/reference/configuration/environment-variables#cubejs_aws_secret) for static credentials, or use [`CUBEJS_AWS_ATHENA_ASSUME_ROLE_ARN`](/reference/configuration/environment-variables#cubejs_aws_athena_assume_role_arn) for role-based authentication. When using role assumption without static credentials, the driver will use the AWS SDK's default credential chain (IAM instance profile, EKS IRSA, etc.).
+<sup>1</sup> Either provide [`CUBEJS_AWS_KEY`](/reference/configuration/environment-variables#cubejs_aws_key) and [`CUBEJS_AWS_SECRET`](/reference/configuration/environment-variables#cubejs_aws_secret) for static credentials, or use [`CUBEJS_AWS_ATHENA_ASSUME_ROLE_ARN`](/reference/configuration/environment-variables#cubejs_aws_athena_assume_role_arn) for role-based authentication. When using role assumption without static credentials, the driver will use the AWS SDK's default credential chain (IAM instance profile, EKS IRSA, or [OIDC workload identity][ref-oidc-aws-athena] in Cube Cloud).
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency
 ## Pre-Aggregation Feature Support
@@ -171,5 +189,6 @@ connections are made over HTTPS.
   https://prestodb.io/docs/current/functions/aggregate.html#approximate-aggregate-functions
 [ref-caching-large-preaggs]: /docs/pre-aggregations/using-pre-aggregations#export-bucket
 [ref-caching-using-preaggs-build-strats]: /docs/pre-aggregations/using-pre-aggregations#pre-aggregation-build-strategies
+[ref-oidc-aws-athena]: /admin/deployment/oidc/aws#athena
 [ref-schema-ref-types-formats-countdistinctapprox]: /reference/data-modeling/measures#type
 [self-preaggs-batching]: #batching

--- a/docs-mintlify/admin/connect-to-data/data-sources/aws-redshift.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/aws-redshift.mdx
@@ -88,6 +88,28 @@ The following fields are required when creating an AWS Redshift connection:
   <img src="https://ucarecdn.com/4ccd3485-36fe-4740-9a11-0e8fb23fe8c3/" alt="Cube Cloud AWS Redshift Configuration Screen" />
 </Frame>
 
+#### OIDC workload identity
+
+Instead of a database password, Cube Cloud deployments can authenticate to
+Redshift with [OIDC workload identity][ref-oidc-aws-redshift]: an IAM role
+in your account trusts Cube's OIDC issuer, and the driver uses it to obtain
+temporary database credentials via [IAM authentication](#iam-authentication).
+Set `AWS_ROLE_ARN` alongside the IAM authentication variables and omit
+`CUBEJS_DB_USER` / `CUBEJS_DB_PASS`:
+
+```dotenv
+CUBEJS_DB_TYPE=redshift
+AWS_ROLE_ARN=arn:aws:iam::123456789012:role/cube-deployment-acme
+CUBEJS_DB_HOST=my-redshift-cluster.xxx.eu-west-1.redshift.amazonaws.com
+CUBEJS_DB_NAME=my_redshift_database
+CUBEJS_DB_SSL=true
+CUBEJS_DB_REDSHIFT_AWS_REGION=eu-west-1
+CUBEJS_DB_REDSHIFT_CLUSTER_IDENTIFIER=my-redshift-cluster
+```
+
+See the [AWS OIDC guide][ref-oidc-aws-redshift] for the IAM role, trust
+policy, and permissions setup.
+
 Cube Cloud also supports connecting to data sources within private VPCs
 if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 [VPC connectivity guide][ref-cloud-conf-vpc] for details.
@@ -112,7 +134,7 @@ if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 | [`CUBEJS_DB_EXPORT_BUCKET_REDSHIFT_ARN`](/reference/configuration/environment-variables#cubejs_db_export_bucket_redshift_arn)      |                                                                                     |                           |    ❌    |
 | [`CUBEJS_CONCURRENCY`](/reference/configuration/environment-variables#cubejs_concurrency)                        | The number of [concurrent queries][ref-data-source-concurrency] to the data source  | A valid number            |    ❌    |
 
-<sup>1</sup> Required when using password-based authentication. When using IAM authentication, omit these and set [`CUBEJS_DB_REDSHIFT_CLUSTER_IDENTIFIER`](/reference/configuration/environment-variables#cubejs_db_redshift_cluster_identifier) and [`CUBEJS_DB_REDSHIFT_AWS_REGION`](/reference/configuration/environment-variables#cubejs_db_redshift_aws_region) instead. The driver uses the AWS SDK's default credential chain (IAM instance profile, EKS IRSA, etc.) to obtain temporary database credentials.
+<sup>1</sup> Required when using password-based authentication. When using IAM authentication, omit these and set [`CUBEJS_DB_REDSHIFT_CLUSTER_IDENTIFIER`](/reference/configuration/environment-variables#cubejs_db_redshift_cluster_identifier) and [`CUBEJS_DB_REDSHIFT_AWS_REGION`](/reference/configuration/environment-variables#cubejs_db_redshift_aws_region) instead. The driver uses the AWS SDK's default credential chain (IAM instance profile, EKS IRSA, or [OIDC workload identity][ref-oidc-aws-redshift] in Cube Cloud) to obtain temporary database credentials.
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency
 ## Pre-Aggregation Feature Support
@@ -195,6 +217,7 @@ Database][ref-recipe-enable-ssl].
   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
 [ref-caching-large-preaggs]: /docs/pre-aggregations/using-pre-aggregations#export-bucket
 [ref-caching-using-preaggs-build-strats]: /docs/pre-aggregations/using-pre-aggregations#pre-aggregation-build-strategies
+[ref-oidc-aws-redshift]: /admin/deployment/oidc/aws#redshift
 [ref-recipe-enable-ssl]: /recipes/configuration/using-ssl-connections-to-data-source
 [ref-schema-ref-types-formats-countdistinctapprox]: /reference/data-modeling/measures#type
 [self-preaggs-batching]: #batching

--- a/docs-mintlify/admin/connect-to-data/data-sources/google-bigquery.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/google-bigquery.mdx
@@ -13,6 +13,9 @@ and **BigQuery Job User** roles enabled. If you plan to use pre-aggregations,
 the account will need the **BigQuery Data Editor** role instead of **BigQuery Data Viewer**. 
 You can learn more about acquiring
 Google BigQuery credentials [here][bq-docs-getting-started].
+In Cube Cloud, you can authenticate with [OIDC workload identity
+federation][ref-oidc-gcp-bigquery] instead of a key file — the same roles
+apply to the impersonated service account.
 
 </Info>
 
@@ -59,6 +62,28 @@ The following fields are required when creating a BigQuery connection:
   <img src="https://ucarecdn.com/9fdfbd5d-5556-48b3-aa6e-fff0f24b30e9/" alt="Cube Cloud BigQuery Configuration Screen" />
 </Frame>
 
+#### OIDC workload identity federation
+
+Instead of a service account key file, Cube Cloud deployments can
+authenticate to BigQuery with [OIDC workload identity
+federation][ref-oidc-gcp-bigquery]: a Workload Identity Federation provider
+in your GCP project trusts Cube's OIDC issuer, and the driver authenticates
+through the GCP default credential chain — no JSON key to provision or
+rotate. Select **OIDC workload identity federation** in the connection
+wizard, or set the equivalent environment variables:
+
+```dotenv
+CUBEJS_DB_TYPE=bigquery
+CUBEJS_DB_BQ_PROJECT_ID=my-bigquery-project-12345
+GCP_POOL_AUDIENCE=//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/cube-pool/providers/cube
+GCP_SERVICE_ACCOUNT_EMAIL=cube-deployment@my-bigquery-project-12345.iam.gserviceaccount.com
+```
+
+`GCP_SERVICE_ACCOUNT_EMAIL` selects the service account Cube impersonates;
+leave it unset to authenticate as the federated principal directly. See the
+[GCP OIDC guide][ref-oidc-gcp-bigquery] for the Workload Identity Pool,
+provider, and IAM setup.
+
 Cube Cloud also supports connecting to data sources within private VPCs
 if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 [VPC connectivity guide][ref-cloud-conf-vpc] for details.
@@ -70,13 +95,17 @@ if [single-tenant infrastructure][ref-dedicated-infra] is used. Check out the
 | Environment Variable           | Description                                                                                                                                                                                     | Possible Values                                                         | Required |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | :------: |
 | [`CUBEJS_DB_BQ_PROJECT_ID`](/reference/configuration/environment-variables#cubejs_db_bq_project_id)      | The Google BigQuery project ID to connect to                                                                                                                                                    | A valid Google BigQuery Project ID                                      |    ✅    |
-| [`CUBEJS_DB_BQ_KEY_FILE`](/reference/configuration/environment-variables#cubejs_db_bq_key_file)        | The path to a JSON key file for connecting to Google BigQuery                                                                                                                                   | A valid Google BigQuery JSON key file                                   |    ✅    |
+| [`CUBEJS_DB_BQ_KEY_FILE`](/reference/configuration/environment-variables#cubejs_db_bq_key_file)        | The path to a JSON key file for connecting to Google BigQuery                                                                                                                                   | A valid Google BigQuery JSON key file                                   |    ✅<sup>1</sup>    |
 | [`CUBEJS_DB_BQ_CREDENTIALS`](/reference/configuration/environment-variables#cubejs_db_bq_credentials)     | A Base64 encoded JSON key file for connecting to Google BigQuery                                                                                                                                | A valid Google BigQuery JSON key file encoded as a Base64 string        |    ❌    |
 | [`CUBEJS_DB_BQ_LOCATION`](/reference/configuration/environment-variables#cubejs_db_bq_location)        | The Google BigQuery dataset location to connect to. Required if used with pre-aggregations outside of US. If not set then BQ driver will fail with `Dataset was not found in location US` error | [A valid Google BigQuery regional location][bq-docs-regional-locations] |    ⚠️    |
 | [`CUBEJS_DB_EXPORT_BUCKET`](/reference/configuration/environment-variables#cubejs_db_export_bucket)      | The name of a bucket in cloud storage                                                                                                                                                           | A valid bucket name from cloud storage                                  |    ❌    |
 | [`CUBEJS_DB_EXPORT_BUCKET_TYPE`](/reference/configuration/environment-variables#cubejs_db_export_bucket_type) | The cloud provider where the bucket is hosted                                                                                                                                                   | `gcp`                                                                   |    ❌    |
 | [`CUBEJS_DB_MAX_POOL`](/reference/configuration/environment-variables#cubejs_db_max_pool)           | The maximum number of concurrent database connections to pool. Default is `40`                                                                                                                  | A valid number                                                          |    ❌    |
 | [`CUBEJS_CONCURRENCY`](/reference/configuration/environment-variables#cubejs_concurrency) | The number of [concurrent queries][ref-data-source-concurrency] to the data source | A valid number |    ❌    |
+
+<sup>1</sup> Not required when authenticating with [OIDC workload identity
+federation][ref-oidc-gcp-bigquery] in Cube Cloud, or when providing the key
+material via [`CUBEJS_DB_BQ_CREDENTIALS`](/reference/configuration/environment-variables#cubejs_db_bq_credentials).
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency
 ## Pre-Aggregation Feature Support
@@ -154,5 +183,6 @@ BigQuery connections are made over HTTPS.
   https://support.google.com/a/answer/7378726?hl=en
 [ref-caching-large-preaggs]: /docs/pre-aggregations/using-pre-aggregations#export-bucket
 [ref-caching-using-preaggs-build-strats]: /docs/pre-aggregations/using-pre-aggregations#pre-aggregation-build-strategies
+[ref-oidc-gcp-bigquery]: /admin/deployment/oidc/gcp#bigquery
 [ref-schema-ref-types-formats-countdistinctapprox]: /reference/data-modeling/measures#type
 [self-preaggs-batching]: #batching

--- a/docs-mintlify/admin/deployment/oidc/aws.mdx
+++ b/docs-mintlify/admin/deployment/oidc/aws.mdx
@@ -1,12 +1,12 @@
 ---
 title: AWS
 sidebarTitle: AWS
-description: Configure AWS IAM trust for Cube's OIDC issuer and use it for Athena, S3 export buckets, Cube Store CSPS, and Bedrock.
+description: Configure AWS IAM trust for Cube's OIDC issuer and use it for Athena, Redshift, S3 export buckets, Cube Store CSPS, and Bedrock.
 ---
 
 This guide walks through configuring AWS to trust Cube's OIDC issuer and
-shows the trust policies for the most common targets — Athena, an S3 export
-bucket, Cube Store CSPS, and Bedrock for bring-your-own LLM.
+shows the trust policies for the most common targets — Athena, Redshift, an
+S3 export bucket, Cube Store CSPS, and Bedrock for bring-your-own LLM.
 
 If you haven't enabled OIDC for your tenant yet, start with the
 [OIDC overview][ref-oidc-overview].
@@ -254,6 +254,59 @@ results from your S3 results bucket.
     default identity, set [`CUBEJS_AWS_ATHENA_ASSUME_ROLE_ARN`][ref-athena-assume-role]
     in addition to `AWS_ROLE_ARN`. The Athena driver uses the deployment
     identity to perform a second `AssumeRole` hop into the Athena role.
+  </Step>
+</Steps>
+
+## Redshift
+
+Configure an IAM role that can obtain temporary Redshift database
+credentials. The Redshift driver uses the deployment's federated identity
+to call `redshift:GetClusterCredentialsWithIAM` — no database password is
+stored anywhere.
+
+<Steps>
+  <Step title="Create the IAM role">
+    Use the same trust policy shape as [Athena](#athena) — federated
+    principal, `aud` pinned to `sts.amazonaws.com`, and `sub` pinned to your
+    deployment.
+  </Step>
+  <Step title="Attach the Redshift permissions">
+    The role needs to fetch temporary credentials and describe the cluster:
+
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "redshift:GetClusterCredentialsWithIAM",
+            "redshift:DescribeClusters"
+          ],
+          "Resource": "*"
+        }
+      ]
+    }
+    ```
+
+    Tighten `Resource` to your cluster and database ARNs in production.
+  </Step>
+  <Step title="Configure the deployment">
+    Set the Redshift driver env vars for [IAM
+    authentication][ref-redshift-driver-iam] and omit `CUBEJS_DB_USER` /
+    `CUBEJS_DB_PASS`. With `AWS_ROLE_ARN` in place, the driver assumes the
+    role via OIDC federation and exchanges it for temporary database
+    credentials:
+
+    ```dotenv
+    CUBEJS_DB_TYPE=redshift
+    AWS_ROLE_ARN=arn:aws:iam::<aws-account-id>:role/cube-deployment-<tenant-name>
+    CUBEJS_DB_HOST=my-cluster.xxx.us-east-1.redshift.amazonaws.com
+    CUBEJS_DB_NAME=my_database
+    CUBEJS_DB_SSL=true
+    CUBEJS_DB_REDSHIFT_AWS_REGION=us-east-1
+    CUBEJS_DB_REDSHIFT_CLUSTER_IDENTIFIER=my-cluster
+    ```
   </Step>
 </Steps>
 
@@ -540,3 +593,4 @@ authenticating against which roles.
 [ref-cube-cloud-region]: /admin/deployment/infrastructure#what-is-a-cube-cloud-region
 [ref-export-bucket]: /admin/connect-to-data#export-bucket
 [ref-athena-assume-role]: /admin/connect-to-data/data-sources/aws-athena#environment-variables
+[ref-redshift-driver-iam]: /admin/connect-to-data/data-sources/aws-redshift#iam-authentication


### PR DESCRIPTION
## What

The Redshift, Athena, and BigQuery data-source pages now mention that Cube Cloud deployments can authenticate via OIDC workload identity — presented as one more authentication option (a subsection under **Cube Cloud**, plus a one-line mention in each page's credentials footnote), not a headline feature.

Each subsection has a copy-pastable config example and links out to the broader OIDC guides:

| Page | Example | Links to |
|---|---|---|
| AWS Athena | `AWS_ROLE_ARN` + standard Athena vars | [/admin/deployment/oidc/aws#athena](https://docs.cube.dev/admin/deployment/oidc/aws#athena) |
| AWS Redshift | `AWS_ROLE_ARN` + IAM-authentication vars, no `CUBEJS_DB_USER`/`PASS` | /admin/deployment/oidc/aws#redshift (new section, below) |
| Google BigQuery | `GCP_POOL_AUDIENCE` + optional `GCP_SERVICE_ACCOUNT_EMAIL`, no key file | [/admin/deployment/oidc/gcp#bigquery](https://docs.cube.dev/admin/deployment/oidc/gcp#bigquery) |

Also:
- **New Redshift section in the AWS OIDC guide** (the guide previously covered Athena/S3/CSPS/Bedrock only, so Redshift links had no anchor): trust policy shape shared with Athena, `redshift:GetClusterCredentialsWithIAM` + `redshift:DescribeClusters` permissions, deployment env vars. Guide description/intro updated to include Redshift.
- BigQuery `CUBEJS_DB_BQ_KEY_FILE` "Required ✅" relaxed to a footnote — it was already not required when `CUBEJS_DB_BQ_CREDENTIALS` is used, and isn't with OIDC either.
- Fixed a stray bold marker on the Athena page (`select AWS Athena**`).

## Verification

- Env var sets cross-checked against the workload-identity design doc and the live implementation: the staging `test-redshift-oidc` deployment and the qa BigQuery/Athena OIDC e2e fixtures use exactly these variables.
- All reference-style links checked bidirectionally (no missing/unused defs); all anchor targets exist.
- No nav changes (no new pages), so `docs.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)