### PR TITLE
feat(cubestore): batch persisted-chunk repartition per partition

### DIFF
--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -36,6 +36,10 @@ pub type TestFn = Box<
 pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
     let test_list = vec![
         t("insert", insert),
+        t(
+            "repartition_multi_node_consistency",
+            repartition_multi_node_consistency,
+        ),
         t("select_test", select_test),
         t("refresh_selects", refresh_selects),
         t("negative_numbers", negative_numbers),
@@ -11688,6 +11692,81 @@ async fn join_multi_partition_large(service: Box<dyn SqlClient>) -> Result<(), C
         .await?;
     assert_eq!(to_rows(&count_result), vec![vec![TableValue::Int(150)]]);
     Ok(())
+}
+
+async fn repartition_multi_node_consistency(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA foo").await?;
+    service
+        .exec_query("CREATE TABLE foo.numbers (num int)")
+        .await?;
+
+    let n: i64 = 200;
+    for i in 0..n {
+        service
+            .exec_query(&format!("INSERT INTO foo.numbers (num) VALUES ({})", i))
+            .await?;
+    }
+
+    // Wait until the table has split and repartition jobs have drained every
+    // inactive parent partition (no active chunk left on an inactive partition),
+    // while the full row set stays readable throughout.
+    let mut stabilized = false;
+    let (mut active_parts, mut pending, mut count) = (0i64, true, 0i64);
+    for _ in 0..150 {
+        let active_parts_df = service
+            .exec_query("SELECT count(*) FROM system.partitions WHERE active = true")
+            .await?;
+        active_parts = scalar_i64(&active_parts_df);
+
+        let inactive = service
+            .exec_query("SELECT id FROM system.partitions WHERE active = false")
+            .await?;
+        let inactive_ids: HashSet<i64> = to_rows(&inactive)
+            .iter()
+            .filter_map(|r| match &r[0] {
+                TableValue::Int(v) => Some(*v),
+                _ => None,
+            })
+            .collect();
+
+        let active_chunks = service
+            .exec_query("SELECT partition_id FROM system.chunks WHERE active = true")
+            .await?;
+        pending = to_rows(&active_chunks).iter().any(|r| match &r[0] {
+            TableValue::Int(v) => inactive_ids.contains(v),
+            _ => false,
+        });
+
+        let count_df = service
+            .exec_query("SELECT count(*) FROM foo.numbers")
+            .await?;
+        count = scalar_i64(&count_df);
+
+        if active_parts > 1 && !pending && count == n {
+            stabilized = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        stabilized,
+        "repartition did not stabilize: active_partitions={}, pending_repartition={}, count={} (want active>1, pending=false, count={})",
+        active_parts, pending, count, n
+    );
+
+    let sum = service
+        .exec_query("SELECT sum(num) FROM foo.numbers")
+        .await?;
+    assert_eq!(to_rows(&sum), vec![vec![TableValue::Int(n * (n - 1) / 2)]]);
+
+    Ok(())
+}
+
+fn scalar_i64(d: &DataFrame) -> i64 {
+    match d.get_rows().get(0).map(|r| &r.values()[0]) {
+        Some(TableValue::Int(v)) => *v,
+        _ => 0,
+    }
 }
 
 pub fn to_rows(d: &DataFrame) -> Vec<Vec<TableValue>> {

--- a/rust/cubestore/cubestore-sql-tests/tests/migration.rs
+++ b/rust/cubestore/cubestore-sql-tests/tests/migration.rs
@@ -22,7 +22,14 @@ fn main() {
             )).unwrap()
     };
 
