### PR TITLE
feat(backend-shared): add CUBEJS_AUTO_RUN_MODE env variable

### DIFF
--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -711,6 +711,14 @@ const variables: Record<string, (...args: any) => any> = {
     .asInt(),
 
   /**
+   * Whether queries are executed automatically without requiring an
+   * explicit user confirmation.
+   */
+  autoRunMode: (): boolean => get('CUBEJS_AUTO_RUN_MODE')
+    .default('true')
+    .asBoolStrict(),
+
+  /**
    * Query stream `highWaterMark` value.
    */
   dbQueryStreamHighWaterMark: (): number => get('CUBEJS_DB_QUERY_STREAM_HIGH_WATER_MARK')

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -712,7 +712,7 @@ const variables: Record<string, (...args: any) => any> = {
 
   /**
    * Whether queries are executed automatically without requiring an
-   * explicit user confirmation.
+   * explicit user confirmation. Only used in Cube Cloud.
    */
   autoRunMode: (): boolean => get('CUBEJS_AUTO_RUN_MODE')
     .default('true')


### PR DESCRIPTION
## Description

Adds a new `CUBEJS_AUTO_RUN_MODE` environment variable to `@cubejs-backend/shared`, resolvable via `getEnv('autoRunMode')`.

It controls whether queries are executed automatically without requiring an explicit user confirmation. Defaults to `true` (current behavior); set to `false` to require confirmation.

The flag will be consumed downstream (exposed via the runtime settings endpoint alongside `defaultLimit` / `maxLimit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)