### PR TITLE
docs: enhance hierarchy documentation in Explore and Workbooks

### DIFF
--- a/docs-mintlify/docs/explore-analyze/explore.mdx
+++ b/docs-mintlify/docs/explore-analyze/explore.mdx
@@ -43,6 +43,11 @@ The functionality in Explore is similar to when working with semantic views in w
 
 Explore state is also saved in the URL, making it easy to share your exploration with other users by simply copying and sharing the link.
 
+If a semantic view exposes [hierarchies][ref-hierarchies] from its data model,
+they appear in the members panel the same way they do in
+[workbooks](/docs/explore-analyze/workbooks/querying-data#hierarchies) — expand a
+hierarchy to reveal its levels and add them to your query.
+
 ## Saving explorations
 
 You can save an exploration so you can return to it later without
@@ -75,3 +80,5 @@ next to **Convert to workbook** and select **Copy to Clipboard**.
 
 Then navigate to the target workbook and press **Cmd+V** (macOS) or
 **Ctrl+V** (Windows/Linux) to paste the exploration as a new tab.
+
+[ref-hierarchies]: /reference/data-modeling/hierarchies

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -7,7 +7,7 @@ description: In the Semantic Query tab, you can query the semantic layer. On the
   <img src="https://lgo0ecceic.ucarecd.net/935959a9-1ce5-430f-8af4-c6aea1a13289/" />
 </Frame>
 
-On the left side, you can select a semantic view you would like to query. Inside the semantic view, you can see the measures and dimensions grouped either by cubes or folders. You can search within your semantic view to find the relevant member.
+On the left side, you can select a semantic view you would like to query. Inside the semantic view, you can see the measures and dimensions grouped either by cubes or folders, along with any [hierarchies](#hierarchies) defined in the data model. You can search within your semantic view to find the relevant member.
 
 ## Running queries
 
@@ -56,6 +56,24 @@ change their values, switch operators, or remove them.
 Resetting the tab or going back to the view list clears default filters
 along with the rest of the query; they are seeded again the next time you
 select a view.
+
+## Hierarchies
+
+When a semantic view exposes [hierarchies][ref-hierarchies] from its data model,
+they appear in the members panel alongside measures and dimensions. A hierarchy
+groups related dimensions into ordered levels — for example, a `Location`
+hierarchy with `State` and `City` levels — so you can drill down or roll up
+during analysis.
+
+- **Expand a hierarchy** to reveal its levels. Each level is a dimension you can
+  add to the query like any other member.
+- **Levels keep their order** from the data model, from least to most granular.
+- When a hierarchy is part of a [folder][ref-folders], it appears nested under
+  that folder, and the same dimension can belong to more than one hierarchy.
+- **Searching** matches both hierarchy names and the dimensions within their
+  levels, expanding the matching hierarchies so you can reach the level you need.
+- Switching to the **used members** view shows only the levels added to the
+  current query.
 
 ## Pivoting
 
@@ -201,4 +219,6 @@ the model behaves as intended.
 [ref-access-control]: /docs/data-modeling/access-control
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
 [ref-auto-run]: /reference/data-modeling/view#auto_run
+[ref-hierarchies]: /reference/data-modeling/hierarchies
+[ref-folders]: /reference/data-modeling/view#folders
 

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -38,7 +38,7 @@ tools][ref-viz-tools]. Some of the features with partial support are listed belo
 
 | Feature | ✅ Supported in |
 | --- | --- |
-| [Hierarchies][ref-hierarchies] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api]<br/>[Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/>[Tableau][ref-tableau] via [Semantic Layer Sync][ref-sls]<br/><br/>Also, supported in [Playground][ref-playground] |
+| [Hierarchies][ref-hierarchies] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api]<br/>[Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/>[Tableau][ref-tableau] via [Semantic Layer Sync][ref-sls]<br/><br/>Also, supported in [Explore][ref-explore], [Workbooks][ref-workbooks], and [Playground][ref-playground] |
 | Flat [folders][ref-folders] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api]<br/>[Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/>[Tableau][ref-tableau] via [Semantic Layer Sync][ref-sls]<br/>[Apache Superset][ref-superset] via [Semantic Layer Sync][ref-sls]<br/>[Preset][ref-preset] via [Semantic Layer Sync][ref-sls]<br/><br/>Also, supported in [Playground][ref-playground] |
 | Nested [folders][ref-folders] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api] |
 | [Custom time formats][ref-custom-time-formats] | [Playground][ref-playground] and [Workbooks][ref-workbooks] |
@@ -97,6 +97,7 @@ tools][ref-viz-tools]:
 [ref-playground]: /admin/workspace/playground
 [ref-custom-time-formats]: /reference/data-modeling/dimensions#format
 [ref-workbooks]: /analytics/workbooks
+[ref-explore]: /docs/explore-analyze/explore
 [ref-groups]: /admin/users-and-permissions/user-groups
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
 [ref-dap]: /docs/data-modeling/data-access-policies

--- a/docs-mintlify/reference/data-modeling/hierarchies.mdx
+++ b/docs-mintlify/reference/data-modeling/hierarchies.mdx
@@ -11,7 +11,9 @@ them into levels of granularity, allowing users to drill down or roll up for ana
 
 Hierarchies display is subject to support in [visualization tools][ref-viz-tools].
 Check [APIs & Integrations][ref-apis-support] for details.
-You can also preview hierarchies in [Playground][ref-playground].
+You can also explore hierarchies directly in Cube — in
+[Explore][ref-explore], [workbooks][ref-workbooks], and the
+[Playground][ref-playground].
 
 </Info>
 
@@ -181,7 +183,7 @@ cube(`users`, {
 </CodeGroup>
 
 You can include the same dimension in multiple hierarchies. It is also possible to
-include a dimension from a joined cube into a hierarchy: 
+include a dimension from a joined cube into a hierarchy:
 
 <CodeGroup>
 
@@ -326,3 +328,5 @@ cube(`users`, {
 [ref-apis-support]: /reference#data-modeling
 [ref-playground]: /docs/workspace/playground#viewing-the-data-model
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools
+[ref-explore]: /docs/explore-analyze/explore
+[ref-workbooks]: /docs/explore-analyze/workbooks/querying-data#hierarchies


### PR DESCRIPTION
Added details on how hierarchies are displayed and utilized within the Explore and Workbooks sections. Updated references to include exploration capabilities and clarified the functionality of hierarchies in the context of querying data. Improved cross-references to related documentation for better navigation.