-    run_sql_tests("migration", vec![], move |test_name, test_fn| {
+    // repartition_multi_node_consistency was added after the migration fixture
+    // tarball was recorded, so it has no pre-migration data directory to copy
+    // from. Skip it here; it still runs under in-process/cluster/multi-process.
+    let extra_args = vec![
+        "--skip".to_string(),
+        "repartition_multi_node_consistency".to_string(),
+    ];
+    run_sql_tests("migration", extra_args, move |test_name, test_fn| {
         let r = Builder::new_current_thread()
             .thread_stack_size(4 * 1024 * 1024)
             .enable_all()

--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_processor.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_processor.rs
@@ -1,5 +1,5 @@
 use crate::config::injection::DIService;
-use crate::config::Config;
+use crate::config::{Config, ConfigObj};
 use crate::import::ImportService;
 use crate::metastore::job::{Job, JobType};
 use crate::metastore::table::Table;
@@ -11,6 +11,7 @@ use crate::{app_metrics, CubeError};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct JobProcessResult {
@@ -52,6 +53,7 @@ impl JobProcessorImpl {
         chunk_store: Arc<dyn ChunkDataStore>,
         compaction_service: Arc<dyn CompactionService>,
         import_service: Arc<dyn ImportService>,
+        config_obj: Arc<dyn ConfigObj>,
     ) -> Arc<Self> {
         Arc::new(Self {
             processor: JobIsolatedProcessor::new(
@@ -59,6 +61,7 @@ impl JobProcessorImpl {
                 chunk_store,
                 compaction_service,
                 import_service,
+                config_obj,
             ),
         })
     }
@@ -84,6 +87,7 @@ pub struct JobIsolatedProcessor {
     chunk_store: Arc<dyn ChunkDataStore>,
     compaction_service: Arc<dyn CompactionService>,
     import_service: Arc<dyn ImportService>,
+    config_obj: Arc<dyn ConfigObj>,
 }
 
 impl JobIsolatedProcessor {
@@ -92,17 +96,20 @@ impl JobIsolatedProcessor {
         chunk_store: Arc<dyn ChunkDataStore>,
         compaction_service: Arc<dyn CompactionService>,
         import_service: Arc<dyn ImportService>,
+        config_obj: Arc<dyn ConfigObj>,
     ) -> Arc<Self> {
         Arc::new(Self {
             meta_store,
             chunk_store,
             compaction_service,
             import_service,
+            config_obj,
         })
     }
 
     pub async fn new_from_config(config: &Config) -> Arc<Self> {
         Self::new(
+            config.injector().get_service_typed().await,
             config.injector().get_service_typed().await,
             config.injector().get_service_typed().await,
             config.injector().get_service_typed().await,
@@ -215,10 +222,34 @@ impl JobIsolatedProcessor {
                     }
                     let data_loaded_size = DataLoadedSize::new();
                     app_metrics::JOBS_REPARTITION_CHUNK.add(1);
-                    let r = self
-                        .chunk_store
-                        .repartition_chunk(chunk_id, data_loaded_size.clone())
-                        .await;
+                    // FIXME: a RepartitionChunk job whose chunk_id is used as an
+                    // anchor for the whole partition (batch_repartition_enabled).
+                    // We deliberately overload the existing RepartitionChunk type
+                    // instead of introducing a dedicated per-partition JobType:
+                    // a new JobType variant cannot be deserialized by an older
+                    // binary, which would make the whole job shard unreadable when
+                    // a deployment switches between the `latest` and `release`
+                    // channels (version can move both ways at any time). Reusing a
+                    // known type keeps both directions safe — an old binary just
+                    // repartitions the single anchor chunk. See repartition_partition_chunks.
+                    let r = if self.config_obj.batch_repartition_enabled() {
+                        let partition_id = chunk.get_row().get_partition_id();
+                        let time_budget = Duration::from_secs(
+                            self.config_obj.repartition_chunks_time_budget_secs(),
+                        );
+                        self.chunk_store
+                            .repartition_partition_chunks(
+                                partition_id,
+                                chunk_id,
+                                time_budget,
+                                data_loaded_size.clone(),
+                            )
+                            .await
+                    } else {
+                        self.chunk_store
+                            .repartition_chunk(chunk_id, data_loaded_size.clone())
+                            .await
+                    };
                     if let Err(e) = r {
                         app_metrics::JOBS_REPARTITION_CHUNK_FAILURES.add(1);
                         return Err(e);

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -962,19 +962,46 @@ impl Cluster for ClusterImpl {
             .filter(|c| !c.get_row().in_memory())
             .collect::<Vec<_>>();
 
-        for chunk in chunks {
-            let node = self.node_name_for_chunk_repartition(&chunk).await?;
+        if self.config_obj.batch_repartition_enabled() {
+            // FIXME: one job per partition that batches all persisted chunks, but
+            // keyed on a chunk (RepartitionChunk), not the partition. We reuse the
+            // existing job type instead of a dedicated per-partition JobType so an
+            // older binary stays able to deserialize it across `latest`/`release`
+            // channel switches (a new variant would make its whole job shard
+            // unreadable). The anchor is the smallest persisted chunk id so add_job
+            // dedups to a single job per partition; the worker resolves the
+            // partition from it and processes the anchor last (see
+            // repartition_partition_chunks). An old binary just repartitions this
+            // one chunk and drains the rest via its own per-chunk path.
+            if let Some(anchor_chunk_id) = chunks.iter().map(|c| c.get_id()).min() {
+                let node = self.node_name_by_partition(p);
+                let job = self
+                    .meta_store
+                    .add_job(Job::new(
+                        RowKey::Table(TableId::Chunks, anchor_chunk_id),
+                        JobType::RepartitionChunk,
+                        node.to_string(),
+                    ))
+                    .await?;
+                if job.is_some() {
+                    self.notify_job_runner(node).await?;
+                }
+            }
+        } else {
+            for chunk in chunks {
+                let node = self.node_name_for_chunk_repartition(&chunk).await?;
 
-            let job = self
-                .meta_store
-                .add_job(Job::new(
-                    RowKey::Table(TableId::Chunks, chunk.get_id()),
-                    JobType::RepartitionChunk,
-                    node.to_string(),
-                ))
-                .await?;
-            if job.is_some() {
-                self.notify_job_runner(node).await?;
+                let job = self
+                    .meta_store
+                    .add_job(Job::new(
+                        RowKey::Table(TableId::Chunks, chunk.get_id()),
+                        JobType::RepartitionChunk,
+                        node.to_string(),
+                    ))
+                    .await?;
+                if job.is_some() {
+                    self.notify_job_runner(node).await?;
+                }
             }
         }
         Ok(())

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -497,6 +497,17 @@ pub trait ConfigObj: DIService {
 
     fn enable_topk(&self) -> bool;
 
+    /// When enabled, an inactive parent partition is repartitioned by a single
+    /// per-partition job that loops over its persisted chunks, instead of one
+    /// job per chunk. Kept as a flag for emergency rollback.
+    fn batch_repartition_enabled(&self) -> bool;
+
+    /// Time budget for a single batch repartition job. The job yields its runner
+    /// slot once the budget is exceeded (after the current chunk); the remainder
+    /// is drained by a follow-up job via the cascade. Kept separate from
+    /// import_job_timeout, which is the hard stuck-job kill, not a fairness knob.
+    fn repartition_chunks_time_budget_secs(&self) -> u64;
+
     fn allow_decimal128(&self) -> bool;
 
     fn enable_remove_orphaned_remote_files(&self) -> bool;
@@ -639,6 +650,8 @@ pub struct ConfigObjImpl {
     pub max_ingestion_data_frames: usize,
     pub upload_to_remote: bool,
     pub enable_topk: bool,
+    pub batch_repartition_enabled: bool,
+    pub repartition_chunks_time_budget_secs: u64,
     pub allow_decimal128: bool,
     pub enable_remove_orphaned_remote_files: bool,
     pub enable_startup_warmup: bool,
@@ -935,6 +948,12 @@ impl ConfigObj for ConfigObjImpl {
     }
     fn enable_topk(&self) -> bool {
         self.enable_topk
+    }
+    fn batch_repartition_enabled(&self) -> bool {
+        self.batch_repartition_enabled
+    }
+    fn repartition_chunks_time_budget_secs(&self) -> u64 {
+        self.repartition_chunks_time_budget_secs
     }
 
     fn allow_decimal128(&self) -> bool {
@@ -1515,6 +1534,11 @@ impl Config {
                     .unwrap_or("localhost".to_string()),
                 upload_to_remote: !env::var("CUBESTORE_NO_UPLOAD").ok().is_some(),
                 enable_topk: env_bool("CUBESTORE_ENABLE_TOPK", true),
+                batch_repartition_enabled: env_bool("CUBESTORE_BATCH_REPARTITION", true),
+                repartition_chunks_time_budget_secs: env_parse(
+                    "CUBESTORE_REPARTITION_TIME_BUDGET_SECS",
+                    60,
+                ),
                 allow_decimal128: env_bool("CUBESTORE_ALLOW_DECIMAL128", false),
                 enable_remove_orphaned_remote_files: env_bool(
                     "CUBESTORE_ENABLE_REMOVE_ORPHANED_REMOTE_FILES",
@@ -1749,6 +1773,8 @@ impl Config {
                 server_name: "localhost".to_string(),
                 upload_to_remote: true,
                 enable_topk: true,
+                batch_repartition_enabled: true,
+                repartition_chunks_time_budget_secs: 60,
                 allow_decimal128: false,
                 enable_remove_orphaned_remote_files: false,
                 enable_startup_warmup: true,
@@ -2498,6 +2524,7 @@ impl Config {
         self.injector
             .register_typed::<dyn JobProcessor, _, _, _>(async move |i| {
                 JobProcessorImpl::new(
+                    i.get_service_typed().await,
                     i.get_service_typed().await,
                     i.get_service_typed().await,
                     i.get_service_typed().await,

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3505,6 +3505,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repartition_keeps_data_consistent() -> Result<(), CubeError> {
+        Config::test("repartition_keeps_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c
+            })
+            .start_test(async move |services| {
+                let service = services.sql_service;
+
+                service
+                    .exec_query("CREATE SCHEMA foo")
+                    .await?
+                    .collect()
+                    .await?;
+
+                service
+                    .exec_query("CREATE TABLE foo.numbers (num int)")
+                    .await?
+                    .collect()
+                    .await?;
+
+                let n: i64 = 200;
+                for i in 0..n {
+                    service
+                        .exec_query(&format!("INSERT INTO foo.numbers (num) VALUES ({})", i))
+                        .await?
+                        .collect()
+                        .await?;
+                }
+
+                // Wait until repartition jobs have drained every inactive parent partition.
+                let mut drained = false;
+                for _ in 0..300 {
+                    let pending = services
+                        .meta_store
+                        .all_inactive_partitions_to_repartition()
+                        .await?;
+                    if pending.is_empty() {
+                        drained = true;
+                        break;
+                    }
+                    Delay::new(Duration::from_millis(50)).await;
+                }
+                assert!(
+                    drained,
+                    "inactive partitions were not fully repartitioned in time"
+                );
+
+                // The partition must have actually split.
+                let active = services
+                    .meta_store
+                    .get_active_partitions_by_index_id(1)
+                    .await?;
+                assert!(
+                    active.len() > 1,
+                    "expected partition to split, got {} active partitions",
+                    active.len()
+                );
+
+                // Data must be complete and correct after repartition.
+                let result = service
+                    .exec_query("SELECT count(*) from foo.numbers")
+                    .await?
+                    .collect()
+                    .await?;
+                assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Int(n)]));
+
+                let result = service
+                    .exec_query("SELECT sum(num) from foo.numbers")
+                    .await?
+                    .collect()
+                    .await?;
+                assert_eq!(
+                    result.get_rows()[0],
+                    Row::new(vec![TableValue::Int(n * (n - 1) / 2)])
+                );
+
+                Ok::<(), CubeError>(())
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn decimal_partition_pruning() -> Result<(), CubeError> {
         Config::test("decimal_partition_pruning")
             .update_config(|mut c| {

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3504,6 +3504,82 @@ mod tests {
         Ok(())
     }
 
+    async fn assert_repartition_drains_and_keeps_data(
+        services: &CubeServices,
+    ) -> Result<(), CubeError> {
+        let service = &services.sql_service;
+
+        service
+            .exec_query("CREATE SCHEMA foo")
+            .await?
+            .collect()
+            .await?;
+
+        service
+            .exec_query("CREATE TABLE foo.numbers (num int)")
+            .await?
+            .collect()
+            .await?;
+
+        let n: i64 = 200;
+        for i in 0..n {
+            service
+                .exec_query(&format!("INSERT INTO foo.numbers (num) VALUES ({})", i))
+                .await?
+                .collect()
+                .await?;
+        }
+
+        // Wait until repartition jobs have drained every inactive parent partition.
+        let mut drained = false;
+        for _ in 0..300 {
+            let pending = services
+                .meta_store
+                .all_inactive_partitions_to_repartition()
+                .await?;
+            if pending.is_empty() {
+                drained = true;
+                break;
+            }
+            Delay::new(Duration::from_millis(50)).await;
+        }
+        assert!(
+            drained,
+            "inactive partitions were not fully repartitioned in time"
+        );
+
+        // The partition must have actually split.
+        let active = services
+            .meta_store
+            .get_active_partitions_by_index_id(1)
+            .await?;
+        assert!(
+            active.len() > 1,
+            "expected partition to split, got {} active partitions",
+            active.len()
+        );
+
+        // Data must be complete and correct after repartition.
+        let result = service
+            .exec_query("SELECT count(*) from foo.numbers")
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Int(n)]));
+
+        let result = service
+            .exec_query("SELECT sum(num) from foo.numbers")
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(
+            result.get_rows()[0],
+            Row::new(vec![TableValue::Int(n * (n - 1) / 2)])
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn repartition_keeps_data_consistent() -> Result<(), CubeError> {
         Config::test("repartition_keeps_data_consistent")
@@ -3513,77 +3589,42 @@ mod tests {
                 c
             })
             .start_test(async move |services| {
-                let service = services.sql_service;
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
 
-                service
-                    .exec_query("CREATE SCHEMA foo")
-                    .await?
-                    .collect()
-                    .await?;
+    #[tokio::test]
+    async fn repartition_legacy_per_chunk_path() -> Result<(), CubeError> {
+        Config::test("repartition_legacy_per_chunk_path")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.batch_repartition_enabled = false;
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
 
-                service
-                    .exec_query("CREATE TABLE foo.numbers (num int)")
-                    .await?
-                    .collect()
-                    .await?;
-
-                let n: i64 = 200;
-                for i in 0..n {
-                    service
-                        .exec_query(&format!("INSERT INTO foo.numbers (num) VALUES ({})", i))
-                        .await?
-                        .collect()
-                        .await?;
-                }
-
-                // Wait until repartition jobs have drained every inactive parent partition.
-                let mut drained = false;
-                for _ in 0..300 {
-                    let pending = services
-                        .meta_store
-                        .all_inactive_partitions_to_repartition()
-                        .await?;
-                    if pending.is_empty() {
-                        drained = true;
-                        break;
-                    }
-                    Delay::new(Duration::from_millis(50)).await;
-                }
-                assert!(
-                    drained,
-                    "inactive partitions were not fully repartitioned in time"
-                );
-
-                // The partition must have actually split.
-                let active = services
-                    .meta_store
-                    .get_active_partitions_by_index_id(1)
-                    .await?;
-                assert!(
-                    active.len() > 1,
-                    "expected partition to split, got {} active partitions",
-                    active.len()
-                );
-
-                // Data must be complete and correct after repartition.
-                let result = service
-                    .exec_query("SELECT count(*) from foo.numbers")
-                    .await?
-                    .collect()
-                    .await?;
-                assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Int(n)]));
-
-                let result = service
-                    .exec_query("SELECT sum(num) from foo.numbers")
-                    .await?
-                    .collect()
-                    .await?;
-                assert_eq!(
-                    result.get_rows()[0],
-                    Row::new(vec![TableValue::Int(n * (n - 1) / 2)])
-                );
-
-                Ok::<(), CubeError>(())
+    #[tokio::test]
+    async fn repartition_small_time_budget_drains_via_cascade() -> Result<(), CubeError> {
+        // A 1s budget forces most per-partition jobs to yield before draining all
+        // chunks; the cascade must reschedule until the parent is empty.
+        Config::test("repartition_small_time_budget_drains_via_cascade")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.batch_repartition_enabled = true;
+                c.repartition_chunks_time_budget_secs = 1;
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
             })
             .await;
         Ok(())

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -249,6 +249,13 @@ pub trait ChunkDataStore: DIService + Send + Sync {
         chunk_id: u64,
         data_loaded_size: Arc<DataLoadedSize>,
     ) -> Result<(), CubeError>;
+    async fn repartition_partition_chunks(
+        &self,
+        partition_id: u64,
+        anchor_chunk_id: u64,
+        time_budget: std::time::Duration,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError>;
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError>;
     async fn has_in_memory_chunk(
         &self,
@@ -581,6 +588,70 @@ impl ChunkDataStore for ChunkStore {
             .swap_chunks(old_chunks, new_chunk_ids, replay_handle_id.clone())
             .await?;
 
+        Ok(())
+    }
+
+    async fn repartition_partition_chunks(
+        &self,
+        partition_id: u64,
+        anchor_chunk_id: u64,
+        time_budget: std::time::Duration,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError> {
+        let start = std::time::SystemTime::now();
+        let mut chunks = self
+            .meta_store
+            .get_chunks_by_partition(partition_id, false)
+            .await?
+            .into_iter()
+            .filter(|c| !c.get_row().in_memory())
+            .map(|c| c.get_id())
+            .collect::<Vec<_>>();
+        // FIXME: anchor_chunk_id is the chunk carried in the RepartitionChunk
+        // job's row_reference (see job_processor). In steady state the scheduler
+        // picks it deterministically (smallest persisted chunk id) so add_job
+        // dedups to a single job per partition, and we process the anchor LAST so
+        // it stays active and keeps holding that dedup key until the job finishes.
+        // That single-job guarantee is steady-state only: across a latest/release
+        // channel switch a per-chunk job and this anchor job can target the same
+        // chunks. Correctness there does NOT rely on dedup — it rests on
+        // swap_chunks being atomic (it deactivates the source chunk under a rocks
+        // transaction and rejects a swap whose source is already inactive), so a
+        // chunk is ever repartitioned exactly once regardless of how many jobs
+        // race for it.
+        chunks.sort_by_key(|&id| id == anchor_chunk_id);
+        // Process chunks one at a time so peak memory stays at a single chunk.
+        // Each repartition_chunk commits its own swap, so a partial run is safe:
+        // a follow-up job re-reads only the still-active chunks and continues.
+        // The budget bounds how long this job holds its runner slot; granularity
+        // is one chunk, so a single oversized chunk may overshoot the budget.
+        for chunk_id in chunks {
+            if let Err(e) = self
+                .repartition_chunk(chunk_id, data_loaded_size.clone())
+                .await
+            {
+                // Losing the swap race (another job repartitioned this chunk
+                // first) leaves it inactive — that work is already done, so keep
+                // draining the rest instead of failing the whole batch. Any other
+                // error leaves the chunk active and is a genuine failure.
+                let still_active = self
+                    .meta_store
+                    .get_chunk(chunk_id)
+                    .await
+                    .map_or(false, |c| c.get_row().active());
+                if still_active {
+                    return Err(e);
+                }
+                log::debug!(
+                    "Skipping chunk {} lost to a concurrent repartition: {}",
+                    chunk_id,
+                    e
+                );
+            }
+            if start.elapsed().map_or(false, |e| e >= time_budget) {
+                break;
+            }
+        }
         Ok(())
     }
 
@@ -1180,6 +1251,172 @@ mod tests {
             let expected: Vec<ArrayRef> = vec![foos, boos, sums];
             assert_eq!(res.columns(), &expected);
         }
+    }
+
+    #[tokio::test]
+    async fn repartition_partition_chunks_yields_on_budget() {
+        let config = Config::test("repartition_partition_chunks_yields_on_budget");
+        let path = "/tmp/test_repartition_yield";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
+            let partition = meta_store
+                .get_active_partitions_by_index_id(index.get_id())
+                .await
+                .unwrap()[0]
+                .clone();
+
+            // Two persisted chunks with real data on the parent partition.
+            let mut chunk_ids = Vec::new();
+            for range in [0..10i64, 10..20i64] {
+                let rows = range
+                    .map(|i| Row::new(vec![TableValue::Int(i)]))
+                    .collect::<Vec<_>>();
+                let data = rows_to_columns(&col, &rows);
+                let (chunk, file_size) = chunk_store
+                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+                meta_store
+                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
+                    .await
+                    .unwrap();
+                chunk_ids.push(chunk.get_id());
+            }
+
+            // Split the parent into two children so swap_active_partitions does not
+            // take the single-child re-parent path; the chunks are left active by
+            // passing an empty chunk list, giving an inactive parent with 2 active
+            // persisted chunks (the state a repartition job runs against).
+            let dest1 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let dest2 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let mid = Row::new(vec![TableValue::Int(10)]);
+            meta_store
+                .swap_active_partitions(
+                    vec![(partition.clone(), vec![])],
+                    // file_size must be non-zero (set_file_size rejects 0); the
+                    // children carry no main table data (row_count 0), so it is a
+                    // placeholder — repartition writes new chunks onto them.
+                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
+                    vec![
+                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
+                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
+                    ],
+                )
+                .await
+                .unwrap();
+
+            let anchor = *chunk_ids.iter().min().unwrap();
+
+            // Zero budget must still process exactly one chunk (progress guarantee),
+            // then yield. The anchor is processed last, so it is the one left active.
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(0),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap();
+            assert_eq!(
+                remaining.len(),
+                1,
+                "zero-budget run must yield after exactly one chunk"
+            );
+            assert_eq!(
+                remaining[0].get_id(),
+                anchor,
+                "anchor must be processed last and remain active after a yield"
+            );
+
+            // A large budget drains the remainder.
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(600),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap();
+            assert!(
+                remaining.is_empty(),
+                "remaining chunks must drain with a large budget"
+            );
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
     }
 }
 

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -598,7 +598,7 @@ impl ChunkDataStore for ChunkStore {
         time_budget: std::time::Duration,
         data_loaded_size: Arc<DataLoadedSize>,
     ) -> Result<(), CubeError> {
-        let start = std::time::SystemTime::now();
+        let start = std::time::Instant::now();
         let mut chunks = self
             .meta_store
             .get_chunks_by_partition(partition_id, false)
@@ -648,7 +648,7 @@ impl ChunkDataStore for ChunkStore {
                     e
                 );
             }
-            if start.elapsed().map_or(false, |e| e >= time_budget) {
+            if start.elapsed() >= time_budget {
                 break;
             }
         }


### PR DESCRIPTION
## Summary

Large imports create one `RepartitionChunk` job per persisted chunk of every inactive (split) parent partition, flooding the small short-term runner pool and paying a subprocess spawn per chunk. This adds a per-partition batch path that emits a single job per partition, cutting job count and spawns while bounding how long it holds a runner slot.

## Changes

- **Batch repartition per partition** behind `CUBESTORE_BATCH_REPARTITION` (default on): `schedule_repartition` emits one job per partition that loops over its persisted chunks **one at a time** (peak memory stays at a single chunk), instead of one job per chunk.
- **Cooperative time budget** `CUBESTORE_REPARTITION_TIME_BUDGET_SECS` (default 60s): the job yields its runner slot after the budget (always processing at least one chunk for progress), so compaction / in-memory compaction are not starved; the existing cascade drains the remainder. Decoupled from `import_job_timeout` (which stays the hard stuck-job kill).
- **Channel-switch safe:** reuses the existing `RepartitionChunk` job type rather than introducing a new `JobType` — an older binary cannot deserialize an unknown variant and would fail its whole job shard when a deployment flips between `latest`/`release`. The job is keyed on the smallest persisted chunk id as a deterministic **anchor** so `add_job` dedups to one job per partition; the anchor is processed **last** so it keeps holding the dedup key while the job runs. An older binary just repartitions that one anchor chunk and drains the rest via its own per-chunk path.
- **Correctness under concurrent jobs** on the same chunk rests on `swap_chunks` atomicity (rejects a swap whose source chunk is already inactive + row-count sanity check), not on dedup. The batch loop also tolerates a lost swap race — it re-checks the chunk and skips only if it became inactive, otherwise propagates the error — instead of failing the whole batch.

## Testing

- `repartition_keeps_data_consistent` — per-partition path drains inactive parents, data complete (count/sum).
- `repartition_legacy_per_chunk_path` — flag off keeps the unchanged per-chunk path.
- `repartition_small_time_budget_drains_via_cascade` — multi-pass drain via cascade.
- `repartition_partition_chunks_yields_on_budget` — deterministic unit test: zero budget processes exactly one chunk then yields (anchor left active), large budget drains the rest.
- `repartition_multi_node_consistency` — green in-process / cluster (router + 2 workers) / multi-process.
- Regressions green: scheduler, store::compaction, high_frequency_inserts, inactive_partitions_cleanup.