### PR TITLE
feat(cubestore): dedicated reserve job pool for CSV imports

### DIFF
--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
@@ -2,7 +2,7 @@ use crate::cluster::ingestion::job_processor::JobProcessor;
 use crate::cluster::rate_limiter::{ProcessRateLimiter, TaskType, TraceIndex};
 use crate::config::ConfigObj;
 use crate::import::ImportService;
-use crate::metastore::job::{Job, JobStatus, JobType};
+use crate::metastore::job::{Job, JobRunnerPool, JobStatus, JobType};
 use crate::metastore::table::Table;
 use crate::metastore::{IdRow, MetaStore, RowKey, TableId};
 use crate::queryplanner::trace_data_loaded::DataLoadedSize;
@@ -32,7 +32,7 @@ pub struct JobRunner {
     pub server_name: String,
     pub notify: Arc<Notify>,
     pub stop_token: CancellationToken,
-    pub is_long_term: bool,
+    pub pool: JobRunnerPool,
     pub job_processor: Arc<dyn JobProcessor>,
 }
 
@@ -57,7 +57,7 @@ impl JobRunner {
     async fn fetch_and_process(&self) -> Result<(), CubeError> {
         let job = self
             .meta_store
-            .start_processing_job(self.server_name.to_string(), self.is_long_term)
+            .start_processing_job(self.server_name.to_string(), self.pool)
             .await?;
         if let Some(to_process) = job {
             self.run_local(to_process).await?;

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -28,7 +28,7 @@ use crate::config::is_router;
 #[allow(unused_imports)]
 use crate::config::{Config, ConfigObj};
 use crate::metastore::chunks::chunk_file_name;
-use crate::metastore::job::{Job, JobStatus, JobType};
+use crate::metastore::job::{Job, JobRunnerPool, JobStatus, JobType};
 use crate::metastore::{
     deactivate_table_on_corrupt_data, Chunk, IdRow, MetaStore, MetaStoreEvent, Partition, RowKey,
     TableId,
@@ -220,6 +220,7 @@ pub struct ClusterImpl {
     server_addresses: Vec<String>,
     job_notify: Arc<Notify>,
     long_running_job_notify: Arc<Notify>,
+    csv_import_job_notify: Arc<Notify>,
     meta_store_sender: Sender<MetaStoreEvent>,
     #[cfg(not(target_os = "windows"))]
     select_process_pool: RwLock<
@@ -541,6 +542,7 @@ impl Cluster for ClusterImpl {
             // TODO `notify_one()` was replaced by `notify_waiters()` here. Revisit in case of delays in job processing.
             self.job_notify.notify_one();
             self.long_running_job_notify.notify_one();
+            self.csv_import_job_notify.notify_one();
         } else {
             self.send_to_worker(&node_name, NetworkMessage::NotifyJobListeners)
                 .await?;
@@ -916,6 +918,7 @@ impl Cluster for ClusterImpl {
                 // TODO `notify_one()` was replaced by `notify_waiters()` here. Revisit in case of delays in job processing.
                 self.job_notify.notify_one();
                 self.long_running_job_notify.notify_one();
+                self.csv_import_job_notify.notify_one();
                 NetworkMessage::NotifyJobListenersSuccess
             }
             NetworkMessage::NotifyJobListenersSuccess => {
@@ -1086,6 +1089,7 @@ impl ClusterImpl {
             cluster_transport,
             job_notify: Arc::new(Notify::new()),
             long_running_job_notify: Arc::new(Notify::new()),
+            csv_import_job_notify: Arc::new(Notify::new()),
             meta_store_sender,
             #[cfg(not(target_os = "windows"))]
             select_process_pool: RwLock::new(None),
@@ -1153,11 +1157,21 @@ impl ClusterImpl {
             job_processor
         };
 
-        for i in
-            0..self.config_obj.job_runners_count() + self.config_obj.long_term_job_runners_count()
-        {
+        let regular_count = self.config_obj.job_runners_count();
+        let long_term_count = self.config_obj.long_term_job_runners_count();
+        let csv_import_count = self.config_obj.csv_import_job_runners_count();
+        for i in 0..regular_count + long_term_count + csv_import_count {
             // TODO number of job event loops
-            let is_long_running = i >= self.config_obj.job_runners_count();
+            let (pool, notify) = if i < regular_count {
+                (JobRunnerPool::Regular, self.job_notify.clone())
+            } else if i < regular_count + long_term_count {
+                (
+                    JobRunnerPool::LongTerm,
+                    self.long_running_job_notify.clone(),
+                )
+            } else {
+                (JobRunnerPool::CsvImport, self.csv_import_job_notify.clone())
+            };
             let job_runner = JobRunner {
                 config_obj: self.config_obj.clone(),
                 meta_store: self.meta_store.clone(),
@@ -1166,13 +1180,9 @@ impl ClusterImpl {
                 import_service: self.injector.upgrade().unwrap().get_service_typed().await,
                 process_rate_limiter: self.process_rate_limiter.clone(),
                 server_name: self.server_name.clone(),
-                notify: if is_long_running {
-                    self.long_running_job_notify.clone()
-                } else {
-                    self.job_notify.clone()
-                },
+                notify,
                 stop_token: self.stop_token.clone(),
-                is_long_term: is_long_running,
+                pool,
                 job_processor: job_processor.clone(),
             };
             futures.push(cube_ext::spawn(async move {
@@ -1185,6 +1195,7 @@ impl ClusterImpl {
         let stop_token = self.stop_token.clone();
         let long_running_job_notify = self.long_running_job_notify.clone();
         let job_notify = self.job_notify.clone();
+        let csv_import_job_notify = self.csv_import_job_notify.clone();
 
         futures.push(cube_ext::spawn(async move {
             loop {
@@ -1195,6 +1206,7 @@ impl ClusterImpl {
                     _ = Delay::new(Duration::from_secs(5)) => {
                         job_notify.notify_one();
                         long_running_job_notify.notify_one();
+                        csv_import_job_notify.notify_one();
                     }
                 };
             }

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1516,7 +1516,7 @@ impl Config {
                 wal_split_threshold: env_parse("CUBESTORE_WAL_SPLIT_THRESHOLD", 1048576 / 2),
                 job_runners_count: env_parse("CUBESTORE_JOB_RUNNERS", 4),
                 long_term_job_runners_count: env_parse("CUBESTORE_LONG_TERM_JOB_RUNNERS", 32),
-                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 2),
+                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 1),
                 connection_timeout: 60,
                 server_name: env::var("CUBESTORE_SERVER_NAME")
                     .ok()

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1516,7 +1516,7 @@ impl Config {
                 wal_split_threshold: env_parse("CUBESTORE_WAL_SPLIT_THRESHOLD", 1048576 / 2),
                 job_runners_count: env_parse("CUBESTORE_JOB_RUNNERS", 4),
                 long_term_job_runners_count: env_parse("CUBESTORE_LONG_TERM_JOB_RUNNERS", 32),
-                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 1),
+                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 0),
                 connection_timeout: 60,
                 server_name: env::var("CUBESTORE_SERVER_NAME")
                     .ok()

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -401,6 +401,8 @@ pub trait ConfigObj: DIService {
 
     fn long_term_job_runners_count(&self) -> usize;
 
+    fn csv_import_job_runners_count(&self) -> usize;
+
     fn bind_address(&self) -> &Option<String>;
 
     fn status_bind_address(&self) -> &Option<String>;
@@ -591,6 +593,7 @@ pub struct ConfigObjImpl {
     pub select_worker_idle_timeout: u64,
     pub job_runners_count: usize,
     pub long_term_job_runners_count: usize,
+    pub csv_import_job_runners_count: usize,
     pub bind_address: Option<String>,
     pub status_bind_address: Option<String>,
     pub http_bind_address: Option<String>,
@@ -754,6 +757,10 @@ impl ConfigObj for ConfigObjImpl {
 
     fn long_term_job_runners_count(&self) -> usize {
         self.long_term_job_runners_count
+    }
+
+    fn csv_import_job_runners_count(&self) -> usize {
+        self.csv_import_job_runners_count
     }
 
     fn bind_address(&self) -> &Option<String> {
@@ -1509,6 +1516,7 @@ impl Config {
                 wal_split_threshold: env_parse("CUBESTORE_WAL_SPLIT_THRESHOLD", 1048576 / 2),
                 job_runners_count: env_parse("CUBESTORE_JOB_RUNNERS", 4),
                 long_term_job_runners_count: env_parse("CUBESTORE_LONG_TERM_JOB_RUNNERS", 32),
+                csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 2),
                 connection_timeout: 60,
                 server_name: env::var("CUBESTORE_SERVER_NAME")
                     .ok()
@@ -1705,6 +1713,7 @@ impl Config {
                 select_worker_idle_timeout: 600,
                 job_runners_count: 4,
                 long_term_job_runners_count: 8,
+                csv_import_job_runners_count: 2,
                 bind_address: None,
                 status_bind_address: None,
                 http_bind_address: None,

--- a/rust/cubestore/cubestore/src/metastore/job.rs
+++ b/rust/cubestore/cubestore/src/metastore/job.rs
@@ -54,6 +54,17 @@ fn get_job_type_priority(j: &JobType) -> u32 {
     }
 }
 
+/// A job runner pool. Each runner serves exactly one pool and only picks up jobs that
+/// belong to it. `CsvImport` overlaps with `Regular`: non-stream CSV imports stay eligible
+/// for regular runners and additionally get a reserved pool so they progress even when all
+/// regular runners are busy with compaction/repartition.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum JobRunnerPool {
+    Regular,
+    LongTerm,
+    CsvImport,
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, Hash, Eq, PartialEq)]
 pub enum JobStatus {
     Scheduled(String),
@@ -125,6 +136,21 @@ impl Job {
         match &self.job_type {
             JobType::TableImportCSV(location) if Table::is_stream_location(location) => true,
             _ => false,
+        }
+    }
+
+    pub fn is_csv_import(&self) -> bool {
+        matches!(
+            &self.job_type,
+            JobType::TableImportCSV(location) if !Table::is_stream_location(location)
+        )
+    }
+
+    pub fn matches_pool(&self, pool: JobRunnerPool) -> bool {
+        match pool {
+            JobRunnerPool::Regular => !self.is_long_term(),
+            JobRunnerPool::LongTerm => self.is_long_term(),
+            JobRunnerPool::CsvImport => self.is_csv_import(),
         }
     }
 
@@ -213,5 +239,41 @@ impl RocksSecondaryIndex<Job, JobIndexKey> for JobRocksIndex {
 
     fn get_id(&self) -> IndexId {
         *self as IndexId
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn job(job_type: JobType) -> Job {
+        Job::new(
+            RowKey::Table(TableId::Tables, 1),
+            job_type,
+            "node".to_string(),
+        )
+    }
+
+    #[test]
+    fn matches_pool_routing() {
+        let file_import = job(JobType::TableImportCSV("file.csv".to_string()));
+        let stream_import = job(JobType::TableImportCSV("stream:topic".to_string()));
+        let compaction = job(JobType::PartitionCompaction);
+
+        // Non-stream CSV import stays eligible for the regular pool and additionally
+        // for the reserved CSV pool, but is never long-term.
+        assert!(file_import.matches_pool(JobRunnerPool::Regular));
+        assert!(file_import.matches_pool(JobRunnerPool::CsvImport));
+        assert!(!file_import.matches_pool(JobRunnerPool::LongTerm));
+
+        // Streaming CSV import is long-term only.
+        assert!(!stream_import.matches_pool(JobRunnerPool::Regular));
+        assert!(!stream_import.matches_pool(JobRunnerPool::CsvImport));
+        assert!(stream_import.matches_pool(JobRunnerPool::LongTerm));
+
+        // Everything else belongs to the regular pool only.
+        assert!(compaction.matches_pool(JobRunnerPool::Regular));
+        assert!(!compaction.matches_pool(JobRunnerPool::CsvImport));
+        assert!(!compaction.matches_pool(JobRunnerPool::LongTerm));
     }
 }

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -7109,6 +7109,89 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn job_pool_selector_test() -> Result<(), CubeError> {
+        let config = Config::test("job_pool_selector_test");
+        let store_path = env::current_dir()?.join("test-job-pool-selector-local");
+        let remote_store_path = env::current_dir()?.join("test-job-pool-selector-remote");
+        let _ = fs::remove_dir_all(store_path.clone());
+        let _ = fs::remove_dir_all(remote_store_path.clone());
+        let remote_fs = LocalDirRemoteFs::new(Some(remote_store_path.clone()), store_path.clone());
+        {
+            let meta_store = RocksMetaStore::new(
+                store_path.clone().join("metastore").as_path(),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )?;
+
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Tables, 1),
+                    JobType::TableImportCSV("file.csv".to_string()),
+                    "node1".to_string(),
+                ))
+                .await?;
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Tables, 2),
+                    JobType::TableImportCSV("stream:topic".to_string()),
+                    "node1".to_string(),
+                ))
+                .await?;
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Partitions, 1),
+                    JobType::PartitionCompaction,
+                    "node1".to_string(),
+                ))
+                .await?;
+
+            // Short-term pool picks the non-stream CSV import and the compaction,
+            // never the streaming import.
+            let mut short_term = Vec::new();
+            while let Some(job) = meta_store
+                .start_processing_job("node1".to_string(), false)
+                .await?
+            {
+                short_term.push((
+                    job.get_row().row_reference().clone(),
+                    job.get_row().job_type().clone(),
+                ));
+            }
+            assert_eq!(short_term.len(), 2);
+            assert!(short_term.contains(&(
+                RowKey::Table(TableId::Tables, 1),
+                JobType::TableImportCSV("file.csv".to_string())
+            )));
+            assert!(short_term.contains(&(
+                RowKey::Table(TableId::Partitions, 1),
+                JobType::PartitionCompaction
+            )));
+
+            // Long-term pool picks only the streaming CSV import.
+            let job = meta_store
+                .start_processing_job("node1".to_string(), true)
+                .await?
+                .unwrap();
+            assert_eq!(
+                job.get_row().row_reference(),
+                &RowKey::Table(TableId::Tables, 2)
+            );
+            assert_eq!(
+                job.get_row().job_type(),
+                &JobType::TableImportCSV("stream:topic".to_string())
+            );
+            assert!(meta_store
+                .start_processing_job("node1".to_string(), true)
+                .await?
+                .is_none());
+        }
+        let _ = fs::remove_dir_all(store_path.clone());
+        let _ = fs::remove_dir_all(remote_store_path.clone());
+
+        Ok(())
+    }
 }
 
 impl RocksMetaStore {

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -33,7 +33,9 @@ use crate::config::injection::DIService;
 use crate::config::{Config, ConfigObj};
 use crate::metastore::chunks::{ChunkIndexKey, ChunkRocksIndex};
 use crate::metastore::index::IndexIndexKey;
-use crate::metastore::job::{Job, JobIndexKey, JobRocksIndex, JobRocksTable, JobStatus, JobType};
+use crate::metastore::job::{
+    Job, JobIndexKey, JobRocksIndex, JobRocksTable, JobRunnerPool, JobStatus, JobType,
+};
 use crate::metastore::multi_index::{
     MultiIndexIndexKey, MultiPartition, MultiPartitionIndexKey, MultiPartitionRocksIndex,
     MultiPartitionRocksTable,
@@ -1125,7 +1127,7 @@ pub trait MetaStore: DIService + Send + Sync {
     async fn start_processing_job(
         &self,
         server_name: String,
-        long_term: bool,
+        pool: JobRunnerPool,
     ) -> Result<Option<IdRow<Job>>, CubeError>;
     async fn update_status(&self, job_id: u64, status: JobStatus) -> Result<IdRow<Job>, CubeError>;
     async fn update_heart_beat(&self, job_id: u64) -> Result<IdRow<Job>, CubeError>;
@@ -4202,7 +4204,7 @@ impl MetaStore for RocksMetaStore {
     async fn start_processing_job(
         &self,
         server_name: String,
-        long_term: bool,
+        pool: JobRunnerPool,
     ) -> Result<Option<IdRow<Job>>, CubeError> {
         self.write_operation("start_processing_job", move |db_ref, batch_pipe| {
             let table = JobRocksTable::new(db_ref);
@@ -4212,7 +4214,7 @@ impl MetaStore for RocksMetaStore {
                     &JobRocksIndex::ByShard,
                 )?
                 .into_iter()
-                .filter(|j| j.get_row().is_long_term() == long_term)
+                .filter(|j| j.get_row().matches_pool(pool))
                 //We use min_by instead of the max_by because of min_by returns the first element
                 //if priority is equal while max_by returns the last element
                 .min_by(|a, b| b.get_row().priority().cmp(&a.get_row().priority()));
@@ -7025,7 +7027,7 @@ mod tests {
                 .await?;
 
             let job = meta_store
-                .start_processing_job("node1".to_string(), false)
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::InMemoryChunksCompaction);
@@ -7035,7 +7037,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node1".to_string(), false)
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::InMemoryChunksCompaction);
@@ -7045,7 +7047,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node1".to_string(), false)
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::PartitionCompaction);
@@ -7055,7 +7057,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node1".to_string(), false)
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::PartitionCompaction);
@@ -7065,7 +7067,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node2".to_string(), false)
+                .start_processing_job("node2".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::InMemoryChunksCompaction);
@@ -7075,7 +7077,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node2".to_string(), false)
+                .start_processing_job("node2".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::InMemoryChunksCompaction);
@@ -7085,7 +7087,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node2".to_string(), false)
+                .start_processing_job("node2".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::PartitionCompaction);
@@ -7095,7 +7097,7 @@ mod tests {
             );
 
             let job = meta_store
-                .start_processing_job("node2".to_string(), false)
+                .start_processing_job("node2".to_string(), JobRunnerPool::Regular)
                 .await?
                 .unwrap();
             assert_eq!(job.get_row().job_type(), &JobType::PartitionCompaction);
@@ -7151,7 +7153,7 @@ mod tests {
             // never the streaming import.
             let mut short_term = Vec::new();
             while let Some(job) = meta_store
-                .start_processing_job("node1".to_string(), false)
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
             {
                 short_term.push((
@@ -7171,7 +7173,7 @@ mod tests {
 
             // Long-term pool picks only the streaming CSV import.
             let job = meta_store
-                .start_processing_job("node1".to_string(), true)
+                .start_processing_job("node1".to_string(), JobRunnerPool::LongTerm)
                 .await?
                 .unwrap();
             assert_eq!(
@@ -7183,7 +7185,80 @@ mod tests {
                 &JobType::TableImportCSV("stream:topic".to_string())
             );
             assert!(meta_store
-                .start_processing_job("node1".to_string(), true)
+                .start_processing_job("node1".to_string(), JobRunnerPool::LongTerm)
+                .await?
+                .is_none());
+        }
+        let _ = fs::remove_dir_all(store_path.clone());
+        let _ = fs::remove_dir_all(remote_store_path.clone());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn csv_import_pool_test() -> Result<(), CubeError> {
+        let config = Config::test("csv_import_pool_test");
+        let store_path = env::current_dir()?.join("test-csv-import-pool-local");
+        let remote_store_path = env::current_dir()?.join("test-csv-import-pool-remote");
+        let _ = fs::remove_dir_all(store_path.clone());
+        let _ = fs::remove_dir_all(remote_store_path.clone());
+        let remote_fs = LocalDirRemoteFs::new(Some(remote_store_path.clone()), store_path.clone());
+        {
+            let meta_store = RocksMetaStore::new(
+                store_path.clone().join("metastore").as_path(),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )?;
+
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Tables, 1),
+                    JobType::TableImportCSV("file.csv".to_string()),
+                    "node1".to_string(),
+                ))
+                .await?;
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Tables, 2),
+                    JobType::TableImportCSV("stream:topic".to_string()),
+                    "node1".to_string(),
+                ))
+                .await?;
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Partitions, 1),
+                    JobType::PartitionCompaction,
+                    "node1".to_string(),
+                ))
+                .await?;
+
+            // The reserved CSV pool picks only the non-stream CSV import and ignores
+            // compaction and streaming imports.
+            let job = meta_store
+                .start_processing_job("node1".to_string(), JobRunnerPool::CsvImport)
+                .await?
+                .unwrap();
+            assert_eq!(
+                job.get_row().row_reference(),
+                &RowKey::Table(TableId::Tables, 1)
+            );
+            assert!(meta_store
+                .start_processing_job("node1".to_string(), JobRunnerPool::CsvImport)
+                .await?
+                .is_none());
+
+            // The regular pool still handles the remaining compaction job; the CSV import
+            // is already reserved above, so it is not picked twice.
+            let job = meta_store
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
+                .await?
+                .unwrap();
+            assert_eq!(
+                job.get_row().row_reference(),
+                &RowKey::Table(TableId::Partitions, 1)
+            );
+            assert!(meta_store
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
                 .is_none());
         }

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -3,7 +3,7 @@ use crate::cachestore::{
     QueueItem, QueueItemStatus, QueueKey, QueueListItem, QueueResult, QueueResultResponse,
     QueueRetrieveResponse,
 };
-use crate::metastore::job::{Job, JobStatus, JobType};
+use crate::metastore::job::{Job, JobRunnerPool, JobStatus, JobType};
 use crate::metastore::multi_index::{MultiIndex, MultiPartition};
 use crate::metastore::replay_handle::{ReplayHandle, SeqPointer};
 use crate::metastore::snapshot_info::SnapshotInfo;
@@ -630,7 +630,7 @@ impl MetaStore for MetaStoreMock {
     async fn start_processing_job(
         &self,
         _server_name: String,
-        _long_term: bool,
+        _pool: JobRunnerPool,
     ) -> Result<Option<IdRow<Job>>, CubeError> {
         panic!("MetaStore mock!")
     }


### PR DESCRIPTION
## Summary

Adds a dedicated reserve job runner pool in CubeStore that only processes non-stream `TableImportCSV` jobs, so CSV imports keep progressing even when all regular runners are saturated with `compaction`/`repartition` work. Disabled by default — opt-in per deployment.

## Changes

- New `JobRunnerPool` selector (`Regular` / `LongTerm` / `CsvImport`) replacing the `long_term: bool` flag in `start_processing_job`. The pool predicate is derived from `job_type` only — no metastore schema/index migration.
- Third runner pool spawned per node, sized by `CUBESTORE_CSV_IMPORT_JOB_RUNNERS` (default `0` — disabled), listening on a new `csv_import_job_notify` channel wired into all notification points. With `0` no extra runner is spawned and behavior is byte-for-byte identical to before.
- Overflow semantics: non-stream CSV imports stay eligible for the `Regular` pool **and** additionally get the reserved `CsvImport` runners. Atomic job reservation in the metastore prevents double processing, so the reserve runners simply add CSV import capacity (under contention they are the guaranteed reserve that breaks starvation).
- CSV imports remain under the existing global `process_rate_limiter`, so the extra runners throttle rather than amplify resource usage.

## Testing

- `matches_pool_routing` (unit) — routing of every job kind across the three pools, incl. the `Regular`/`CsvImport` overlap.
- `csv_import_pool_test` (metastore) — reserve pool picks only non-stream CSV, ignores compaction/streaming; regular pool handles the rest; no double pickup.
- `job_pool_selector_test` (baseline) + `job_priority_test` updated to the new API, still green.
- `cargo test -p cubestore --lib` for the above passes; `cargo check -p cubestore --tests` clean.
