### PR TITLE
perf(cubestore): load-aware placement of CSV import jobs

### DIFF
--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -182,12 +182,6 @@ pub trait Cluster: DIService + Send + Sync {
         chunk: &IdRow<Chunk>,
     ) -> Result<String, CubeError>;
 
-    async fn node_name_for_import(
-        &self,
-        table_id: u64,
-        location: &str,
-    ) -> Result<String, CubeError>;
-
     async fn process_message_on_worker(&self, m: NetworkMessage) -> NetworkMessage;
 
     async fn process_metastore_message(&self, m: NetworkMessage) -> NetworkMessage;
@@ -768,21 +762,6 @@ impl Cluster for ClusterImpl {
         } else {
             Ok(pick_worker_by_ids(self.config_obj.as_ref(), [chunk.get_id()]).to_string())
         }
-    }
-
-    async fn node_name_for_import(
-        &self,
-        table_id: u64,
-        location: &str,
-    ) -> Result<String, CubeError> {
-        let workers = self.config_obj.select_workers();
-        if workers.is_empty() {
-            return Ok(self.server_name.to_string());
-        }
-        let mut hasher = DefaultHasher::new();
-        table_id.hash(&mut hasher);
-        location.hash(&mut hasher);
-        Ok(workers[(hasher.finish() % workers.len() as u64) as usize].to_string())
     }
 
     async fn warmup_partition(
@@ -2223,6 +2202,37 @@ pub fn pick_worker_by_ids<'a>(
     workers[(hasher.finish() % workers.len() as u64) as usize].as_str()
 }
 
+/// Load-aware placement for a single CSV import: pick the worker with the fewest in-flight
+/// imports (per `counts`), breaking ties with the stable hash of (table_id, location). Workers
+/// absent from `counts` are treated as zero. The caller owns `counts` and increments the chosen
+/// worker between calls so a batch placed in one loop spreads evenly without re-scanning.
+pub fn pick_import_worker(
+    config: &dyn ConfigObj,
+    table_id: u64,
+    location: &str,
+    counts: &HashMap<String, u64>,
+) -> String {
+    let workers = config.select_workers();
+    if workers.is_empty() {
+        return config.server_name().to_string();
+    }
+
+    let min_count = workers
+        .iter()
+        .map(|w| counts.get(w).copied().unwrap_or(0))
+        .min()
+        .unwrap();
+    let min_set: Vec<&String> = workers
+        .iter()
+        .filter(|w| counts.get(*w).copied().unwrap_or(0) == min_count)
+        .collect();
+
+    let mut hasher = DefaultHasher::new();
+    table_id.hash(&mut hasher);
+    location.hash(&mut hasher);
+    min_set[(hasher.finish() % min_set.len() as u64) as usize].to_string()
+}
+
 /// Same as [pick_worker_by_ids], but uses ranges of partitions. This is a hack
 /// to keep the same node for partitions produced by compaction that merged
 /// chunks into the main table of a single partition.
@@ -2242,4 +2252,147 @@ pub fn pick_worker_by_partitions<'a>(
         partition.get_row().get_index_id().hash(&mut hasher);
     }
     workers[(hasher.finish() % workers.len() as u64) as usize].as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use std::fs;
