### PR TITLE
docs: document meta.auto_run to disable workbook auto-run per view

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -9,6 +9,21 @@ description: In the Semantic Query tab, you can query the semantic layer. On the
 
 On the left side, you can select a semantic view you would like to query. Inside the semantic view, you can see the measures and dimensions grouped either by cubes or folders. You can search within your semantic view to find the relevant member.
 
+## Running queries
+
+As you build a query — adding members, changing filters, adjusting sorting —
+the workbook runs it automatically and refreshes the results. You can turn
+this off with the auto-run toggle in the query controls: with auto-run
+disabled, the results are marked as outdated while you edit the query, and
+the query only runs when you click **Run query**. The toggle applies to the
+current tab only.
+
+A data model author can change the default for a semantic view with the
+[`meta.auto_run`][ref-auto-run] parameter — selecting a view with
+`auto_run: false` starts the tab with auto-run disabled. This is useful for
+views that are expensive to query. You can still toggle auto-run back on at
+any time.
+
 ## Filtering
 
 Dimensions and measures can be added as filters to focus on specific rows of data.
@@ -185,4 +200,5 @@ the model behaves as intended.
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-access-control]: /docs/data-modeling/access-control
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
+[ref-auto-run]: /reference/data-modeling/view#auto_run
 

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -230,6 +230,60 @@ view(`active_users`, {
 
 </CodeGroup>
 
+#### `auto_run`
+
+In the Cube cloud platform, you can use the `auto_run` key in a view's `meta`
+to control whether [workbook][ref-workbook-running] queries against the view
+run automatically. By default, a workbook re-runs the query every time a data
+consumer changes it — adds a member, edits a filter, and so on. Setting
+`auto_run: false` turns this off for the view: the query only runs when the
+user clicks **Run query**.
+
+This is useful for views backed by heavy or expensive queries, where running
+on every change would be wasteful.
+
+<Info>
+
+Please note, currently `auto_run` is defined inside the `meta` property; this
+may change in the future.
+
+</Info>
+
+<CodeGroup>
+
+```yaml title="YAML"
+views:
+  - name: orders_view
+
+    cubes:
+      - join_path: orders
+        includes: "*"
+
+    meta:
+      auto_run: false
+```
+
+```javascript title="JavaScript"
+view(`orders_view`, {
+  cubes: [
+    {
+      join_path: orders,
+      includes: `*`
+    }
+  ],
+
+  meta: {
+    auto_run: false
+  }
+});
+```
+
+</CodeGroup>
+
+The setting only provides the default for the view. Data consumers can toggle
+auto-run on or off in each workbook tab, and their choice takes precedence
+over the view's default. When `auto_run` is not set, auto-run is on.
+
 #### `default_ui_filters`
 
 In the Cube cloud platform, you can use the `default_ui_filters` key in a
@@ -872,6 +926,7 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 [ref-playground]: /docs/workspace/playground#viewing-the-data-model
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools
 [ref-workbook-filtering]: /docs/explore-analyze/workbooks/querying-data#filtering
+[ref-workbook-running]: /docs/explore-analyze/workbooks/querying-data#running-queries
 [ref-extension]: /docs/data-modeling/extending-cubes
 [ref-dim-name]: /reference/data-modeling/dimensions#name
 [ref-dim-title]: /reference/data-modeling/dimensions#title


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Documents the `meta.auto_run` parameter on views (docs-only change):

- Adds an `auto_run` subsection under the view `meta` parameter in the data modeling reference. Setting `auto_run: false` on a view makes workbook tabs start with auto-run disabled, so queries only execute when the user clicks **Run query** — useful for views backed by expensive queries. The view setting is only a default: data consumers can toggle auto-run per tab, and auto-run is on when the key is unset.
- Adds a "Running queries" section to the workbook querying page describing the auto-run behavior and toggle, linking to the reference for the model-author default.

Follows the same structure as the recently merged `meta.default_ui_filters` docs (#11058), including the note that the parameter currently lives under `meta` and may move in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)