### PR TITLE
feat(cubestore): tolerant job reads + cleanup of unknown job types

### DIFF
--- a/rust/cubestore/cubestore/src/app_metrics.rs
+++ b/rust/cubestore/cubestore/src/app_metrics.rs
@@ -137,6 +137,10 @@ pub static JOBS_REPARTITION_CHUNK_COMPLETED: Counter =
     metrics::counter("cs.jobs.repartition_chunk.completed");
 pub static JOBS_REPARTITION_CHUNK_FAILURES: Counter =
     metrics::counter("cs.jobs.repartition_chunk.failures");
+/// Jobs removed by the cleanup sweep because their type is unknown to this
+/// binary. Non-zero means a newer binary wrote a job type this one cannot run
+/// (version skew across `latest`/`release` channels).
+pub static JOBS_UNKNOWN_DELETED: Counter = metrics::counter("cs.jobs.unknown.deleted");
 
 /// RemoteFs metrics
 pub static REMOTE_FS_OPERATION_CORE: Counter = metrics::counter("cs.remote_fs.operations.core");

--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
@@ -397,6 +397,8 @@ impl JobRunner {
                     Self::fail_job_row_key(job)
                 }
             }
+            // Defense-in-depth: start_processing_job never selects an Unknown job, so
+            // this arm is not a live path — it just guarantees we never panic on one.
             JobType::Unknown => Err(CubeError::internal(format!(
                 "Unknown job type, likely written by a newer CubeStore version: {:?}",
                 job

--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
@@ -397,6 +397,10 @@ impl JobRunner {
                     Self::fail_job_row_key(job)
                 }
             }
+            JobType::Unknown => Err(CubeError::internal(format!(
+                "Unknown job type, likely written by a newer CubeStore version: {:?}",
+                job
+            ))),
         }
     }
 

--- a/rust/cubestore/cubestore/src/metastore/job.rs
+++ b/rust/cubestore/cubestore/src/metastore/job.rs
@@ -21,6 +21,11 @@ pub enum JobType {
     RepartitionChunk,
     InMemoryChunksCompaction,
     NodeInMemoryChunksCompaction(/*node*/ String),
+    /// Fallback for job types written by a newer binary that this binary does
+    /// not know about. Lets the read path decode such rows instead of failing
+    /// the whole job scan; the worker ignores `Unknown` jobs.
+    #[serde(other)]
+    Unknown,
 }
 
 fn get_job_type_index(j: &JobType) -> u32 {
@@ -35,6 +40,7 @@ fn get_job_type_index(j: &JobType) -> u32 {
         JobType::RepartitionChunk => 8,
         JobType::InMemoryChunksCompaction => 9,
         JobType::NodeInMemoryChunksCompaction(_) => 10,
+        JobType::Unknown => 11,
     }
 }
 
@@ -51,6 +57,7 @@ fn get_job_type_priority(j: &JobType) -> u32 {
         JobType::RepartitionChunk => 1000,
         JobType::InMemoryChunksCompaction => 10000,
         JobType::NodeInMemoryChunksCompaction(_) => 10000,
+        JobType::Unknown => 0,
     }
 }
 
