### PR TITLE
refactor(cubestore): append CSV import values directly into Arrow builders

### DIFF
--- a/rust/cubestore/cubestore/src/import/mod.rs
+++ b/rust/cubestore/cubestore/src/import/mod.rs
@@ -521,7 +521,12 @@ fn append_csv_value(
         builder
             .as_any_mut()
             .downcast_mut::<datafusion::arrow::array::StringBuilder>()
-            .unwrap()
+            .ok_or_else(|| {
+                CubeError::internal(format!(
+                    "Expected StringBuilder for String column '{}' during CSV import",
+                    column.get_name()
+                ))
+            })?
             .append_value(value);
         return Ok(());
     }

--- a/rust/cubestore/cubestore/src/import/mod.rs
+++ b/rust/cubestore/cubestore/src/import/mod.rs
@@ -37,7 +37,7 @@ use crate::remotefs::RemoteFs;
 use crate::sql::timestamp_from_string;
 use crate::store::ChunkDataStore;
 use crate::streaming::StreamingService;
-use crate::table::data::{append_row, create_array_builders};
+use crate::table::data::{append_value, create_array_builders};
 use crate::table::{Row, TableValue};
 use crate::util::batch_memory::columns_vec_buffer_size;
 use crate::util::decimal::{Decimal, Decimal96};
