### PR TITLE
docs(byoc): allow RDS service-linked role creation in AWS BYOC policy

### DIFF
--- a/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
+++ b/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
@@ -199,7 +199,8 @@ actual account ID.
                     "iam:AWSServiceName": [
                         "eks.amazonaws.com",
                         "eks-nodegroup.amazonaws.com",
-                        "eks-fargate.amazonaws.com"
+                        "eks-fargate.amazonaws.com",
+                        "rds.amazonaws.com"
                     ]
                 }
             }


### PR DESCRIPTION
## What

Adds `rds.amazonaws.com` to the `iam:AWSServiceName` allowlist on the `iam:CreateServiceLinkedRole` statement in the AWS BYOC IAM policy (`admin/deployment/dedicated/aws/byoc`).

## Why

The documented policy only allowed the role to create EKS service-linked roles. Customers enabling the **AI Engineer external RDS** feature in a **fresh AWS account** — one that has never created an RDS instance, so `AWSServiceRoleForRDS` doesn't yet exist — hit:

```
RDS CreateDBInstance → 400 InvalidParameterValue: Unable to create the resource.
Verify that you have permission to create service linked role.
```

On the first RDS instance, `CreateDBInstance` auto-creates the `AWSServiceRoleForRDS` service-linked role, which requires `iam:CreateServiceLinkedRole` for `rds.amazonaws.com`. That service name was absent from the allowlist, so the create was denied. Adding it lets the BYOC role provision RDS on first use without any manual pre-step.

Scope is unchanged for everything else — this only widens the SLR allowlist by one AWS-owned service name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)