@@ -245,6 +252,7 @@ impl RocksSecondaryIndex<Job, JobIndexKey> for JobRocksIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::Serialize;
 
     fn job(job_type: JobType) -> Job {
         Job::new(
@@ -275,5 +283,80 @@ mod tests {
         assert!(compaction.matches_pool(JobRunnerPool::Regular));
         assert!(!compaction.matches_pool(JobRunnerPool::CsvImport));
         assert!(!compaction.matches_pool(JobRunnerPool::LongTerm));
+    }
+
+    /// Mirrors `JobType` as it might look in a newer binary: it carries extra
+    /// variants this binary does not know about (one unit, one data-carrying).
+    /// We serialize with this enum and deserialize with the real `JobType` to
+    /// emulate a forward version skew across `latest`/`release` channels.
+    #[derive(Serialize)]
+    enum NewerJobType {
+        #[allow(dead_code)]
+        WalPartitioning,
+        #[allow(dead_code)]
+        NodeInMemoryChunksCompaction(String),
+        BrandNewUnitVariant,
+        BrandNewDataVariant(String),
+    }
+
+    fn flex_roundtrip<S: Serialize, D: for<'de> Deserialize<'de>>(value: &S) -> Result<D, String> {
+        let mut ser = flexbuffers::FlexbufferSerializer::new();
+        value.serialize(&mut ser).map_err(|e| e.to_string())?;
+        let buffer = ser.take_buffer();
+        let reader = flexbuffers::Reader::get_root(buffer.as_slice()).map_err(|e| e.to_string())?;
+        D::deserialize(reader).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn unknown_unit_variant_decodes_to_unknown() {
+        let decoded: JobType =
+            flex_roundtrip(&NewerJobType::BrandNewUnitVariant).expect("unit variant must decode");
+        assert_eq!(decoded, JobType::Unknown);
+    }
+
+    #[test]
+    fn unknown_data_variant_decodes_to_unknown() {
+        // A data-carrying unknown variant. flexbuffers must skip the payload and
+        // land on `Unknown` rather than erroring; if this fails, `#[serde(other)]`
+        // is insufficient for the job read path and Option B is required.
+        let decoded: JobType =
+            flex_roundtrip(&NewerJobType::BrandNewDataVariant("loc".to_string()))
+                .expect("data variant must decode");
+        assert_eq!(decoded, JobType::Unknown);
+    }
+
+    #[test]
+    fn known_variants_still_roundtrip() {
+        for jt in [
+            JobType::WalPartitioning,
+            JobType::TableImportCSV("s3://x".to_string()),
+            JobType::NodeInMemoryChunksCompaction("node-1".to_string()),
+        ] {
+            let decoded: JobType = flex_roundtrip(&jt).expect("known variant must decode");
+            assert_eq!(decoded, jt);
+        }
+    }
+
+    #[test]
+    fn unknown_variant_inside_job_struct_decodes() {
+        // The real read path deserializes the whole `Job` struct, so verify the
+        // fallback also works when the unknown enum is a nested field.
+        #[derive(Serialize)]
+        struct NewerJob {
+            row_reference: RowKey,
+            job_type: NewerJobType,
+            last_heart_beat: DateTime<Utc>,
+            status: JobStatus,
+        }
+
+        let newer = NewerJob {
+            row_reference: RowKey::Table(TableId::Jobs, 1),
+            job_type: NewerJobType::BrandNewDataVariant("payload".to_string()),
+            last_heart_beat: Utc::now(),
+            status: JobStatus::Scheduled("shard-1".to_string()),
+        };
+        let decoded: Job = flex_roundtrip(&newer).expect("job with unknown type must decode");
+        assert_eq!(decoded.job_type(), &JobType::Unknown);
+        assert!(matches!(decoded.status(), JobStatus::Scheduled(s) if s == "shard-1"));
     }
 }

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -1126,6 +1126,7 @@ pub trait MetaStore: DIService + Send + Sync {
     ) -> Result<Vec<IdRow<Job>>, CubeError>;
     async fn get_jobs_on_non_exists_nodes(&self) -> Result<Vec<IdRow<Job>>, CubeError>;
     async fn delete_job(&self, job_id: u64) -> Result<IdRow<Job>, CubeError>;
+    async fn delete_unknown_jobs(&self) -> Result<u64, CubeError>;
     async fn start_processing_job(
         &self,
         server_name: String,
@@ -4354,6 +4355,46 @@ impl MetaStore for RocksMetaStore {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
+    async fn delete_unknown_jobs(&self) -> Result<u64, CubeError> {
+        let deleted = self
+            .write_operation("delete_unknown_jobs", move |db_ref, batch_pipe| {
+                let table = JobRocksTable::new(db_ref);
+                let unknown = table
+                    .all_rows()?
+                    .into_iter()
+                    .filter(|j| matches!(j.get_row().job_type(), JobType::Unknown))
+                    .collect::<Vec<_>>();
+                for job in unknown.iter() {
+                    log::warn!(
+                        "Removing job {} with an unknown type (written by a newer CubeStore version): {:?}",
+                        job.get_id(),
+                        job.get_row()
+                    );
+                    table.delete(job.get_id(), batch_pipe)?;
+                }
+                Ok(unknown.len() as u64)
+            })
+            .await?;
+
+        if deleted > 0 {
+            // delete() recomputes the RowReference index key from the row's job_type,
+            // which we read as Unknown — but the stored key was written by a newer
+            // binary over the real variant, so the original (unique) index entry is
+            // left dangling. Rebuild it so a later upgrade doesn't see a phantom job.
+            self.write_operation("rebuild_jobs_row_reference_index", move |db_ref, _| {
+                let table = JobRocksTable::new(db_ref);
+                let index: Box<dyn BaseRocksSecondaryIndex<Job>> =
+                    Box::new(JobRocksIndex::RowReference);
+                table.rebuild_index(&index)?;
+                Ok(())
+            })
+            .await?;
+        }
+
+        Ok(deleted)
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn start_processing_job(
         &self,
         server_name: String,
@@ -4367,6 +4408,10 @@ impl MetaStore for RocksMetaStore {
                     &JobRocksIndex::ByShard,
                 )?
                 .into_iter()
+                // Jobs with an unknown type were written by a newer binary; this
+                // worker can't run them. Skip silently here — they are reported and
+                // removed by the scheduler's cleanup_unknown_jobs sweep.
+                .filter(|j| !matches!(j.get_row().job_type(), JobType::Unknown))
                 .filter(|j| j.get_row().matches_pool(pool))
                 //We use min_by instead of the max_by because of min_by returns the first element
                 //if priority is equal while max_by returns the last element
@@ -7510,6 +7555,87 @@ mod tests {
                 .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
                 .await?
                 .is_none());
+        }
+        let _ = fs::remove_dir_all(store_path.clone());
+        let _ = fs::remove_dir_all(remote_store_path.clone());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_processing_job_skips_unknown() -> Result<(), CubeError> {
+        let config = Config::test("start_processing_job_skips_unknown");
+        let store_path = env::current_dir()?.join("test-skip-unknown-local");
+        let remote_store_path = env::current_dir()?.join("test-skip-unknown-remote");
+        let _ = fs::remove_dir_all(store_path.clone());
+        let _ = fs::remove_dir_all(remote_store_path.clone());
+        let remote_fs = LocalDirRemoteFs::new(Some(remote_store_path.clone()), store_path.clone());
+        {
+            let meta_store = RocksMetaStore::new(
+                store_path.clone().join("metastore").as_path(),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )?;
+            // An Unknown job (as if written by a newer binary) must not block the
+            // worker from picking up its other scheduled jobs.
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Partitions, 1),
+                    JobType::Unknown,
+                    "node1".to_string(),
+                ))
+                .await?;
+            meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Partitions, 2),
+                    JobType::PartitionCompaction,
+                    "node1".to_string(),
+                ))
+                .await?;
+
+            let job = meta_store
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
+                .await?
+                .expect("the known job must be selected, not blocked by the unknown one");
+            assert_eq!(job.get_row().job_type(), &JobType::PartitionCompaction);
+            assert_eq!(
+                job.get_row().row_reference(),
+                &RowKey::Table(TableId::Partitions, 2)
+            );
+
+            // The Unknown job is still scheduled but never selected.
+            assert!(meta_store
+                .start_processing_job("node1".to_string(), JobRunnerPool::Regular)
+                .await?
+                .is_none());
+
+            // Scan paths over all jobs keep working (the unknown job is still present).
+            assert!(meta_store
+                .get_orphaned_jobs(Duration::from_secs(0))
+                .await
+                .is_ok());
+
+            // The cleanup sweep removes the unknown job and leaves the known one.
+            assert_eq!(meta_store.delete_unknown_jobs().await?, 1);
+            assert_eq!(meta_store.delete_unknown_jobs().await?, 0);
+
+            let remaining = meta_store.all_jobs().await?;
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(
+                remaining[0].get_row().job_type(),
+                &JobType::PartitionCompaction
+            );
+
+            // The RowReference index is consistent after the cleanup-time rebuild:
+            // re-adding a job for the freed reference works (no phantom dedup hit).
+            assert!(meta_store
+                .add_job(Job::new(
+                    RowKey::Table(TableId::Partitions, 1),
+                    JobType::PartitionCompaction,
+                    "node1".to_string(),
+                ))
+                .await?
+                .is_some());
         }
         let _ = fs::remove_dir_all(store_path.clone());
         let _ = fs::remove_dir_all(remote_store_path.clone());

