### PR TITLE
fix(tesseract): Unexpected panic when pre-aggregation time_dimension are not resolved

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -578,11 +578,13 @@ impl PreAggregationsCompiler {
         }
 
         symbols.into_iter().next().ok_or_else(|| {
-            // Render the reference the way the JS planner sees it (cube refs
-            // as plain cube names) and match its error message format.
             let path = sql_call.debug_sql(true);
             let member_name = path.rsplit('.').next().unwrap_or(&path);
-            CubeError::user(format!("'{}' not found for path '{}'", member_name, path))
+
+            CubeError::user(format!(
+                "'{}' not found for path '{}' in pre-aggregation '{}.{}'",
+                member_name, path, name.cube_name, name.name
+            ))
         })
     }
 
@@ -660,7 +662,7 @@ mod tests {
                       - count
                     time_dimension: created_at
                     granularity: day
-                  - name: broken_rollup
+                  - name: broken_rollup_unsupported
                     type: rollup
                     measures:
                       - count
@@ -709,11 +711,11 @@ mod tests {
     #[test]
     fn test_time_dimension_resolved_to_cube_ref_returns_error() {
         let ctx = create_time_dimension_context();
-        let err = compile_pre_agg(&ctx, "broken_rollup")
+        let err = compile_pre_agg(&ctx, "broken_rollup_unsupported")
             .expect_err("Pre-aggregation with unresolvable time dimension should fail to compile");
         assert_eq!(
             err.message,
-            "'created_at' not found for path 'orders.created_at'"
+            "'created_at' not found for path 'orders.created_at' in pre-aggregation 'orders.broken_rollup_unsupported'"
         );
     }
 
@@ -724,7 +726,7 @@ mod tests {
             .expect_err("Pre-aggregation with unresolvable time dimension should fail to compile");
         assert_eq!(
             err.message,
-            "'created_at' not found for path 'orders.created_at'"
+            "'created_at' not found for path 'orders.created_at' in pre-aggregation 'orders.broken_rollup_no_granularity'"
         );
     }
 
@@ -737,7 +739,7 @@ mod tests {
             .expect_err("Pre-aggregation with unresolvable time dimension should fail to compile");
         assert_eq!(
             err.message,
-            "'created_at_day' not found for path 'orders.created_at_day'"
+            "'created_at_day' not found for path 'orders.created_at_day' in pre-aggregation 'orders.broken_rollup_granularity_suffix'"
         );
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -15,6 +15,7 @@ use crate::planner::query_tools::QueryTools;
 use crate::planner::GranularityHelper;
 use crate::planner::MemberSymbol;
 use crate::planner::TimeDimensionSymbol;
+use crate::utils::debug::DebugSql;
 use cubenativeutils::CubeError;
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -135,23 +136,14 @@ impl PreAggregationsCompiler {
         let time_dimensions = if let Some(td_refs) = description.time_dimension_references()? {
             let mut resolved = Vec::new();
             for td_ref in td_refs.iter() {
-                let dims = Self::symbols_from_ref(
+                let base_symbol = Self::time_dimension_symbol_from_ref(
                     self.query_tools.clone(),
-                    &name.cube_name,
+                    name,
                     td_ref.dimension()?,
-                    Self::check_is_time_dimension,
                 )?;
-                let base_symbol = dims.first().ok_or_else(|| {
-                    CubeError::internal(format!(
-                        "No time dimension symbols resolved for pre-aggregation '{:?}'",
-                        name
-                    ))
-                })?;
-                resolved.push((
-                    base_symbol.clone(),
-                    td_ref.static_data().granularity.clone(),
-                ));
+                resolved.push((base_symbol, td_ref.static_data().granularity.clone()));
             }
+
             let evaluator_compiler_cell = self.query_tools.evaluator_compiler().clone();
             let mut evaluator_compiler = evaluator_compiler_cell.borrow_mut();
             let mut result = Vec::new();
@@ -173,17 +165,12 @@ impl PreAggregationsCompiler {
             }
             result
         } else if let Some(refs) = description.time_dimension_reference()? {
-            let dims = Self::symbols_from_ref(
-                self.query_tools.clone(),
-                &name.cube_name,
-                refs,
-                Self::check_is_time_dimension,
-            )?;
+            let base_symbol =
+                Self::time_dimension_symbol_from_ref(self.query_tools.clone(), name, refs)?;
 
             if static_data.granularity.is_some() {
                 let evaluator_compiler_cell = self.query_tools.evaluator_compiler().clone();
                 let mut evaluator_compiler = evaluator_compiler_cell.borrow_mut();
-                let base_symbol = dims[0].clone();
 
                 let granularity_obj = GranularityHelper::make_granularity_obj(
                     self.query_tools.cube_evaluator().clone(),
@@ -201,7 +188,7 @@ impl PreAggregationsCompiler {
 
                 vec![symbol]
             } else {
-                vec![dims[0].clone()]
+                vec![base_symbol]
             }
         } else {
             Vec::new()
@@ -574,6 +561,31 @@ impl PreAggregationsCompiler {
         Ok(res)
     }
 
+    fn time_dimension_symbol_from_ref(
+        query_tools: Rc<QueryTools>,
+        name: &PreAggregationFullName,
+        ref_func: Rc<dyn MemberSql>,
+    ) -> Result<Rc<MemberSymbol>, CubeError> {
+        let evaluator_compiler_cell = query_tools.evaluator_compiler().clone();
+        let mut evaluator_compiler = evaluator_compiler_cell.borrow_mut();
+        let sql_call = evaluator_compiler.compile_sql_call(&name.cube_name, ref_func)?;
+
+        let mut symbols = Vec::new();
+
+        for symbol in sql_call.get_dependencies().into_iter() {
+            Self::check_is_time_dimension(&symbol)?;
+            symbols.push(symbol);
+        }
+
+        symbols.into_iter().next().ok_or_else(|| {
+            // Render the reference the way the JS planner sees it (cube refs
+            // as plain cube names) and match its error message format.
+            let path = sql_call.debug_sql(true);
+            let member_name = path.rsplit('.').next().unwrap_or(&path);
+            CubeError::user(format!("'{}' not found for path '{}'", member_name, path))
+        })
+    }
+
     fn check_is_measure(symbol: &MemberSymbol) -> Result<(), CubeError> {
         symbol
             .as_measure()
@@ -617,6 +629,117 @@ mod tests {
     use super::*;
     use crate::test_fixtures::cube_bridge::MockSchema;
     use crate::test_fixtures::test_utils::TestContext;
+    use indoc::indoc;
+
+    fn create_time_dimension_context() -> TestContext {
+        // `time_dimension: \"{CUBE}.created_at\"` models a JS reference built
+        // via string interpolation — `(CUBE) => `${CUBE}.created_at``. The JS
+        // planner resolves it (reference evaluation stringifies `${CUBE}` to
+        // the cube name), but here `{CUBE}` compiles to a cube reference and
+        // `.created_at` stays literal text, so the compiled reference has no
+        // member symbol dependencies.
+        let schema = MockSchema::from_yaml(indoc! {"
+            cubes:
+              - name: orders
+                sql: SELECT * FROM orders
+                dimensions:
+                  - name: id
+                    type: number
+                    sql: id
+                    primary_key: true
+                  - name: created_at
+                    type: time
+                    sql: created_at
+                measures:
+                  - name: count
+                    type: count
+                pre_aggregations:
+                  - name: working_rollup
+                    type: rollup
+                    measures:
+                      - count
+                    time_dimension: created_at
+                    granularity: day
+                  - name: broken_rollup
+                    type: rollup
+                    measures:
+                      - count
+                    time_dimension: '{CUBE}.created_at'
+                    granularity: day
+                  - name: broken_rollup_no_granularity
+                    type: rollup
+                    measures:
+                      - count
+                    time_dimension: '{CUBE}.created_at'
+                  - name: broken_rollup_granularity_suffix
+                    type: rollup
+                    measures:
+                      - count
+                    time_dimension: '{CUBE}.created_at_day'
+                    granularity: day
+        "})
+        .unwrap();
+        TestContext::new(schema).unwrap()
+    }
+
+    fn compile_pre_agg(
+        ctx: &TestContext,
+        pre_agg_name: &str,
+    ) -> Result<Rc<CompiledPreAggregation>, CubeError> {
+        let cube_names = vec!["orders".to_string()];
+        let mut compiler =
+            PreAggregationsCompiler::try_new(ctx.query_tools().clone(), &cube_names).unwrap();
+        let name = PreAggregationFullName::new("orders".to_string(), pre_agg_name.to_string());
+        compiler.compile_pre_aggregation(&name)
+    }
+
+    #[test]
+    fn test_time_dimension_resolves_to_member_symbol() {
+        let ctx = create_time_dimension_context();
+        let compiled = compile_pre_agg(&ctx, "working_rollup").unwrap();
+
+        assert_eq!(compiled.time_dimensions.len(), 1);
+        assert_eq!(
+            compiled.time_dimensions[0].full_name(),
+            "orders.created_at_day"
+        );
+        assert_eq!(compiled.granularity, Some("day".to_string()));
+    }
+
+    #[test]
+    fn test_time_dimension_resolved_to_cube_ref_returns_error() {
+        let ctx = create_time_dimension_context();
+        let err = compile_pre_agg(&ctx, "broken_rollup")
+            .expect_err("Pre-aggregation with unresolvable time dimension should fail to compile");
+        assert_eq!(
+            err.message,
+            "'created_at' not found for path 'orders.created_at'"
+        );
+    }
+
+    #[test]
+    fn test_time_dimension_resolved_to_cube_ref_without_granularity_returns_error() {
+        let ctx = create_time_dimension_context();
+        let err = compile_pre_agg(&ctx, "broken_rollup_no_granularity")
+            .expect_err("Pre-aggregation with unresolvable time dimension should fail to compile");
+        assert_eq!(
+            err.message,
+            "'created_at' not found for path 'orders.created_at'"
+        );
+    }
+
+    // Interpolated reference with a granularity-suffixed member name,
+    // e.g. `(CUBE) => `${CUBE}.created_at_day``.
+    #[test]
+    fn test_time_dimension_with_granularity_suffix_returns_error() {
+        let ctx = create_time_dimension_context();
+        let err = compile_pre_agg(&ctx, "broken_rollup_granularity_suffix")
+            .expect_err("Pre-aggregation with unresolvable time dimension should fail to compile");
+        assert_eq!(
+            err.message,
+            "'created_at_day' not found for path 'orders.created_at_day'"
+        );
+    }
 
     #[test]
     fn test_compile_simple_rollup() {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/pre_aggregation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/yaml/pre_aggregation.rs
@@ -142,5 +142,12 @@ fn build_array_references(members: Vec<String>) -> Result<Rc<dyn MemberSql>, Cub
 }
 
 fn build_single_reference(member: String) -> Result<Rc<dyn MemberSql>, CubeError> {
-    MockMemberSql::pre_agg_single_ref(member).map(|m| Rc::new(m) as Rc<dyn MemberSql>)
+    // Template syntax like "{CUBE}.created_at" models JS references built via
+    // string interpolation (e.g. `${CUBE}.created_at`), where the member name
+    // is literal text rather than a symbol path.
+    if member.contains('{') {
+        MockMemberSql::new(member).map(|m| Rc::new(m) as Rc<dyn MemberSql>)
+    } else {
+        MockMemberSql::pre_agg_single_ref(member).map(|m| Rc::new(m) as Rc<dyn MemberSql>)
+    }
 }


### PR DESCRIPTION
… no member symbols

A pre-aggregation time_dimension reference built via string interpolation (e.g. `(CUBE) => `${CUBE}.issued_date``) compiles to a cube reference with the member name left as literal template text, so it yields no member symbol dependencies. PreAggregationsCompiler then panicked with "index out of bounds: the len is 0 but the index is 0" on `dims[0]`, crashing buildSqlAndParams through the Neon bridge.

Resolve time_dimension references through a shared helper that returns a proper CubeError naming the reference and the pre-aggregation:

    Unable to resolve time-dimension '{cube}.member' for pre-aggregation 'cube.name'

The JS planner resolves this reference shape via string evaluation; making Tesseract resolve it the same way is left as a follow-up.