@@ -50,18 +50,12 @@ use tokio::time::{sleep, Duration};
 pub mod limits;
 
 impl ImportFormat {
-    async fn row_stream(
-        &self,
-        file: File,
-        location: String,
-        columns: Vec<Column>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Option<Row>, CubeError>> + Send>>, CubeError> {
-        let reader: Pin<Box<dyn AsyncBufRead + Send>> = if location.contains(".gz") {
+    fn open_reader(file: File, location: &str) -> Pin<Box<dyn AsyncBufRead + Send>> {
+        if location.contains(".gz") {
             Box::pin(BufReader::new(GzipDecoder::new(BufReader::new(file))))
         } else {
             Box::pin(BufReader::new(file))
-        };
-        self.row_stream_from_reader(reader, columns)
+        }
     }
 
     pub fn row_stream_from_reader<'a>(
@@ -70,114 +64,27 @@ impl ImportFormat {
         columns: Vec<Column>,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<Option<Row>, CubeError>> + Send + 'a>>, CubeError>
     {
-        match self {
-            ImportFormat::CSV | ImportFormat::CSVNoHeader | ImportFormat::CSVOptions { .. } => {
-                let (delimiter, disable_quoting) = match self {
-                    ImportFormat::CSV | ImportFormat::CSVNoHeader => (',', false),
-                    ImportFormat::CSVOptions {
-                        delimiter, quote, ..
-                    } => (delimiter.unwrap_or(','), quote.is_none()),
-                };
-
-                let lines_stream: Pin<Box<dyn Stream<Item = Result<String, CubeError>> + Send>> =
-                    Box::pin(CsvLineStream::new(reader, disable_quoting));
-
-                let mut header_mapping = match self {
-                    ImportFormat::CSVNoHeader
-                    | ImportFormat::CSVOptions {
-                        has_header: false, ..
-                    } => Some(
-                        columns
-                            .iter()
-                            .enumerate()
-                            .map(|(i, c)| (i, c.clone()))
-                            .collect(),
-                    ),
-                    _ => None,
-                };
-
-                if delimiter as u16 > 255 {
-                    return Err(CubeError::user(format!(
-                        "Non ASCII delimiters are unsupported: '{}'",
-                        delimiter
-                    )));
+        let mut parser = CsvImportParser::new(self, columns)?;
+        let disable_quoting = parser.disable_quoting;
+        let num_columns = parser.columns.len();
+        let lines_stream = CsvLineStream::new(reader, disable_quoting);
+        let rows = lines_stream.map(move |line| -> Result<Option<Row>, CubeError> {
+            let line = line?;
+            let mut row = vec![TableValue::Null; num_columns];
+            let is_data_row = parser.visit_line(line.as_str(), |insert_pos, column, value| {
+                if let Some(value) = value {
+                    row[insert_pos] = ImportFormat::parse_column_value_str(column, value)
+                        .map_err(|e| parse_value_error(value, column, e))?;
                 }
-
-                let rows = lines_stream.map(move |line| -> Result<Option<Row>, CubeError> {
-                    let str = line?;
-
-                    let mut parser =
-                        CsvLineParser::new(delimiter as u8, disable_quoting, str.as_str());
-
-                    if header_mapping.is_none() {
-                        let mut mapping = Vec::new();
-                        for _ in 0..columns.len() {
-                            let next_column_buf = parser.next_value()?;
-                            let next_column = next_column_buf.as_ref();
-                            let (insert_pos, to_insert) = columns
-                                .iter()
-                                .find_position(|c| c.get_name() == &next_column)
-                                .map(|(i, c)| (i, c.clone()))
-                                .ok_or(CubeError::user(format!(
-                                    "Column '{}' is not found during import in {:?}",
-                                    next_column, columns
-                                )))?;
-                            mapping.push((insert_pos, to_insert));
-                            parser.advance()?;
-                        }
-                        header_mapping = Some(mapping);
-                        return Ok(None);
-                    }
-
-                    let resolved_mapping = header_mapping.as_ref().ok_or(CubeError::user(
-                        "Header is required for CSV import".to_string(),
-                    ))?;
-
-                    let mut row = vec![TableValue::Null; columns.len()];
-
-                    for (insert_pos, column) in resolved_mapping.iter() {
-                        let value_buf = parser.next_value()?;
-                        let value = value_buf.as_ref();
-
-                        if value == "" || value == "\\N" || value == "\\\\N" {
-                            row[*insert_pos] = TableValue::Null;
-                        } else {
-                            let mut value_buf_opt = Some(value_buf);
-                            row[*insert_pos] =
-                                ImportFormat::parse_column_value(column, &mut value_buf_opt)
-                                    .map_err(|e| {
-                                        if let Some(value_buf) = value_buf_opt {
-                                            CubeError::user(format!(
-                                                "Can't parse '{}' column value for '{}' column: {}",
-                                                value_buf.as_ref(),
-                                                column.get_name(),
-                                                e
-                                            ))
-                                        } else {
-                                            CubeError::user(format!(
-                                                "Can't parse column value for '{}' column: {}",
-                                                column.get_name(),
-                                                e
-                                            ))
-                                        }
-                                    })?;
-                        }
-
-                        parser.advance()?;
-                    }
-                    Ok(Some(Row::new(row)))
-                });
-                Ok(rows.boxed())
-            }
-        }
-    }
-
-    fn parse_column_value(
-        column: &Column,
-        value_buf: &mut Option<MaybeOwnedStr>,
-    ) -> Result<TableValue, CubeError> {
-        let value = value_buf.as_ref().unwrap().as_ref();
-        ImportFormat::parse_column_value_str(column, value)
+                Ok(())
+            })?;
+            Ok(if is_data_row {
+                Some(Row::new(row))
+            } else {
+                None
+            })
+        });
+        Ok(rows.boxed())
     }
 
     pub fn parse_column_value_str(column: &Column, value: &str) -> Result<TableValue, CubeError> {
@@ -492,6 +399,137 @@ impl<R: AsyncBufRead> Stream for CsvLineStream<R> {
     }
 }
 
+/// Splits a CSV line into fields and resolves them to table column positions, lazily consuming
+/// the header row on first call. The destination of each parsed value is left to the visitor, so
+/// both the `Row`-producing path and the direct-to-builder import path share identical mapping,
+/// header and null-marker handling.
+struct CsvImportParser {
+    delimiter: u8,
+    disable_quoting: bool,
+    columns: Vec<Column>,
+    header_mapping: Option<Vec<(usize, Column)>>,
+}
+
+impl CsvImportParser {
+    fn new(format: &ImportFormat, columns: Vec<Column>) -> Result<Self, CubeError> {
+        let (delimiter, disable_quoting) = match format {
+            ImportFormat::CSV | ImportFormat::CSVNoHeader => (',', false),
+            ImportFormat::CSVOptions {
+                delimiter, quote, ..
+            } => (delimiter.unwrap_or(','), quote.is_none()),
+        };
+        if delimiter as u16 > 255 {
+            return Err(CubeError::user(format!(
+                "Non ASCII delimiters are unsupported: '{}'",
+                delimiter
+            )));
+        }
+        let header_mapping = match format {
+            ImportFormat::CSVNoHeader
+            | ImportFormat::CSVOptions {
+                has_header: false, ..
+            } => Some(
+                columns
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| (i, c.clone()))
+                    .collect(),
+            ),
+            _ => None,
+        };
+        Ok(Self {
+            delimiter: delimiter as u8,
+            disable_quoting,
+            columns,
+            header_mapping,
+        })
+    }
+
+    /// Returns `false` when the line was consumed as the header, `true` for a data row. The visitor
+    /// is called once per table column (`None` value = null), so every builder advances exactly
+    /// once per row. A header that resolves two fields to the same column is rejected, since that
+    /// would append twice to one column and desync the builder lengths.
+    fn visit_line<F>(&mut self, line: &str, mut visit: F) -> Result<bool, CubeError>
+    where
+        F: FnMut(usize, &Column, Option<&str>) -> Result<(), CubeError>,
+    {
+        let mut parser = CsvLineParser::new(self.delimiter, self.disable_quoting, line);
+        if self.header_mapping.is_none() {
+            let mut mapping = Vec::new();
+            let mut seen = std::collections::HashSet::new();
+            for _ in 0..self.columns.len() {
+                let next_column_buf = parser.next_value()?;
+                let next_column = next_column_buf.as_ref();
+                let (insert_pos, to_insert) = self
+                    .columns
+                    .iter()
+                    .find_position(|c| c.get_name() == &next_column)
+                    .map(|(i, c)| (i, c.clone()))
+                    .ok_or_else(|| {
+                        CubeError::user(format!(
+                            "Column '{}' is not found during import in {:?}",
+                            next_column, self.columns
+                        ))
+                    })?;
+                if !seen.insert(insert_pos) {
+                    return Err(CubeError::user(format!(
+                        "Duplicate column '{}' in CSV header",
+                        to_insert.get_name()
+                    )));
+                }
+                mapping.push((insert_pos, to_insert));
+                parser.advance()?;
+            }
+            self.header_mapping = Some(mapping);
+            return Ok(false);
+        }
+
+        let mapping = self.header_mapping.as_ref().unwrap();
+        for (insert_pos, column) in mapping.iter() {
+            let value_buf = parser.next_value()?;
+            let value = value_buf.as_ref();
+            let value = if value == "" || value == "\\N" || value == "\\\\N" {
+                None
+            } else {
+                Some(value)
+            };
+            visit(*insert_pos, column, value)?;
+            parser.advance()?;
+        }
+        Ok(true)
+    }
+}
+
+fn parse_value_error(value: &str, column: &Column, e: CubeError) -> CubeError {
+    CubeError::user(format!(
+        "Can't parse '{}' column value for '{}' column: {}",
+        value,
+        column.get_name(),
+        e
+    ))
+}
+
+/// Parses a CSV field and appends it directly into the Arrow builder, bypassing `Row`/`TableValue`.
+/// Strings are appended verbatim (no `TableValue::String` allocation); other types reuse the shared
+/// `parse_column_value_str` + `append_value` logic.
+fn append_csv_value(
+    builder: &mut dyn ArrayBuilder,
+    column: &Column,
+    value: &str,
+) -> Result<(), CubeError> {
+    if matches!(column.get_column_type(), ColumnType::String) {
+        builder
+            .as_any_mut()
+            .downcast_mut::<datafusion::arrow::array::StringBuilder>()
+            .unwrap()
+            .append_value(value);
+        return Ok(());
+    }
+    let value = ImportFormat::parse_column_value_str(column, value)?;
+    append_value(builder, column.get_column_type(), &value);
+    Ok(())
+}
+
 #[async_trait]
 pub trait LocationsValidator: DIService + Send + Sync {
     async fn validate(&self, locations: &Vec<String>) -> Result<(), CubeError>;
@@ -717,13 +755,10 @@ impl ImportServiceImpl {
         let (file, tmp_path) = self
             .resolve_location(location, table.get_id(), &temp_dir)
             .await?;
-        let mut row_stream = format
-            .row_stream(
-                file,
-                location.to_string(),
-                table.get_row().get_columns().clone(),
-            )
-            .await?;
+        let reader = ImportFormat::open_reader(file, location);
+        let mut parser = CsvImportParser::new(&format, table.get_row().get_columns().clone())?;
+        let disable_quoting = parser.disable_quoting;
+        let mut lines = Box::pin(CsvLineStream::new(reader, disable_quoting));
 
         let mut ingestion = Ingestion::new(
             self.meta_store.clone(),
@@ -739,24 +774,38 @@ impl ImportServiceImpl {
         let table_cols = table.get_row().get_columns().as_slice();
         let mut builders = create_array_builders(table_cols);
         let mut num_rows = 0;
-        while let Some(row) = row_stream.next().await {
-            if let Some(row) = row? {
-                append_row(&mut builders, table_cols, &row);
-                num_rows += 1;
-
-                if num_rows >= self.config_obj.wal_split_threshold() as usize {
-                    let mut to_add = create_array_builders(table_cols);
-                    mem::swap(&mut builders, &mut to_add);
-                    num_rows = 0;
-
-                    let builded_rows = finish(to_add);
-
-                    if let Some(data_loaded_size) = &data_loaded_size {
-                        data_loaded_size.add(columns_vec_buffer_size(&builded_rows));
+        while let Some(line) = lines.next().await {
+            let line = line?;
+            let is_data_row = parser.visit_line(line.as_str(), |insert_pos, column, value| {
+                let builder = builders[insert_pos].as_mut();
+                match value {
+                    None => {
+                        append_value(builder, column.get_column_type(), &TableValue::Null);
                     }
-
-                    ingestion.queue_data_frame(builded_rows).await?;
+                    Some(value) => {
+                        append_csv_value(builder, column, value)
+                            .map_err(|e| parse_value_error(value, column, e))?;
+                    }
                 }
+                Ok(())
+            })?;
+            if !is_data_row {
+                continue;
+            }
+            num_rows += 1;
+
+            if num_rows >= self.config_obj.wal_split_threshold() as usize {
+                let mut to_add = create_array_builders(table_cols);
+                mem::swap(&mut builders, &mut to_add);
+                num_rows = 0;
+
+                let builded_rows = finish(to_add);
+
+                if let Some(data_loaded_size) = &data_loaded_size {
+                    data_loaded_size.add(columns_vec_buffer_size(&builded_rows));
+                }
+
+                ingestion.queue_data_frame(builded_rows).await?;
             }
         }
 
@@ -1004,16 +1053,61 @@ impl Ingestion {
 #[cfg(test)]
 mod tests {
     use crate::cube_ext::ordfloat::OrdF64;
-    use crate::import::{parse_binary_data, parse_decimal};
+    use crate::import::{
+        append_csv_value, parse_binary_data, parse_decimal, CsvImportParser, CsvLineStream,
+    };
     use crate::metastore::{Column, ColumnType, HllFlavour, ImportFormat};
+    use crate::table::data::{append_value, create_array_builders, rows_to_columns};
     use crate::table::{Row, TableValue, TimestampValue};
     use crate::util::decimal::{Decimal, Decimal96};
     use crate::util::int96::Int96;
     use cubehll::HllSketch;
+    use datafusion::arrow::array::ArrayRef;
     use indoc::indoc;
     use std::pin::Pin;
     use tokio::io::{AsyncBufRead, BufReader};
     use tokio_stream::StreamExt;
+
+    /// Runs the direct-to-builder import path (the one used by `do_import`) over a CSV reader and
+    /// returns the finished Arrow columns, mirroring how `collect_rows` exercises the `Row` path.
+    async fn collect_columns(
+        format: ImportFormat,
+        reader: Pin<Box<dyn AsyncBufRead + Send>>,
+        columns: Vec<Column>,
+    ) -> Vec<ArrayRef> {
+        let mut parser = CsvImportParser::new(&format, columns.clone()).unwrap();
+        let disable_quoting = parser.disable_quoting;
+        let mut builders = create_array_builders(&columns);
+        let mut lines = Box::pin(CsvLineStream::new(reader, disable_quoting));
+        while let Some(line) = lines.next().await {
+            let line = line.unwrap();
+            parser
+                .visit_line(line.as_str(), |insert_pos, column, value| {
+                    let builder = builders[insert_pos].as_mut();
+                    match value {
+                        None => append_value(builder, column.get_column_type(), &TableValue::Null),
+                        Some(value) => append_csv_value(builder, column, value)?,
+                    }
+                    Ok(())
+                })
+                .unwrap();
+        }
+        builders.into_iter().map(|mut b| b.finish()).collect()
+    }
+
+    fn arrays_to_rows(arrays: &[ArrayRef]) -> Vec<Row> {
+        let num_rows = arrays.first().map(|a| a.len()).unwrap_or(0);
+        (0..num_rows)
+            .map(|ri| {
+                Row::new(
+                    arrays
+                        .iter()
+                        .map(|a| TableValue::from_array(a.as_ref(), ri))
+                        .collect(),
+                )
+            })
+            .collect()
+    }
 
     async fn collect_rows(
         format: ImportFormat,
@@ -1362,6 +1456,98 @@ mod tests {
                 TableValue::Bytes(pg_expected),
                 TableValue::Bytes(sf_expected),
             ])]
+        );
+    }
+
+    // Both paths are compared through identical Arrow reconstruction to neutralize any
+    // representation differences and isolate "does the builder path produce the same data".
+    fn assert_paths_match(columns: &[Column], row_path: Vec<Row>, builder_path: Vec<ArrayRef>) {
+        assert_eq!(
+            arrays_to_rows(&rows_to_columns(columns, &row_path)),
+            arrays_to_rows(&builder_path)
+        );
+    }
+
+    #[tokio::test]
+    async fn builder_path_matches_row_path_no_header() {
+        let data = concat!(
+            "hello,42,1.50,2020-01-01T00:00:00.000Z,true,AQID\n",
+            ",,,,,\n",
+            r#""a,b",bad,2.5,2020-01-01T00:00:00.000Z,f,01 02"#,
+            "\n"
+        );
+        let columns = vec![
+            Column::new("A".to_string(), ColumnType::String, 0),
+            Column::new("B".to_string(), ColumnType::Int, 1),
+            Column::new(
+                "C".to_string(),
+                ColumnType::Decimal {
+                    scale: 5,
+                    precision: 18,
+                },
+                2,
+            ),
+            Column::new("D".to_string(), ColumnType::Timestamp, 3),
+            Column::new("E".to_string(), ColumnType::Boolean, 4),
+            Column::new("F".to_string(), ColumnType::Bytes, 5),
+        ];
+        let row_path = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns.clone(),
+        )
+        .await;
+        let builder_path = collect_columns(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns.clone(),
+        )
+        .await;
+        assert_paths_match(&columns, row_path, builder_path);
+    }
+
+    #[tokio::test]
+    async fn builder_path_matches_row_path_with_header() {
+        // Header reorders columns; second data row carries nulls in the reordered positions.
+        let data = "C,A,B\ntrue,hello,42\n,world,\n";
+        let columns = vec![
+            Column::new("A".to_string(), ColumnType::String, 0),
+            Column::new("B".to_string(), ColumnType::Int, 1),
+            Column::new("C".to_string(), ColumnType::Boolean, 2),
+        ];
+        let row_path = collect_rows(
+            ImportFormat::CSV,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns.clone(),
+        )
+        .await;
+        let builder_path = collect_columns(
+            ImportFormat::CSV,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns.clone(),
+        )
+        .await;
+        assert_paths_match(&columns, row_path, builder_path);
+    }
+
+    #[tokio::test]
+    async fn duplicate_header_column_is_rejected() {
+        // Two header fields resolving to the same column would append twice to one builder and
+        // desync column lengths, so it must be a hard error rather than silent last-write-wins.
+        let data = "A,A\n1,2\n";
+        let columns = vec![
+            Column::new("A".to_string(), ColumnType::Int, 0),
+            Column::new("B".to_string(), ColumnType::Int, 1),
+        ];
+        let mut stream = ImportFormat::CSV
+            .row_stream_from_reader(Box::pin(BufReader::new(data.as_bytes())), columns)
+            .unwrap();
+        let first = stream.next().await.unwrap();
+        let err = first.unwrap_err().to_string();
+        assert!(
+            err.contains("Duplicate column"),
+            "unexpected error: {}",
+            err
         );
     }
 }

--- a/rust/cubestore/cubestore/src/import/mod.rs
+++ b/rust/cubestore/cubestore/src/import/mod.rs
@@ -1003,12 +1003,32 @@ impl Ingestion {
 
 #[cfg(test)]
 mod tests {
-    use crate::import::parse_decimal;
-    use crate::metastore::{Column, ColumnType, ImportFormat};
-    use crate::table::{Row, TableValue};
+    use crate::cube_ext::ordfloat::OrdF64;
+    use crate::import::{parse_binary_data, parse_decimal};
+    use crate::metastore::{Column, ColumnType, HllFlavour, ImportFormat};
+    use crate::table::{Row, TableValue, TimestampValue};
+    use crate::util::decimal::{Decimal, Decimal96};
+    use crate::util::int96::Int96;
+    use cubehll::HllSketch;
     use indoc::indoc;
-    use tokio::io::BufReader;
+    use std::pin::Pin;
+    use tokio::io::{AsyncBufRead, BufReader};
     use tokio_stream::StreamExt;
+
+    async fn collect_rows(
+        format: ImportFormat,
+        reader: Pin<Box<dyn AsyncBufRead + Send>>,
+        columns: Vec<Column>,
+    ) -> Vec<Row> {
+        let mut row_stream = format.row_stream_from_reader(reader, columns).unwrap();
+        let mut rows = vec![];
+        while let Some(row) = row_stream.next().await {
+            if let Some(row) = row.unwrap() {
+                rows.push(row);
+            }
+        }
+        rows
+    }
 
     #[test]
     fn parse_decimal_test() {
@@ -1028,42 +1048,73 @@ mod tests {
             parse_decimal("-200.040000", 5).unwrap().to_string(5),
             "-200.04",
         );
+
+        // A value too large to fit i128 at the target scale is an error, not a silent Null.
+        let huge = format!("1{}", "0".repeat(40));
+        let err = parse_decimal(&huge, 5).unwrap_err().to_string();
+        assert!(err.contains("precision"), "unexpected error: {}", err);
     }
 
     #[tokio::test]
     async fn read_nulls() {
-        let data = indoc! {"
-            one,1
-            ,
-            three,3
+        // Every null marker ("", \N, \\N) must short-circuit to Null *before* type parsing,
+        // including for Decimal/Timestamp where the parser would otherwise raise an error.
+        let data = indoc! {r"
+            real,42,1.50,2020-01-01T00:00:00.000Z
+            ,,,
+            \N,\N,\N,\N
+            \\N,\\N,\\N,\\N
         "};
-        let csv_reader = Box::pin(BufReader::new(data.as_bytes()));
         let columns = vec![
             Column::new("A".to_string(), ColumnType::String, 0),
             Column::new("B".to_string(), ColumnType::Int, 1),
+            Column::new(
+                "C".to_string(),
+                ColumnType::Decimal {
+                    scale: 5,
+                    precision: 18,
+                },
+                2,
+            ),
+            Column::new("D".to_string(), ColumnType::Timestamp, 3),
         ];
-        let mut row_stream = ImportFormat::CSVNoHeader
-            .row_stream_from_reader(csv_reader, columns)
-            .unwrap();
-        let mut rows = vec![];
-        while let Some(row) = row_stream.next().await {
-            if let Some(row) = row.unwrap() {
-                rows.push(row)
-            }
-        }
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns,
+        )
+        .await;
+        let nulls = || Row::new(vec![TableValue::Null; 4]);
         assert_eq!(
             rows,
             vec![
                 Row::new(vec![
-                    TableValue::String("one".to_string()),
-                    TableValue::Int(1)
+                    TableValue::String("real".to_string()),
+                    TableValue::Int(42),
+                    TableValue::Decimal(Decimal::new(150000)), // 1.50 * 10^5
+                    TableValue::Timestamp(TimestampValue::new(1577836800000000000)),
                 ]),
-                Row::new(vec![TableValue::Null, TableValue::Null]),
-                Row::new(vec![
-                    TableValue::String("three".to_string()),
-                    TableValue::Int(3)
-                ]),
+                nulls(),
+                nulls(),
+                nulls(),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn quoted_empty_is_null() {
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new("\"\",\"\"\n".as_bytes())),
+            vec![
+                Column::new("A".to_string(), ColumnType::String, 0),
+                Column::new("B".to_string(), ColumnType::Int, 1),
+            ],
+        )
+        .await;
+        assert_eq!(
+            rows,
+            vec![Row::new(vec![TableValue::Null, TableValue::Null])]
         );
     }
     #[tokio::test]
@@ -1114,6 +1165,203 @@ mod tests {
                     TableValue::Boolean(true),
                 ]),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_numeric_types() {
+        let data = "123456789012345,3.5,200.35,-200.04\nabc,1.5,,\n";
+        let columns = vec![
+            Column::new("A".to_string(), ColumnType::Int96, 0),
+            Column::new("B".to_string(), ColumnType::Float, 1),
+            Column::new(
+                "C".to_string(),
+                ColumnType::Decimal {
+                    scale: 5,
+                    precision: 18,
+                },
+                2,
+            ),
+            Column::new(
+                "D".to_string(),
+                ColumnType::Decimal96 {
+                    scale: 5,
+                    precision: 30,
+                },
+                3,
+            ),
+        ];
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns,
+        )
+        .await;
+        assert_eq!(
+            rows,
+            vec![
+                Row::new(vec![
+                    TableValue::Int96(Int96::new(123456789012345)),
+                    TableValue::Float(OrdF64(3.5)),
+                    TableValue::Decimal(Decimal::new(20035000)), // 200.35 * 10^5
+                    TableValue::Decimal96(Decimal96::new(-20004000)), // -200.04 * 10^5
+                ]),
+                // Unparseable int -> Null, empty decimal cells -> Null.
+                Row::new(vec![
+                    TableValue::Null,
+                    TableValue::Float(OrdF64(1.5)),
+                    TableValue::Null,
+                    TableValue::Null,
+                ]),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_bytes_and_timestamp() {
+        // "AQID" is base64 for [1, 2, 3]; "01 02 03" is the space-separated hex form.
+        let data = "AQID,01 02 03,2020-01-01T00:00:00.000Z\n";
+        let columns = vec![
+            Column::new("A".to_string(), ColumnType::Bytes, 0),
+            Column::new("B".to_string(), ColumnType::Bytes, 1),
+            Column::new("C".to_string(), ColumnType::Timestamp, 2),
+        ];
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            columns,
+        )
+        .await;
+        assert_eq!(
+            rows,
+            vec![Row::new(vec![
+                TableValue::Bytes(vec![1, 2, 3]),
+                TableValue::Bytes(vec![1, 2, 3]),
+                TableValue::Timestamp(TimestampValue::new(1577836800000000000)),
+            ])]
+        );
+    }
+
+    fn quoted_columns() -> Vec<Column> {
+        vec![
+            Column::new("A".to_string(), ColumnType::String, 0),
+            Column::new("B".to_string(), ColumnType::String, 1),
+            Column::new("C".to_string(), ColumnType::String, 2),
+        ]
+    }
+
+    fn quoted_expected() -> Vec<Row> {
+        // Field B carries a quoted newline; field C carries an escaped quote.
+        vec![Row::new(vec![
+            TableValue::String("a,b".to_string()),
+            TableValue::String("line1\nline2".to_string()),
+            TableValue::String("say \"hi\"".to_string()),
+        ])]
+    }
+
+    #[tokio::test]
+    async fn quoted_fields_with_delimiter_newline_and_escapes() {
+        let data = "\"a,b\",\"line1\nline2\",\"say \"\"hi\"\"\"\n";
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            quoted_columns(),
+        )
+        .await;
+        assert_eq!(rows, quoted_expected());
+    }
+
+    #[tokio::test]
+    async fn quoting_survives_chunk_boundaries() {
+        // A 1-byte read buffer forces quotes and newlines to straddle poll_fill_buf calls.
+        let data = "\"a,b\",\"line1\nline2\",\"say \"\"hi\"\"\"\n";
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::with_capacity(1, data.as_bytes())),
+            quoted_columns(),
+        )
+        .await;
+        assert_eq!(rows, quoted_expected());
+    }
+
+    #[tokio::test]
+    async fn parse_failures_are_typed() {
+        // Int/Int96: an unparseable value is silently coerced to Null.
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new("xx,yy\n".as_bytes())),
+            vec![
+                Column::new("A".to_string(), ColumnType::Int, 0),
+                Column::new("B".to_string(), ColumnType::Int96, 1),
+            ],
+        )
+        .await;
+        assert_eq!(
+            rows,
+            vec![Row::new(vec![TableValue::Null, TableValue::Null])]
+        );
+
+        // Float/Decimal/Timestamp: an unparseable value is a hard error, not Null.
+        let failing = [
+            ColumnType::Float,
+            ColumnType::Decimal {
+                scale: 5,
+                precision: 18,
+            },
+            ColumnType::Timestamp,
+        ];
+        for col_type in failing {
+            let columns = vec![Column::new("A".to_string(), col_type.clone(), 0)];
+            let mut row_stream = ImportFormat::CSVNoHeader
+                .row_stream_from_reader(Box::pin(BufReader::new("xx\n".as_bytes())), columns)
+                .unwrap();
+            let first = row_stream.next().await.unwrap();
+            assert!(first.is_err(), "expected parse error for {:?}", col_type);
+        }
+    }
+
+    #[tokio::test]
+    async fn parse_hll_flavors_reserialize() {
+        // HLL columns are not raw Bytes: the value is decoded and re-serialized via
+        // HllSketch::write(). Pin the round-trip so a plain-Bytes path would regress.
+        // Airlift/ZetaSketch store the decoded bytes verbatim, so the two re-serializing
+        // flavors are used here: Postgres (binary input) and Snowflake (JSON input).
+        let pg_expected = HllSketch::read_hll_storage_spec(&parse_binary_data("11 8b 7f").unwrap())
+            .unwrap()
+            .write();
+        let sf_expected =
+            HllSketch::read_snowflake(r#"{ "precision": 1, "dense": [0, 0], "version": 4 }"#)
+                .unwrap()
+                .write();
+
+        // Field B is the Snowflake JSON, CSV-quoted with doubled inner quotes.
+        let data = concat!(
+            r#"11 8b 7f,"{ ""precision"": 1, ""dense"": [0, 0], ""version"": 4 }""#,
+            "\n"
+        );
+        let rows = collect_rows(
+            ImportFormat::CSVNoHeader,
+            Box::pin(BufReader::new(data.as_bytes())),
+            vec![
+                Column::new(
+                    "A".to_string(),
+                    ColumnType::HyperLogLog(HllFlavour::Postgres),
+                    0,
+                ),
+                Column::new(
+                    "B".to_string(),
+                    ColumnType::HyperLogLog(HllFlavour::Snowflake),
+                    1,
+                ),
+            ],
+        )
+        .await;
+        assert_eq!(
+            rows,
+            vec![Row::new(vec![
+                TableValue::Bytes(pg_expected),
+                TableValue::Bytes(sf_expected),
+            ])]
         );
     }
 }


### PR DESCRIPTION
## Summary

Removes the per-row `Row`/`Vec<TableValue>` intermediate from the CubeStore CSV file-import path, appending parsed values straight into the Arrow column builders. This drops the allocations that scale with row count — one `Vec<TableValue>` per row (unconditional) and the `TableValue::String` copy per string cell (the most common column type) — to relieve allocator pressure on large imports.

## Changes

- `do_import` now drives the CSV line stream through a shared `CsvImportParser` and appends each field directly into its `ArrayBuilder`; strings go straight into `StringBuilder`, skipping the `TableValue::String` allocation.
- Line splitting, header mapping and null-marker handling are factored into `CsvImportParser` and shared between the builder path and the `Row`-producing path (still used by HTTP inline tables), so the two cannot diverge.
- A CSV header that resolves two fields to the same column is now rejected with a clear error instead of silent last-write-wins — this preserves the one-append-per-column invariant the builder path relies on (avoids a length desync / panic at `finish()`).
- `parse_column_value_str` + `append_value` are reused for all non-string types, so type mapping and null semantics are unchanged.

## Testing

- New baseline unit tests pin CSV type mapping and null semantics (null markers across String/Int/Decimal/Timestamp, typed parse-failure semantics, HLL flavor re-serialization, decimal precision-overflow, quoting across read-buffer boundaries).
- Differential unit tests assert the builder path produces identical data to the `Row` path (compared through identical Arrow reconstruction), with and without a header.
- Unit suite: 13/13 green. In-process integration tests green end-to-end: `create_table_with_csv*` (5) and `create_table_with_location*` (6, incl. gzip, reordered columns, invalid-digit error path, and all three HLL flavors).