### PR TITLE
fix(cubesql): Normalize BETWEEN timestamp/date bounds

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -36,6 +36,8 @@ use crate::compile::{engine::CubeContext, rewrite::rules::utils::DatePartToken};
 /// - binary operations between a timestamp and a date to a timestamp and timestamp operation
 /// - IN list expressions where expression being tested is `TIMESTAMP`
 ///   and values might be `DATE` to values casted to `TIMESTAMP`
+/// - BETWEEN expressions where expression being tested is `TIMESTAMP`
+///   and bounds are temporal to bounds casted to `TIMESTAMP`
 pub struct PlanNormalize<'a> {
     cube_ctx: &'a CubeContext,
 }
@@ -944,18 +946,16 @@ fn expr_normalize_cold_path(
             negated,
             low,
             high,
-        } => {
-            let expr = expr_normalize(optimizer, expr, schema, remapped_columns, optimizer_config)?;
-            let negated = *negated;
-            let low = expr_normalize(optimizer, low, schema, remapped_columns, optimizer_config)?;
-            let high = expr_normalize(optimizer, high, schema, remapped_columns, optimizer_config)?;
-            Ok(Box::new(Expr::Between {
-                expr,
-                negated,
-                low,
-                high,
-            }))
-        }
+        } => between_expr_normalize(
+            optimizer,
+            expr,
+            *negated,
+            low,
+            high,
+            schema,
+            remapped_columns,
+            optimizer_config,
+        ),
 
         Expr::Case {
             expr,
@@ -1517,6 +1517,70 @@ fn in_list_expr_normalize(
         expr,
         list,
         negated,
+    }))
+}
+
+/// Recursively normalizes BETWEEN expressions.
+/// Currently this includes replacing:
+/// - BETWEEN expressions where the expression being tested is `TIMESTAMP` and the bounds are
+///   temporal to bounds casted to that `TIMESTAMP`, so all three operands share one type.
+///
+/// The bound is casted when its type differs from the tested expression (e.g. a `DATE` bound
+/// such as `CURRENT_DATE`), or when it is a computed expression. The latter is needed because
+/// some expressions are typed as `TIMESTAMP` by DataFusion yet rendered as `DATE`/`DATETIME`
+/// by strict dialects (e.g. `DATE - INTERVAL`, which DataFusion types as `TIMESTAMP`); an
+/// explicit cast keeps all three operands the same type in the generated SQL. Plain columns,
+/// literals and existing casts already carry the right type, so they are left untouched.
+#[inline(never)]
+fn between_expr_normalize(
+    optimizer: &PlanNormalize,
+    expr: &Expr,
+    negated: bool,
+    low: &Expr,
+    high: &Expr,
+    schema: &DFSchema,
+    remapped_columns: &HashMap<Column, Column>,
+    optimizer_config: &OptimizerConfig,
+) -> Result<Box<Expr>> {
+    let expr = expr_normalize(optimizer, expr, schema, remapped_columns, optimizer_config)?;
+    let expr_type = expr.get_type(schema)?;
+    let expr_is_timestamp = matches!(expr_type, DataType::Timestamp(_, _));
+
+    let normalize_bound = |bound: &Expr| -> Result<Box<Expr>> {
+        let bound =
+            expr_normalize_stacked(optimizer, bound, schema, remapped_columns, optimizer_config)?;
+        if !expr_is_timestamp {
+            return Ok(Box::new(bound));
+        }
+
+        let bound_type = bound.get_type(schema)?;
+        let bound_is_temporal = matches!(
+            bound_type,
+            DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _)
+        );
+        let bound_is_computed = !matches!(
+            bound,
+            Expr::Column(_) | Expr::Literal(_) | Expr::Cast { .. }
+        );
+        if !bound_is_temporal || (bound_type == expr_type && !bound_is_computed) {
+            return Ok(Box::new(bound));
+        }
+
+        let casted = Expr::Cast {
+            expr: Box::new(bound),
+            data_type: expr_type.clone(),
+        };
+        Ok(Box::new(evaluate_expr_stacked(optimizer, casted)?))
+    };
+
+    let low = normalize_bound(low)?;
+    let high = normalize_bound(high)?;
+
+    Ok(Box::new(Expr::Between {
+        expr,
+        negated,
+        low,
+        high,
     }))
 }
 

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -2316,6 +2316,61 @@ async fn test_wrapper_between() {
 }
 
 #[tokio::test]
+async fn test_wrapper_between_timestamp_date_bounds() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    // `order_date` is a TIMESTAMP time dimension; the BETWEEN bounds are DATE-typed
+    // (`CURRENT_DATE` / `CURRENT_DATE - INTERVAL '52 weeks'`). PlanNormalize coerces the bounds
+    // to the tested TIMESTAMP so all three operands share one type; here they fold to TIMESTAMP
+    // literals. Without this, strict engines (e.g. BigQuery) reject the mixed-type BETWEEN.
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            customer_gender
+        FROM KibanaSampleDataEcommerce
+        WHERE
+            KibanaSampleDataEcommerce.customer_gender = customer_gender
+            AND order_date BETWEEN CURRENT_DATE - INTERVAL '52 weeks' AND CURRENT_DATE
+        GROUP BY 1
+        ;"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let sql = query_plan
+        .as_logical_plan()
+        .find_cube_scan_wrapped_sql()
+        .wrapped_sql
+        .sql;
+    println!("Generated SQL: {sql}");
+
+    // Both bounds must end up as the same TIMESTAMP type as `order_date`: `CURRENT_DATE` and
+    // `CURRENT_DATE - INTERVAL '52 weeks'` are coerced and fold to TIMESTAMP literals. Assert the
+    // structural shape (rather than concrete dates) to stay independent of the wall clock.
+    let between_re = Regex::new(
+        r"\$\{KibanaSampleDataEcommerce\.order_date\} BETWEEN timestamptz '[^']+' AND timestamptz '[^']+'",
+    )
+    .unwrap();
+    assert!(
+        between_re.is_match(&sql),
+        "expected both BETWEEN bounds coerced to TIMESTAMP literals, got: {}",
+        sql
+    );
+    // No DATE / INTERVAL operands should leak through to the generated SQL.
+    let upper = sql.to_uppercase();
+    assert!(
+        !upper.contains("CURRENT_DATE") && !upper.contains("INTERVAL"),
+        "DATE/INTERVAL bound should have been coerced away, got: {}",
+        sql
+    );
+}
+
+#[tokio::test]
 async fn test_wrapper_subqueries_filter_params_not_mixed() {
     if !Rewriter::sql_push_down_enabled() {
         return;


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR extends `PlanNormalize` to coerce the bounds of a `TIMESTAMP BETWEEN ...` to the tested expression's `TIMESTAMP` type, so all three operands share one type. A bound is cast when its type differs (e.g. a `DATE` bound such as `CURRENT_DATE`) or when it is a computed expression -- the latter covers cases like `DATE - INTERVAL`, which DataFusion types as `TIMESTAMP` but strict dialects render as `DATE`/`DATETIME`. Related test is included.
