### PR TITLE
perf(cubestore): enable bloom filter for metastore rocksdb reads

### DIFF
--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -1290,6 +1290,14 @@ impl RocksStoreDetails for RocksMetaStoreDetails {
             let cache = Cache::new_lru_cache(rocksdb_config.cache_capacity)?;
             block_opts.set_block_cache(&cache);
 
+            // A fixed_prefix(13) extractor is set above, so this builds a prefix bloom by
+            // default; the hot path is whole-key point-gets (RowKey::Table(table_id, id)),
+            // so enable whole-key filtering too. Blooms are per-SST and materialize lazily
+            // on flush/compaction, so existing SSTs open and read fine without one (a one-time
+            // online compact_range would give immediate full coverage but is not required).
+            block_opts.set_bloom_filter(10.0, false);
+            block_opts.set_whole_key_filtering(true);
+
             block_opts
         };
 
@@ -1319,6 +1327,14 @@ impl RocksStoreDetails for RocksMetaStoreDetails {
 
             let cache = Cache::new_lru_cache(rocksdb_config.cache_capacity)?;
             block_opts.set_block_cache(&cache);
+
+            // A fixed_prefix(13) extractor is set above, so this builds a prefix bloom by
+            // default; the hot path is whole-key point-gets (RowKey::Table(table_id, id)),
+            // so enable whole-key filtering too. Blooms are per-SST and materialize lazily
+            // on flush/compaction, so existing SSTs open and read fine without one (a one-time
+            // online compact_range would give immediate full coverage but is not required).
+            block_opts.set_bloom_filter(10.0, false);
+            block_opts.set_whole_key_filtering(true);
 
             block_opts
         };


### PR DESCRIPTION
## Summary

Speeds up CubeStore **metastore** RocksDB point-gets by enabling bloom filters. Under load (mass pre-aggregation imports → huge partition/chunk space), the metastore coordinator does many `get_row(id)` point lookups that hit disk; bloom filters let RocksDB skip SSTs that can't contain a key.

## Changes

- Add `set_bloom_filter(10.0, false)` + `set_whole_key_filtering(true)` to the metastore `BlockBasedOptions` in both `open_db` and `open_readonly_db` (`metastore/mod.rs`).
- A `fixed_prefix(13)` extractor is already set, so by default this yields a prefix bloom; the hot path is whole-key point-gets (`RowKey::Table(table_id, id)`), so whole-key filtering is enabled too.
- Metastore only — cachestore options are untouched.

## Compatibility

Read-path / open-time options only: no on-disk key format or table/index VERSION change, so an existing store opens **without** rebuild/reindex/migration. Blooms are per-SST and materialize lazily on flush/compaction — existing SSTs read fine without one (a one-time online `compact_range` would give immediate full coverage but is not required).

## Testing

- `cargo build -p cubestore` — green.
- `cargo test -p cubestore metastore::` — 28 passed, 0 failed (DB open + round-trip, snapshots, cold start, log replay).
- Local stend brought up from this branch against an **existing** store: opened intact (1.5M-row table served, no migration in logs), re-confirming no-rebuild compatibility.