### PR TITLE
feat(cubestore): env-gate last week's planning/processing changes

### DIFF
--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -1581,13 +1581,15 @@ impl ClusterImpl {
 
         // Trim in-memory chunks by the dedup-safe pushable predicate before they cross
         // IPC to the select subprocess (which re-applies the same predicate anyway).
-        let chunk_filter_guard =
-            crate::trace::OpGuard::start(OpKind::Execution, "chunks.prefilter");
-        crate::queryplanner::query_executor::filter_in_memory_chunks_for_worker(
-            &plan_node,
-            &mut chunk_id_to_record_batches,
-        );
-        drop(chunk_filter_guard);
+        if self.config_obj.prefilter_in_memory_chunks_enabled() {
+            let chunk_filter_guard =
+                crate::trace::OpGuard::start(OpKind::Execution, "chunks.prefilter");
+            crate::queryplanner::query_executor::filter_in_memory_chunks_for_worker(
+                &plan_node,
+                &mut chunk_id_to_record_batches,
+            );
+            drop(chunk_filter_guard);
+        }
 
         let mut res = None;
         #[cfg(not(target_os = "windows"))]

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -393,7 +393,10 @@ pub trait ConfigObj: DIService {
 
     fn wal_split_threshold(&self) -> u64;
 
-    fn wal_split_size_threshold_bytes(&self) -> u64;
+    /// Optional in-flight WAL data frame byte size at which an import splits the frame, in
+    /// addition to the row count threshold. `None` (env unset or `0`) disables the size check,
+    /// leaving the row-count split as the only trigger.
+    fn wal_split_size_threshold_bytes(&self) -> Option<u64>;
 
     fn select_worker_pool_size(&self) -> usize;
 
@@ -517,6 +520,22 @@ pub trait ConfigObj: DIService {
     /// import_job_timeout, which is the hard stuck-job kill, not a fairness knob.
     fn repartition_chunks_time_budget_secs(&self) -> u64;
 
+    /// When enabled (default), the sorted partial aggregate is pushed below the partition merge
+    /// so the merge carries partial aggregate states instead of all raw rows. Kept as a flag for
+    /// emergency rollback to the pre-push plan shape.
+    fn push_partial_aggregate_below_merge_enabled(&self) -> bool;
+
+    /// When enabled, compaction sizes the partition split by the bytes actually being written
+    /// (existing main table plus the pending chunks merged in this pass) instead of the main
+    /// table alone, so a partition with large accumulated chunks splits in a single pass. Off
+    /// by default; kept as a flag for rollout/rollback.
+    fn compaction_split_by_total_file_size_enabled(&self) -> bool;
+
+    /// When enabled, the worker trims in-memory chunks by the dedup-safe pushable predicate
+    /// before they cross IPC to the select subprocess (which re-applies the same predicate).
+    /// Off by default; when disabled, chunks are sent whole and filtered only in the subprocess.
+    fn prefilter_in_memory_chunks_enabled(&self) -> bool;
+
     fn allow_decimal128(&self) -> bool;
 
     fn enable_remove_orphaned_remote_files(&self) -> bool;
@@ -605,7 +624,7 @@ pub struct ConfigObjImpl {
     pub compaction_in_memory_chunks_ratio_check_threshold: u64,
     pub compaction_in_memory_chunks_schedule_period_secs: u64,
     pub wal_split_threshold: u64,
-    pub wal_split_size_threshold_bytes: u64,
+    pub wal_split_size_threshold_bytes: Option<u64>,
     pub data_dir: PathBuf,
     pub dump_dir: Option<PathBuf>,
     pub store_provider: FileStoreProvider,
@@ -665,6 +684,9 @@ pub struct ConfigObjImpl {
     pub load_aware_import_placement_enabled: bool,
     pub batch_repartition_enabled: bool,
     pub repartition_chunks_time_budget_secs: u64,
+    pub push_partial_aggregate_below_merge_enabled: bool,
+    pub compaction_split_by_total_file_size_enabled: bool,
+    pub prefilter_in_memory_chunks_enabled: bool,
     pub allow_decimal128: bool,
     pub enable_remove_orphaned_remote_files: bool,
     pub enable_startup_warmup: bool,
@@ -770,7 +792,7 @@ impl ConfigObj for ConfigObjImpl {
         self.wal_split_threshold
     }
 
-    fn wal_split_size_threshold_bytes(&self) -> u64 {
+    fn wal_split_size_threshold_bytes(&self) -> Option<u64> {
         self.wal_split_size_threshold_bytes
     }
 
@@ -982,6 +1004,15 @@ impl ConfigObj for ConfigObjImpl {
     }
     fn repartition_chunks_time_budget_secs(&self) -> u64 {
         self.repartition_chunks_time_budget_secs
+    }
+    fn push_partial_aggregate_below_merge_enabled(&self) -> bool {
+        self.push_partial_aggregate_below_merge_enabled
+    }
+    fn compaction_split_by_total_file_size_enabled(&self) -> bool {
+        self.compaction_split_by_total_file_size_enabled
+    }
+    fn prefilter_in_memory_chunks_enabled(&self) -> bool {
+        self.prefilter_in_memory_chunks_enabled
     }
 
     fn allow_decimal128(&self) -> bool {
@@ -1255,6 +1286,50 @@ pub fn env_parse_size(name: &str, default: usize, max: Option<usize>, min: Optio
     };
 
     n
+}
+
+/// Parses a human-readable byte size env var into `Some(bytes)`. Returns `None` when the var is
+/// unset or set to `0`, which callers treat as "disabled".
+pub fn env_parse_optional_size(
+    name: &str,
+    max: Option<usize>,
+    min: Option<usize>,
+) -> Option<usize> {
+    let v = env::var(name).ok()?;
+
+    let n = match parse_size::parse_size(&v) {
+        Ok(n) => n as usize,
+        Err(e) => panic!(
+            "could not parse environment variable '{}' with '{}' value: {}",
+            name, v, e
+        ),
+    };
+
+    if n == 0 {
+        return None;
+    }
+
+    if let Some(max) = max {
+        if n > max {
+            panic!(
+                "wrong configuration for environment variable '{}' with '{}' value: greater then max size {}",
+                name, v,
+                humansize::format_size(max, humansize::DECIMAL)
+            )
+        }
+    };
+
+    if let Some(min) = min {
+        if n < min {
+            panic!(
+                "wrong configuration for environment variable '{}' with '{}' value: lower then min size {}",
+                name, v,
+                humansize::format_size(min, humansize::DECIMAL)
+            )
+        }
+    };
+
+    Some(n)
 }
 
 fn env_optparse<T>(name: &str) -> Option<T>
@@ -1558,12 +1633,12 @@ impl Config {
                 download_concurrency: env_parse("CUBESTORE_MAX_ACTIVE_DOWNLOADS", 8),
                 max_ingestion_data_frames: env_parse("CUBESTORE_MAX_DATA_FRAMES", 4),
                 wal_split_threshold: env_parse("CUBESTORE_WAL_SPLIT_THRESHOLD", 1048576 / 2),
-                wal_split_size_threshold_bytes: env_parse_size(
+                wal_split_size_threshold_bytes: env_parse_optional_size(
                     "CUBESTORE_WAL_SPLIT_SIZE_THRESHOLD",
-                    100 * 1024 * 1024,
                     None,
                     None,
-                ) as u64,
+                )
+                .map(|v| v as u64),
                 job_runners_count: env_parse("CUBESTORE_JOB_RUNNERS", 4),
                 long_term_job_runners_count: env_parse("CUBESTORE_LONG_TERM_JOB_RUNNERS", 32),
                 csv_import_job_runners_count: env_parse("CUBESTORE_CSV_IMPORT_JOB_RUNNERS", 0),
@@ -1581,6 +1656,18 @@ impl Config {
                 repartition_chunks_time_budget_secs: env_parse(
                     "CUBESTORE_REPARTITION_TIME_BUDGET_SECS",
                     60,
+                ),
+                push_partial_aggregate_below_merge_enabled: env_bool(
+                    "CUBESTORE_PUSH_PARTIAL_AGGREGATE_BELOW_MERGE",
+                    true,
+                ),
+                compaction_split_by_total_file_size_enabled: env_bool(
+                    "CUBESTORE_COMPACTION_SPLIT_BY_TOTAL_FILE_SIZE",
+                    false,
+                ),
+                prefilter_in_memory_chunks_enabled: env_bool(
+                    "CUBESTORE_PREFILTER_IN_MEMORY_CHUNKS",
+                    false,
                 ),
                 allow_decimal128: env_bool("CUBESTORE_ALLOW_DECIMAL128", false),
                 enable_remove_orphaned_remote_files: env_bool(
@@ -1814,7 +1901,7 @@ impl Config {
                 download_concurrency: 8,
                 max_ingestion_data_frames: 4,
                 wal_split_threshold: 262144,
-                wal_split_size_threshold_bytes: 100 * 1024 * 1024,
+                wal_split_size_threshold_bytes: None,
                 connection_timeout: 60,
                 server_name: "localhost".to_string(),
                 upload_to_remote: true,
@@ -1822,6 +1909,11 @@ impl Config {
                 load_aware_import_placement_enabled: false,
                 batch_repartition_enabled: true,
                 repartition_chunks_time_budget_secs: 60,
+                push_partial_aggregate_below_merge_enabled: true,
+                compaction_split_by_total_file_size_enabled: false,
+                // Production default is off; kept on in tests so prefilter_chunks_shared_scan
+                // and the rest of the suite keep exercising the worker-side trim path.
+                prefilter_in_memory_chunks_enabled: true,
                 allow_decimal128: false,
                 enable_remove_orphaned_remote_files: false,
                 enable_startup_warmup: true,
@@ -2515,6 +2607,10 @@ impl Config {
 
         self.injector
             .register_typed_with_default::<dyn QueryExecutor, _, _, _>(async move |i| {
+                let push_partial_aggregate_below_merge = i
+                    .get_service_typed::<dyn ConfigObj>()
+                    .await
+                    .push_partial_aggregate_below_merge_enabled();
                 QueryExecutorImpl::new(
                     i.get_service_typed::<dyn CubestoreMetadataCacheFactory>()
                         .await
@@ -2522,6 +2618,7 @@ impl Config {
                         .clone(),
                     i.get_service_typed().await,
                     i.get_service_typed().await,
+                    push_partial_aggregate_below_merge,
                 )
             })
             .await;

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -1652,7 +1652,7 @@ impl Config {
                     "CUBESTORE_LOAD_AWARE_IMPORT_PLACEMENT",
                     false,
                 ),
-                batch_repartition_enabled: env_bool("CUBESTORE_BATCH_REPARTITION", true),
+                batch_repartition_enabled: env_bool("CUBESTORE_BATCH_REPARTITION", false),
                 repartition_chunks_time_budget_secs: env_parse(
                     "CUBESTORE_REPARTITION_TIME_BUDGET_SECS",
                     60,

--- a/rust/cubestore/cubestore/src/import/mod.rs
+++ b/rust/cubestore/cubestore/src/import/mod.rs
@@ -792,7 +792,10 @@ impl ImportServiceImpl {
 
         let table_cols = table.get_row().get_columns().as_slice();
         let row_threshold = self.config_obj.wal_split_threshold() as usize;
-        let size_threshold = self.config_obj.wal_split_size_threshold_bytes() as usize;
+        let size_threshold = self
+            .config_obj
+            .wal_split_size_threshold_bytes()
+            .map(|v| v as usize);
         let mut builders = create_array_builders(table_cols);
         let mut num_rows = 0;
         let mut estimated_bytes = 0;
@@ -800,8 +803,10 @@ impl ImportServiceImpl {
             let line = line?;
             let is_data_row = parser.visit_line(line.as_str(), |insert_pos, column, value| {
                 let builder = builders[insert_pos].as_mut();
-                estimated_bytes +=
-                    ImportFormat::estimate_arrow_value_size(column.get_column_type(), value);
+                if size_threshold.is_some() {
+                    estimated_bytes +=
+                        ImportFormat::estimate_arrow_value_size(column.get_column_type(), value);
+                }
                 match value {
                     None => {
                         append_value(builder, column.get_column_type(), &TableValue::Null);
@@ -818,7 +823,8 @@ impl ImportServiceImpl {
             }
             num_rows += 1;
 
-            if num_rows >= row_threshold || estimated_bytes >= size_threshold {
+            let over_size_threshold = size_threshold.map_or(false, |t| estimated_bytes >= t);
+            if num_rows >= row_threshold || over_size_threshold {
                 let mut to_add = create_array_builders(table_cols);
                 mem::swap(&mut builders, &mut to_add);
                 num_rows = 0;

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -55,6 +55,7 @@ use crate::metastore::wal::{WALIndexKey, WALRocksIndex};
 
 use crate::table::{Row, TableValue};
 
+use crate::util::lock::acquire_lock;
 use crate::util::WorkerLoop;
 use crate::{meta_store_table_impl, CubeError};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -1557,7 +1558,11 @@ impl RocksMetaStore {
         if let Some(by_node) = self.in_memory_compaction_cached().await? {
             return Ok(by_node.get(&node).cloned().unwrap_or_default());
         }
-        let _compute_guard = self.in_memory_compaction_compute_lock.lock().await;
+        let _compute_guard = acquire_lock(
+            "in-memory compaction discovery compute",
+            self.in_memory_compaction_compute_lock.lock(),
+        )
+        .await?;
         if let Some(by_node) = self.in_memory_compaction_cached().await? {
             return Ok(by_node.get(&node).cloned().unwrap_or_default());
         }
@@ -2823,7 +2828,21 @@ impl MetaStore for RocksMetaStore {
             // Single-flight: serialize the scan so a burst of concurrent callers
             // (e.g. many partition writes during an import/repartition) share one
             // computation instead of each materializing a full metastore scan.
-            let _compute_guard = self.disk_space_compute_lock.lock().await;
+            let _compute_guard =
+                match acquire_lock("disk space compute", self.disk_space_compute_lock.lock()).await
+                {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        log::error!(
+                        "Timed out waiting for the disk space scan lock: {}. The single-flight \
+                         scan is stuck; reporting 0 used disk space so the disk-space check \
+                         passes. THE DISK-SPACE LIMIT IS NOT BEING ENFORCED until the scan \
+                         recovers.",
+                        e
+                    );
+                        return Ok(0);
+                    }
+                };
             if let Some(sizes) = self.disk_space_cached().await? {
                 sizes
             } else {

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/mod.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/mod.rs
@@ -110,11 +110,15 @@ impl QueryPlanner for CubeQueryPlanner {
 }
 
 #[derive(Debug)]
-pub struct PreOptimizeRule {}
+pub struct PreOptimizeRule {
+    push_partial_aggregate_below_merge: bool,
+}
 
 impl PreOptimizeRule {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(push_partial_aggregate_below_merge: bool) -> Self {
+        Self {
+            push_partial_aggregate_below_merge,
+        }
     }
 }
 
@@ -124,7 +128,7 @@ impl PhysicalOptimizerRule for PreOptimizeRule {
         plan: Arc<dyn ExecutionPlan>,
         _config: &ConfigOptions,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
-        pre_optimize_physical_plan(plan)
+        pre_optimize_physical_plan(plan, self.push_partial_aggregate_below_merge)
     }
 
     fn name(&self) -> &str {
@@ -138,6 +142,7 @@ impl PhysicalOptimizerRule for PreOptimizeRule {
 
 fn pre_optimize_physical_plan(
     p: Arc<dyn ExecutionPlan>,
+    push_partial_aggregate_below_merge: bool,
 ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
     let p = rewrite_physical_plan(p, &mut |p| push_aggregate_to_workers(p))?;
 
@@ -147,7 +152,11 @@ fn pre_optimize_physical_plan(
     let p = ensure_partition_merge(p)?;
 
     // Make the merge carry partial aggregate states instead of all raw rows
-    let p = rewrite_physical_plan(p, &mut |p| push_sorted_partial_aggregate_below_merge(p))?;
+    let p = if push_partial_aggregate_below_merge {
+        rewrite_physical_plan(p, &mut |p| push_sorted_partial_aggregate_below_merge(p))?
+    } else {
+        p
+    };
 
     // Global (no GROUP BY) aggregates don't need their input merged in the sort order
     let p = rewrite_physical_plan(p, &mut |p| drop_sort_merge_under_global_aggregate(p))?;

--- a/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/query_executor.rs
@@ -226,6 +226,7 @@ pub struct QueryExecutorImpl {
     metadata_cache_factory: Arc<dyn MetadataCacheFactory>,
     parquet_metadata_cache: Arc<dyn CubestoreParquetMetadataCache>,
     memory_handler: Arc<dyn MemoryHandler>,
+    push_partial_aggregate_below_merge: bool,
 }
 
 crate::di_service!(QueryExecutorImpl, [QueryExecutor]);
@@ -546,11 +547,13 @@ impl QueryExecutorImpl {
         metadata_cache_factory: Arc<dyn MetadataCacheFactory>,
         parquet_metadata_cache: Arc<dyn CubestoreParquetMetadataCache>,
         memory_handler: Arc<dyn MemoryHandler>,
+        push_partial_aggregate_below_merge: bool,
     ) -> Arc<Self> {
         Arc::new(QueryExecutorImpl {
             metadata_cache_factory,
             parquet_metadata_cache,
             memory_handler,
+            push_partial_aggregate_below_merge,
         })
     }
 
@@ -599,7 +602,9 @@ impl QueryExecutorImpl {
     fn physical_optimizer_rules(&self) -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
         vec![
             // Cube rules
-            Arc::new(PreOptimizeRule::new()),
+            Arc::new(PreOptimizeRule::new(
+                self.push_partial_aggregate_below_merge,
+            )),
             // DF rules without EnforceDistribution.  We do need to keep EnforceSorting.
             Arc::new(OutputRequirements::new_add_mode()),
             Arc::new(AggregateStatistics::new()),

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -1673,6 +1673,10 @@ mod tests {
             .expect_compaction_chunks_total_size_threshold()
             .returning(|| 30);
 
+        config
+            .expect_compaction_split_by_total_file_size_enabled()
+            .returning(|| false);
+
         let compaction_service = CompactionServiceImpl::new(
             metastore.clone(),
             Arc::new(chunk_store),

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -583,13 +583,20 @@ impl CompactionService for CompactionServiceImpl {
             ) as usize)
                 // Do not allow to much of new partitions to limit partition accuracy trade off
                 .min(16);
-            // Size the split by the bytes actually being written: the existing main table plus
-            // the pending chunks merged in this pass. A partition with a small (or empty) main
-            // table but large accumulated chunks must still split by size in a single pass,
-            // otherwise it under-splits and re-splits on the next round.
+            // Size the split by file size. By default this counts only the existing main table.
+            // When compaction_split_by_total_file_size_enabled is on, the pending chunks merged in
+            // this pass are added too, so a partition with a small (or empty) main table but large
+            // accumulated chunks splits by size in a single pass instead of under-splitting and
+            // re-splitting on the next round.
             let new_partitions_count_by_file_size = {
+                let pending_file_size = if self.config.compaction_split_by_total_file_size_enabled()
+                {
+                    chunks_total_file_size
+                } else {
+                    0
+                };
                 let total_file_size =
-                    partition.get_row().file_size().unwrap_or(0) + chunks_total_file_size;
+                    partition.get_row().file_size().unwrap_or(0) + pending_file_size;
                 if total_file_size > 0 {
                     let threshold = self.config.partition_size_split_threshold_bytes();
                     (div_ceil(total_file_size, threshold) as usize).min(16)
@@ -2463,6 +2470,7 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 2000;
                 c.partition_size_split_threshold_bytes = 10000;
+                c.compaction_split_by_total_file_size_enabled = true;
                 c
             })
             .start_test(async move |services| {


### PR DESCRIPTION
## Summary

Put behind env flags the CubeStore planning/processing changes merged over the past week, so each one can be rolled back to its prior behavior independently. Disabling a flag restores the old behavior; flags default to the safe (old) behavior except where noted. Also hardens the new single-flight metastore scan locks with a wait timeout.

## Changes

**New rollback env flags** (default = old behavior unless noted):
- `CUBESTORE_COMPACTION_SPLIT_BY_TOTAL_FILE_SIZE` (default off) — when off, compaction sizes the partition split by the main table only, excluding pending chunks merged in the pass.
- `CUBESTORE_WAL_SPLIT_SIZE_THRESHOLD` is now optional — unset or `0` disables the import byte-size split, leaving the row-count split as the only trigger.
- `CUBESTORE_PUSH_PARTIAL_AGGREGATE_BELOW_MERGE` (**default on**) — gates pushing the sorted partial aggregate below the partition merge; kept enabled, with an off switch for emergencies.
- `CUBESTORE_PREFILTER_IN_MEMORY_CHUNKS` (default off) — when off, in-memory chunks cross IPC whole and are filtered only in the select subprocess. Kept on in test config so the shared-scan regression test still exercises the worker-side trim path.

**Existing flag default flipped:**
- `CUBESTORE_BATCH_REPARTITION` default flipped to off (prior one-job-per-chunk behavior is the default again); test config keeps it on for coverage.

**Lock hardening:**
- The disk-space and in-memory-compaction single-flight compute locks waited on the holder indefinitely. Both now use `acquire_lock` (10s timeout). Disk space: on timeout, log a loud warning and report 0 used space so the disk-space check passes rather than stalling writes (the limit is briefly unenforced until the scan recovers). In-memory compaction discovery: on timeout, propagate the error so the job fails and retries instead of hanging.

## Testing

- `cargo check -p cubestore` and `--tests` green.
- `cargo fmt` clean (pre-commit hook passes).
- Targeted tests pass: `partition_split_by_file_size`, `prefilter_chunks_shared_scan`, `disk_space_limit`, `disk_space_limit_per_worker`.
