### PR TITLE
docs: use userAttributes in access policy operators example for consistency

### DIFF
--- a/docs-mintlify/reference/data-modeling/data-access-policies.mdx
+++ b/docs-mintlify/reference/data-modeling/data-access-policies.mdx
@@ -242,16 +242,16 @@ for the policy to take effect:
 
 ```yaml title="YAML"
 conditions:
-  - if: "{ not securityContext.is_blocked }"
-  - if: "{ securityContext.is_admin or securityContext.is_EMEA_based }"
-  - if: "{ securityContext.groups.includes('admins') }"
+  - if: "{ not userAttributes.is_blocked }"
+  - if: "{ userAttributes.is_admin or userAttributes.is_EMEA_based }"
+  - if: "{ userAttributes.groups.includes('admins') }"
 ```
 
 ```javascript title="JavaScript"
 conditions: [
-  { if: !securityContext.is_blocked },
-  { if: securityContext.is_admin || securityContext.is_EMEA_based },
-  { if: securityContext.groups.includes(`admins`) }
+  { if: !userAttributes.is_blocked },
+  { if: userAttributes.is_admin || userAttributes.is_EMEA_based },
+  { if: userAttributes.groups.includes(`admins`) }
 ]
 ```
 


### PR DESCRIPTION
## Summary

- Follow-up to #11116 addressing a review nit: the operators example in the access policy `conditions` section used `securityContext.*`, while every other example in that section uses `userAttributes.*`.
- Switches the example to `userAttributes.*` so the section is internally consistent and readers don't see an unexplained variable switch (the `securityContext` vs `userAttributes` distinction is explained further down the page).

## Test plan

- [x] Both examples (YAML and JavaScript) verified to compile.
- [x] Page renders without MDX errors in the Mintlify dev server.