### PR TITLE
docs: document supported operators in access policy conditions

### DIFF
--- a/docs-mintlify/reference/data-modeling/data-access-policies.mdx
+++ b/docs-mintlify/reference/data-modeling/data-access-policies.mdx
@@ -233,30 +233,44 @@ The following operators and constructs are supported:
 | Ternary | — | `? :` |
 | Optional chaining | — | `?.` |
 
-For example, the following condition checks that a user belongs to the EMEA region
-and is not blocked:
+For example, the following policy applies to users who are not blocked, are either
+administrators or based in the EMEA region, and belong to the `admins` group. Each
+requirement is expressed as a separate condition, and all conditions must be `true`
+for the policy to take effect:
 
 <CodeGroup>
 
 ```yaml title="YAML"
 conditions:
-  - if: "{ securityContext.is_EMEA_based and not securityContext.is_blocked }"
+  - if: "{ not securityContext.is_blocked }"
+  - if: "{ securityContext.is_admin or securityContext.is_EMEA_based }"
+  - if: "{ securityContext.groups.includes('admins') }"
 ```
 
 ```javascript title="JavaScript"
 conditions: [
-  { if: securityContext.region === `EMEA` && !securityContext.is_blocked }
+  { if: !securityContext.is_blocked },
+  { if: securityContext.is_admin || securityContext.is_EMEA_based },
+  { if: securityContext.groups.includes(`admins`) }
 ]
 ```
 
 </CodeGroup>
+
+<Tip>
+
+Prefer decomposing a condition chained with logical AND into separate
+conditions. Since conditions are combined with AND, the result is equivalent
+but easier to read and maintain.
+
+</Tip>
 
 <Note>
 
 The set of operators supported in JavaScript data models is currently broader than
 in YAML data models. If you'd like to use additional operators in YAML, please
 request support by opening an issue on
-[GitHub](https://github.com/cube-js/cube/issues).
+[GitHub](https://github.com/cube-js/cube/issues?q=is%3Aissue+label%3A%22data+modeling%3Aaccess+policies%22).
 
 </Note>
 

--- a/docs-mintlify/reference/data-modeling/data-access-policies.mdx
+++ b/docs-mintlify/reference/data-modeling/data-access-policies.mdx
@@ -208,6 +208,58 @@ cube(`orders`, {
 
 </CodeGroup>
 
+#### Supported operators
+
+The `if` expression must evaluate to a boolean. The syntax you can use inside it
+depends on the data model format:
+
+- In **YAML** data models, the expression inside `{ }` is evaluated as a Python
+expression. Only logical operators, member access, and method calls are supported.
+- In **JavaScript** data models, the expression is evaluated as a JavaScript
+expression, so a broader set of operators is available.
+
+The following operators and constructs are supported:
+
+| Operator | Python (YAML) | JavaScript |
+| --- | --- | --- |
+| Logical AND | `and` | `&&` |
+| Logical OR | `or` | <code>&#124;&#124;</code> |
+| Logical NOT | `not` | `!` |
+| Member access | `.` | `.` |
+| Method call (e.g., `includes`) | `.includes(…)` | `.includes(…)` |
+| Equality and inequality | — | `===`, `!==`, `==`, `!=` |
+| Comparison | — | `<`, `>`, `<=`, `>=` |
+| Arithmetic | — | `+`, `-`, `*`, `/`, `%`, `**` |
+| Ternary | — | `? :` |
+| Optional chaining | — | `?.` |
+
+For example, the following condition checks that a user belongs to the EMEA region
+and is not blocked:
+
+<CodeGroup>
+
+```yaml title="YAML"
+conditions:
+  - if: "{ securityContext.is_EMEA_based and not securityContext.is_blocked }"
+```
+
+```javascript title="JavaScript"
+conditions: [
+  { if: securityContext.region === `EMEA` && !securityContext.is_blocked }
+]
+```
+
+</CodeGroup>
+
+<Note>
+
+The set of operators supported in JavaScript data models is currently broader than
+in YAML data models. If you'd like to use additional operators in YAML, please
+request support by opening an issue on
+[GitHub](https://github.com/cube-js/cube/issues).
+
+</Note>
+
 ### `member_level`
 
 The optional `member_level` parameter, when present, configures [member-level


### PR DESCRIPTION
## Summary

- Documents which operators can be used inside the `if` expression of an `access_policy` condition, in the data access policies reference.
- Adds a table mapping each operator to its **Python (YAML)** and **JavaScript** form, with em-dashes where an operator is not available in YAML.
- Clarifies that in YAML the `if` expression is evaluated as a Python expression (only logical operators, member access, and method calls are supported), while in JavaScript the full set of JS operators is available.
- Adds a note that the JavaScript operator set is currently broader and that more YAML operators can be requested via a GitHub issue.

The operator support was verified by compiling data models and evaluating the conditions at runtime against passing/failing security contexts, in both YAML and JavaScript formats.

## Test plan

- [x] Both new code examples (YAML and JavaScript) verified to compile.
- [x] Page renders without MDX errors in the Mintlify dev server; table (including the `||` cell) renders correctly.