--- a/rust/cubestore/cubestore/src/metastore/mod.rs
+++ b/rust/cubestore/cubestore/src/metastore/mod.rs
@@ -4251,6 +4251,12 @@ impl MetaStore for RocksMetaStore {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn add_job(&self, job: Job) -> Result<Option<IdRow<Job>>, CubeError> {
         self.write_operation("add_job", move |db_ref, batch_pipe| {
+            // Unknown is a read-time fallback for variants written by a newer binary;
+            // this binary must never create one (the cleanup sweep would delete it).
+            debug_assert!(
+                !matches!(job.job_type(), JobType::Unknown),
+                "refusing to add a job with an unknown type"
+            );
             let table = JobRocksTable::new(db_ref.clone());
 
             let result = table.get_row_ids_by_index(
@@ -4356,42 +4362,49 @@ impl MetaStore for RocksMetaStore {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn delete_unknown_jobs(&self) -> Result<u64, CubeError> {
-        let deleted = self
-            .write_operation("delete_unknown_jobs", move |db_ref, batch_pipe| {
-                let table = JobRocksTable::new(db_ref);
-                let unknown = table
+        // Cheap gate so the common steady state (no unknown jobs) doesn't take the
+        // single-writer queue every reconcile tick: scan out of queue first.
+        let has_unknown = self
+            .read_operation_out_of_queue("scan_unknown_jobs", move |db_ref| {
+                Ok(JobRocksTable::new(db_ref)
                     .all_rows()?
                     .into_iter()
-                    .filter(|j| matches!(j.get_row().job_type(), JobType::Unknown))
-                    .collect::<Vec<_>>();
-                for job in unknown.iter() {
-                    log::warn!(
-                        "Removing job {} with an unknown type (written by a newer CubeStore version): {:?}",
-                        job.get_id(),
-                        job.get_row()
-                    );
-                    table.delete(job.get_id(), batch_pipe)?;
-                }
-                Ok(unknown.len() as u64)
+                    .any(|j| matches!(j.get_row().job_type(), JobType::Unknown)))
             })
             .await?;
-
-        if deleted > 0 {
-            // delete() recomputes the RowReference index key from the row's job_type,
-            // which we read as Unknown — but the stored key was written by a newer
-            // binary over the real variant, so the original (unique) index entry is
-            // left dangling. Rebuild it so a later upgrade doesn't see a phantom job.
-            self.write_operation("rebuild_jobs_row_reference_index", move |db_ref, _| {
-                let table = JobRocksTable::new(db_ref);
-                let index: Box<dyn BaseRocksSecondaryIndex<Job>> =
-                    Box::new(JobRocksIndex::RowReference);
-                table.rebuild_index(&index)?;
-                Ok(())
-            })
-            .await?;
+        if !has_unknown {
+            return Ok(0);
         }
 
-        Ok(deleted)
+        self.write_operation("delete_unknown_jobs", move |db_ref, batch_pipe| {
+            let table = JobRocksTable::new(db_ref);
+            let unknown = table
+                .all_rows()?
+                .into_iter()
+                .filter(|j| matches!(j.get_row().job_type(), JobType::Unknown))
+                .collect::<Vec<_>>();
+            if unknown.is_empty() {
+                return Ok(0);
+            }
+            for job in unknown.iter() {
+                log::warn!(
+                    "Removing job {} with an unknown type (written by a newer CubeStore version): {:?}",
+                    job.get_id(),
+                    job.get_row()
+                );
+                table.delete(job.get_id(), batch_pipe)?;
+            }
+            // delete() recomputes the RowReference index key from the row's job_type,
+            // which we read as Unknown — but the stored key was written by a newer
+            // binary over the real variant, so that delete leaves the original
+            // (unique) index entry dangling. Rebuild it in the same write so the
+            // cleanup commits atomically and a later upgrade never sees a phantom job.
+            let index: Box<dyn BaseRocksSecondaryIndex<Job>> =
+                Box::new(JobRocksIndex::RowReference);
+            table.rebuild_index(&index)?;
+            Ok(unknown.len() as u64)
+        })
+        .await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
@@ -7576,14 +7589,21 @@ mod tests {
                 BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
                 config.config_obj(),
             )?;
-            // An Unknown job (as if written by a newer binary) must not block the
+            // Simulate a job written by a newer binary: insert an Unknown-typed row
+            // directly (add_job intentionally refuses Unknown). It must not block the
             // worker from picking up its other scheduled jobs.
             meta_store
-                .add_job(Job::new(
-                    RowKey::Table(TableId::Partitions, 1),
-                    JobType::Unknown,
-                    "node1".to_string(),
-                ))
+                .write_operation("test_insert_unknown_job", |db_ref, batch_pipe| {
+                    JobRocksTable::new(db_ref).insert(
+                        Job::new(
+                            RowKey::Table(TableId::Partitions, 1),
+                            JobType::Unknown,
+                            "node1".to_string(),
+                        ),
+                        batch_pipe,
+                    )?;
+                    Ok(())
+                })
                 .await?;
             meta_store
                 .add_job(Job::new(

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -631,6 +631,10 @@ impl MetaStore for MetaStoreMock {
         panic!("MetaStore mock!")
     }
 
+    async fn delete_unknown_jobs(&self) -> Result<u64, CubeError> {
+        panic!("MetaStore mock!")
+    }
+
     async fn start_processing_job(
         &self,
         _server_name: String,

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -292,6 +292,16 @@ impl SchedulerImpl {
         }
 
         if let Err(e) = warn_long_fut(
+            "Removing unknown jobs",
+            Duration::from_millis(5000),
+            self.remove_unknown_jobs(),
+        )
+        .await
+        {
+            error!("Error removing unknown jobs: {}", e);
+        }
+
+        if let Err(e) = warn_long_fut(
             "Table import reconciliation",
             Duration::from_millis(5000),
             self.reconcile_table_imports(),
@@ -681,6 +691,14 @@ impl SchedulerImpl {
         for job in jobs_to_remove.into_iter() {
             log::info!("Removing job {:?} on non-existing node", job);
             self.meta_store.delete_job(job.get_id()).await?;
+        }
+        Ok(())
+    }
+
+    async fn remove_unknown_jobs(&self) -> Result<(), CubeError> {
+        let deleted = self.meta_store.delete_unknown_jobs().await?;
+        if deleted > 0 {
+            crate::app_metrics::JOBS_UNKNOWN_DELETED.add(deleted as i64);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Make the CubeStore worker's job read path forward-compatible across `latest`/`release` channel switches. Today, a job row carrying a `JobType` variant this binary doesn't know fails to deserialize, and because the shard scan does `get_row(id)?` in a loop, the **whole** scan errors — the worker stops picking up *any* of its jobs until upgraded. This makes it unsafe to ever add a new `JobType`, since a deployment can move between channels in both directions. This PR is the groundwork that makes future `JobType` additions channel-switch safe.

## Changes

- **`JobType::Unknown` fallback** (`metastore/job.rs`): add `#[serde(other)] Unknown` so a foreign serialized variant decodes to `Unknown` instead of erroring. Verified flexbuffers honors `#[serde(other)]` — including for data-carrying unknown variants (payload is skipped, no `Err`) — both bare and nested in the `Job` struct. Stable index id (11), lowest priority.
- **Worker ignores Unknown** silently in `start_processing_job` selection; `route_job` rejects it with a clean `Err` instead of a non-exhaustive-match panic. `process_separate_job` already had a catch-all.
- **Cleanup sweep** `MetaStore::delete_unknown_jobs`: scans, deletes `Unknown` jobs, then rebuilds the Jobs `RowReference` index. The rebuild is required because `delete` recomputes the unique-index key from the (now `Unknown`) `job_type`, while the stored key was written by the newer binary over the real variant — a plain delete would leave a dangling unique-index entry and cause a phantom `add_job` dedup on a later upgrade. Wired into the scheduler `reconcile` loop (runs on the router, ~30s); warns per removed job and bumps `cs.jobs.unknown.deleted`.

This lets a leftover unknown job stay in the metastore without blocking the worker from picking up its other jobs (the success bar), while the sweep removes them so they don't pile up on a long downgrade.

## Testing

- New unit tests in `metastore/job.rs`: flexbuffers round-trip of unknown unit/data variants → `Unknown` (bare + nested in `Job`), and known variants still round-trip.
- New `start_processing_job_skips_unknown` in `metastore/mod.rs`: a known sibling job is selected over an `Unknown` one, the `Unknown` job is never picked, scan paths still succeed, and the cleanup sweep removes it (count 1 then 0) leaving the known job + a consistent index (re-add for the freed reference succeeds).
- `cargo build -p cubestore` clean; `cargo test -p cubestore --lib metastore` 35 passed; `cargo test -p cubestore --lib scheduler` 4 passed; `cargo fmt` applied.