### PR TITLE
fix(cubestore): repartition merge commits with unchecked swap (fixes RepartitionRange row-count regression)

### DIFF
--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_processor.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_processor.rs
@@ -1,5 +1,5 @@
 use crate::config::injection::DIService;
-use crate::config::{Config, ConfigObj};
+use crate::config::{Config, ConfigObj, RepartitionStrategy};
 use crate::import::ImportService;
 use crate::metastore::job::{Job, JobType};
 use crate::metastore::table::Table;
@@ -222,17 +222,14 @@ impl JobIsolatedProcessor {
                     }
                     let data_loaded_size = DataLoadedSize::new();
                     app_metrics::JOBS_REPARTITION_CHUNK.add(1);
-                    // FIXME: a RepartitionChunk job whose chunk_id is used as an
-                    // anchor for the whole partition (batch_repartition_enabled).
-                    // We deliberately overload the existing RepartitionChunk type
-                    // instead of introducing a dedicated per-partition JobType:
-                    // a new JobType variant cannot be deserialized by an older
-                    // binary, which would make the whole job shard unreadable when
-                    // a deployment switches between the `latest` and `release`
-                    // channels (version can move both ways at any time). Reusing a
-                    // known type keeps both directions safe — an old binary just
-                    // repartitions the single anchor chunk. See repartition_partition_chunks.
-                    let r = if self.config_obj.batch_repartition_enabled() {
+                    // PerPartition reuses the RepartitionChunk job with the smallest chunk
+                    // as the anchor (one job per partition) and merges all its chunks;
+                    // PerChunk gets one job per chunk and repartitions just that chunk. We
+                    // overload the existing RepartitionChunk type (no new JobType) so an
+                    // older binary stays able to deserialize it across channel switches.
+                    let r = if self.config_obj.repartition_strategy()
+                        == RepartitionStrategy::PerPartition
+                    {
                         let partition_id = chunk.get_row().get_partition_id();
                         let time_budget = Duration::from_secs(
                             self.config_obj.repartition_chunks_time_budget_secs(),

--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_processor.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_processor.rs
@@ -260,6 +260,30 @@ impl JobIsolatedProcessor {
                     Self::fail_job_row_key(job)
                 }
             }
+            JobType::RepartitionRange(end_chunk_id) => {
+                if let RowKey::Table(TableId::Chunks, start_chunk_id) = job.row_reference() {
+                    let start_chunk_id = *start_chunk_id;
+                    let end_chunk_id = *end_chunk_id;
+                    let data_loaded_size = DataLoadedSize::new();
+                    app_metrics::JOBS_REPARTITION_CHUNK.add(1);
+                    let r = self
+                        .chunk_store
+                        .repartition_chunk_range(
+                            start_chunk_id,
+                            end_chunk_id,
+                            data_loaded_size.clone(),
+                        )
+                        .await;
+                    if let Err(e) = r {
+                        app_metrics::JOBS_REPARTITION_CHUNK_FAILURES.add(1);
+                        return Err(e);
+                    }
+                    app_metrics::JOBS_REPARTITION_CHUNK_COMPLETED.add(1);
+                    Ok(JobProcessResult::new(data_loaded_size.get()))
+                } else {
+                    Self::fail_job_row_key(job)
+                }
+            }
             _ => Err(CubeError::internal(format!(
                 "Job {:?} cannot be processed in separate process",
                 job.job_type()

--- a/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
+++ b/rust/cubestore/cubestore/src/cluster/ingestion/job_runner.rs
@@ -397,6 +397,47 @@ impl JobRunner {
                     Self::fail_job_row_key(job)
                 }
             }
+            JobType::RepartitionRange(_) => {
+                if let RowKey::Table(TableId::Chunks, start_chunk_id) = job.row_reference() {
+                    let start_chunk_id = *start_chunk_id;
+                    let process_rate_limiter = self.process_rate_limiter.clone();
+                    let timeout = Some(Duration::from_secs(self.config_obj.import_job_timeout()));
+                    let metastore = self.meta_store.clone();
+                    let job_to_move = job.clone();
+                    let job_processor = self.job_processor.clone();
+                    Ok(cube_ext::spawn(async move {
+                        let wait_ms = process_rate_limiter
+                            .wait_for_allow(TaskType::Job, timeout)
+                            .await?;
+                        let chunk = metastore.get_chunk(start_chunk_id).await?;
+                        let (_, _, table, _) = metastore
+                            .get_partition_for_compaction(chunk.get_row().get_partition_id())
+                            .await?;
+                        let table_id = table.get_id();
+                        let trace_obj = metastore.get_trace_obj_by_table_id(table_id).await?;
+                        let trace_index = TraceIndex {
+                            table_id: Some(table_id),
+                            trace_obj,
+                        };
+                        match job_processor.process_job(job_to_move).await {
+                            Ok(job_res) => {
+                                process_rate_limiter
+                                    .commit_task_usage(
+                                        TaskType::Job,
+                                        job_res.data_loaded_size() as i64,
+                                        wait_ms,
+                                        trace_index,
+                                    )
+                                    .await;
+                                Ok(())
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }))
+                } else {
+                    Self::fail_job_row_key(job)
+                }
+            }
             // Defense-in-depth: start_processing_job never selects an Unknown job, so
             // this arm is not a live path — it just guarantees we never panic on one.
             JobType::Unknown => Err(CubeError::internal(format!(

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -954,8 +954,11 @@ impl Cluster for ClusterImpl {
             // range is only scheduled when it still has an active chunk; the end is
             // carried as the job's data, not its dedup key, so a tail that extends the
             // trailing range dedups on the start.
-            let max_rows = self.config_obj.repartition_merge_max_rows();
-            let max_files = self.config_obj.repartition_merge_max_input_files();
+            // Clamp to >= 1 so a misconfigured 0 cap doesn't break the inner loop before
+            // adding any chunk. Even 1 degrades to one chunk per range (no merge gain);
+            // the sane range is >= 2.
+            let max_rows = self.config_obj.repartition_merge_max_rows().max(1);
+            let max_files = self.config_obj.repartition_merge_max_input_files().max(1);
             let mut all = self
                 .meta_store
                 .get_chunks_by_partition(p.get_id(), true)

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -26,7 +26,7 @@ use crate::cluster::transport::{ClusterTransport, MetaStoreTransport, WorkerConn
 use crate::config::injection::{DIService, Injector};
 use crate::config::is_router;
 #[allow(unused_imports)]
-use crate::config::{Config, ConfigObj};
+use crate::config::{Config, ConfigObj, RepartitionStrategy};
 use crate::metastore::chunks::chunk_file_name;
 use crate::metastore::job::{Job, JobRunnerPool, JobStatus, JobType};
 use crate::metastore::{
@@ -945,17 +945,74 @@ impl Cluster for ClusterImpl {
             .filter(|c| !c.get_row().in_memory())
             .collect::<Vec<_>>();
 
-        if self.config_obj.batch_repartition_enabled() {
-            // FIXME: one job per partition that batches all persisted chunks, but
-            // keyed on a chunk (RepartitionChunk), not the partition. We reuse the
-            // existing job type instead of a dedicated per-partition JobType so an
-            // older binary stays able to deserialize it across `latest`/`release`
-            // channel switches (a new variant would make its whole job shard
-            // unreadable). The anchor is the smallest persisted chunk id so add_job
-            // dedups to a single job per partition; the worker resolves the
-            // partition from it and processes the anchor last (see
-            // repartition_partition_chunks). An old binary just repartitions this
-            // one chunk and drains the rest via its own per-chunk path.
+        if self.config_obj.repartition_strategy() == RepartitionStrategy::Range {
+            // Slice the parent's persisted chunks into RepartitionRange jobs. Walk ALL
+            // chunks (active and inactive) sorted by id so the [start, end] boundaries
+            // stay pinned to chunk ids and don't shift when chunks deactivate; cut a
+            // range once its rows reach max_rows or its chunk count reaches the fan-in
+            // cap, so a range never merges an unbounded number of chunks at once. A
+            // range is only scheduled when it still has an active chunk; the end is
+            // carried as the job's data, not its dedup key, so a tail that extends the
+            // trailing range dedups on the start.
+            let max_rows = self.config_obj.repartition_merge_max_rows();
+            let max_files = self.config_obj.repartition_merge_max_input_files();
+            let mut all = self
+                .meta_store
+                .get_chunks_by_partition(p.get_id(), true)
+                .await?
+                .into_iter()
+                .filter(|c| !c.get_row().in_memory())
+                .collect::<Vec<_>>();
+            all.sort_by_key(|c| c.get_id());
+
+            let mut i = 0;
+            while i < all.len() {
+                let start = all[i].get_id();
+                let mut rows = 0u64;
+                let mut count = 0usize;
+                let mut end = start;
+                let mut has_active = false;
+                while i < all.len() {
+                    let c = &all[i];
+                    rows += c.get_row().get_row_count();
+                    count += 1;
+                    end = c.get_id();
+                    has_active |= c.get_row().active();
+                    i += 1;
+                    if rows >= max_rows || count >= max_files {
+                        break;
+                    }
+                }
+                if has_active {
+                    let node =
+                        pick_worker_by_ids(self.config_obj.as_ref(), [start, end]).to_string();
+                    let job = self
+                        .meta_store
+                        .add_job(Job::new(
+                            RowKey::Table(TableId::Chunks, start),
+                            JobType::RepartitionRange(end),
+                            node.clone(),
+                        ))
+                        .await?;
+                    if job.is_some() {
+                        self.notify_job_runner(node).await?;
+                    }
+                }
+            }
+        } else if self.config_obj.repartition_strategy() == RepartitionStrategy::PerPartition
+            || self.config_obj.batch_repartition_enabled()
+        {
+            // One job per partition that batches all persisted chunks, but keyed on a
+            // chunk (RepartitionChunk), not the partition. We reuse the existing job
+            // type instead of a dedicated per-partition JobType so an older binary stays
+            // able to deserialize it across `latest`/`release` channel switches (a new
+            // variant would make its whole job shard unreadable). The anchor is the
+            // smallest persisted chunk id so add_job dedups to a single job per
+            // partition; the worker resolves the partition from it and processes the
+            // anchor last (see repartition_partition_chunks). The PerPartition strategy
+            // requires this single-job form: a per-chunk job under it would re-merge the
+            // whole partition. An old binary just repartitions this one chunk and drains
+            // the rest via its own per-chunk path.
             if let Some(anchor_chunk_id) = chunks.iter().map(|c| c.get_id()).min() {
                 let node = self.node_name_by_partition(p);
                 let job = self

--- a/rust/cubestore/cubestore/src/cluster/mod.rs
+++ b/rust/cubestore/cubestore/src/cluster/mod.rs
@@ -1002,20 +1002,14 @@ impl Cluster for ClusterImpl {
                     }
                 }
             }
-        } else if self.config_obj.repartition_strategy() == RepartitionStrategy::PerPartition
-            || self.config_obj.batch_repartition_enabled()
-        {
-            // One job per partition that batches all persisted chunks, but keyed on a
-            // chunk (RepartitionChunk), not the partition. We reuse the existing job
-            // type instead of a dedicated per-partition JobType so an older binary stays
-            // able to deserialize it across `latest`/`release` channel switches (a new
-            // variant would make its whole job shard unreadable). The anchor is the
-            // smallest persisted chunk id so add_job dedups to a single job per
-            // partition; the worker resolves the partition from it and processes the
-            // anchor last (see repartition_partition_chunks). The PerPartition strategy
-            // requires this single-job form: a per-chunk job under it would re-merge the
-            // whole partition. An old binary just repartitions this one chunk and drains
-            // the rest via its own per-chunk path.
+        } else if self.config_obj.repartition_strategy() == RepartitionStrategy::PerPartition {
+            // One job per partition, keyed on a chunk (RepartitionChunk) rather than a
+            // dedicated per-partition JobType so an older binary can still deserialize it
+            // across `latest`/`release` channel switches. The anchor is the smallest
+            // persisted chunk id so add_job dedups to a single job per partition; the
+            // worker resolves the partition from it and merges all its chunks (see
+            // repartition_partition_chunks). An old binary just repartitions this one
+            // chunk and drains the rest via its own per-chunk path.
             if let Some(anchor_chunk_id) = chunks.iter().map(|c| c.get_id()).min() {
                 let node = self.node_name_by_partition(p);
                 let job = self

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -536,6 +536,14 @@ pub trait ConfigObj: DIService {
     /// Off by default; when disabled, chunks are sent whole and filtered only in the subprocess.
     fn prefilter_in_memory_chunks_enabled(&self) -> bool;
 
+    /// Byte budget for prefetching persisted chunk parquets ahead of a batch
+    /// repartition job. A sequential producer downloads upcoming chunks (anchor
+    /// last) while the job processes the current one, bounded so that no more
+    /// than this many bytes of fetched-but-unprocessed data sit on local disk.
+    /// The env value accepts size suffixes (e.g. `512MB`). `None` (env unset) or
+    /// `Some(0)` disables prefetching.
+    fn repartition_prefetch_budget_bytes(&self) -> Option<u64>;
+
     fn allow_decimal128(&self) -> bool;
 
     fn enable_remove_orphaned_remote_files(&self) -> bool;
@@ -687,6 +695,7 @@ pub struct ConfigObjImpl {
     pub push_partial_aggregate_below_merge_enabled: bool,
     pub compaction_split_by_total_file_size_enabled: bool,
     pub prefilter_in_memory_chunks_enabled: bool,
+    pub repartition_prefetch_budget_bytes: Option<u64>,
     pub allow_decimal128: bool,
     pub enable_remove_orphaned_remote_files: bool,
     pub enable_startup_warmup: bool,
@@ -1013,6 +1022,9 @@ impl ConfigObj for ConfigObjImpl {
     }
     fn prefilter_in_memory_chunks_enabled(&self) -> bool {
         self.prefilter_in_memory_chunks_enabled
+    }
+    fn repartition_prefetch_budget_bytes(&self) -> Option<u64> {
+        self.repartition_prefetch_budget_bytes
     }
 
     fn allow_decimal128(&self) -> bool {
@@ -1669,6 +1681,12 @@ impl Config {
                     "CUBESTORE_PREFILTER_IN_MEMORY_CHUNKS",
                     false,
                 ),
+                repartition_prefetch_budget_bytes: env_parse_optional_size(
+                    "CUBESTORE_REPARTITION_PREFETCH_BUDGET",
+                    None,
+                    None,
+                )
+                .map(|n| n as u64),
                 allow_decimal128: env_bool("CUBESTORE_ALLOW_DECIMAL128", false),
                 enable_remove_orphaned_remote_files: env_bool(
                     "CUBESTORE_ENABLE_REMOVE_ORPHANED_REMOTE_FILES",
@@ -1914,6 +1932,7 @@ impl Config {
                 // Production default is off; kept on in tests so prefilter_chunks_shared_scan
                 // and the rest of the suite keep exercising the worker-side trim path.
                 prefilter_in_memory_chunks_enabled: true,
+                repartition_prefetch_budget_bytes: None,
                 allow_decimal128: false,
                 enable_remove_orphaned_remote_files: false,
                 enable_startup_warmup: true,

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -544,6 +544,13 @@ pub trait ConfigObj: DIService {
     /// `Some(0)` disables prefetching.
     fn repartition_prefetch_budget_bytes(&self) -> Option<u64>;
 
+    /// Max number of persisted input chunks merged in one group when repartitioning
+    /// an inactive parent. `Some(m >= 2)` streams the parent's chunks through a k-way
+    /// merge in groups of up to m and splits each group into the active children at
+    /// the wal-split limit, capping each merge+swap group at m chunks. `None` /
+    /// `Some(0)` / `Some(1)` disable the merge path.
+    fn repartition_merge_max_input_files(&self) -> Option<usize>;
+
     fn allow_decimal128(&self) -> bool;
 
     fn enable_remove_orphaned_remote_files(&self) -> bool;
@@ -696,6 +703,7 @@ pub struct ConfigObjImpl {
     pub compaction_split_by_total_file_size_enabled: bool,
     pub prefilter_in_memory_chunks_enabled: bool,
     pub repartition_prefetch_budget_bytes: Option<u64>,
+    pub repartition_merge_max_input_files: Option<usize>,
     pub allow_decimal128: bool,
     pub enable_remove_orphaned_remote_files: bool,
     pub enable_startup_warmup: bool,
@@ -1025,6 +1033,9 @@ impl ConfigObj for ConfigObjImpl {
     }
     fn repartition_prefetch_budget_bytes(&self) -> Option<u64> {
         self.repartition_prefetch_budget_bytes
+    }
+    fn repartition_merge_max_input_files(&self) -> Option<usize> {
+        self.repartition_merge_max_input_files
     }
 
     fn allow_decimal128(&self) -> bool {
@@ -1687,6 +1698,9 @@ impl Config {
                     None,
                 )
                 .map(|n| n as u64),
+                repartition_merge_max_input_files: env_optparse(
+                    "CUBESTORE_REPARTITION_MERGE_MAX_INPUT_FILES",
+                ),
                 allow_decimal128: env_bool("CUBESTORE_ALLOW_DECIMAL128", false),
                 enable_remove_orphaned_remote_files: env_bool(
                     "CUBESTORE_ENABLE_REMOVE_ORPHANED_REMOTE_FILES",
@@ -1933,6 +1947,7 @@ impl Config {
                 // and the rest of the suite keep exercising the worker-side trim path.
                 prefilter_in_memory_chunks_enabled: true,
                 repartition_prefetch_budget_bytes: None,
+                repartition_merge_max_input_files: None,
                 allow_decimal128: false,
                 enable_remove_orphaned_remote_files: false,
                 enable_startup_warmup: true,

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -361,6 +361,37 @@ pub struct Config {
     injector: Arc<Injector>,
 }
 
+/// How an inactive parent's persisted chunks are repartitioned into its children.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RepartitionStrategy {
+    /// One chunk at a time, each split independently into the children.
+    PerChunk,
+    /// One job per partition that k-way merges all its chunks in groups and splits the
+    /// merged stream into the children at the wal-split limit.
+    PerPartition,
+    /// Many jobs sliced at schedule time, each merging an inclusive chunk-id range;
+    /// spreads across workers by the hash of the range bounds.
+    Range,
+}
+
+impl FromStr for RepartitionStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "per_chunk" | "perchunk" | "per-chunk" => Ok(RepartitionStrategy::PerChunk),
+            "per_partition" | "perpartition" | "per-partition" => {
+                Ok(RepartitionStrategy::PerPartition)
+            }
+            "range" => Ok(RepartitionStrategy::Range),
+            _ => Err(format!(
+                "unknown repartition strategy '{}' (expected per_chunk, per_partition or range)",
+                s
+            )),
+        }
+    }
+}
+
 #[automock]
 pub trait ConfigObj: DIService {
     fn partition_split_threshold(&self) -> u64;
@@ -544,12 +575,17 @@ pub trait ConfigObj: DIService {
     /// `Some(0)` disables prefetching.
     fn repartition_prefetch_budget_bytes(&self) -> Option<u64>;
 
-    /// Max number of persisted input chunks merged in one group when repartitioning
-    /// an inactive parent. `Some(m >= 2)` streams the parent's chunks through a k-way
-    /// merge in groups of up to m and splits each group into the active children at
-    /// the wal-split limit, capping each merge+swap group at m chunks. `None` /
-    /// `Some(0)` / `Some(1)` disable the merge path.
-    fn repartition_merge_max_input_files(&self) -> Option<usize>;
+    /// Which repartition strategy to use for an inactive parent's persisted chunks.
+    /// Defaults to PerChunk.
+    fn repartition_strategy(&self) -> RepartitionStrategy;
+
+    /// Cap on the number of chunks merged together in one Merge group / RepartitionRange.
+    /// Bounds the concurrent parquet readers, the k-way merge width, the swap size and
+    /// (since a range downloads its chunks sequentially) the per-job download time.
+    fn repartition_merge_max_input_files(&self) -> usize;
+
+    /// Cap on the total rows merged together in one Merge group / RepartitionRange.
+    fn repartition_merge_max_rows(&self) -> u64;
 
     fn allow_decimal128(&self) -> bool;
 
@@ -703,7 +739,9 @@ pub struct ConfigObjImpl {
     pub compaction_split_by_total_file_size_enabled: bool,
     pub prefilter_in_memory_chunks_enabled: bool,
     pub repartition_prefetch_budget_bytes: Option<u64>,
-    pub repartition_merge_max_input_files: Option<usize>,
+    pub repartition_strategy: RepartitionStrategy,
+    pub repartition_merge_max_input_files: usize,
+    pub repartition_merge_max_rows: u64,
     pub allow_decimal128: bool,
     pub enable_remove_orphaned_remote_files: bool,
     pub enable_startup_warmup: bool,
@@ -1034,8 +1072,14 @@ impl ConfigObj for ConfigObjImpl {
     fn repartition_prefetch_budget_bytes(&self) -> Option<u64> {
         self.repartition_prefetch_budget_bytes
     }
-    fn repartition_merge_max_input_files(&self) -> Option<usize> {
+    fn repartition_strategy(&self) -> RepartitionStrategy {
+        self.repartition_strategy
+    }
+    fn repartition_merge_max_input_files(&self) -> usize {
         self.repartition_merge_max_input_files
+    }
+    fn repartition_merge_max_rows(&self) -> u64 {
+        self.repartition_merge_max_rows
     }
 
     fn allow_decimal128(&self) -> bool {
@@ -1369,6 +1413,24 @@ where
     })
 }
 
+// Unlike env_optparse, an unparseable value is not fatal: it logs a warning and falls
+// back to per_chunk, so a typo in the strategy env never takes the process down.
+fn env_repartition_strategy() -> RepartitionStrategy {
+    match env::var("CUBESTORE_REPARTITION_STRATEGY") {
+        Ok(v) => match v.parse::<RepartitionStrategy>() {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!(
+                    "Ignoring CUBESTORE_REPARTITION_STRATEGY: {}; using per_chunk",
+                    e
+                );
+                RepartitionStrategy::PerChunk
+            }
+        },
+        Err(_) => RepartitionStrategy::PerChunk,
+    }
+}
+
 impl Config {
     fn calculate_cache_compaction_trigger_size(cache_max_size: usize) -> usize {
         let trigger_size = match cache_max_size >> 20 {
@@ -1698,8 +1760,14 @@ impl Config {
                     None,
                 )
                 .map(|n| n as u64),
-                repartition_merge_max_input_files: env_optparse(
+                repartition_strategy: env_repartition_strategy(),
+                repartition_merge_max_input_files: env_parse(
                     "CUBESTORE_REPARTITION_MERGE_MAX_INPUT_FILES",
+                    50,
+                ),
+                repartition_merge_max_rows: env_parse(
+                    "CUBESTORE_REPARTITION_MERGE_MAX_ROWS",
+                    4_000_000,
                 ),
                 allow_decimal128: env_bool("CUBESTORE_ALLOW_DECIMAL128", false),
                 enable_remove_orphaned_remote_files: env_bool(
@@ -1947,7 +2015,9 @@ impl Config {
                 // and the rest of the suite keep exercising the worker-side trim path.
                 prefilter_in_memory_chunks_enabled: true,
                 repartition_prefetch_budget_bytes: None,
-                repartition_merge_max_input_files: None,
+                repartition_strategy: RepartitionStrategy::PerChunk,
+                repartition_merge_max_input_files: 50,
+                repartition_merge_max_rows: 4_000_000,
                 allow_decimal128: false,
                 enable_remove_orphaned_remote_files: false,
                 enable_startup_warmup: true,
@@ -2813,4 +2883,26 @@ pub async fn uses_remote_metastore(i: &Injector) -> bool {
 
 pub fn is_router(c: &dyn ConfigObj) -> bool {
     !c.worker_bind_address().is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repartition_strategy_from_str() {
+        assert_eq!(
+            "per_chunk".parse::<RepartitionStrategy>().unwrap(),
+            RepartitionStrategy::PerChunk
+        );
+        assert_eq!(
+            "per_partition".parse::<RepartitionStrategy>().unwrap(),
+            RepartitionStrategy::PerPartition
+        );
+        assert_eq!(
+            "RANGE".parse::<RepartitionStrategy>().unwrap(),
+            RepartitionStrategy::Range
+        );
+        assert!("nonsense".parse::<RepartitionStrategy>().is_err());
+    }
 }

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -540,11 +540,6 @@ pub trait ConfigObj: DIService {
     /// default (hash placement); kept as a flag for rollout/rollback.
     fn load_aware_import_placement_enabled(&self) -> bool;
 
-    /// When enabled, an inactive parent partition is repartitioned by a single
-    /// per-partition job that loops over its persisted chunks, instead of one
-    /// job per chunk. Kept as a flag for emergency rollback.
-    fn batch_repartition_enabled(&self) -> bool;
-
     /// Time budget for a single batch repartition job. The job yields its runner
     /// slot once the budget is exceeded (after the current chunk); the remainder
     /// is drained by a follow-up job via the cascade. Kept separate from
@@ -567,13 +562,11 @@ pub trait ConfigObj: DIService {
     /// Off by default; when disabled, chunks are sent whole and filtered only in the subprocess.
     fn prefilter_in_memory_chunks_enabled(&self) -> bool;
 
-    /// Byte budget for prefetching persisted chunk parquets ahead of a batch
-    /// repartition job. A sequential producer downloads upcoming chunks (anchor
-    /// last) while the job processes the current one, bounded so that no more
-    /// than this many bytes of fetched-but-unprocessed data sit on local disk.
-    /// The env value accepts size suffixes (e.g. `512MB`). `None` (env unset) or
-    /// `Some(0)` disables prefetching.
-    fn repartition_prefetch_budget_bytes(&self) -> Option<u64>;
+    /// When enabled, a merge group's chunk parquets (PerPartition / Range strategies) are
+    /// downloaded concurrently before building the merge inputs, instead of one at a time.
+    /// The group is already bounded by repartition_merge_max_input_files and the download
+    /// pool by download_concurrency, so no extra budget is needed. Off by default.
+    fn repartition_concurrent_download(&self) -> bool;
 
     /// Which repartition strategy to use for an inactive parent's persisted chunks.
     /// Defaults to PerChunk.
@@ -733,12 +726,11 @@ pub struct ConfigObjImpl {
     pub upload_to_remote: bool,
     pub enable_topk: bool,
     pub load_aware_import_placement_enabled: bool,
-    pub batch_repartition_enabled: bool,
     pub repartition_chunks_time_budget_secs: u64,
     pub push_partial_aggregate_below_merge_enabled: bool,
     pub compaction_split_by_total_file_size_enabled: bool,
     pub prefilter_in_memory_chunks_enabled: bool,
-    pub repartition_prefetch_budget_bytes: Option<u64>,
+    pub repartition_concurrent_download: bool,
     pub repartition_strategy: RepartitionStrategy,
     pub repartition_merge_max_input_files: usize,
     pub repartition_merge_max_rows: u64,
@@ -1054,9 +1046,6 @@ impl ConfigObj for ConfigObjImpl {
     fn load_aware_import_placement_enabled(&self) -> bool {
         self.load_aware_import_placement_enabled
     }
-    fn batch_repartition_enabled(&self) -> bool {
-        self.batch_repartition_enabled
-    }
     fn repartition_chunks_time_budget_secs(&self) -> u64 {
         self.repartition_chunks_time_budget_secs
     }
@@ -1069,8 +1058,8 @@ impl ConfigObj for ConfigObjImpl {
     fn prefilter_in_memory_chunks_enabled(&self) -> bool {
         self.prefilter_in_memory_chunks_enabled
     }
-    fn repartition_prefetch_budget_bytes(&self) -> Option<u64> {
-        self.repartition_prefetch_budget_bytes
+    fn repartition_concurrent_download(&self) -> bool {
+        self.repartition_concurrent_download
     }
     fn repartition_strategy(&self) -> RepartitionStrategy {
         self.repartition_strategy
@@ -1737,7 +1726,6 @@ impl Config {
                     "CUBESTORE_LOAD_AWARE_IMPORT_PLACEMENT",
                     false,
                 ),
-                batch_repartition_enabled: env_bool("CUBESTORE_BATCH_REPARTITION", false),
                 repartition_chunks_time_budget_secs: env_parse(
                     "CUBESTORE_REPARTITION_TIME_BUDGET_SECS",
                     60,
@@ -1754,12 +1742,10 @@ impl Config {
                     "CUBESTORE_PREFILTER_IN_MEMORY_CHUNKS",
                     false,
                 ),
-                repartition_prefetch_budget_bytes: env_parse_optional_size(
-                    "CUBESTORE_REPARTITION_PREFETCH_BUDGET",
-                    None,
-                    None,
-                )
-                .map(|n| n as u64),
+                repartition_concurrent_download: env_bool(
+                    "CUBESTORE_REPARTITION_CONCURRENT_DOWNLOAD",
+                    false,
+                ),
                 repartition_strategy: env_repartition_strategy(),
                 repartition_merge_max_input_files: env_parse(
                     "CUBESTORE_REPARTITION_MERGE_MAX_INPUT_FILES",
@@ -2007,14 +1993,13 @@ impl Config {
                 upload_to_remote: true,
                 enable_topk: true,
                 load_aware_import_placement_enabled: false,
-                batch_repartition_enabled: true,
                 repartition_chunks_time_budget_secs: 60,
                 push_partial_aggregate_below_merge_enabled: true,
                 compaction_split_by_total_file_size_enabled: false,
                 // Production default is off; kept on in tests so prefilter_chunks_shared_scan
                 // and the rest of the suite keep exercising the worker-side trim path.
                 prefilter_in_memory_chunks_enabled: true,
-                repartition_prefetch_budget_bytes: None,
+                repartition_concurrent_download: false,
                 repartition_strategy: RepartitionStrategy::PerChunk,
                 repartition_merge_max_input_files: 50,
                 repartition_merge_max_rows: 4_000_000,

--- a/rust/cubestore/cubestore/src/metastore/job.rs
+++ b/rust/cubestore/cubestore/src/metastore/job.rs
@@ -21,6 +21,12 @@ pub enum JobType {
     RepartitionChunk,
     InMemoryChunksCompaction,
     NodeInMemoryChunksCompaction(/*node*/ String),
+    // Repartition an inclusive [start, end] chunk-id range of an inactive parent in
+    // one merge+swap. row_reference carries the start chunk; the end is data only and
+    // is deliberately excluded from the job index key (see key_to_bytes) so a tail
+    // that extends the trailing range dedups on the start instead of spawning a
+    // second job for the same start.
+    RepartitionRange(/*end_chunk_id*/ u64),
     /// Fallback for job types written by a newer binary that this binary does
     /// not know about. Lets the read path decode such rows instead of failing
     /// the whole job scan; the worker ignores `Unknown` jobs.
@@ -41,6 +47,7 @@ fn get_job_type_index(j: &JobType) -> u32 {
         JobType::InMemoryChunksCompaction => 9,
         JobType::NodeInMemoryChunksCompaction(_) => 10,
         JobType::Unknown => 11,
+        JobType::RepartitionRange(_) => 12,
     }
 }
 
@@ -55,6 +62,7 @@ fn get_job_type_priority(j: &JobType) -> u32 {
         JobType::MultiPartitionSplit => 1000,
         JobType::FinishMultiSplit => 1000,
         JobType::RepartitionChunk => 1000,
+        JobType::RepartitionRange(_) => 1000,
         JobType::InMemoryChunksCompaction => 10000,
         JobType::NodeInMemoryChunksCompaction(_) => 10000,
         JobType::Unknown => 0,

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -51,6 +51,9 @@ pub struct SchedulerImpl {
     // Serializes load-aware import placement so concurrent CREATE TABLE events don't read
     // the same in-flight counts and pile onto the same worker before either job is scheduled.
     import_placement_lock: Mutex<()>,
+    // Short-TTL memo of the inactive parents still draining (range repartition), so the GC
+    // loop doesn't re-scan the whole chunk table on every cycle just to gate their deletion.
+    repartition_parents_cache: Mutex<Option<(Instant, Arc<HashSet<u64>>)>>,
 }
 
 crate::di_service!(SchedulerImpl, []);
@@ -107,7 +110,35 @@ impl SchedulerImpl {
             node_last_actions: Mutex::new(workers),
             chunk_processing_loop: WorkerLoop::new("ChunkProcessing"),
             import_placement_lock: Mutex::new(()),
+            repartition_parents_cache: Mutex::new(None),
         }
+    }
+
+    // Inactive parents that still have active chunks (range repartition in progress),
+    // memoized with a short TTL. The GC loop consults this to keep such parents' inactive
+    // chunks until they fully drain; the underlying query scans the chunk table, so caching
+    // avoids re-scanning it on every GC cycle. Staleness up to the TTL is harmless: the
+    // actual chunk deletion is already delayed by not_used_timeout.
+    async fn draining_repartition_parents(&self) -> Result<Arc<HashSet<u64>>, CubeError> {
+        const TTL: Duration = Duration::from_secs(5);
+        {
+            let guard = self.repartition_parents_cache.lock().await;
+            if let Some((at, set)) = guard.as_ref() {
+                if at.elapsed() < TTL {
+                    return Ok(set.clone());
+                }
+            }
+        }
+        let set = Arc::new(
+            self.meta_store
+                .all_inactive_partitions_to_repartition()
+                .await?
+                .into_iter()
+                .map(|p| p.get_id())
+                .collect::<HashSet<u64>>(),
+        );
+        *self.repartition_parents_cache.lock().await = Some((Instant::now(), set.clone()));
+        Ok(set)
     }
 
     pub fn spawn_processing_loops(self: Arc<Self>) -> Vec<JoinHandle<Result<(), CubeError>>> {
@@ -639,17 +670,11 @@ impl SchedulerImpl {
             // them would shift the slicing boundaries on the next re-slice. Once the
             // parent has no active chunks it is no longer in this set and its inactive
             // chunks are collected normally.
-            let keep_parents: HashSet<u64> =
-                if self.config.repartition_strategy() == RepartitionStrategy::Range {
-                    self.meta_store
-                        .all_inactive_partitions_to_repartition()
-                        .await?
-                        .into_iter()
-                        .map(|p| p.get_id())
-                        .collect()
-                } else {
-                    HashSet::new()
-                };
+            let keep_parents = if self.config.repartition_strategy() == RepartitionStrategy::Range {
+                self.draining_repartition_parents().await?
+            } else {
+                Arc::new(HashSet::new())
+            };
             let ids = persistent_inactive
                 .iter()
                 .filter(|c| !keep_parents.contains(&c.get_row().get_partition_id()))

--- a/rust/cubestore/cubestore/src/scheduler/mod.rs
+++ b/rust/cubestore/cubestore/src/scheduler/mod.rs
@@ -1,5 +1,5 @@
 use crate::cluster::{pick_import_worker, pick_worker_by_ids, Cluster};
-use crate::config::ConfigObj;
+use crate::config::{ConfigObj, RepartitionStrategy};
 use crate::metastore::chunks::chunk_file_name;
 use crate::metastore::job::{Job, JobStatus, JobType};
 use crate::metastore::partition::partition_file_name;
@@ -633,8 +633,26 @@ impl SchedulerImpl {
         if !persistent_inactive.is_empty() {
             let seconds = self.config.not_used_timeout();
             let deadline = Instant::now() + Duration::from_secs(seconds);
+            // Range-based repartition slices an inactive parent over ALL its chunks
+            // (active and inactive) so the [start, end] ranges stay pinned to chunk ids.
+            // While such a parent is still draining, keep its inactive chunks: deleting
+            // them would shift the slicing boundaries on the next re-slice. Once the
+            // parent has no active chunks it is no longer in this set and its inactive
+            // chunks are collected normally.
+            let keep_parents: HashSet<u64> =
+                if self.config.repartition_strategy() == RepartitionStrategy::Range {
+                    self.meta_store
+                        .all_inactive_partitions_to_repartition()
+                        .await?
+                        .into_iter()
+                        .map(|p| p.get_id())
+                        .collect()
+                } else {
+                    HashSet::new()
+                };
             let ids = persistent_inactive
                 .iter()
+                .filter(|c| !keep_parents.contains(&c.get_row().get_partition_id()))
                 .map(|c| c.get_id())
                 .collect::<Vec<_>>();
             for part in ids.as_slice().chunks(10000) {
@@ -859,20 +877,25 @@ impl SchedulerImpl {
         }
         if let MetaStoreEvent::DeleteJob(job) = event {
             match job.get_row().job_type() {
-                JobType::RepartitionChunk => match job.get_row().row_reference() {
-                    RowKey::Table(TableId::Chunks, c) => {
-                        let c = self.meta_store.get_chunk(*c).await?;
-                        let p = self
-                            .meta_store
-                            .get_partition(c.get_row().get_partition_id())
-                            .await?;
-                        self.schedule_repartition_if_needed(&p).await?
+                JobType::RepartitionChunk | JobType::RepartitionRange(_) => {
+                    match job.get_row().row_reference() {
+                        RowKey::Table(TableId::Chunks, c) => {
+                            let c = self.meta_store.get_chunk(*c).await?;
+                            let p = self
+                                .meta_store
+                                .get_partition(c.get_row().get_partition_id())
+                                .await?;
+                            // Re-slice the parent: drains any range whose job has not run
+                            // yet and picks up a tail chunk that landed after the previous
+                            // slicing (re-slicing is id-pinned, so existing ranges dedup).
+                            self.schedule_repartition_if_needed(&p).await?
+                        }
+                        _ => panic!(
+                            "Unexpected row reference: {:?}",
+                            job.get_row().row_reference()
+                        ),
                     }
-                    _ => panic!(
-                        "Unexpected row reference: {:?}",
-                        job.get_row().row_reference()
-                    ),
-                },
+                }
                 JobType::MultiPartitionSplit => match job.get_row().row_reference() {
                     RowKey::Table(TableId::MultiPartitions, m) => {
                         self.schedule_finish_multi_split_if_needed(*m).await?

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3615,6 +3615,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repartition_prefetch_keeps_data_consistent() -> Result<(), CubeError> {
+        // Batch repartition with chunk parquet prefetch enabled must drain and
+        // keep data consistent end-to-end (real downloads through the prefetch
+        // producer/consumer path).
+        Config::test("repartition_prefetch_keeps_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.batch_repartition_enabled = true;
+                c.repartition_prefetch_budget_bytes = Some(64 * 1024 * 1024);
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn repartition_small_time_budget_drains_via_cascade() -> Result<(), CubeError> {
         // A 1s budget forces most per-partition jobs to yield before draining all
         // chunks; the cascade must reschedule until the parent is empty.

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3589,6 +3589,7 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerChunk;
                 c
             })
             .start_test(async move |services| {
@@ -3643,8 +3644,47 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
-                c.batch_repartition_enabled = true;
-                c.repartition_merge_max_input_files = Some(4);
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
+                c.repartition_merge_max_input_files = 4;
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repartition_range_jobs_keep_data_consistent() -> Result<(), CubeError> {
+        // Range-job mechanism: schedule_repartition slices the parent's chunks into
+        // RepartitionRange jobs (by row cap), each merging its range into the children
+        // in one swap. Must drain and keep data consistent end-to-end.
+        Config::test("repartition_range_jobs_keep_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.repartition_strategy = crate::config::RepartitionStrategy::Range;
+                c.repartition_merge_max_rows = 40;
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repartition_range_jobs_small_rows_keep_data_consistent() -> Result<(), CubeError> {
+        // A tiny row cap plus a chunk-count cap forces many small RepartitionRange jobs.
+        Config::test("repartition_range_jobs_small_rows_keep_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.repartition_strategy = crate::config::RepartitionStrategy::Range;
+                c.repartition_merge_max_rows = 10;
+                c.repartition_merge_max_input_files = 2;
                 c
             })
             .start_test(async move |services| {
@@ -3662,8 +3702,8 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
-                c.batch_repartition_enabled = true;
-                c.repartition_merge_max_input_files = Some(2);
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
+                c.repartition_merge_max_input_files = 2;
                 c
             })
             .start_test(async move |services| {

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3605,7 +3605,7 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
-                c.batch_repartition_enabled = false;
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerChunk;
                 c
             })
             .start_test(async move |services| {
@@ -3616,16 +3616,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repartition_prefetch_keeps_data_consistent() -> Result<(), CubeError> {
-        // Batch repartition with chunk parquet prefetch enabled must drain and
-        // keep data consistent end-to-end (real downloads through the prefetch
-        // producer/consumer path).
-        Config::test("repartition_prefetch_keeps_data_consistent")
+    async fn repartition_concurrent_download_keeps_data_consistent() -> Result<(), CubeError> {
+        // PerPartition merge with concurrent chunk download enabled must drain and keep
+        // data consistent end-to-end (real concurrent downloads in the merge group build).
+        Config::test("repartition_concurrent_download_keeps_data_consistent")
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
-                c.batch_repartition_enabled = true;
-                c.repartition_prefetch_budget_bytes = Some(64 * 1024 * 1024);
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
+                c.repartition_merge_max_input_files = 4;
+                c.repartition_concurrent_download = true;
                 c
             })
             .start_test(async move |services| {
@@ -3721,7 +3721,8 @@ mod tests {
             .update_config(|mut c| {
                 c.partition_split_threshold = 20;
                 c.compaction_chunks_count_threshold = 10;
-                c.batch_repartition_enabled = true;
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
+                c.repartition_merge_max_input_files = 2;
                 c.repartition_chunks_time_budget_secs = 1;
                 c
             })

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3583,6 +3583,155 @@ mod tests {
         Ok(())
     }
 
+    // Same drain-and-verify flow, but on an aggregate-index table whose chunks share
+    // dimension keys across inserts. The repartition merge groups those rows by the
+    // sort key and emits fewer rows than it consumed, so the swap activates fewer rows
+    // than it deactivates. This is the production scenario that failed with "Deactivated
+    // row count (..) doesn't match activated row count (..) during swap"; the merge path
+    // must commit with the unchecked swap. `sum(m)` is conserved by the aggregation, so it
+    // is the invariant we assert end-to-end.
+    async fn assert_repartition_drains_and_keeps_aggregate_data(
+        services: &CubeServices,
+    ) -> Result<(), CubeError> {
+        let service = &services.sql_service;
+
+        service
+            .exec_query("CREATE SCHEMA foo")
+            .await?
+            .collect()
+            .await?;
+
+        service
+            .exec_query(
+                "CREATE TABLE foo.aggr (g int, m int) \
+                 AGGREGATIONS (sum(m)) AGGREGATE INDEX byg (g)",
+            )
+            .await?
+            .collect()
+            .await?;
+
+        // 200 single-row inserts cycling g over 0..40, so every g is inserted 5 times
+        // across distinct chunks. Aggregated, the table holds 40 rows; sum(m) stays 200.
+        let n: i64 = 200;
+        let distinct: i64 = 40;
+        for i in 0..n {
+            service
+                .exec_query(&format!(
+                    "INSERT INTO foo.aggr (g, m) VALUES ({}, 1)",
+                    i % distinct
+                ))
+                .await?
+                .collect()
+                .await?;
+        }
+
+        let mut drained = false;
+        for _ in 0..300 {
+            let pending = services
+                .meta_store
+                .all_inactive_partitions_to_repartition()
+                .await?;
+            if pending.is_empty() {
+                drained = true;
+                break;
+            }
+            Delay::new(Duration::from_millis(50)).await;
+        }
+        assert!(
+            drained,
+            "inactive partitions were not fully repartitioned in time"
+        );
+
+        // The aggregate index must have actually split into more than one partition.
+        let aggr_index = services
+            .meta_store
+            .get_table_indexes(1)
+            .await?
+            .into_iter()
+            .find(|i| i.get_row().get_name() == "byg")
+            .expect("aggregate index byg must exist");
+        let active = services
+            .meta_store
+            .get_active_partitions_by_index_id(aggr_index.get_id())
+            .await?;
+        assert!(
+            active.len() > 1,
+            "expected aggregate index to split, got {} active partitions",
+            active.len()
+        );
+
+        let result = service
+            .exec_query("SELECT sum(m) from foo.aggr")
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(result.get_rows()[0], Row::new(vec![TableValue::Int(n)]));
+
+        let result = service
+            .exec_query("SELECT g, sum(m) from foo.aggr GROUP BY g ORDER BY g")
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(
+            result.get_rows().len(),
+            distinct as usize,
+            "every distinct dimension value must survive the repartition"
+        );
+        for (g, row) in result.get_rows().iter().enumerate() {
+            assert_eq!(
+                row,
+                &Row::new(vec![
+                    TableValue::Int(g as i64),
+                    TableValue::Int(n / distinct)
+                ]),
+                "aggregated sum for g={} must be conserved",
+                g
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repartition_range_jobs_aggregate_index_keeps_data_consistent() -> Result<(), CubeError>
+    {
+        // Range strategy on an aggregate-index table: the repartition merge dedups rows by
+        // the sort key, so the commit must use the unchecked swap. Guards the production
+        // RepartitionRange row-count-mismatch regression end-to-end.
+        Config::test("repartition_range_jobs_aggregate_index_keeps_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.repartition_strategy = crate::config::RepartitionStrategy::Range;
+                c.repartition_merge_max_rows = 40;
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_aggregate_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repartition_merge_aggregate_index_keeps_data_consistent() -> Result<(), CubeError> {
+        // PerPartition merge on an aggregate-index table; same dedup invariant as the range
+        // variant above.
+        Config::test("repartition_merge_aggregate_index_keeps_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
+                c.repartition_merge_max_input_files = 4;
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_aggregate_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn repartition_keeps_data_consistent() -> Result<(), CubeError> {
         Config::test("repartition_keeps_data_consistent")

--- a/rust/cubestore/cubestore/src/sql/mod.rs
+++ b/rust/cubestore/cubestore/src/sql/mod.rs
@@ -3635,6 +3635,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repartition_merge_keeps_data_consistent() -> Result<(), CubeError> {
+        // Streaming merge-repartition path (group cap >= 2): the parent's chunks are
+        // merged and split into the children in one pass. Must drain and keep data
+        // consistent end-to-end.
+        Config::test("repartition_merge_keeps_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.batch_repartition_enabled = true;
+                c.repartition_merge_max_input_files = Some(4);
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repartition_merge_small_group_keeps_data_consistent() -> Result<(), CubeError> {
+        // Group cap of exactly 2 forces many small merge+swap groups; data must stay
+        // consistent and the parent must fully drain.
+        Config::test("repartition_merge_small_group_keeps_data_consistent")
+            .update_config(|mut c| {
+                c.partition_split_threshold = 20;
+                c.compaction_chunks_count_threshold = 10;
+                c.batch_repartition_enabled = true;
+                c.repartition_merge_max_input_files = Some(2);
+                c
+            })
+            .start_test(async move |services| {
+                assert_repartition_drains_and_keeps_data(&services).await
+            })
+            .await;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn repartition_small_time_budget_drains_via_cascade() -> Result<(), CubeError> {
         // A 1s budget forces most per-partition jobs to yield before draining all
         // chunks; the cascade must reschedule until the parent is empty.

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -1435,6 +1435,119 @@ async fn write_to_files_by_keys(
     Ok(row_counts)
 }
 
+/// One chunk file produced by `write_chunks_split_into_children`: which child (index into the
+/// ordered children list) it belongs to, the temp file it was written to, its row count and the
+/// min/max sort-key rows. Empty children yield an entry with `num_rows == 0`.
+pub(crate) struct WrittenChunk {
+    pub child_index: usize,
+    pub file: String,
+    pub num_rows: usize,
+    pub min: Vec<TableValue>,
+    pub max: Vec<TableValue>,
+}
+
+/// Splits a sorted [records] stream into chunk files for repartitioning a parent's chunks into its
+/// already-active children. Cuts a new file whenever a row crosses into the next child (per the
+/// exclusive upper bounds in [boundaries], one per child except the last) OR the current file
+/// reaches [rows_per_chunk]. [files] must over-estimate the number of produced files
+/// (`children + ceil(num_rows / rows_per_chunk)` is a safe bound). Returns the produced files in
+/// order; the caller creates a chunk per non-empty file under `children[child_index]`.
+pub(crate) async fn write_chunks_split_into_children(
+    records: SendableRecordBatchStream,
+    store: ParquetTableStore,
+    table: &IdRow<Table>,
+    files: Vec<String>,
+    boundaries: Vec<Row>,
+    rows_per_chunk: usize,
+) -> Result<Vec<WrittenChunk>, CubeError> {
+    assert!(rows_per_chunk > 0);
+    let key_size = store.key_size() as usize;
+    // Route on the partition-split key prefix (the authoritative partition boundary),
+    // but record chunk min/max on the full sort key.
+    let partition_split_key_size = store.partition_split_key_size() as usize;
+    let written = Arc::new(Mutex::new(vec![WrittenChunk {
+        child_index: 0,
+        file: files[0].clone(),
+        num_rows: 0,
+        min: Vec::new(),
+        max: Vec::new(),
+    }]));
+    let written_ref = written.clone();
+    let files_ref = files.clone();
+    // Current child index == number of boundaries already crossed.
+    let mut current_child = 0usize;
+    let mut next_file = 1usize;
+
+    let pick_writer = move |b: &RecordBatch| -> WriteBatchTo {
+        let n = b.num_rows();
+        let mut written = written_ref.lock().unwrap();
+
+        let rows_until_boundary = if current_child < boundaries.len() {
+            let mut i = 0;
+            while i < n
+                && cmp_partition_key(
+                    partition_split_key_size,
+                    boundaries[current_child].values().as_slice(),
+                    b.columns(),
+                    i,
+                ) > Ordering::Equal
+            {
+                i += 1;
+            }
+            i
+        } else {
+            n
+        };
+
+        let cur = written.last_mut().unwrap();
+        let rows_until_size = rows_per_chunk.saturating_sub(cur.num_rows);
+        let cut = rows_until_boundary.min(rows_until_size);
+
+        if cut >= n {
+            if n > 0 {
+                if cur.num_rows == 0 {
+                    cur.min = TableValue::from_columns(&b.columns()[0..key_size], 0);
+                }
+                cur.max = TableValue::from_columns(&b.columns()[0..key_size], n - 1);
+                cur.num_rows += n;
+            }
+            return WriteBatchTo::Current;
+        }
+
+        if cut > 0 {
+            if cur.num_rows == 0 {
+                cur.min = TableValue::from_columns(&b.columns()[0..key_size], 0);
+            }
+            cur.max = TableValue::from_columns(&b.columns()[0..key_size], cut - 1);
+            cur.num_rows += cut;
+        }
+
+        // Boundary cut advances the child; a pure size cut keeps the same child.
+        if rows_until_boundary <= rows_until_size {
+            current_child += 1;
+        }
+        let file = files_ref[next_file].clone();
+        next_file += 1;
+        written.push(WrittenChunk {
+            child_index: current_child,
+            file,
+            num_rows: 0,
+            min: Vec::new(),
+            max: Vec::new(),
+        });
+        WriteBatchTo::Next {
+            rows_for_current: cut,
+        }
+    };
+
+    write_to_files_impl(records, store, files, table, pick_writer).await?;
+
+    Ok(Arc::try_unwrap(written)
+        .map_err(|_| CubeError::internal("write_chunks stats still borrowed".to_string()))?
+        .into_inner()
+        .unwrap())
+}
+
 /// Builds a `SendableRecordBatchStream` merging the persistent partition data `l` with the
 /// already-sorted chunk inputs `r` (one sorted ExecutionPlan per chunk). Inputs are merged with a
 /// k-way `SortPreservingMergeExec` instead of being concatenated and re-sorted.

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -39,7 +39,7 @@ use std::{
 use crate::app_metrics;
 use crate::cluster::{node_name_by_partition, Cluster};
 use crate::config::injection::DIService;
-use crate::config::ConfigObj;
+use crate::config::{ConfigObj, RepartitionStrategy};
 use crate::metastore::chunks::chunk_file_name;
 use crate::queryplanner::trace_data_loaded::{DataLoadedSize, TraceDataLoadedExec};
 use crate::table::data::{cmp_min_rows, cmp_partition_key};
@@ -259,6 +259,12 @@ pub trait ChunkDataStore: DIService + Send + Sync {
         partition_id: u64,
         anchor_chunk_id: u64,
         time_budget: std::time::Duration,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError>;
+    async fn repartition_chunk_range(
+        &self,
+        start_chunk_id: u64,
+        end_chunk_id: u64,
         data_loaded_size: Arc<DataLoadedSize>,
     ) -> Result<(), CubeError>;
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError>;
@@ -618,19 +624,15 @@ impl ChunkDataStore for ChunkStore {
     ) -> Result<(), CubeError> {
         let start = std::time::Instant::now();
 
-        // Merge path: stream the parent's persisted chunks through a k-way merge and
-        // split into the active children at the wal-split limit, instead of emitting
-        // one chunk per (old chunk x child). Enabled by a group cap of >= 2.
-        if let Some(max_group) = self
-            .config
-            .repartition_merge_max_input_files()
-            .filter(|&m| m >= 2)
-        {
+        // PerPartition strategy: this single job k-way merges the parent's persisted
+        // chunks in groups and splits them into the active children at the wal-split
+        // limit, rather than splitting each chunk independently below.
+        if self.config.repartition_strategy() == RepartitionStrategy::PerPartition {
             return self
                 .repartition_partition_chunks_merged(
                     partition_id,
                     anchor_chunk_id,
-                    max_group,
+                    self.config.repartition_merge_max_input_files().max(1),
                     start,
                     time_budget,
                     data_loaded_size,
@@ -695,6 +697,71 @@ impl ChunkDataStore for ChunkStore {
                 Ok(())
             }
         }
+    }
+
+    // Repartition the active persisted chunks of one inclusive [start, end] chunk-id
+    // range into the parent's children, as a single RepartitionRange job. The range is
+    // resolved through the start chunk's partition; the boundary chunks must share that
+    // partition (Error::internal otherwise) and may be inactive (read for the partition
+    // only). Only active persisted chunks of the range are merged, in one atomic swap.
+    async fn repartition_chunk_range(
+        &self,
+        start_chunk_id: u64,
+        end_chunk_id: u64,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError> {
+        let start_chunk = self.meta_store.get_chunk(start_chunk_id).await?;
+        let end_chunk = self.meta_store.get_chunk(end_chunk_id).await?;
+        let partition_id = start_chunk.get_row().get_partition_id();
+        if end_chunk.get_row().get_partition_id() != partition_id {
+            return Err(CubeError::internal(format!(
+                "RepartitionRange boundary chunks {} and {} belong to different partitions",
+                start_chunk_id, end_chunk_id
+            )));
+        }
+        let partition = self.meta_store.get_partition(partition_id).await?;
+        if partition.get_row().is_active() {
+            return Err(CubeError::internal(format!(
+                "Tried to repartition active partition: {:?}",
+                partition
+            )));
+        }
+        let index = self
+            .meta_store
+            .get_index(partition.get_row().get_index_id())
+            .await?;
+        let table = self
+            .meta_store
+            .get_table_by_id(index.get_row().table_id())
+            .await?;
+        let (children, boundaries) = self
+            .compute_repartition_children(&partition, &index)
+            .await?;
+
+        let group = self
+            .meta_store
+            .get_chunks_by_partition(partition_id, false)
+            .await?
+            .into_iter()
+            .filter(|c| {
+                !c.get_row().in_memory()
+                    && c.get_id() >= start_chunk_id
+                    && c.get_id() <= end_chunk_id
+            })
+            .collect::<Vec<_>>();
+        if group.is_empty() {
+            return Ok(());
+        }
+        self.merge_chunk_group_into_children(
+            &partition,
+            &index,
+            &table,
+            &children,
+            &boundaries,
+            &group,
+            data_loaded_size,
+        )
+        .await
     }
 
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError> {
@@ -1016,18 +1083,58 @@ impl ChunkStore {
             .meta_store
             .get_table_by_id(index.get_row().table_id())
             .await?;
-        let key_size = index.get_row().sort_key_size() as usize;
+        let (children, boundaries) = self
+            .compute_repartition_children(&partition, &index)
+            .await?;
 
-        // The parent's children: active partitions of the index whose range lies
-        // within the parent's range, ordered by min bound. Their interior min bounds
-        // are the split boundaries fed to the writer, so order by the same bound the
-        // writer routes on (get_min_val) to keep the boundary sequence monotonic.
+        let mut chunks = self
+            .meta_store
+            .get_chunks_by_partition(partition_id, false)
+            .await?
+            .into_iter()
+            .filter(|c| !c.get_row().in_memory())
+            .collect::<Vec<_>>();
+        chunks.sort_by_key(|c| (c.get_id() == anchor_chunk_id, c.get_id()));
+
+        let groups = chunks
+            .chunks(max_group)
+            .map(|g| g.to_vec())
+            .collect::<Vec<_>>();
+        for group in groups {
+            self.merge_chunk_group_into_children(
+                &partition,
+                &index,
+                &table,
+                &children,
+                &boundaries,
+                &group,
+                data_loaded_size.clone(),
+            )
+            .await?;
+            if start.elapsed() >= time_budget {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    // Resolve the parent's children for repartition: active partitions of the index
+    // within the parent's range, ordered by min bound (the bound the writer routes on,
+    // kept monotonic), plus the interior split boundaries. The children must tile the
+    // parent's range exactly (matching outer bounds, touching interior bounds) or the
+    // table is deactivated as corrupt, the same guard partition_rows applies.
+    async fn compute_repartition_children(
+        &self,
+        partition: &IdRow<Partition>,
+        index: &IdRow<Index>,
+    ) -> Result<(Vec<IdRow<Partition>>, Vec<Row>), CubeError> {
+        let key_size = index.get_row().sort_key_size() as usize;
         let mut children = self
             .meta_store
             .get_active_partitions_by_index_id(index.get_id())
             .await?
             .into_iter()
-            .filter(|c| Self::partition_within(&partition, c, key_size))
+            .filter(|c| Self::partition_within(partition, c, key_size))
             .collect::<Vec<_>>();
         children.sort_by(|a, b| {
             cmp_min_rows(
@@ -1037,11 +1144,6 @@ impl ChunkStore {
             )
         });
 
-        // The children must tile the parent's range exactly: matching outer bounds and
-        // touching interior bounds, leaving no gap a row could fall through. Anything
-        // else means the partition metadata is inconsistent (same condition
-        // partition_rows guards), so deactivate the table rather than silently routing
-        // rows into a child whose range does not contain them.
         let bounds_eq = |a: Option<&Row>, b: Option<&Row>| match (a, b) {
             (None, None) => true,
             (Some(x), Some(y)) => cmp_min_rows(key_size, Some(x), Some(y)) == Ordering::Equal,
@@ -1065,7 +1167,7 @@ impl ChunkStore {
         if !tiles_parent {
             let message = format!(
                 "Repartition of {} found children that do not tile its range: {:?}",
-                partition_id,
+                partition.get_id(),
                 children.iter().map(|c| c.get_id()).collect::<Vec<_>>()
             );
             deactivate_table_due_to_corrupt_data(
@@ -1085,19 +1187,28 @@ impl ChunkStore {
             .ok_or_else(|| {
                 CubeError::internal("Child partition without a min bound during repartition".into())
             })?;
+        Ok((children, boundaries))
+    }
 
-        let mut chunks = self
-            .meta_store
-            .get_chunks_by_partition(partition_id, false)
-            .await?
-            .into_iter()
-            .filter(|c| !c.get_row().in_memory())
-            .collect::<Vec<_>>();
-        chunks.sort_by_key(|c| (c.get_id() == anchor_chunk_id, c.get_id()));
-        if chunks.is_empty() {
+    // Merge one group of (active) persisted chunks into the parent's children: k-way
+    // merge the chunks, stream-split the sorted output across the children at the
+    // wal-split limit, then commit a single atomic swap. An empty group (all sources
+    // had no rows) deactivates the sources directly. Losing the swap to a concurrent
+    // job that already repartitioned a source is tolerated (its new chunks are GC'd).
+    async fn merge_chunk_group_into_children(
+        &self,
+        partition: &IdRow<Partition>,
+        index: &IdRow<Index>,
+        table: &IdRow<Table>,
+        children: &[IdRow<Partition>],
+        boundaries: &[Row],
+        group: &[IdRow<Chunk>],
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError> {
+        if group.is_empty() {
             return Ok(());
         }
-
+        let key_size = index.get_row().sort_key_size() as usize;
         let wal_split = table
             .get_row()
             .partition_split_threshold_or_default(self.config.partition_split_threshold())
@@ -1109,157 +1220,139 @@ impl ChunkStore {
         };
         let schema = Arc::new(arrow_schema(index.get_row()));
 
-        let groups = chunks
-            .chunks(max_group)
-            .map(|g| g.to_vec())
-            .collect::<Vec<_>>();
-        for group in groups {
-            let mut chunk_inputs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(group.len());
-            for chunk in group.iter() {
-                let exec = self
-                    .chunk_exec(chunk.clone(), partition.clone(), index.clone())
-                    .await?;
-                chunk_inputs.push(Arc::new(TraceDataLoadedExec::new(
-                    exec,
-                    data_loaded_size.clone(),
-                )));
-            }
+        let mut chunk_inputs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(group.len());
+        for chunk in group.iter() {
+            let exec = self
+                .chunk_exec(chunk.clone(), partition.clone(), index.clone())
+                .await?;
+            chunk_inputs.push(Arc::new(TraceDataLoadedExec::new(
+                exec,
+                data_loaded_size.clone(),
+            )));
+        }
+        let task_context = QueryPlannerImpl::make_execution_context(
+            self.metadata_cache_factory
+                .cache_factory()
+                .make_session_config(),
+        )
+        .task_ctx();
+        let records = merge_chunks(
+            key_size,
+            Arc::new(EmptyExec::new(schema.clone())),
+            chunk_inputs,
+            unique_key,
+            aggregate_columns,
+            task_context,
+        )
+        .await?;
 
-            let task_context = QueryPlannerImpl::make_execution_context(
-                self.metadata_cache_factory
-                    .cache_factory()
-                    .make_session_config(),
-            )
-            .task_ctx();
-            let records = merge_chunks(
-                key_size,
-                Arc::new(EmptyExec::new(schema.clone())),
-                chunk_inputs,
-                unique_key.clone(),
-                aggregate_columns.clone(),
-                task_context,
-            )
-            .await?;
+        for child in children.iter() {
+            self.check_node_disk_space(child).await?;
+        }
 
-            for child in children.iter() {
-                self.check_node_disk_space(child).await?;
-            }
-
-            let group_rows: u64 = group.iter().map(|c| c.get_row().get_row_count()).sum();
-            let max_files = children.len() + (group_rows as usize).div_ceil(wal_split.max(1)) + 1;
-            // A random salt keeps temp paths unique even if two repartition jobs ever
-            // run for the same partition concurrently (e.g. across a channel switch).
-            let salt = rand::random::<u64>();
-            let mut files = Vec::with_capacity(max_files);
-            for i in 0..max_files {
-                files.push(
-                    self.remote_fs
-                        .temp_upload_path(format!(
-                            "repartition/{}-{:x}-{}.chunk.parquet",
-                            partition_id, salt, i
-                        ))
-                        .await?,
-                );
-            }
-            let store = ParquetTableStore::new(
-                index.get_row().clone(),
-                ROW_GROUP_SIZE,
-                self.metadata_cache_factory.clone(),
+        let group_rows: u64 = group.iter().map(|c| c.get_row().get_row_count()).sum();
+        let max_files = children.len() + (group_rows as usize).div_ceil(wal_split.max(1)) + 1;
+        // A random salt keeps temp paths unique even if two repartition jobs ever run
+        // against the same partition concurrently (e.g. across a channel switch).
+        let salt = rand::random::<u64>();
+        let mut files = Vec::with_capacity(max_files);
+        for i in 0..max_files {
+            files.push(
+                self.remote_fs
+                    .temp_upload_path(format!(
+                        "repartition/{}-{:x}-{}.chunk.parquet",
+                        partition.get_id(),
+                        salt,
+                        i
+                    ))
+                    .await?,
             );
-            let written = write_chunks_split_into_children(
-                records,
-                store,
-                &table,
-                files,
-                boundaries.clone(),
-                wal_split.max(1),
-            )
-            .await?;
+        }
+        let store = ParquetTableStore::new(
+            index.get_row().clone(),
+            ROW_GROUP_SIZE,
+            self.metadata_cache_factory.clone(),
+        );
+        let written = write_chunks_split_into_children(
+            records,
+            store,
+            table,
+            files,
+            boundaries.to_vec(),
+            wal_split.max(1),
+        )
+        .await?;
 
-            let mut new_chunk_ids: Vec<(u64, Option<u64>)> = Vec::new();
-            for w in written {
-                if w.num_rows == 0 {
-                    let _ = tokio::fs::remove_file(&w.file).await;
-                    continue;
-                }
-                let child = &children[w.child_index];
-                let chunk = self
-                    .meta_store
-                    .create_chunk(
-                        child.get_id(),
-                        w.num_rows,
-                        Some(Row::new(w.min)),
-                        Some(Row::new(w.max)),
-                        false,
-                    )
-                    .await?;
-                let remote = ChunkStore::chunk_file_name(chunk.clone());
-                let file_size = self.remote_fs.upload_file(w.file, remote).await?;
-                new_chunk_ids.push((chunk.get_id(), Some(file_size)));
-            }
-
-            let group_ids: Vec<u64> = group.iter().map(|c| c.get_id()).collect();
-
-            // A fully empty group (every source chunk had no rows) produces no new
-            // chunks; swap_chunks rejects an empty activation list, so just deactivate
-            // the sources directly, matching the per-chunk path's empty-chunk handling.
-            if new_chunk_ids.is_empty() {
-                self.meta_store.deactivate_chunks(group_ids).await?;
-                if start.elapsed() >= time_budget {
-                    break;
-                }
+        let mut new_chunk_ids: Vec<(u64, Option<u64>)> = Vec::new();
+        for w in written {
+            if w.num_rows == 0 {
+                let _ = tokio::fs::remove_file(&w.file).await;
                 continue;
             }
-
-            // Carry the oldest insert time across the merge so repartitioned chunks
-            // keep their real age (the min, mirroring how replay handles are merged)
-            // instead of looking freshly inserted.
-            let oldest_insert_at = group
-                .iter()
-                .filter_map(|c| c.get_row().oldest_insert_at().clone())
-                .min();
-            self.meta_store
-                .chunk_update_last_inserted(
-                    new_chunk_ids.iter().map(|c| c.0).collect(),
-                    oldest_insert_at,
+            let child = &children[w.child_index];
+            let chunk = self
+                .meta_store
+                .create_chunk(
+                    child.get_id(),
+                    w.num_rows,
+                    Some(Row::new(w.min)),
+                    Some(Row::new(w.max)),
+                    false,
                 )
                 .await?;
+            let remote = ChunkStore::chunk_file_name(chunk.clone());
+            let file_size = self.remote_fs.upload_file(w.file, remote).await?;
+            new_chunk_ids.push((chunk.get_id(), Some(file_size)));
+        }
 
-            let replay_handle_id =
-                merge_replay_handles(self.meta_store.clone(), &group, table.get_id()).await?;
-            if let Err(e) = self
-                .meta_store
-                .swap_chunks(group_ids.clone(), new_chunk_ids, replay_handle_id)
-                .await
-            {
-                // Group-level race tolerance: if any source chunk is already inactive
-                // a concurrent job won the swap, so the work is done — the new chunks
-                // we created stay inactive and are GC'd. If all sources are still
-                // active the swap failed for a real reason.
-                let mut all_active = true;
-                for id in &group_ids {
-                    let active = self
-                        .meta_store
-                        .get_chunk(*id)
-                        .await
-                        .map_or(false, |c| c.get_row().active());
-                    if !active {
-                        all_active = false;
-                        break;
-                    }
-                }
-                if all_active {
-                    return Err(e);
-                }
-                log::debug!(
-                    "Skipping repartition group lost to a concurrent swap: {}",
-                    e
-                );
-            }
+        let group_ids: Vec<u64> = group.iter().map(|c| c.get_id()).collect();
 
-            if start.elapsed() >= time_budget {
-                break;
+        // A fully empty group produces no new chunks; swap_chunks rejects an empty
+        // activation list, so deactivate the sources directly.
+        if new_chunk_ids.is_empty() {
+            self.meta_store.deactivate_chunks(group_ids).await?;
+            return Ok(());
+        }
+
+        // Carry the oldest insert time across the merge (the min) so repartitioned
+        // chunks keep their real age instead of looking freshly inserted.
+        let oldest_insert_at = group
+            .iter()
+            .filter_map(|c| c.get_row().oldest_insert_at().clone())
+            .min();
+        self.meta_store
+            .chunk_update_last_inserted(
+                new_chunk_ids.iter().map(|c| c.0).collect(),
+                oldest_insert_at,
+            )
+            .await?;
+
+        let replay_handle_id =
+            merge_replay_handles(self.meta_store.clone(), &group.to_vec(), table.get_id()).await?;
+        if let Err(e) = self
+            .meta_store
+            .swap_chunks(group_ids.clone(), new_chunk_ids, replay_handle_id)
+            .await
+        {
+            let mut all_active = true;
+            for id in &group_ids {
+                let active = self
+                    .meta_store
+                    .get_chunk(*id)
+                    .await
+                    .map_or(false, |c| c.get_row().active());
+                if !active {
+                    all_active = false;
+                    break;
+                }
             }
+            if all_active {
+                return Err(e);
+            }
+            log::debug!(
+                "Skipping repartition group lost to a concurrent swap: {}",
+                e
+            );
         }
         Ok(())
     }
@@ -2040,7 +2133,8 @@ mod tests {
         // the first group (anchor, processed last, stays active); a large budget
         // drains the rest. Row counts must be conserved across the children.
         let config = Config::test("repartition_merge_drains_and_yields").update_config(|mut c| {
-            c.repartition_merge_max_input_files = Some(2);
+            c.repartition_strategy = RepartitionStrategy::PerPartition;
+            c.repartition_merge_max_input_files = 2;
             c
         });
         let path = "/tmp/test_repartition_merge";
@@ -2229,11 +2323,180 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn repartition_chunk_range_merges_only_range() {
+        // repartition_chunk_range must merge only the active persisted chunks within
+        // [start, end], leaving the rest active, and conserve rows into the children.
+        let config = Config::test("repartition_chunk_range_merges_only_range");
+        let path = "/tmp/test_repartition_range";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
+            let partition = meta_store
+                .get_active_partitions_by_index_id(index.get_id())
+                .await
+                .unwrap()[0]
+                .clone();
+
+            let mut chunk_ids = Vec::new();
+            for range in [0..10i64, 10..20i64, 20..30i64] {
+                let rows = range
+                    .map(|i| Row::new(vec![TableValue::Int(i)]))
+                    .collect::<Vec<_>>();
+                let data = rows_to_columns(&col, &rows);
+                let (chunk, file_size) = chunk_store
+                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+                meta_store
+                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
+                    .await
+                    .unwrap();
+                chunk_ids.push(chunk.get_id());
+            }
+
+            let dest1 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let dest2 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let mid = Row::new(vec![TableValue::Int(15)]);
+            meta_store
+                .swap_active_partitions(
+                    vec![(partition.clone(), vec![])],
+                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
+                    vec![
+                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
+                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
+                    ],
+                )
+                .await
+                .unwrap();
+
+            let active_count = |partition_id: u64| {
+                let meta_store = meta_store.clone();
+                async move {
+                    meta_store
+                        .get_chunks_by_partition(partition_id, false)
+                        .await
+                        .unwrap()
+                        .into_iter()
+                        .filter(|c| c.get_row().active())
+                        .count()
+                }
+            };
+            let child_rows = |dest_id: u64| {
+                let meta_store = meta_store.clone();
+                async move {
+                    meta_store
+                        .get_chunks_by_partition(dest_id, false)
+                        .await
+                        .unwrap()
+                        .iter()
+                        .filter(|c| c.get_row().active())
+                        .map(|c| c.get_row().get_row_count())
+                        .sum::<u64>()
+                }
+            };
+
+            // Merge only [c1, c2]; c3 must stay active on the parent.
+            chunk_store
+                .repartition_chunk_range(chunk_ids[0], chunk_ids[1], DataLoadedSize::new())
+                .await
+                .unwrap();
+            assert_eq!(
+                active_count(partition.get_id()).await,
+                1,
+                "only the chunk outside the range stays active"
+            );
+            assert_eq!(
+                child_rows(dest1.get_id()).await + child_rows(dest2.get_id()).await,
+                20,
+                "the range's rows land in the children"
+            );
+
+            // Now merge the remaining chunk; the parent drains.
+            chunk_store
+                .repartition_chunk_range(chunk_ids[2], chunk_ids[2], DataLoadedSize::new())
+                .await
+                .unwrap();
+            assert_eq!(
+                active_count(partition.get_id()).await,
+                0,
+                "parent drains after the last range"
+            );
+            assert_eq!(child_rows(dest1.get_id()).await, 15);
+            assert_eq!(child_rows(dest2.get_id()).await, 15);
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
+    }
+
+    #[tokio::test]
     async fn repartition_merge_drains_empty_group() {
         // A group whose chunks are all empty produces no new chunks; the merge path
         // must deactivate the sources directly instead of failing on an empty swap.
         let config = Config::test("repartition_merge_drains_empty_group").update_config(|mut c| {
-            c.repartition_merge_max_input_files = Some(4);
+            c.repartition_strategy = RepartitionStrategy::PerPartition;
+            c.repartition_merge_max_input_files = 4;
             c
         });
         let path = "/tmp/test_repartition_merge_empty";

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -1830,7 +1830,11 @@ mod tests {
 
     #[tokio::test]
     async fn repartition_partition_chunks_yields_on_budget() {
-        let config = Config::test("repartition_partition_chunks_yields_on_budget");
+        let config =
+            Config::test("repartition_partition_chunks_yields_on_budget").update_config(|mut c| {
+                c.repartition_strategy = RepartitionStrategy::PerChunk;
+                c
+            });
         let path = "/tmp/test_repartition_yield";
         let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
         let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
@@ -2001,6 +2005,7 @@ mod tests {
         // (one chunk, anchor last) and drain semantics intact.
         let config =
             Config::test("repartition_partition_chunks_prefetch_drains").update_config(|mut c| {
+                c.repartition_strategy = RepartitionStrategy::PerChunk;
                 c.repartition_prefetch_budget_bytes = Some(64 * 1024 * 1024);
                 c
             });

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -39,7 +39,7 @@ use std::{
 use crate::app_metrics;
 use crate::cluster::{node_name_by_partition, Cluster};
 use crate::config::injection::DIService;
-use crate::config::{ConfigObj, RepartitionStrategy};
+use crate::config::ConfigObj;
 use crate::metastore::chunks::chunk_file_name;
 use crate::queryplanner::trace_data_loaded::{DataLoadedSize, TraceDataLoadedExec};
 use crate::table::data::{cmp_min_rows, cmp_partition_key};
@@ -58,7 +58,7 @@ use log::trace;
 use mockall::automock;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use tokio::sync::{mpsc, OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
 pub const ROW_GROUP_SIZE: usize = 16384; // TODO config
@@ -615,6 +615,10 @@ impl ChunkDataStore for ChunkStore {
         Ok(())
     }
 
+    // PerPartition repartition: this single job (keyed on the anchor chunk) k-way merges
+    // the parent's persisted chunks in groups and splits them into the active children at
+    // the wal-split limit. anchor_chunk_id is the dedup key (smallest persisted chunk);
+    // chunks are processed anchor-last so it stays active until the run finishes/yields.
     async fn repartition_partition_chunks(
         &self,
         partition_id: u64,
@@ -623,80 +627,15 @@ impl ChunkDataStore for ChunkStore {
         data_loaded_size: Arc<DataLoadedSize>,
     ) -> Result<(), CubeError> {
         let start = std::time::Instant::now();
-
-        // PerPartition strategy: this single job k-way merges the parent's persisted
-        // chunks in groups and splits them into the active children at the wal-split
-        // limit, rather than splitting each chunk independently below.
-        if self.config.repartition_strategy() == RepartitionStrategy::PerPartition {
-            return self
-                .repartition_partition_chunks_merged(
-                    partition_id,
-                    anchor_chunk_id,
-                    self.config.repartition_merge_max_input_files().max(1),
-                    start,
-                    time_budget,
-                    data_loaded_size,
-                )
-                .await;
-        }
-
-        let mut chunks = self
-            .meta_store
-            .get_chunks_by_partition(partition_id, false)
-            .await?
-            .into_iter()
-            .filter(|c| !c.get_row().in_memory())
-            .collect::<Vec<_>>();
-        // FIXME: anchor_chunk_id is the chunk carried in the RepartitionChunk
-        // job's row_reference (see job_processor). In steady state the scheduler
-        // picks it deterministically (smallest persisted chunk id) so add_job
-        // dedups to a single job per partition, and we process the anchor LAST so
-        // it stays active and keeps holding that dedup key until the job finishes.
-        // That single-job guarantee is steady-state only: across a latest/release
-        // channel switch a per-chunk job and this anchor job can target the same
-        // chunks. Correctness there does NOT rely on dedup — it rests on
-        // swap_chunks being atomic (it deactivates the source chunk under a rocks
-        // transaction and rejects a swap whose source is already inactive), so a
-        // chunk is ever repartitioned exactly once regardless of how many jobs
-        // race for it.
-        //
-        // Order: anchor last, the rest by ascending id. The ascending order also
-        // drives the prefetch producer below, which warms upcoming chunks while
-        // the current one is processed.
-        chunks.sort_by_key(|c| (c.get_id() == anchor_chunk_id, c.get_id()));
-
-        let prefetch_budget = self
-            .config
-            .repartition_prefetch_budget_bytes()
-            .filter(|&b| b > 0);
-
-        // Process chunks one at a time so peak memory stays at a single chunk.
-        // Each repartition_chunk commits its own swap, so a partial run is safe:
-        // a follow-up job re-reads only the still-active chunks and continues.
-        // The budget bounds how long this job holds its runner slot; granularity
-        // is one chunk, so a single oversized chunk may overshoot the budget.
-        match prefetch_budget {
-            Some(budget) => {
-                self.repartition_partition_chunks_prefetched(
-                    chunks,
-                    budget,
-                    start,
-                    time_budget,
-                    data_loaded_size,
-                )
-                .await
-            }
-            None => {
-                for chunk in chunks {
-                    self.repartition_chunk_tolerant(chunk.get_id(), data_loaded_size.clone())
-                        .await?;
-                    if start.elapsed() >= time_budget {
-                        break;
-                    }
-                }
-                Ok(())
-            }
-        }
+        self.repartition_partition_chunks_merged(
+            partition_id,
+            anchor_chunk_id,
+            self.config.repartition_merge_max_input_files().max(1),
+            start,
+            time_budget,
+            data_loaded_size,
+        )
+        .await
     }
 
     // Repartition the active persisted chunks of one inclusive [start, end] chunk-id
@@ -951,108 +890,6 @@ impl ChunkDataStore for ChunkStore {
 }
 
 impl ChunkStore {
-    // Repartition a single chunk, tolerating the swap race. Losing the swap
-    // (another job repartitioned this chunk first) leaves it inactive — that
-    // work is already done, so we keep draining the rest instead of failing the
-    // whole batch. Any other error leaves the chunk active and is a genuine
-    // failure that propagates.
-    async fn repartition_chunk_tolerant(
-        &self,
-        chunk_id: u64,
-        data_loaded_size: Arc<DataLoadedSize>,
-    ) -> Result<(), CubeError> {
-        if let Err(e) = self.repartition_chunk(chunk_id, data_loaded_size).await {
-            let still_active = self
-                .meta_store
-                .get_chunk(chunk_id)
-                .await
-                .map_or(false, |c| c.get_row().active());
-            if still_active {
-                return Err(e);
-            }
-            log::debug!(
-                "Skipping chunk {} lost to a concurrent repartition: {}",
-                chunk_id,
-                e
-            );
-        }
-        Ok(())
-    }
-
-    // Prefetch variant of the repartition loop. A sequential producer downloads
-    // upcoming chunk parquets (in the order given, anchor last) into the local
-    // cache while the consumer processes the current chunk. A byte-budget
-    // semaphore bounds how much fetched-but-unprocessed data sits on disk: each
-    // chunk holds permits worth its file size from before its download starts
-    // until the consumer finishes processing it. download_file is idempotent and
-    // dedups in-flight downloads, so the consumer's repartition_chunk just hits
-    // the warm local file. Chunks prefetched past the time budget stay on local
-    // disk and warm the follow-up job, which lands on the same node by partition.
-    async fn repartition_partition_chunks_prefetched(
-        &self,
-        chunks: Vec<IdRow<Chunk>>,
-        budget: u64,
-        start: std::time::Instant,
-        time_budget: std::time::Duration,
-        data_loaded_size: Arc<DataLoadedSize>,
-    ) -> Result<(), CubeError> {
-        let capacity = budget.min(u32::MAX as u64) as usize;
-        let semaphore = Arc::new(Semaphore::new(capacity));
-        let (tx, mut rx) = mpsc::channel::<(u64, OwnedSemaphorePermit)>(chunks.len().max(1));
-
-        let remote_fs = self.remote_fs.clone();
-        let producer: JoinHandle<()> = cube_ext::spawn(async move {
-            for chunk in chunks {
-                // A chunk with no recorded file_size is billed at the full budget
-                // (conservative) rather than ~free, so an unknown-size prefetch can't
-                // overshoot the on-disk budget. Persisted chunks normally have a size.
-                let permits = chunk
-                    .get_row()
-                    .file_size()
-                    .unwrap_or(capacity as u64)
-                    .min(capacity as u64)
-                    .max(1) as u32;
-                let permit = match semaphore.clone().acquire_many_owned(permits).await {
-                    Ok(p) => p,
-                    Err(_) => return,
-                };
-                let file_size = chunk.get_row().file_size();
-                let remote_path = ChunkStore::chunk_file_name(chunk.clone());
-                // Warm the local cache; ignore errors here — the consumer's
-                // repartition_chunk re-issues the download and surfaces a genuine
-                // failure with proper handling (including table deactivation).
-                if let Err(e) = remote_fs.download_file(remote_path, file_size).await {
-                    log::debug!("Prefetch of chunk {} failed: {}", chunk.get_id(), e);
-                }
-                if tx.send((chunk.get_id(), permit)).await.is_err() {
-                    // Consumer stopped (time budget reached); drop the rest.
-                    return;
-                }
-            }
-        });
-
-        let result = async {
-            while let Some((chunk_id, permit)) = rx.recv().await {
-                let res = self
-                    .repartition_chunk_tolerant(chunk_id, data_loaded_size.clone())
-                    .await;
-                // Free this chunk's disk budget so the producer can advance.
-                drop(permit);
-                res?;
-                if start.elapsed() >= time_budget {
-                    break;
-                }
-            }
-            Ok(())
-        }
-        .await;
-
-        // Stop the producer even if it is blocked mid-download; the queued
-        // download itself proceeds independently, so an abort leaks nothing.
-        producer.abort();
-        result
-    }
-
     // Streaming merge variant of repartition. The parent's persisted chunks are
     // merged k-way (in groups of <= max_group input files) and the sorted stream is
     // split directly into the parent's already-active children at the wal-split
@@ -1246,6 +1083,27 @@ impl ChunkStore {
             IndexType::Aggregate => Some(table.get_row().aggregate_columns()),
         };
         let schema = Arc::new(arrow_schema(index.get_row()));
+
+        // Download the group's chunk parquets into the local cache concurrently before
+        // building the merge inputs, so downloads overlap instead of running one-at-a-time
+        // in chunk_exec below. The group is bounded by max_input_files and the download
+        // pool by download_concurrency. download_file is idempotent so chunk_exec then hits
+        // the cache.
+        if self.config.repartition_concurrent_download() {
+            let mut downloads = Vec::with_capacity(group.len());
+            for chunk in group.iter() {
+                let file_size = chunk.get_row().file_size();
+                let remote_path = ChunkStore::chunk_file_name(chunk.clone());
+                let remote_fs = self.remote_fs.clone();
+                downloads.push(cube_ext::spawn(async move {
+                    // Warm the cache; a genuine error surfaces later in chunk_exec.
+                    let _ = remote_fs.download_file(remote_path, file_size).await;
+                }));
+            }
+            for d in downloads {
+                let _ = d.await;
+            }
+        }
 
         let mut chunk_inputs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(group.len());
         for chunk in group.iter() {
@@ -1829,349 +1687,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repartition_partition_chunks_yields_on_budget() {
-        let config =
-            Config::test("repartition_partition_chunks_yields_on_budget").update_config(|mut c| {
-                c.repartition_strategy = RepartitionStrategy::PerChunk;
-                c
-            });
-        let path = "/tmp/test_repartition_yield";
-        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
-        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
-
-        let _ = DB::destroy(&Options::default(), path);
-        let _ = fs::remove_dir_all(chunk_store_path.clone());
-        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
-        {
-            let remote_fs = LocalDirRemoteFs::new(
-                Some(PathBuf::from(chunk_remote_store_path.clone())),
-                PathBuf::from(chunk_store_path.clone()),
-            );
-            let meta_store = RocksMetaStore::new(
-                Path::new(path),
-                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
-                config.config_obj(),
-            )
-            .unwrap();
-            let chunk_store = ChunkStore::new(
-                meta_store.clone(),
-                remote_fs.clone(),
-                Arc::new(MockCluster::new()),
-                config.config_obj(),
-                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
-                10,
-            );
-
-            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
-            meta_store
-                .create_schema("foo".to_string(), false)
-                .await
-                .unwrap();
-            let table = meta_store
-                .create_table(
-                    "foo".to_string(),
-                    "bar".to_string(),
-                    col.clone(),
-                    None,
-                    None,
-                    vec![],
-                    true,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                    None,
-                )
-                .await
-                .unwrap();
-            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
-            let partition = meta_store
-                .get_active_partitions_by_index_id(index.get_id())
-                .await
-                .unwrap()[0]
-                .clone();
-
-            // Two persisted chunks with real data on the parent partition.
-            let mut chunk_ids = Vec::new();
-            for range in [0..10i64, 10..20i64] {
-                let rows = range
-                    .map(|i| Row::new(vec![TableValue::Int(i)]))
-                    .collect::<Vec<_>>();
-                let data = rows_to_columns(&col, &rows);
-                let (chunk, file_size) = chunk_store
-                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap()
-                    .unwrap();
-                meta_store
-                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
-                    .await
-                    .unwrap();
-                chunk_ids.push(chunk.get_id());
-            }
-
-            // Split the parent into two children so swap_active_partitions does not
-            // take the single-child re-parent path; the chunks are left active by
-            // passing an empty chunk list, giving an inactive parent with 2 active
-            // persisted chunks (the state a repartition job runs against).
-            let dest1 = meta_store
-                .create_partition(Partition::new_child(&partition, None))
-                .await
-                .unwrap();
-            let dest2 = meta_store
-                .create_partition(Partition::new_child(&partition, None))
-                .await
-                .unwrap();
-            let mid = Row::new(vec![TableValue::Int(10)]);
-            meta_store
-                .swap_active_partitions(
-                    vec![(partition.clone(), vec![])],
-                    // file_size must be non-zero (set_file_size rejects 0); the
-                    // children carry no main table data (row_count 0), so it is a
-                    // placeholder — repartition writes new chunks onto them.
-                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
-                    vec![
-                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
-                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
-                    ],
-                )
-                .await
-                .unwrap();
-
-            let anchor = *chunk_ids.iter().min().unwrap();
-
-            // Zero budget must still process exactly one chunk (progress guarantee),
-            // then yield. The anchor is processed last, so it is the one left active.
-            chunk_store
-                .repartition_partition_chunks(
-                    partition.get_id(),
-                    anchor,
-                    std::time::Duration::from_secs(0),
-                    DataLoadedSize::new(),
-                )
-                .await
-                .unwrap();
-            let remaining = meta_store
-                .get_chunks_by_partition(partition.get_id(), false)
-                .await
-                .unwrap();
-            assert_eq!(
-                remaining.len(),
-                1,
-                "zero-budget run must yield after exactly one chunk"
-            );
-            assert_eq!(
-                remaining[0].get_id(),
-                anchor,
-                "anchor must be processed last and remain active after a yield"
-            );
-
-            // A large budget drains the remainder.
-            chunk_store
-                .repartition_partition_chunks(
-                    partition.get_id(),
-                    anchor,
-                    std::time::Duration::from_secs(600),
-                    DataLoadedSize::new(),
-                )
-                .await
-                .unwrap();
-            let remaining = meta_store
-                .get_chunks_by_partition(partition.get_id(), false)
-                .await
-                .unwrap();
-            assert!(
-                remaining.is_empty(),
-                "remaining chunks must drain with a large budget"
-            );
-        }
-        let _ = DB::destroy(&Options::default(), path);
-        let _ = fs::remove_dir_all(chunk_store_path);
-        let _ = fs::remove_dir_all(chunk_remote_store_path);
-    }
-
-    #[tokio::test]
-    async fn repartition_partition_chunks_prefetch_drains() {
-        // Same parent/chunk setup as repartition_partition_chunks_yields_on_budget,
-        // but with prefetch enabled, asserting the prefetch path keeps the yield
-        // (one chunk, anchor last) and drain semantics intact.
-        let config =
-            Config::test("repartition_partition_chunks_prefetch_drains").update_config(|mut c| {
-                c.repartition_strategy = RepartitionStrategy::PerChunk;
-                c.repartition_prefetch_budget_bytes = Some(64 * 1024 * 1024);
-                c
-            });
-        let path = "/tmp/test_repartition_prefetch";
-        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
-        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
-
-        let _ = DB::destroy(&Options::default(), path);
-        let _ = fs::remove_dir_all(chunk_store_path.clone());
-        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
-        {
-            let remote_fs = LocalDirRemoteFs::new(
-                Some(PathBuf::from(chunk_remote_store_path.clone())),
-                PathBuf::from(chunk_store_path.clone()),
-            );
-            let meta_store = RocksMetaStore::new(
-                Path::new(path),
-                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
-                config.config_obj(),
-            )
-            .unwrap();
-            let chunk_store = ChunkStore::new(
-                meta_store.clone(),
-                remote_fs.clone(),
-                Arc::new(MockCluster::new()),
-                config.config_obj(),
-                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
-                10,
-            );
-
-            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
-            meta_store
-                .create_schema("foo".to_string(), false)
-                .await
-                .unwrap();
-            let table = meta_store
-                .create_table(
-                    "foo".to_string(),
-                    "bar".to_string(),
-                    col.clone(),
-                    None,
-                    None,
-                    vec![],
-                    true,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    false,
-                    None,
-                )
-                .await
-                .unwrap();
-            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
-            let partition = meta_store
-                .get_active_partitions_by_index_id(index.get_id())
-                .await
-                .unwrap()[0]
-                .clone();
-
-            let mut chunk_ids = Vec::new();
-            for range in [0..10i64, 10..20i64, 20..30i64] {
-                let rows = range
-                    .map(|i| Row::new(vec![TableValue::Int(i)]))
-                    .collect::<Vec<_>>();
-                let data = rows_to_columns(&col, &rows);
-                let (chunk, file_size) = chunk_store
-                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
-                    .await
-                    .unwrap()
-                    .await
-                    .unwrap()
-                    .unwrap();
-                meta_store
-                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
-                    .await
-                    .unwrap();
-                chunk_ids.push(chunk.get_id());
-            }
-
-            let dest1 = meta_store
-                .create_partition(Partition::new_child(&partition, None))
-                .await
-                .unwrap();
-            let dest2 = meta_store
-                .create_partition(Partition::new_child(&partition, None))
-                .await
-                .unwrap();
-            let mid = Row::new(vec![TableValue::Int(15)]);
-            meta_store
-                .swap_active_partitions(
-                    vec![(partition.clone(), vec![])],
-                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
-                    vec![
-                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
-                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
-                    ],
-                )
-                .await
-                .unwrap();
-
-            let anchor = *chunk_ids.iter().min().unwrap();
-
-            // Zero budget still processes exactly one chunk, then yields; the
-            // anchor is processed last so it stays active even though the producer
-            // may have prefetched the others ahead.
-            chunk_store
-                .repartition_partition_chunks(
-                    partition.get_id(),
-                    anchor,
-                    std::time::Duration::from_secs(0),
-                    DataLoadedSize::new(),
-                )
-                .await
-                .unwrap();
-            let remaining = meta_store
-                .get_chunks_by_partition(partition.get_id(), false)
-                .await
-                .unwrap();
-            assert_eq!(
-                remaining.len(),
-                2,
-                "zero-budget prefetch run must yield after exactly one chunk"
-            );
-            assert!(
-                remaining.iter().any(|c| c.get_id() == anchor),
-                "anchor must be processed last and remain active after a yield"
-            );
-
-            // A large budget drains the remainder through the prefetch path.
-            chunk_store
-                .repartition_partition_chunks(
-                    partition.get_id(),
-                    anchor,
-                    std::time::Duration::from_secs(600),
-                    DataLoadedSize::new(),
-                )
-                .await
-                .unwrap();
-            let remaining = meta_store
-                .get_chunks_by_partition(partition.get_id(), false)
-                .await
-                .unwrap();
-            assert!(
-                remaining.is_empty(),
-                "remaining chunks must drain with a large budget under prefetch"
-            );
-        }
-        let _ = DB::destroy(&Options::default(), path);
-        let _ = fs::remove_dir_all(chunk_store_path);
-        let _ = fs::remove_dir_all(chunk_remote_store_path);
-    }
-
-    #[tokio::test]
     async fn repartition_merge_drains_and_yields() {
         // Merge path with a group cap of 2: the parent's 3 persisted chunks are
         // merged in groups and split into two children. A zero budget yields after
         // the first group (anchor, processed last, stays active); a large budget
         // drains the rest. Row counts must be conserved across the children.
         let config = Config::test("repartition_merge_drains_and_yields").update_config(|mut c| {
-            c.repartition_strategy = RepartitionStrategy::PerPartition;
+            c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
             c.repartition_merge_max_input_files = 2;
             c
         });
@@ -2533,7 +2055,7 @@ mod tests {
         // A group whose chunks are all empty produces no new chunks; the merge path
         // must deactivate the sources directly instead of failing on an empty swap.
         let config = Config::test("repartition_merge_drains_empty_group").update_config(|mut c| {
-            c.repartition_strategy = RepartitionStrategy::PerPartition;
+            c.repartition_strategy = crate::config::RepartitionStrategy::PerPartition;
             c.repartition_merge_max_input_files = 4;
             c
         });

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -1220,9 +1220,13 @@ impl ChunkStore {
 
         let replay_handle_id =
             merge_replay_handles(self.meta_store.clone(), &group.to_vec(), table.get_id()).await?;
+        // Commit with the unchecked swap (like compaction does): merge_chunks aggregates /
+        // last-row-dedups the group for aggregate indexes and unique-key tables, so the
+        // activated row count is legitimately smaller than the deactivated one. The checked
+        // swap_chunks would reject that as a row-count mismatch, failing the repartition job.
         if let Err(e) = self
             .meta_store
-            .swap_chunks(group_ids.clone(), new_chunk_ids, replay_handle_id)
+            .swap_chunks_without_check(group_ids.clone(), new_chunk_ids, replay_handle_id)
             .await
         {
             let mut all_active = true;
@@ -2185,6 +2189,200 @@ mod tests {
                 .filter(|c| c.get_row().active())
                 .count();
             assert_eq!(remaining, 0, "empty group must drain via deactivation");
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
+    }
+
+    #[tokio::test]
+    async fn repartition_merge_aggregate_index_collapses_rows() {
+        // Regression guard for the merge-based repartition path (per_partition / range
+        // strategies). merge_chunk_group_into_children k-way merges a group of source
+        // chunks through merge_chunks, which for an aggregate index groups rows by the
+        // sort key and so emits FEWER rows than it consumed. The swap that commits the
+        // new chunks must therefore not enforce activated_row_count == deactivated_row_count
+        // (the same reason compaction commits with swap_chunks_without_check). Before the
+        // fix this raised "Deactivated row count (20) doesn't match activated row count (10)
+        // during swap" and the repartition job failed.
+        let config = Config::test("repartition_merge_aggregate_index_collapses_rows");
+        let path = "/tmp/test_repartition_merge_aggr";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            // Aggregate index keyed on `g` with a sum over `m`. The index sort key is `g`,
+            // so the merge groups by `g` and sums `m`.
+            let col = vec![
+                Column::new("g".to_string(), ColumnType::Int, 0),
+                Column::new("m".to_string(), ColumnType::Int, 1),
+            ];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let ind = IndexDef {
+                name: "agg".to_string(),
+                columns: vec!["g".to_string()],
+                multi_index: None,
+                index_type: IndexType::Aggregate,
+            };
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![ind],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(vec![("sum".to_string(), "m".to_string())]),
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store
+                .get_table_indexes(table.get_id())
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|i| i.get_row().get_name() == "agg")
+                .unwrap();
+            let partition = meta_store
+                .get_active_partitions_by_index_id(index.get_id())
+                .await
+                .unwrap()[0]
+                .clone();
+
+            // Two persisted chunks that share every `g` value (0..10), so the aggregate
+            // merge collapses 20 source rows into 10 grouped rows.
+            let mut chunk_ids = Vec::new();
+            for _ in 0..2 {
+                let rows = (0..10i64)
+                    .map(|g| Row::new(vec![TableValue::Int(g), TableValue::Int(1)]))
+                    .collect::<Vec<_>>();
+                let data = rows_to_columns(&col, &rows);
+                let (chunk, file_size) = chunk_store
+                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+                meta_store
+                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
+                    .await
+                    .unwrap();
+                chunk_ids.push(chunk.get_id());
+            }
+
+            let dest1 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let dest2 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let mid = Row::new(vec![TableValue::Int(5)]);
+            meta_store
+                .swap_active_partitions(
+                    vec![(partition.clone(), vec![])],
+                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
+                    vec![
+                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
+                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
+                    ],
+                )
+                .await
+                .unwrap();
+
+            let active_count = |partition_id: u64| {
+                let meta_store = meta_store.clone();
+                async move {
+                    meta_store
+                        .get_chunks_by_partition(partition_id, false)
+                        .await
+                        .unwrap()
+                        .into_iter()
+                        .filter(|c| c.get_row().active())
+                        .count()
+                }
+            };
+            let child_rows = |dest_id: u64| {
+                let meta_store = meta_store.clone();
+                async move {
+                    meta_store
+                        .get_chunks_by_partition(dest_id, false)
+                        .await
+                        .unwrap()
+                        .iter()
+                        .filter(|c| c.get_row().active())
+                        .map(|c| c.get_row().get_row_count())
+                        .sum::<u64>()
+                }
+            };
+
+            // Merge the whole [first, last] range in one swap. The aggregate merge reduces
+            // the 20 source rows to 10, so the swap activates fewer rows than it deactivates.
+            let start = *chunk_ids.iter().min().unwrap();
+            let end = *chunk_ids.iter().max().unwrap();
+            chunk_store
+                .repartition_chunk_range(start, end, DataLoadedSize::new())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                active_count(partition.get_id()).await,
+                0,
+                "parent drains after the merge swap"
+            );
+            assert_eq!(
+                child_rows(dest1.get_id()).await + child_rows(dest2.get_id()).await,
+                10,
+                "aggregate merge collapses the 20 source rows into 10 grouped rows"
+            );
+            assert_eq!(
+                child_rows(dest1.get_id()).await,
+                5,
+                "groups below the split go to the first child"
+            );
+            assert_eq!(
+                child_rows(dest2.get_id()).await,
+                5,
+                "groups at/above the split go to the second child"
+            );
         }
         let _ = DB::destroy(&Options::default(), path);
         let _ = fs::remove_dir_all(chunk_store_path);

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -1003,10 +1003,13 @@ impl ChunkStore {
         let remote_fs = self.remote_fs.clone();
         let producer: JoinHandle<()> = cube_ext::spawn(async move {
             for chunk in chunks {
+                // A chunk with no recorded file_size is billed at the full budget
+                // (conservative) rather than ~free, so an unknown-size prefetch can't
+                // overshoot the on-disk budget. Persisted chunks normally have a size.
                 let permits = chunk
                     .get_row()
                     .file_size()
-                    .unwrap_or(0)
+                    .unwrap_or(capacity as u64)
                     .min(capacity as u64)
                     .max(1) as u32;
                 let permit = match semaphore.clone().acquire_many_owned(permits).await {
@@ -1144,26 +1147,38 @@ impl ChunkStore {
             )
         });
 
+        // No active children in the parent's range is treated as a transient topology
+        // read (e.g. a concurrent split swapping children to grandchildren between our
+        // separate metastore reads), NOT corruption: return an error so the scheduler
+        // retries instead of deactivating a possibly-healthy table.
+        if children.is_empty() {
+            return Err(CubeError::internal(format!(
+                "Repartition of {} found no active children in its range; will retry",
+                partition.get_id()
+            )));
+        }
+
+        // Children that are present but do not tile the parent's range exactly (gap or
+        // overlap) is genuine metadata corruption — rows could be routed into a child
+        // whose range does not contain them. Deactivate the table, the same response
+        // partition_rows gives when a row cannot be assigned to any partition.
         let bounds_eq = |a: Option<&Row>, b: Option<&Row>| match (a, b) {
             (None, None) => true,
             (Some(x), Some(y)) => cmp_min_rows(key_size, Some(x), Some(y)) == Ordering::Equal,
             _ => false,
         };
-        let tiles_parent = !children.is_empty()
-            && bounds_eq(
-                children[0].get_row().get_min_val().as_ref(),
-                partition.get_row().get_min_val().as_ref(),
+        let tiles_parent = bounds_eq(
+            children[0].get_row().get_min_val().as_ref(),
+            partition.get_row().get_min_val().as_ref(),
+        ) && bounds_eq(
+            children.last().unwrap().get_row().get_max_val().as_ref(),
+            partition.get_row().get_max_val().as_ref(),
+        ) && children.windows(2).all(|w| {
+            bounds_eq(
+                w[0].get_row().get_max_val().as_ref(),
+                w[1].get_row().get_min_val().as_ref(),
             )
-            && bounds_eq(
-                children.last().unwrap().get_row().get_max_val().as_ref(),
-                partition.get_row().get_max_val().as_ref(),
-            )
-            && children.windows(2).all(|w| {
-                bounds_eq(
-                    w[0].get_row().get_max_val().as_ref(),
-                    w[1].get_row().get_min_val().as_ref(),
-                )
-            });
+        });
         if !tiles_parent {
             let message = format!(
                 "Repartition of {} found children that do not tile its range: {:?}",

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -1099,11 +1099,23 @@ impl ChunkStore {
             .collect::<Vec<_>>();
         chunks.sort_by_key(|c| (c.get_id() == anchor_chunk_id, c.get_id()));
 
-        let groups = chunks
-            .chunks(max_group)
-            .map(|g| g.to_vec())
-            .collect::<Vec<_>>();
-        for group in groups {
+        // Group the chunks the same way the range strategy slices its jobs: cut a group
+        // once it reaches max_rows rows or max_group chunks, whichever comes first. The
+        // anchor is last, so it lands in the final group and stays active until the run
+        // finishes or yields on the time budget.
+        let max_rows = self.config.repartition_merge_max_rows().max(1);
+        let mut i = 0;
+        while i < chunks.len() {
+            let mut group = Vec::new();
+            let mut rows = 0u64;
+            while i < chunks.len() {
+                rows += chunks[i].get_row().get_row_count();
+                group.push(chunks[i].clone());
+                i += 1;
+                if rows >= max_rows || group.len() >= max_group {
+                    break;
+                }
+            }
             self.merge_chunk_group_into_children(
                 &partition,
                 &index,
@@ -1251,6 +1263,12 @@ impl ChunkStore {
                 .make_session_config(),
         )
         .task_ctx();
+        // merge_chunks aggregates / last-row-dedups the group, the same way compaction
+        // does. For unique-key tables the full sort key ends with the seq column, so the
+        // surviving row is the one with the max seq (latest); group order only decides
+        // ties on the full sort key, i.e. rows with identical (unique key, seq) that are
+        // duplicates anyway. Dedup is group-local and re-applied at query/compaction time
+        // over the child's chunks, so the final result matches the per-chunk path.
         let records = merge_chunks(
             key_size,
             Arc::new(EmptyExec::new(schema.clone())),

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -58,7 +58,7 @@ use log::trace;
 use mockall::automock;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, OwnedSemaphorePermit, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 
 pub const ROW_GROUP_SIZE: usize = 16384; // TODO config
@@ -623,7 +623,6 @@ impl ChunkDataStore for ChunkStore {
             .await?
             .into_iter()
             .filter(|c| !c.get_row().in_memory())
-            .map(|c| c.get_id())
             .collect::<Vec<_>>();
         // FIXME: anchor_chunk_id is the chunk carried in the RepartitionChunk
         // job's row_reference (see job_processor). In steady state the scheduler
@@ -637,40 +636,44 @@ impl ChunkDataStore for ChunkStore {
         // transaction and rejects a swap whose source is already inactive), so a
         // chunk is ever repartitioned exactly once regardless of how many jobs
         // race for it.
-        chunks.sort_by_key(|&id| id == anchor_chunk_id);
+        //
+        // Order: anchor last, the rest by ascending id. The ascending order also
+        // drives the prefetch producer below, which warms upcoming chunks while
+        // the current one is processed.
+        chunks.sort_by_key(|c| (c.get_id() == anchor_chunk_id, c.get_id()));
+
+        let prefetch_budget = self
+            .config
+            .repartition_prefetch_budget_bytes()
+            .filter(|&b| b > 0);
+
         // Process chunks one at a time so peak memory stays at a single chunk.
         // Each repartition_chunk commits its own swap, so a partial run is safe:
         // a follow-up job re-reads only the still-active chunks and continues.
         // The budget bounds how long this job holds its runner slot; granularity
         // is one chunk, so a single oversized chunk may overshoot the budget.
-        for chunk_id in chunks {
-            if let Err(e) = self
-                .repartition_chunk(chunk_id, data_loaded_size.clone())
+        match prefetch_budget {
+            Some(budget) => {
+                self.repartition_partition_chunks_prefetched(
+                    chunks,
+                    budget,
+                    start,
+                    time_budget,
+                    data_loaded_size,
+                )
                 .await
-            {
-                // Losing the swap race (another job repartitioned this chunk
-                // first) leaves it inactive — that work is already done, so keep
-                // draining the rest instead of failing the whole batch. Any other
-                // error leaves the chunk active and is a genuine failure.
-                let still_active = self
-                    .meta_store
-                    .get_chunk(chunk_id)
-                    .await
-                    .map_or(false, |c| c.get_row().active());
-                if still_active {
-                    return Err(e);
-                }
-                log::debug!(
-                    "Skipping chunk {} lost to a concurrent repartition: {}",
-                    chunk_id,
-                    e
-                );
             }
-            if start.elapsed() >= time_budget {
-                break;
+            None => {
+                for chunk in chunks {
+                    self.repartition_chunk_tolerant(chunk.get_id(), data_loaded_size.clone())
+                        .await?;
+                    if start.elapsed() >= time_budget {
+                        break;
+                    }
+                }
+                Ok(())
             }
         }
-        Ok(())
     }
 
     async fn get_chunk_columns(&self, chunk: IdRow<Chunk>) -> Result<Vec<RecordBatch>, CubeError> {
@@ -860,6 +863,105 @@ impl ChunkDataStore for ChunkStore {
 }
 
 impl ChunkStore {
+    // Repartition a single chunk, tolerating the swap race. Losing the swap
+    // (another job repartitioned this chunk first) leaves it inactive — that
+    // work is already done, so we keep draining the rest instead of failing the
+    // whole batch. Any other error leaves the chunk active and is a genuine
+    // failure that propagates.
+    async fn repartition_chunk_tolerant(
+        &self,
+        chunk_id: u64,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError> {
+        if let Err(e) = self.repartition_chunk(chunk_id, data_loaded_size).await {
+            let still_active = self
+                .meta_store
+                .get_chunk(chunk_id)
+                .await
+                .map_or(false, |c| c.get_row().active());
+            if still_active {
+                return Err(e);
+            }
+            log::debug!(
+                "Skipping chunk {} lost to a concurrent repartition: {}",
+                chunk_id,
+                e
+            );
+        }
+        Ok(())
+    }
+
+    // Prefetch variant of the repartition loop. A sequential producer downloads
+    // upcoming chunk parquets (in the order given, anchor last) into the local
+    // cache while the consumer processes the current chunk. A byte-budget
+    // semaphore bounds how much fetched-but-unprocessed data sits on disk: each
+    // chunk holds permits worth its file size from before its download starts
+    // until the consumer finishes processing it. download_file is idempotent and
+    // dedups in-flight downloads, so the consumer's repartition_chunk just hits
+    // the warm local file. Chunks prefetched past the time budget stay on local
+    // disk and warm the follow-up job, which lands on the same node by partition.
+    async fn repartition_partition_chunks_prefetched(
+        &self,
+        chunks: Vec<IdRow<Chunk>>,
+        budget: u64,
+        start: std::time::Instant,
+        time_budget: std::time::Duration,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError> {
+        let capacity = budget.min(u32::MAX as u64) as usize;
+        let semaphore = Arc::new(Semaphore::new(capacity));
+        let (tx, mut rx) = mpsc::channel::<(u64, OwnedSemaphorePermit)>(chunks.len().max(1));
+
+        let remote_fs = self.remote_fs.clone();
+        let producer: JoinHandle<()> = cube_ext::spawn(async move {
+            for chunk in chunks {
+                let permits = chunk
+                    .get_row()
+                    .file_size()
+                    .unwrap_or(0)
+                    .min(capacity as u64)
+                    .max(1) as u32;
+                let permit = match semaphore.clone().acquire_many_owned(permits).await {
+                    Ok(p) => p,
+                    Err(_) => return,
+                };
+                let file_size = chunk.get_row().file_size();
+                let remote_path = ChunkStore::chunk_file_name(chunk.clone());
+                // Warm the local cache; ignore errors here — the consumer's
+                // repartition_chunk re-issues the download and surfaces a genuine
+                // failure with proper handling (including table deactivation).
+                if let Err(e) = remote_fs.download_file(remote_path, file_size).await {
+                    log::debug!("Prefetch of chunk {} failed: {}", chunk.get_id(), e);
+                }
+                if tx.send((chunk.get_id(), permit)).await.is_err() {
+                    // Consumer stopped (time budget reached); drop the rest.
+                    return;
+                }
+            }
+        });
+
+        let result = async {
+            while let Some((chunk_id, permit)) = rx.recv().await {
+                let res = self
+                    .repartition_chunk_tolerant(chunk_id, data_loaded_size.clone())
+                    .await;
+                // Free this chunk's disk budget so the producer can advance.
+                drop(permit);
+                res?;
+                if start.elapsed() >= time_budget {
+                    break;
+                }
+            }
+            Ok(())
+        }
+        .await;
+
+        // Stop the producer even if it is blocked mid-download; the queued
+        // download itself proceeds independently, so an abort leaks nothing.
+        producer.abort();
+        result
+    }
+
     async fn download_chunk(
         &self,
         chunk: IdRow<Chunk>,
@@ -1433,6 +1535,171 @@ mod tests {
             assert!(
                 remaining.is_empty(),
                 "remaining chunks must drain with a large budget"
+            );
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
+    }
+
+    #[tokio::test]
+    async fn repartition_partition_chunks_prefetch_drains() {
+        // Same parent/chunk setup as repartition_partition_chunks_yields_on_budget,
+        // but with prefetch enabled, asserting the prefetch path keeps the yield
+        // (one chunk, anchor last) and drain semantics intact.
+        let config =
+            Config::test("repartition_partition_chunks_prefetch_drains").update_config(|mut c| {
+                c.repartition_prefetch_budget_bytes = Some(64 * 1024 * 1024);
+                c
+            });
+        let path = "/tmp/test_repartition_prefetch";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
+            let partition = meta_store
+                .get_active_partitions_by_index_id(index.get_id())
+                .await
+                .unwrap()[0]
+                .clone();
+
+            let mut chunk_ids = Vec::new();
+            for range in [0..10i64, 10..20i64, 20..30i64] {
+                let rows = range
+                    .map(|i| Row::new(vec![TableValue::Int(i)]))
+                    .collect::<Vec<_>>();
+                let data = rows_to_columns(&col, &rows);
+                let (chunk, file_size) = chunk_store
+                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+                meta_store
+                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
+                    .await
+                    .unwrap();
+                chunk_ids.push(chunk.get_id());
+            }
+
+            let dest1 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let dest2 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let mid = Row::new(vec![TableValue::Int(15)]);
+            meta_store
+                .swap_active_partitions(
+                    vec![(partition.clone(), vec![])],
+                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
+                    vec![
+                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
+                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
+                    ],
+                )
+                .await
+                .unwrap();
+
+            let anchor = *chunk_ids.iter().min().unwrap();
+
+            // Zero budget still processes exactly one chunk, then yields; the
+            // anchor is processed last so it stays active even though the producer
+            // may have prefetched the others ahead.
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(0),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap();
+            assert_eq!(
+                remaining.len(),
+                2,
+                "zero-budget prefetch run must yield after exactly one chunk"
+            );
+            assert!(
+                remaining.iter().any(|c| c.get_id() == anchor),
+                "anchor must be processed last and remain active after a yield"
+            );
+
+            // A large budget drains the remainder through the prefetch path.
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(600),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap();
+            assert!(
+                remaining.is_empty(),
+                "remaining chunks must drain with a large budget under prefetch"
             );
         }
         let _ = DB::destroy(&Options::default(), path);

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -41,10 +41,10 @@ use crate::cluster::{node_name_by_partition, Cluster};
 use crate::config::injection::DIService;
 use crate::config::ConfigObj;
 use crate::metastore::chunks::chunk_file_name;
-use crate::queryplanner::trace_data_loaded::DataLoadedSize;
-use crate::table::data::cmp_partition_key;
+use crate::queryplanner::trace_data_loaded::{DataLoadedSize, TraceDataLoadedExec};
+use crate::table::data::{cmp_min_rows, cmp_partition_key};
 use crate::table::parquet::{arrow_schema, CubestoreMetadataCacheFactory, ParquetTableStore};
-use compaction::{merge_chunks, merge_replay_handles};
+use compaction::{merge_chunks, merge_replay_handles, write_chunks_split_into_children};
 use datafusion::arrow::array::{Array, ArrayRef, Int64Builder, StringBuilder, UInt64Array};
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -617,6 +617,27 @@ impl ChunkDataStore for ChunkStore {
         data_loaded_size: Arc<DataLoadedSize>,
     ) -> Result<(), CubeError> {
         let start = std::time::Instant::now();
+
+        // Merge path: stream the parent's persisted chunks through a k-way merge and
+        // split into the active children at the wal-split limit, instead of emitting
+        // one chunk per (old chunk x child). Enabled by a group cap of >= 2.
+        if let Some(max_group) = self
+            .config
+            .repartition_merge_max_input_files()
+            .filter(|&m| m >= 2)
+        {
+            return self
+                .repartition_partition_chunks_merged(
+                    partition_id,
+                    anchor_chunk_id,
+                    max_group,
+                    start,
+                    time_budget,
+                    data_loaded_size,
+                )
+                .await;
+        }
+
         let mut chunks = self
             .meta_store
             .get_chunks_by_partition(partition_id, false)
@@ -960,6 +981,311 @@ impl ChunkStore {
         // download itself proceeds independently, so an abort leaks nothing.
         producer.abort();
         result
+    }
+
+    // Streaming merge variant of repartition. The parent's persisted chunks are
+    // merged k-way (in groups of <= max_group input files) and the sorted stream is
+    // split directly into the parent's already-active children at the wal-split
+    // limit, producing full-size chunks in one streaming pass. Each group commits
+    // with a single atomic swap_chunks; correctness against a concurrent job racing
+    // for the same chunks rests on that swap rejecting an already-inactive source
+    // (the loser's new chunks stay inactive and are GC'd). The anchor sits in the
+    // last group so it stays active (holding the job dedup key) until the run
+    // finishes or yields on the time budget.
+    async fn repartition_partition_chunks_merged(
+        &self,
+        partition_id: u64,
+        anchor_chunk_id: u64,
+        max_group: usize,
+        start: std::time::Instant,
+        time_budget: std::time::Duration,
+        data_loaded_size: Arc<DataLoadedSize>,
+    ) -> Result<(), CubeError> {
+        let partition = self.meta_store.get_partition(partition_id).await?;
+        if partition.get_row().is_active() {
+            return Err(CubeError::internal(format!(
+                "Tried to repartition active partition: {:?}",
+                partition
+            )));
+        }
+        let index = self
+            .meta_store
+            .get_index(partition.get_row().get_index_id())
+            .await?;
+        let table = self
+            .meta_store
+            .get_table_by_id(index.get_row().table_id())
+            .await?;
+        let key_size = index.get_row().sort_key_size() as usize;
+
+        // The parent's children: active partitions of the index whose range lies
+        // within the parent's range, ordered by min bound. Their interior min bounds
+        // are the split boundaries fed to the writer, so order by the same bound the
+        // writer routes on (get_min_val) to keep the boundary sequence monotonic.
+        let mut children = self
+            .meta_store
+            .get_active_partitions_by_index_id(index.get_id())
+            .await?
+            .into_iter()
+            .filter(|c| Self::partition_within(&partition, c, key_size))
+            .collect::<Vec<_>>();
+        children.sort_by(|a, b| {
+            cmp_min_rows(
+                key_size,
+                a.get_row().get_min_val().as_ref(),
+                b.get_row().get_min_val().as_ref(),
+            )
+        });
+
+        // The children must tile the parent's range exactly: matching outer bounds and
+        // touching interior bounds, leaving no gap a row could fall through. Anything
+        // else means the partition metadata is inconsistent (same condition
+        // partition_rows guards), so deactivate the table rather than silently routing
+        // rows into a child whose range does not contain them.
+        let bounds_eq = |a: Option<&Row>, b: Option<&Row>| match (a, b) {
+            (None, None) => true,
+            (Some(x), Some(y)) => cmp_min_rows(key_size, Some(x), Some(y)) == Ordering::Equal,
+            _ => false,
+        };
+        let tiles_parent = !children.is_empty()
+            && bounds_eq(
+                children[0].get_row().get_min_val().as_ref(),
+                partition.get_row().get_min_val().as_ref(),
+            )
+            && bounds_eq(
+                children.last().unwrap().get_row().get_max_val().as_ref(),
+                partition.get_row().get_max_val().as_ref(),
+            )
+            && children.windows(2).all(|w| {
+                bounds_eq(
+                    w[0].get_row().get_max_val().as_ref(),
+                    w[1].get_row().get_min_val().as_ref(),
+                )
+            });
+        if !tiles_parent {
+            let message = format!(
+                "Repartition of {} found children that do not tile its range: {:?}",
+                partition_id,
+                children.iter().map(|c| c.get_id()).collect::<Vec<_>>()
+            );
+            deactivate_table_due_to_corrupt_data(
+                self.meta_store.clone(),
+                index.get_row().table_id(),
+                message.clone(),
+            )
+            .await?;
+            return Err(CubeError::internal(message));
+        }
+
+        let boundaries: Vec<Row> = children
+            .iter()
+            .skip(1)
+            .map(|c| c.get_row().get_min_val().clone())
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| {
+                CubeError::internal("Child partition without a min bound during repartition".into())
+            })?;
+
+        let mut chunks = self
+            .meta_store
+            .get_chunks_by_partition(partition_id, false)
+            .await?
+            .into_iter()
+            .filter(|c| !c.get_row().in_memory())
+            .collect::<Vec<_>>();
+        chunks.sort_by_key(|c| (c.get_id() == anchor_chunk_id, c.get_id()));
+        if chunks.is_empty() {
+            return Ok(());
+        }
+
+        let wal_split = table
+            .get_row()
+            .partition_split_threshold_or_default(self.config.partition_split_threshold())
+            as usize;
+        let unique_key = table.get_row().unique_key_columns();
+        let aggregate_columns = match index.get_row().get_type() {
+            IndexType::Regular => None,
+            IndexType::Aggregate => Some(table.get_row().aggregate_columns()),
+        };
+        let schema = Arc::new(arrow_schema(index.get_row()));
+
+        let groups = chunks
+            .chunks(max_group)
+            .map(|g| g.to_vec())
+            .collect::<Vec<_>>();
+        for group in groups {
+            let mut chunk_inputs: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(group.len());
+            for chunk in group.iter() {
+                let exec = self
+                    .chunk_exec(chunk.clone(), partition.clone(), index.clone())
+                    .await?;
+                chunk_inputs.push(Arc::new(TraceDataLoadedExec::new(
+                    exec,
+                    data_loaded_size.clone(),
+                )));
+            }
+
+            let task_context = QueryPlannerImpl::make_execution_context(
+                self.metadata_cache_factory
+                    .cache_factory()
+                    .make_session_config(),
+            )
+            .task_ctx();
+            let records = merge_chunks(
+                key_size,
+                Arc::new(EmptyExec::new(schema.clone())),
+                chunk_inputs,
+                unique_key.clone(),
+                aggregate_columns.clone(),
+                task_context,
+            )
+            .await?;
+
+            for child in children.iter() {
+                self.check_node_disk_space(child).await?;
+            }
+
+            let group_rows: u64 = group.iter().map(|c| c.get_row().get_row_count()).sum();
+            let max_files = children.len() + (group_rows as usize).div_ceil(wal_split.max(1)) + 1;
+            // A random salt keeps temp paths unique even if two repartition jobs ever
+            // run for the same partition concurrently (e.g. across a channel switch).
+            let salt = rand::random::<u64>();
+            let mut files = Vec::with_capacity(max_files);
+            for i in 0..max_files {
+                files.push(
+                    self.remote_fs
+                        .temp_upload_path(format!(
+                            "repartition/{}-{:x}-{}.chunk.parquet",
+                            partition_id, salt, i
+                        ))
+                        .await?,
+                );
+            }
+            let store = ParquetTableStore::new(
+                index.get_row().clone(),
+                ROW_GROUP_SIZE,
+                self.metadata_cache_factory.clone(),
+            );
+            let written = write_chunks_split_into_children(
+                records,
+                store,
+                &table,
+                files,
+                boundaries.clone(),
+                wal_split.max(1),
+            )
+            .await?;
+
+            let mut new_chunk_ids: Vec<(u64, Option<u64>)> = Vec::new();
+            for w in written {
+                if w.num_rows == 0 {
+                    let _ = tokio::fs::remove_file(&w.file).await;
+                    continue;
+                }
+                let child = &children[w.child_index];
+                let chunk = self
+                    .meta_store
+                    .create_chunk(
+                        child.get_id(),
+                        w.num_rows,
+                        Some(Row::new(w.min)),
+                        Some(Row::new(w.max)),
+                        false,
+                    )
+                    .await?;
+                let remote = ChunkStore::chunk_file_name(chunk.clone());
+                let file_size = self.remote_fs.upload_file(w.file, remote).await?;
+                new_chunk_ids.push((chunk.get_id(), Some(file_size)));
+            }
+
+            let group_ids: Vec<u64> = group.iter().map(|c| c.get_id()).collect();
+
+            // A fully empty group (every source chunk had no rows) produces no new
+            // chunks; swap_chunks rejects an empty activation list, so just deactivate
+            // the sources directly, matching the per-chunk path's empty-chunk handling.
+            if new_chunk_ids.is_empty() {
+                self.meta_store.deactivate_chunks(group_ids).await?;
+                if start.elapsed() >= time_budget {
+                    break;
+                }
+                continue;
+            }
+
+            // Carry the oldest insert time across the merge so repartitioned chunks
+            // keep their real age (the min, mirroring how replay handles are merged)
+            // instead of looking freshly inserted.
+            let oldest_insert_at = group
+                .iter()
+                .filter_map(|c| c.get_row().oldest_insert_at().clone())
+                .min();
+            self.meta_store
+                .chunk_update_last_inserted(
+                    new_chunk_ids.iter().map(|c| c.0).collect(),
+                    oldest_insert_at,
+                )
+                .await?;
+
+            let replay_handle_id =
+                merge_replay_handles(self.meta_store.clone(), &group, table.get_id()).await?;
+            if let Err(e) = self
+                .meta_store
+                .swap_chunks(group_ids.clone(), new_chunk_ids, replay_handle_id)
+                .await
+            {
+                // Group-level race tolerance: if any source chunk is already inactive
+                // a concurrent job won the swap, so the work is done — the new chunks
+                // we created stay inactive and are GC'd. If all sources are still
+                // active the swap failed for a real reason.
+                let mut all_active = true;
+                for id in &group_ids {
+                    let active = self
+                        .meta_store
+                        .get_chunk(*id)
+                        .await
+                        .map_or(false, |c| c.get_row().active());
+                    if !active {
+                        all_active = false;
+                        break;
+                    }
+                }
+                if all_active {
+                    return Err(e);
+                }
+                log::debug!(
+                    "Skipping repartition group lost to a concurrent swap: {}",
+                    e
+                );
+            }
+
+            if start.elapsed() >= time_budget {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    // A child partition lies within the parent when its lower bound is >= the
+    // parent's (None = -inf) and its upper bound is <= the parent's (None = +inf),
+    // compared on the partition-key prefix.
+    fn partition_within(
+        parent: &IdRow<Partition>,
+        child: &IdRow<Partition>,
+        key_size: usize,
+    ) -> bool {
+        let lower_ok = cmp_min_rows(
+            key_size,
+            child.get_row().get_min_val().as_ref(),
+            parent.get_row().get_min_val().as_ref(),
+        ) != Ordering::Less;
+        let upper_ok = match (
+            child.get_row().get_max_val().as_ref(),
+            parent.get_row().get_max_val().as_ref(),
+        ) {
+            (_, None) => true,
+            (None, Some(_)) => false,
+            (Some(c), Some(p)) => cmp_min_rows(key_size, Some(c), Some(p)) != Ordering::Greater,
+        };
+        lower_ok && upper_ok
     }
 
     async fn download_chunk(
@@ -1701,6 +2027,341 @@ mod tests {
                 remaining.is_empty(),
                 "remaining chunks must drain with a large budget under prefetch"
             );
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
+    }
+
+    #[tokio::test]
+    async fn repartition_merge_drains_and_yields() {
+        // Merge path with a group cap of 2: the parent's 3 persisted chunks are
+        // merged in groups and split into two children. A zero budget yields after
+        // the first group (anchor, processed last, stays active); a large budget
+        // drains the rest. Row counts must be conserved across the children.
+        let config = Config::test("repartition_merge_drains_and_yields").update_config(|mut c| {
+            c.repartition_merge_max_input_files = Some(2);
+            c
+        });
+        let path = "/tmp/test_repartition_merge";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
+            let partition = meta_store
+                .get_active_partitions_by_index_id(index.get_id())
+                .await
+                .unwrap()[0]
+                .clone();
+
+            let mut chunk_ids = Vec::new();
+            for range in [0..10i64, 10..20i64, 20..30i64] {
+                let rows = range
+                    .map(|i| Row::new(vec![TableValue::Int(i)]))
+                    .collect::<Vec<_>>();
+                let data = rows_to_columns(&col, &rows);
+                let (chunk, file_size) = chunk_store
+                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+                meta_store
+                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
+                    .await
+                    .unwrap();
+                chunk_ids.push(chunk.get_id());
+            }
+
+            let dest1 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let dest2 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let mid = Row::new(vec![TableValue::Int(15)]);
+            meta_store
+                .swap_active_partitions(
+                    vec![(partition.clone(), vec![])],
+                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
+                    vec![
+                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
+                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
+                    ],
+                )
+                .await
+                .unwrap();
+
+            let anchor = *chunk_ids.iter().min().unwrap();
+
+            let child_rows = |dest_id: u64| {
+                let meta_store = meta_store.clone();
+                async move {
+                    meta_store
+                        .get_chunks_by_partition(dest_id, false)
+                        .await
+                        .unwrap()
+                        .iter()
+                        .filter(|c| c.get_row().active())
+                        .map(|c| c.get_row().get_row_count())
+                        .sum::<u64>()
+                }
+            };
+
+            // Zero budget: only the first group (the two non-anchor chunks) is
+            // processed; the anchor stays active on the parent.
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(0),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|c| c.get_row().active())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                remaining.len(),
+                1,
+                "zero-budget merge run must yield after the first group"
+            );
+            assert_eq!(
+                remaining[0].get_id(),
+                anchor,
+                "anchor must be processed last and remain active after a yield"
+            );
+
+            // Large budget drains the rest; all 30 rows must land in the children.
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(600),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|c| c.get_row().active())
+                .collect::<Vec<_>>();
+            assert!(remaining.is_empty(), "parent chunks must drain under merge");
+
+            let total = child_rows(dest1.get_id()).await + child_rows(dest2.get_id()).await;
+            assert_eq!(total, 30, "all rows must be conserved across children");
+            assert_eq!(
+                child_rows(dest1.get_id()).await,
+                15,
+                "rows below the split go to the first child"
+            );
+            assert_eq!(
+                child_rows(dest2.get_id()).await,
+                15,
+                "rows at/above the split go to the second child"
+            );
+        }
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path);
+        let _ = fs::remove_dir_all(chunk_remote_store_path);
+    }
+
+    #[tokio::test]
+    async fn repartition_merge_drains_empty_group() {
+        // A group whose chunks are all empty produces no new chunks; the merge path
+        // must deactivate the sources directly instead of failing on an empty swap.
+        let config = Config::test("repartition_merge_drains_empty_group").update_config(|mut c| {
+            c.repartition_merge_max_input_files = Some(4);
+            c
+        });
+        let path = "/tmp/test_repartition_merge_empty";
+        let chunk_store_path = path.to_string() + &"_store_chunk".to_string();
+        let chunk_remote_store_path = path.to_string() + &"_remote_store_chunk".to_string();
+
+        let _ = DB::destroy(&Options::default(), path);
+        let _ = fs::remove_dir_all(chunk_store_path.clone());
+        let _ = fs::remove_dir_all(chunk_remote_store_path.clone());
+        {
+            let remote_fs = LocalDirRemoteFs::new(
+                Some(PathBuf::from(chunk_remote_store_path.clone())),
+                PathBuf::from(chunk_store_path.clone()),
+            );
+            let meta_store = RocksMetaStore::new(
+                Path::new(path),
+                BaseRocksStoreFs::new_for_metastore(remote_fs.clone(), config.config_obj()),
+                config.config_obj(),
+            )
+            .unwrap();
+            let chunk_store = ChunkStore::new(
+                meta_store.clone(),
+                remote_fs.clone(),
+                Arc::new(MockCluster::new()),
+                config.config_obj(),
+                CubestoreMetadataCacheFactoryImpl::new(Arc::new(BasicMetadataCacheFactory::new())),
+                10,
+            );
+
+            let col = vec![Column::new("n".to_string(), ColumnType::Int, 0)];
+            meta_store
+                .create_schema("foo".to_string(), false)
+                .await
+                .unwrap();
+            let table = meta_store
+                .create_table(
+                    "foo".to_string(),
+                    "bar".to_string(),
+                    col.clone(),
+                    None,
+                    None,
+                    vec![],
+                    true,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+            let index = meta_store.get_default_index(table.get_id()).await.unwrap();
+            let partition = meta_store
+                .get_active_partitions_by_index_id(index.get_id())
+                .await
+                .unwrap()[0]
+                .clone();
+
+            // Two empty persisted chunks on the parent.
+            for _ in 0..2 {
+                let data = rows_to_columns(&col, &[]);
+                let (chunk, file_size) = chunk_store
+                    .add_chunk_columns(index.clone(), partition.clone(), data, false)
+                    .await
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+                meta_store
+                    .swap_chunks(Vec::new(), vec![(chunk.get_id(), file_size)], None)
+                    .await
+                    .unwrap();
+            }
+
+            let dest1 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let dest2 = meta_store
+                .create_partition(Partition::new_child(&partition, None))
+                .await
+                .unwrap();
+            let mid = Row::new(vec![TableValue::Int(15)]);
+            meta_store
+                .swap_active_partitions(
+                    vec![(partition.clone(), vec![])],
+                    vec![(dest1.clone(), 1), (dest2.clone(), 1)],
+                    vec![
+                        (0, (None, Some(mid.clone())), (None, Some(mid.clone()))),
+                        (0, (Some(mid.clone()), None), (Some(mid.clone()), None)),
+                    ],
+                )
+                .await
+                .unwrap();
+
+            let anchor = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap()
+                .iter()
+                .map(|c| c.get_id())
+                .min()
+                .unwrap();
+
+            chunk_store
+                .repartition_partition_chunks(
+                    partition.get_id(),
+                    anchor,
+                    std::time::Duration::from_secs(600),
+                    DataLoadedSize::new(),
+                )
+                .await
+                .unwrap();
+
+            let remaining = meta_store
+                .get_chunks_by_partition(partition.get_id(), false)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|c| c.get_row().active())
+                .count();
+            assert_eq!(remaining, 0, "empty group must drain via deactivation");
         }
         let _ = DB::destroy(&Options::default(), path);
         let _ = fs::remove_dir_all(chunk_store_path);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #11088 introduced a merge-based repartition path (`per_partition` and `range` strategies). In production with `range` enabled this regressed with a flood of failing `RepartitionRange` jobs:

```
Error("Internal: Deactivated row count (484102) doesn't match activated row count (360063)
during swap of (5907991, 5908005) to (5971515, 5971547, 5971587) chunks")
```

### Root cause

The new merge path (`ChunkStore::merge_chunk_group_into_children`) k-way merges a group of source chunks through `merge_chunks`, then commits the new child chunks. `merge_chunks` **aggregates** (for aggregate indexes — i.e. pre-aggregation rollups) and **last-row-dedups** (for unique-key tables) the group, so it legitimately emits *fewer* rows than it consumed.

The commit used the **checked** `swap_chunks`, which enforces `activated_row_count == deactivated_row_count`. For any aggregate/unique-key table the merge collapses rows, so the check rejected the swap and the repartition job failed permanently — the inactive parent never drained.

The legacy per-chunk path (`partition_rows`) never aggregated (it only routes rows by partition key), so the row count was always conserved there and the check passed — which is why this only surfaced on the new merge strategies.

### Fix

Commit the merge with `swap_chunks_without_check`, exactly as compaction already does for its own dedup'd merges (`compact_chunks_to_in_memory` / `compact_chunks_to_persistent`). The row-count equality invariant does not hold for an aggregating/deduping merge, so enforcing it is incorrect for this path.

```19:21:rust/cubestore/cubestore/src/store/compaction.rs
        self.meta_store
            .swap_chunks_without_check(old_chunk_ids, new_chunk_ids, replay_handle_id)
            .await?;
```

## Tests

Following the request to reproduce the error first, then fix it:

- **Unit test** `store::tests::repartition_merge_aggregate_index_collapses_rows`: builds an aggregate index whose two source chunks share every key, drives `repartition_chunk_range`, and asserts the children conserve the *aggregated* row count. Before the fix this panics with the exact production error: `Deactivated row count (20) doesn't match activated row count (10) during swap of (1, 2) to (3, 4) chunks`.
- **End-to-end SQL tests** `repartition_range_jobs_aggregate_index_keeps_data_consistent` and `repartition_merge_aggregate_index_keeps_data_consistent`: aggregate-index table, dimension keys repeated across inserts, forced split, full scheduler → range-slicing → job-runner path. Before the fix the inactive parents never drain (jobs keep failing the swap); after it `sum(m)` and every per-key sum are conserved.

All 15 `repartition*` unit/SQL tests pass with the fix; the three new tests fail without it.

## Risk

Mirrors the long-standing compaction behavior; default strategy remains `per_chunk` (unchanged). No metastore/schema changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cb2bee1-0732-48ed-b986-a07133d9b143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cb2bee1-0732-48ed-b986-a07133d9b143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

