### PR TITLE
perf(schema-compiler): optimize granularityHierarchies for large data models

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -1871,40 +1871,41 @@ export class BaseQuery {
       // Because of that it's not possible to correctly precalculate
       // granularities hierarchies on startup as they are specific for each timezone.
       ['granularityHierarchies', this.timezone],
-      () => R.reduce(
-        (hierarchies, cube) => R.reduce(
-          (acc, [tdName, td]) => {
+      () => {
+        // Mutating a single accumulator object instead of repeatedly spreading
+        // it keeps this O(n) in the number of dimensions/granularities. The
+        // previous `{ ...acc, ... }` approach copied the whole accumulator on
+        // every iteration, making it O(n^2) and extremely slow on large models.
+        const hierarchies = {};
+        const standardGranularityNames = R.keys(standardGranularitiesParents);
+
+        for (const cube of R.keys(this.cubeEvaluator.evaluatedCubes)) {
+          const timeDimensions = this.cubeEvaluator.timeDimensionsForCube(cube);
+
+          for (const tdName of Object.keys(timeDimensions)) {
+            const td = timeDimensions[tdName];
             const dimensionKey = `${cube}.${tdName}`;
 
             // constructing standard granularities for time dimension
-            const standardEntries = R.fromPairs(
-              R.keys(standardGranularitiesParents).map(gr => [
-                `${dimensionKey}.${gr}`,
-                standardGranularitiesParents[gr],
-              ]),
-            );
+            for (const gr of standardGranularityNames) {
+              hierarchies[`${dimensionKey}.${gr}`] = standardGranularitiesParents[gr];
+            }
 
             // If we have custom granularities in time dimension
-            const customEntries = td.granularities
-              ? R.fromPairs(
-                R.keys(td.granularities).map(granularityName => {
-                  const grObj = new Granularity(this, { dimension: dimensionKey, granularity: granularityName });
-                  return [
-                    `${dimensionKey}.${granularityName}`,
-                    [granularityName, ...standardGranularitiesParents[grObj.minGranularity()]],
-                  ];
-                }),
-              )
-              : {};
+            if (td.granularities) {
+              for (const granularityName of Object.keys(td.granularities)) {
+                const grObj = new Granularity(this, { dimension: dimensionKey, granularity: granularityName });
+                hierarchies[`${dimensionKey}.${granularityName}`] = [
+                  granularityName,
+                  ...standardGranularitiesParents[grObj.minGranularity()],
+                ];
+              }
+            }
+          }
+        }
 
-            return { ...acc, ...standardEntries, ...customEntries };
-          },
-          hierarchies,
-          R.toPairs(this.cubeEvaluator.timeDimensionsForCube(cube)),
-        ),
-        {},
-        R.keys(this.cubeEvaluator.evaluatedCubes),
-      ),
+        return hierarchies;
+      },
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`BaseQuery.granularityHierarchies()` could take ~8 seconds to compute on large data models.

The root cause was the `{ ...acc, ...standardEntries, ...customEntries }` object spread inside the nested `R.reduce`. On every iteration (per time dimension, per cube) the **entire** accumulated hierarchies object was copied into a new object. With many cubes/dimensions this makes the algorithm **O(n²)** in the number of entries, plus heavy GC pressure from allocating throwaway objects.

## Fix

Rewrote the reducer to build a single accumulator object and mutate it in place with plain loops. This makes it **O(n)** in the number of dimensions/granularities while preserving identical output:

- Standard granularity entries are written first, then custom granularity entries overwrite on key collision — exactly matching the original spread precedence (`...standardEntries` then `...customEntries`).
- Iteration order over cubes and dimensions is unchanged.
- `standardGranularitiesParents` key list is computed once instead of per dimension.

No behavioral change; only the internal construction is optimized. The result is still memoized via `cacheValue` keyed on `['granularityHierarchies', this.timezone]`.

## Notes

`for...of` is already used extensively in `BaseQuery.js`, so the new loops are consistent with the existing code style.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4295bee-500a-4165-afc9-110e01ecad26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4295bee-500a-4165-afc9-110e01ecad26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

