### PR TITLE
feat(cubesql): Support `ILIKE` SQL push down for BigQuery

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -354,7 +354,7 @@ export class BigqueryQuery extends BaseQuery {
     templates.expressions.extract = 'EXTRACT({% if date_part == \'DOW\' %}DAYOFWEEK{% elif date_part == \'DOY\' %}DAYOFYEAR{% else %}{{ date_part }}{% endif %} FROM {{ expr }})';
     templates.expressions.timestamp_literal = 'TIMESTAMP(\'{{ value }}\')';
     templates.expressions.rolling_window_expr_timestamp_cast = 'TIMESTAMP({{ value }})';
-    delete templates.expressions.ilike;
+    templates.expressions.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE LOWER({{ pattern }})';
     delete templates.expressions.like_escape;
     templates.filters.like_pattern = 'CONCAT({% if start_wild %}\'%\'{% else %}\'\'{% endif %}, LOWER({{ value }}), {% if end_wild %}\'%\'{% else %}\'\'{% endif %})';
     templates.tesseract.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %} LIKE {{ pattern }}';

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/binary_expr.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/wrapper/binary_expr.rs
@@ -4,10 +4,11 @@ use crate::{
         rewriter::{CubeEGraph, CubeRewrite},
         rules::wrapper::WrapperRules,
         transforming_rewrite, wrapper_pullup_replacer, wrapper_pushdown_replacer,
-        wrapper_replacer_context,
+        wrapper_replacer_context, BinaryExprOp,
     },
-    var,
+    var, var_iter,
 };
+use datafusion::logical_plan::Operator;
 use egg::Subst;
 
 impl WrapperRules {
@@ -70,9 +71,10 @@ impl WrapperRules {
 
     fn transform_binary_expr(
         &self,
-        _operator_var: &'static str,
+        operator_var: &'static str,
         input_data_source_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
+        let operator_var = var!(operator_var);
         let input_data_source_var = var!(input_data_source_var);
         let meta = self.meta_context.clone();
         move |egraph, subst| {
@@ -81,8 +83,27 @@ impl WrapperRules {
                 return false;
             };
 
-            // TODO check supported operators
-            Self::can_rewrite_template(&data_source, &meta, "expressions/binary")
+            if !Self::can_rewrite_template(&data_source, &meta, "expressions/binary") {
+                return false;
+            }
+
+            for op in var_iter!(egraph[subst[operator_var]], BinaryExprOp) {
+                match op {
+                    Operator::Like | Operator::NotLike => {
+                        if Self::can_rewrite_template(&data_source, &meta, "expressions/like") {
+                            return true;
+                        }
+                    }
+                    Operator::ILike | Operator::NotILike => {
+                        if Self::can_rewrite_template(&data_source, &meta, "expressions/ilike") {
+                            return true;
+                        }
+                    }
+                    _ => return true,
+                }
+            }
+
+            false
         }
     }
 }

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1060,6 +1060,35 @@ async fn test_case_wrapper_escaping() {
         .contains("\\\\\\\\\\\\`"));
 }
 
+#[tokio::test]
+async fn test_wrapper_ilike_lowered_pushdown() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan_customized(
+        "SELECT customer_gender ILIKE 'fem' AS g, AVG(avgPrice) mp FROM KibanaSampleDataEcommerce a GROUP BY 1"
+            .to_string(),
+        DatabaseProtocol::PostgreSQL,
+        vec![(
+            "expressions/ilike".to_string(),
+            "LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE LOWER({{ pattern }})".to_string(),
+        )],
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains(") LIKE LOWER("),
+        "expected lowered ILIKE pushdown (LOWER(..) LIKE LOWER(..)), got: {}",
+        sql
+    );
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+}
+
 /// Test aliases for grouped CubeScan in wrapper
 /// qualifiers from join should get remapped to single from alias
 /// long generated aliases from Datafusion should get shortened


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR adds support for `ILIKE` SQL pushdown for BigQuery. Related test is included.