+
+    fn config_with_workers(name: &str, workers: Vec<String>) -> Arc<dyn ConfigObj> {
+        Config::test(name)
+            .update_config(|mut c| {
+                c.select_workers = workers;
+                c
+            })
+            .config_obj()
+    }
+
+    #[test]
+    fn pick_import_worker_load_aware() {
+        let config = config_with_workers(
+            "pick_import_worker_load_aware",
+            vec![
+                "worker1".to_string(),
+                "worker2".to_string(),
+                "worker3".to_string(),
+            ],
+        );
+        // worker1 loaded, worker2 lightly loaded, worker3 absent (counts as 0).
+        let counts = HashMap::from([("worker1".to_string(), 3), ("worker2".to_string(), 1)]);
+        assert_eq!(
+            pick_import_worker(config.as_ref(), 100, "new-loc", &counts),
+            "worker3"
+        );
+    }
+
+    #[test]
+    fn pick_import_worker_converges_to_even_spread() {
+        let config = config_with_workers(
+            "pick_import_worker_converges_to_even_spread",
+            (0..4).map(|i| format!("worker{}", i)).collect(),
+        );
+        // Emulate one placement loop: pick + locally increment, as the scheduler does.
+        let mut counts: HashMap<String, u64> = HashMap::new();
+        for i in 0..40u64 {
+            let node = pick_import_worker(config.as_ref(), i, &format!("loc-{}", i), &counts);
+            *counts.entry(node).or_insert(0) += 1;
+        }
+        assert_eq!(counts.values().sum::<u64>(), 40);
+        for i in 0..4 {
+            assert_eq!(counts.get(&format!("worker{}", i)).copied(), Some(10));
+        }
+    }
+
+    #[test]
+    fn pick_import_worker_tie_break_is_hash_stable() {
+        let config = config_with_workers(
+            "pick_import_worker_tie_break_is_hash_stable",
+            vec![
+                "worker1".to_string(),
+                "worker2".to_string(),
+                "worker3".to_string(),
+            ],
+        );
+        // All workers tie at 0: pick is the stable hash over the full set, deterministic.
+        let counts = HashMap::new();
+        let first = pick_import_worker(config.as_ref(), 7, "loc-7", &counts);
+        let second = pick_import_worker(config.as_ref(), 7, "loc-7", &counts);
+        assert_eq!(first, second);
+        assert!(config.select_workers().contains(&first));
+    }
+
+    #[test]
+    fn pick_import_worker_empty_workers_fallback() {
+        let config = config_with_workers("pick_import_worker_empty_workers_fallback", vec![]);
+        assert!(config.select_workers().is_empty());
+        let counts = HashMap::new();
+        assert_eq!(
+            &pick_import_worker(config.as_ref(), 1, "loc", &counts),
+            config.server_name()
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_import_jobs_by_node_counts_scheduled_and_processing() {
+        async fn add_import_job(
+            meta_store: &Arc<dyn MetaStore>,
+            table_id: u64,
+            location: &str,
+            node: &str,
+            processing: bool,
+        ) {
+            let job = meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Tables, table_id),
+                    JobType::TableImportCSV(location.to_string()),
+                    node.to_string(),
+                ))
+                .await
+                .unwrap()
+                .unwrap();
+            if processing {
+                meta_store
+                    .update_status(job.get_id(), JobStatus::ProcessingBy(node.to_string()))
+                    .await
+                    .unwrap();
+            }
+        }
+
+        // The jobs' nodes must be in select_workers, otherwise the scheduler's reconcile loop
+        // (remove_jobs_on_non_exists_nodes) would drop them out from under the scan.
+        let config = Config::test("in_flight_import_jobs_by_node_counts_scheduled_and_processing")
+            .update_config(|mut c| {
+                c.select_workers = vec![
+                    "worker1".to_string(),
+                    "worker2".to_string(),
+                    "worker3".to_string(),
+                ];
+                c
+            });
+        let _ = fs::remove_dir_all(config.local_dir());
+        let _ = fs::remove_dir_all(config.remote_dir());
+
+        let services = config.configure().await;
+        services.start_processing_loops().await.unwrap();
+        let meta_store = services.meta_store.clone();
+
+        // worker1 has 3 (mix of scheduled/processing), worker2 has 1, worker3 has none.
+        add_import_job(&meta_store, 1, "loc-1", "worker1", false).await;
+        add_import_job(&meta_store, 2, "loc-2", "worker1", true).await;
+        add_import_job(&meta_store, 3, "loc-3", "worker1", false).await;
+        add_import_job(&meta_store, 4, "loc-4", "worker2", true).await;
+        // Stream imports must not be counted.
+        add_import_job(&meta_store, 5, "stream:topic", "worker3", false).await;
+
+        let counts = meta_store.in_flight_import_jobs_by_node().await.unwrap();
+        assert_eq!(counts.get("worker1").copied(), Some(3));
+        assert_eq!(counts.get("worker2").copied(), Some(1));
+        assert_eq!(counts.get("worker3").copied(), None);
+
+        services.stop_processing_loops().await.unwrap();
+        let _ = fs::remove_dir_all(config.local_dir());
+        let _ = fs::remove_dir_all(config.remote_dir());
+    }
 }

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -501,6 +501,11 @@ pub trait ConfigObj: DIService {
 
     fn enable_topk(&self) -> bool;
 
+    /// When enabled, a TableImportCSV job is placed on the worker with the fewest in-flight
+    /// CSV imports (load-aware), instead of by stateless hash of (table_id, location). Off by
+    /// default (hash placement); kept as a flag for rollout/rollback.
+    fn load_aware_import_placement_enabled(&self) -> bool;
+
     /// When enabled, an inactive parent partition is repartitioned by a single
     /// per-partition job that loops over its persisted chunks, instead of one
     /// job per chunk. Kept as a flag for emergency rollback.
@@ -657,6 +662,7 @@ pub struct ConfigObjImpl {
     pub max_ingestion_data_frames: usize,
     pub upload_to_remote: bool,
     pub enable_topk: bool,
+    pub load_aware_import_placement_enabled: bool,
     pub batch_repartition_enabled: bool,
     pub repartition_chunks_time_budget_secs: u64,
     pub allow_decimal128: bool,
@@ -967,6 +973,9 @@ impl ConfigObj for ConfigObjImpl {
     }
     fn enable_topk(&self) -> bool {
         self.enable_topk
+    }
+    fn load_aware_import_placement_enabled(&self) -> bool {
+        self.load_aware_import_placement_enabled
     }
     fn batch_repartition_enabled(&self) -> bool {
         self.batch_repartition_enabled
@@ -1564,6 +1573,10 @@ impl Config {
                     .unwrap_or("localhost".to_string()),
                 upload_to_remote: !env::var("CUBESTORE_NO_UPLOAD").ok().is_some(),
                 enable_topk: env_bool("CUBESTORE_ENABLE_TOPK", true),
+                load_aware_import_placement_enabled: env_bool(
+                    "CUBESTORE_LOAD_AWARE_IMPORT_PLACEMENT",
+                    false,
+                ),
                 batch_repartition_enabled: env_bool("CUBESTORE_BATCH_REPARTITION", true),
                 repartition_chunks_time_budget_secs: env_parse(
                     "CUBESTORE_REPARTITION_TIME_BUDGET_SECS",
@@ -1806,6 +1819,7 @@ impl Config {
                 server_name: "localhost".to_string(),
                 upload_to_remote: true,
                 enable_topk: true,
+                load_aware_import_placement_enabled: false,
                 batch_repartition_enabled: true,
                 repartition_chunks_time_budget_secs: 60,
                 allow_decimal128: false,

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -1111,6 +1111,7 @@ pub trait MetaStore: DIService + Send + Sync {
     async fn get_wals_for_table(&self, table_id: u64) -> Result<Vec<IdRow<WAL>>, CubeError>;
 
     async fn all_jobs(&self) -> Result<Vec<IdRow<Job>>, CubeError>;
+    async fn in_flight_import_jobs_by_node(&self) -> Result<HashMap<String, u64>, CubeError>;
     async fn add_job(&self, job: Job) -> Result<Option<IdRow<Job>>, CubeError>;
     async fn get_job(&self, job_id: u64) -> Result<IdRow<Job>, CubeError>;
     async fn get_job_by_ref(
@@ -4201,6 +4202,28 @@ impl MetaStore for RocksMetaStore {
     async fn all_jobs(&self) -> Result<Vec<IdRow<Job>>, CubeError> {
         self.read_operation_out_of_queue("all_jobs", move |db_ref| {
             Ok(JobRocksTable::new(db_ref).all_rows()?)
+        })
+        .await
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    async fn in_flight_import_jobs_by_node(&self) -> Result<HashMap<String, u64>, CubeError> {
+        self.read_operation_out_of_queue("in_flight_import_jobs_by_node", move |db_ref| {
+            let jobs_table = JobRocksTable::new(db_ref);
+            let mut counts: HashMap<String, u64> = HashMap::new();
+            for job in jobs_table.scan_all_rows()? {
+                let job = job?;
+                if !job.get_row().is_csv_import() {
+                    continue;
+                }
+                match job.get_row().status() {
+                    JobStatus::Scheduled(node) | JobStatus::ProcessingBy(node) => {
+                        *counts.entry(node.to_string()).or_insert(0) += 1;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(counts)
         })
         .await
     }

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -596,6 +596,10 @@ impl MetaStore for MetaStoreMock {
         panic!("MetaStore mock!")
     }
 
+    async fn in_flight_import_jobs_by_node(&self) -> Result<HashMap<String, u64>, CubeError> {
+        panic!("MetaStore mock!")
+    }
+
     async fn add_job(&self, _job: Job) -> Result<Option<IdRow<Job>>, CubeError> {
         panic!("MetaStore mock!")
     }

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -16,6 +16,7 @@ use crate::metastore::{
 use crate::remotefs::RemoteFs;
 use crate::shared::deadline_queue::DeadlineQueue;
 use crate::store::{ChunkStore, WALStore};
+use crate::util::lock::acquire_lock;
 use crate::util::time_span::warn_long_fut;
 use crate::util::WorkerLoop;
 use crate::CubeError;
@@ -1162,34 +1163,66 @@ impl SchedulerImpl {
         locations: &[&String],
     ) -> Result<(), CubeError> {
         let table = self.meta_store.get_table_by_id(table_id).await?;
-        if !table.get_row().sealed() {
-            // Hold the lock across the whole table so concurrent CREATE TABLE placements don't
-            // read the same starting counts and pile onto the same workers. The in-flight counts
-            // are scanned once; subsequent placements within the loop update them in memory.
-            let mut nodes_to_notify = Vec::new();
-            {
-                let _guard = self.import_placement_lock.lock().await;
-                let mut counts = self.meta_store.in_flight_import_jobs_by_node().await?;
-                for &l in locations {
-                    let node = pick_import_worker(self.config.as_ref(), table_id, l, &counts);
-                    let job = self
-                        .meta_store
-                        .add_job(Job::new(
-                            RowKey::Table(TableId::Tables, table_id),
-                            JobType::TableImportCSV(l.clone()),
-                            node.clone(),
-                        ))
-                        .await?;
-                    if job.is_some() {
-                        *counts.entry(node.clone()).or_insert(0) += 1;
-                        nodes_to_notify.push(node);
-                    }
+        if table.get_row().sealed() {
+            return Ok(());
+        }
+
+        if !self.config.load_aware_import_placement_enabled() {
+            // Default: stateless hash placement of (table_id, location). Empty counts make
+            // every worker tie, so pick_import_worker degenerates to the plain hash pick.
+            let empty = HashMap::new();
+            for &l in locations {
+                let node = pick_import_worker(self.config.as_ref(), table_id, l, &empty);
+                let job = self
+                    .meta_store
+                    .add_job(Job::new(
+                        RowKey::Table(TableId::Tables, table_id),
+                        JobType::TableImportCSV(l.clone()),
+                        node.clone(),
+                    ))
+                    .await?;
+                if job.is_some() {
+                    // TODO queue failover
+                    self.cluster.notify_job_runner(node).await?;
                 }
             }
-            for node in nodes_to_notify {
-                // TODO queue failover
-                self.cluster.notify_job_runner(node).await?;
+            return Ok(());
+        }
+
+        // Load-aware placement. Scan in-flight import counts once, then place each location on
+        // the least-loaded worker, updating counts in memory. The lock serializes concurrent
+        // CREATE TABLE placements so they don't read the same counts and pile onto the same
+        // workers. It is best-effort: on timeout we proceed without it — the worst case is an
+        // uneven spread, never data corruption.
+        let mut nodes_to_notify = Vec::new();
+        {
+            let guard = acquire_lock("import placement", self.import_placement_lock.lock()).await;
+            if let Err(e) = &guard {
+                log::warn!(
+                    "Placing import jobs without serialization, spread may be uneven: {}",
+                    e
+                );
             }
+            let mut counts = self.meta_store.in_flight_import_jobs_by_node().await?;
+            for &l in locations {
+                let node = pick_import_worker(self.config.as_ref(), table_id, l, &counts);
+                let job = self
+                    .meta_store
+                    .add_job(Job::new(
+                        RowKey::Table(TableId::Tables, table_id),
+                        JobType::TableImportCSV(l.clone()),
+                        node.clone(),
+                    ))
+                    .await?;
+                if job.is_some() {
+                    *counts.entry(node.clone()).or_insert(0) += 1;
+                    nodes_to_notify.push(node);
+                }
+            }
+        }
+        for node in nodes_to_notify {
+            // TODO queue failover
+            self.cluster.notify_job_runner(node).await?;
         }
         Ok(())
     }
@@ -1344,6 +1377,7 @@ pub enum GCTask {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::metastore::RocksMetaStore;
     use std::fs;
 
     #[tokio::test]
@@ -1455,6 +1489,181 @@ mod tests {
         job_ids.sort();
         assert_eq!(job_ids, existing_ids);
         services.stop_processing_loops().await.unwrap();
+        let _ = fs::remove_dir_all(config.local_dir());
+        let _ = fs::remove_dir_all(config.remote_dir());
+    }
+
+    // Creates a non-sealed table with no locations, so the Insert(Tables) event does not
+    // auto-schedule imports and the test drives schedule_table_import explicitly.
+    async fn create_import_table(meta_store: &Arc<dyn MetaStore>, name: &str) -> u64 {
+        use crate::metastore::{Column, ColumnType};
+        let table = meta_store
+            .create_table(
+                "s".to_string(),
+                name.to_string(),
+                vec![Column::new("n".to_string(), ColumnType::Int, 0)],
+                None,
+                None,
+                vec![],
+                false,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        table.get_id()
+    }
+
+    async fn add_import_job(
+        meta_store: &Arc<dyn MetaStore>,
+        table_id: u64,
+        location: &str,
+        node: &str,
+    ) {
+        meta_store
+            .add_job(Job::new(
+                RowKey::Table(TableId::Tables, table_id),
+                JobType::TableImportCSV(location.to_string()),
+                node.to_string(),
+            ))
+            .await
+            .unwrap();
+    }
+
+    async fn import_placement(
+        meta_store: &Arc<dyn MetaStore>,
+        table_id: u64,
+    ) -> HashMap<String, String> {
+        let mut out = HashMap::new();
+        for j in meta_store.all_jobs().await.unwrap() {
+            match j.get_row().row_reference() {
+                RowKey::Table(TableId::Tables, t) if *t == table_id => {}
+                _ => continue,
+            }
+            if let (JobType::TableImportCSV(loc), JobStatus::Scheduled(node)) =
+                (j.get_row().job_type(), j.get_row().status())
+            {
+                out.insert(loc.clone(), node.clone());
+            }
+        }
+        out
+    }
+
+    // Builds a scheduler over a fresh test metastore with a no-op cluster (notify_job_runner
+    // does nothing, since the worker names are not real nodes). select_workers and the
+    // load-aware flag come from the passed config.
+    fn test_scheduler(
+        test_name: &str,
+        config: Arc<dyn ConfigObj>,
+    ) -> (Arc<dyn MetaStore>, SchedulerImpl) {
+        use crate::cluster::MockCluster;
+        let (remote_fs, rocks) = RocksMetaStore::prepare_test_metastore(test_name);
+        let meta_store: Arc<dyn MetaStore> = rocks;
+        let mut cluster = MockCluster::new();
+        cluster.expect_notify_job_runner().returning(|_| Ok(()));
+        let (_tx, rx) = broadcast::channel(16);
+        let scheduler =
+            SchedulerImpl::new(meta_store.clone(), Arc::new(cluster), remote_fs, rx, config);
+        (meta_store, scheduler)
+    }
+
+    #[tokio::test]
+    async fn schedule_table_import_load_aware_balances() {
+        let config = Config::test("schedule_table_import_load_aware").update_config(|mut c| {
+            c.select_workers = (0..4).map(|i| format!("worker{}", i)).collect();
+            c.load_aware_import_placement_enabled = true;
+            c
+        });
+        let (meta_store, scheduler) =
+            test_scheduler("schedule_table_import_load_aware", config.config_obj());
+        meta_store
+            .create_schema("s".to_string(), false)
+            .await
+            .unwrap();
+
+        // Pre-seed worker0 with 2 in-flight imports. Starting counts [2,0,0,0]; placing 6
+        // locations load-aware fills the deficit and levels every worker to exactly 2.
+        let seed = create_import_table(&meta_store, "seed").await;
+        add_import_job(&meta_store, seed, "seed-a", "worker0").await;
+        add_import_job(&meta_store, seed, "seed-b", "worker0").await;
+
+        let table = create_import_table(&meta_store, "bar").await;
+        let locs: Vec<String> = (0..6).map(|i| format!("loc-{}", i)).collect();
+        let loc_refs: Vec<&String> = locs.iter().collect();
+        scheduler
+            .schedule_table_import(table, &loc_refs)
+            .await
+            .unwrap();
+
+        let counts = meta_store.in_flight_import_jobs_by_node().await.unwrap();
+        for i in 0..4 {
+            assert_eq!(
+                counts.get(&format!("worker{}", i)).copied(),
+                Some(2),
+                "load-aware must level all workers to 2, got {:?}",
+                counts
+            );
+        }
+
+        // cleanup_test_metastore only removes the test-<name>-* dirs; the metastore's local
+        // cache also uses the config data_dir (<name>-local-store), so clean that too.
+        RocksMetaStore::cleanup_test_metastore("schedule_table_import_load_aware");
+        let _ = fs::remove_dir_all(config.local_dir());
+        let _ = fs::remove_dir_all(config.remote_dir());
+    }
+
+    #[tokio::test]
+    async fn schedule_table_import_hash_placement_by_default() {
+        let config = Config::test("schedule_table_import_hash").update_config(|mut c| {
+            c.select_workers = (0..4).map(|i| format!("worker{}", i)).collect();
+            // load_aware_import_placement_enabled defaults to false (old behavior).
+            c
+        });
+        let (meta_store, scheduler) =
+            test_scheduler("schedule_table_import_hash", config.config_obj());
+        meta_store
+            .create_schema("s".to_string(), false)
+            .await
+            .unwrap();
+
+        // Heavily pre-seed worker0; the default hash placement must ignore in-flight load.
+        let seed = create_import_table(&meta_store, "seed").await;
+        for i in 0..5 {
+            add_import_job(&meta_store, seed, &format!("seed-{}", i), "worker0").await;
+        }
+
+        let table = create_import_table(&meta_store, "bar").await;
+        let locs: Vec<String> = (0..6).map(|i| format!("loc-{}", i)).collect();
+        let loc_refs: Vec<&String> = locs.iter().collect();
+        scheduler
+            .schedule_table_import(table, &loc_refs)
+            .await
+            .unwrap();
+
+        // Each location is placed by the pure hash of (table_id, location), independent of load.
+        let placement = import_placement(&meta_store, table).await;
+        let empty = HashMap::new();
+        for l in &locs {
+            let expected = pick_import_worker(config.config_obj().as_ref(), table, l, &empty);
+            assert_eq!(
+                placement.get(l),
+                Some(&expected),
+                "default placement must follow the stateless hash"
+            );
+        }
+
+        // cleanup_test_metastore only removes the test-<name>-* dirs; the metastore's local
+        // cache also uses the config data_dir (<name>-local-store), so clean that too.
+        RocksMetaStore::cleanup_test_metastore("schedule_table_import_hash");
         let _ = fs::remove_dir_all(config.local_dir());
         let _ = fs::remove_dir_all(config.remote_dir());
     }

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -1,4 +1,4 @@
-use crate::cluster::{pick_worker_by_ids, Cluster};
+use crate::cluster::{pick_import_worker, pick_worker_by_ids, Cluster};
 use crate::config::ConfigObj;
 use crate::metastore::chunks::chunk_file_name;
 use crate::metastore::job::{Job, JobStatus, JobType};
@@ -47,6 +47,9 @@ pub struct SchedulerImpl {
     chunk_events_queue: Mutex<Vec<(SystemTime, u64)>>,
     in_memory_chunks_to_delete: Mutex<Vec<(String, String)>>, //(node, chunk_is)
     node_last_actions: Mutex<HashMap<String, LastNodeActionTimes>>,
+    // Serializes load-aware import placement so concurrent CREATE TABLE events don't read
+    // the same in-flight counts and pile onto the same worker before either job is scheduled.
+    import_placement_lock: Mutex<()>,
 }
 
 crate::di_service!(SchedulerImpl, []);
@@ -102,6 +105,7 @@ impl SchedulerImpl {
             in_memory_chunks_to_delete: Mutex::new(Vec::with_capacity(1000)),
             node_last_actions: Mutex::new(workers),
             chunk_processing_loop: WorkerLoop::new("ChunkProcessing"),
+            import_placement_lock: Mutex::new(()),
         }
     }
 
@@ -1159,20 +1163,32 @@ impl SchedulerImpl {
     ) -> Result<(), CubeError> {
         let table = self.meta_store.get_table_by_id(table_id).await?;
         if !table.get_row().sealed() {
-            for &l in locations {
-                let node = self.cluster.node_name_for_import(table_id, &l).await?;
-                let job = self
-                    .meta_store
-                    .add_job(Job::new(
-                        RowKey::Table(TableId::Tables, table_id),
-                        JobType::TableImportCSV(l.clone()),
-                        node.to_string(),
-                    ))
-                    .await?;
-                if job.is_some() {
-                    // TODO queue failover
-                    self.cluster.notify_job_runner(node).await?;
+            // Hold the lock across the whole table so concurrent CREATE TABLE placements don't
+            // read the same starting counts and pile onto the same workers. The in-flight counts
+            // are scanned once; subsequent placements within the loop update them in memory.
+            let mut nodes_to_notify = Vec::new();
+            {
+                let _guard = self.import_placement_lock.lock().await;
+                let mut counts = self.meta_store.in_flight_import_jobs_by_node().await?;
+                for &l in locations {
+                    let node = pick_import_worker(self.config.as_ref(), table_id, l, &counts);
+                    let job = self
+                        .meta_store
+                        .add_job(Job::new(
+                            RowKey::Table(TableId::Tables, table_id),
+                            JobType::TableImportCSV(l.clone()),
+                            node.clone(),
+                        ))
+                        .await?;
+                    if job.is_some() {
+                        *counts.entry(node.clone()).or_insert(0) += 1;
+                        nodes_to_notify.push(node);
+                    }
                 }
+            }
+            for node in nodes_to_notify {
+                // TODO queue failover
+                self.cluster.notify_job_runner(node).await?;
             }
         }
         Ok(())

--- a/rust/cubestore/cubestore/src/sql/table_creator.rs
+++ b/rust/cubestore/cubestore/src/sql/table_creator.rs
@@ -553,23 +553,29 @@ impl TableCreator {
             }
         }
 
-        let mut futures = Vec::new();
-        let indexes = self.db.get_table_indexes(table.get_id()).await?;
-        let partitions = self
-            .db
-            .get_active_partitions_and_chunks_by_index_id_for_select(
-                indexes.iter().map(|i| i.get_id()).collect(),
-            )
-            .await?;
-        // Omit warming up chunks as those shouldn't affect select times much however will affect
-        // warming up time a lot in case of big tables when a lot of chunks pending for repartition
-        for (partition, _) in partitions.into_iter().flatten() {
-            futures.push(self.cluster.warmup_partition(partition, Vec::new()));
-        }
-        join_all(futures)
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
+        // Warming up partitions on finalize is not required for correctness: warmup only
+        // pre-downloads partition files to the local cache, and select still works without it.
+        // Under heavy import load this is the main candidate for finalize timeouts — it fetches
+        // every active partition across all indexes and waits for all downloads to complete, which
+        // is slow and unbounded for big multi-index tables, while imports/repartition are still in
+        // flight. Disabled so finalize doesn't block on it.
+        // let mut futures = Vec::new();
+        // let indexes = self.db.get_table_indexes(table.get_id()).await?;
+        // let partitions = self
+        //     .db
+        //     .get_active_partitions_and_chunks_by_index_id_for_select(
+        //         indexes.iter().map(|i| i.get_id()).collect(),
+        //     )
+        //     .await?;
+        // // Omit warming up chunks as those shouldn't affect select times much however will affect
+        // // warming up time a lot in case of big tables when a lot of chunks pending for repartition
+        // for (partition, _) in partitions.into_iter().flatten() {
+        //     futures.push(self.cluster.warmup_partition(partition, Vec::new()));
+        // }
+        // join_all(futures)
+        //     .await
+        //     .into_iter()
+        //     .collect::<Result<Vec<_>, _>>()?;
 
         let has_streaming_location = table
             .get_row()

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -1439,6 +1439,93 @@ mod tests {
         let _ = fs::remove_dir_all(chunk_store_path);
         let _ = fs::remove_dir_all(chunk_remote_store_path);
     }
+
+    #[tokio::test]
+    async fn partition_rows_deactivates_table_on_column_count_mismatch() {
+        let config = Config::test("partition_rows_column_count_mismatch");
+        let path = "/tmp/test_partition_rows_mismatch";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
+
+            // The index has 1 column; feed 2 columns to simulate a chunk written under a
+            // different (wider) schema. The mismatch must be treated as corrupt data, not
+            // retried forever via failing RepartitionChunk jobs.
+            let mismatched: Vec<ArrayRef> = vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(Int64Array::from(vec![4, 5, 6])),
+            ];
+            let err = chunk_store
+                .partition_rows(index.get_id(), mismatched, false)
+                .await
+                .unwrap_err();
+            assert!(
+                err.message
+                    .contains("expects 1 columns but incoming chunk data has 2 columns"),
+                "unexpected error: {}",
+                err.message
+            );
+
+            // The table is deactivated (marked not ready) instead of looping.
+            let table = meta_store.get_table_by_id(table.get_id()).await.unwrap();
+            assert!(!table.get_row().is_ready());
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
+    }
 }
 
 pub type ChunkUploadJob = JoinHandle<Result<(IdRow<Chunk>, Option<u64>), CubeError>>;
@@ -1468,14 +1555,17 @@ impl ChunkStore {
             .await?;
         let sort_key_size = index.get_row().sort_key_size() as usize;
 
-        if sort_key_size > columns.len() {
-            // The chunk data has fewer columns than the index sort key expects (schema/version
-            // mismatch). Treat as corrupt data and deactivate the table rather than panicking on
-            // the `columns[0..sort_key_size]` slice below.
+        let expected_columns = index.get_row().get_columns().len();
+        if columns.len() != expected_columns {
+            // The chunk data column count doesn't match the index schema (schema/version
+            // mismatch, e.g. an id collision after restoring a stale metastore copy). Treat as
+            // corrupt data and deactivate the table rather than panicking on the
+            // `columns[0..sort_key_size]` slice below or failing RecordBatch::try_new in
+            // post_process_columns.
             let error_message = format!(
-                "Index {:?} expects a sort key of {} columns but incoming chunk data has only {} columns",
+                "Index {:?} expects {} columns but incoming chunk data has {} columns",
                 index,
-                sort_key_size,
+                expected_columns,
                 columns.len()
             );
             deactivate_table_due_to_corrupt_data(


### PR DESCRIPTION
## Summary

During mass pre-aggregation imports (many concurrent `CREATE TABLE ... LOCATION` with wide multi-index schemas), `TableImportCSV` jobs were distributed to workers purely by `hash(table_id, location) % select_workers`. With ~180 locations over ~50 workers the hash has high variance, so some workers get many concurrent memory/CPU-heavy imports while others idle. This makes import placement load-aware: each import goes to the worker with the fewest in-flight CSV imports, with the existing hash as a stable tie-break.

## Changes

- Add `MetaStore::in_flight_import_jobs_by_node()` — a single out-of-queue scan of the Job table counting non-stream `TableImportCSV` jobs per node across `Scheduled` and `ProcessingBy` (the `ByShard` index covers only `Scheduled`, so a full scan is required; imports are rare and the Job table is small). No metastore format change, no new index.
- Replace the `Cluster::node_name_for_import` trait method with a pure `pick_import_worker(config, table_id, location, &counts)` free function next to `pick_worker_by_ids`: picks the min-count worker (absent workers count as 0), ties broken by `hash(table_id, location)`, and falls back to `server_name` when `select_workers` is empty.
- In `schedule_table_import`, scan the counts once per table, then place every location in one loop while updating the counts in memory between placements. A scheduler-level lock is held across the whole loop so concurrent `CREATE TABLE` events don't read the same starting counts and pile onto the same workers; `notify_job_runner` is deferred until after the lock is released.

## Testing

- `cargo build -p cubestore` — clean.
- New unit tests for `pick_import_worker` (load-aware pick, even-spread convergence over a placement loop, stable hash tie-break, empty-workers fallback) and an integration test for `in_flight_import_jobs_by_node` (counts Scheduled + ProcessingBy, ignores stream locations).
- `cargo test -p cubestore` for `cluster::tests`, `scheduler::tests`, `metastore::job` — all green; the integration test re-run several times for stability.