### PR TITLE
docs: platform client v0.1.2, security context, deployment-scoped API keys

### DIFF
--- a/docs-mintlify/admin/account-billing/api-keys.mdx
+++ b/docs-mintlify/admin/account-billing/api-keys.mdx
@@ -12,4 +12,30 @@ Create and revoke API keys for your Cube organization.
   playsInline
   className="w-full aspect-video rounded-xl"
   src="https://lgo0ecceic.ucarecd.net/4f31a10c-c77f-4185-873c-d6893379d6ad/"
-></video> 
+></video>
+
+## Deployment scope
+
+By default, an API key is **not scoped** to any deployment—it can be used with
+every deployment in your organization (the **All deployments** option). When
+creating or editing a key, you can instead scope it to one or more **specific
+deployments**.
+
+The scope determines which requests a key can authorize:
+
+- **Deployment-scoped endpoints**—such as generating an embed session for a
+  deployment—require the key to be scoped either to that deployment or to all
+  deployments. A request targeting a deployment outside the key's scope is
+  rejected.
+- **Endpoints that aren't tied to a specific deployment** continue to work with
+  any key, regardless of its scope.
+
+Each key's scope—**All** or the specific deployments it's limited to—is shown in
+the API keys table.
+
+<Note>
+
+Scoping is optional and backward compatible. Existing keys remain unscoped (**All
+deployments**) until you change them.
+
+</Note>

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -23,9 +23,23 @@ tags:
   - name: Workbooks
   - name: Notifications
   - name: Workspace
+  - name: App Theme
   - name: Embed
   - name: Embed Tenants
 paths:
+  /v1/app-config:
+    get:
+      operationId: getAppConfig
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppConfigResponse'
+          description: ''
+      summary: Get app config
+      tags:
+        - App Theme
   /v1/deployments:
     get:
       operationId: getDeployments
@@ -503,10 +517,87 @@ paths:
             oneOf:
               - minimum: 1
                 type: integer
+                description: >-
+                  Optional filter: only return notifications for this numeric dashboard id. Provide
+                  this OR dashboardPublicId, not both.
               - type: 'null'
             type: integer
             minimum: 1
-          description: 'Optional filter: only return notifications for this dashboard id.'
+          description: >-
+            Optional filter: only return notifications for this numeric dashboard id. Provide this
+            OR `dashboardPublicId`, not both.
+        - in: query
+          name: dashboardPublicId
+          required: false
+          schema:
+            oneOf:
+              - type: string
+                description: >-
+                  Optional filter: only return notifications for this dashboard public id. Provide
+                  this OR dashboardId, not both.
+              - type: 'null'
+            type: string
+          description: >-
+            Optional filter: only return notifications for this dashboard public id. Provide this OR
+            `dashboardId`, not both.
+        - in: query
+          name: recipientUserId
+          required: false
+          schema:
+            oneOf:
+              - minimum: 1
+                type: integer
+                description: >-
+                  Optional filter: only return notifications received by this user, by user id.
+                  Mutually exclusive with recipientEmail and the embed-user filter.
+              - type: 'null'
+            type: integer
+            minimum: 1
+          description: >-
+            Optional filter: only return notifications received by this user, by user id. Mutually
+            exclusive with `recipientEmail` and the embed-user filter.
+        - in: query
+          name: recipientEmail
+          required: false
+          schema:
+            oneOf:
+              - type: string
+                description: >-
+                  Optional filter: only return notifications received by this user, by email.
+                  Mutually exclusive with recipientUserId and the embed-user filter.
+              - type: 'null'
+            type: string
+          description: >-
+            Optional filter: only return notifications received by this user, by email. Mutually
+            exclusive with `recipientUserId` and the embed-user filter.
+        - in: query
+          name: recipientEmbedTenantName
+          required: false
+          schema:
+            oneOf:
+              - type: string
+                description: >-
+                  Optional filter: only return notifications received by this embed user. Required
+                  together with recipientExternalId; mutually exclusive with the user filters.
+              - type: 'null'
+            type: string
+          description: >-
+            Optional filter: only return notifications received by this embed user. Required
+            together with `recipientExternalId`; mutually exclusive with the user filters.
+        - in: query
+          name: recipientExternalId
+          required: false
+          schema:
+            oneOf:
+              - type: string
+                description: >-
+                  Optional filter: only return notifications received by this embed user. Required
+                  together with recipientEmbedTenantName; mutually exclusive with the user filters.
+              - type: 'null'
+            type: string
+          description: >-
+            Optional filter: only return notifications received by this embed user. Required
+            together with `recipientEmbedTenantName`; mutually exclusive with the user filters.
         - in: query
           name: first
           required: false
@@ -540,8 +631,11 @@ paths:
 
           Returns the deployment’s scheduled notifications (recurring dashboard runs), ordered by
           creation time (newest first) and cursor-paginated. Optionally filter to a single dashboard
-          with `dashboardId`. Each item describes the schedule only; recipients are managed through
-          the `/recipients` sub-resource.
+          with either `dashboardId` (numeric) or `dashboardPublicId` (string), and/or to the
+          notifications a single recipient receives — a user (`recipientUserId` or `recipientEmail`)
+          or an embed user (`recipientEmbedTenantName` + `recipientExternalId`). At most one
+          identifier per dashboard/recipient dimension. Each item describes the schedule only;
+          recipients are managed through the `/recipients` sub-resource.
     post:
       operationId: createNotification
       parameters:
@@ -577,9 +671,10 @@ paths:
           Creates a scheduled notification — a recurring run of a dashboard whose rendered result is
           delivered to its recipients. The cadence is set by `scheduleType` plus the relevant time
           fields (`minute`, `hour`, `dayOfWeek`, `dayOfMonth`) or a raw `customCron` expression when
-          `scheduleType` is `CUSTOM`; `timezone` defaults to UTC. The target `dashboardId` must
-          belong to this deployment, otherwise `404` is returned. The created notification has no
-          recipients — add them via `POST /notifications/{id}/recipients`.
+          `scheduleType` is `CUSTOM`; `timezone` defaults to UTC. Identify the target dashboard with
+          either `dashboardId` (numeric) or `dashboardPublicId` (string) — supply exactly one; it
+          must belong to this deployment, otherwise `404` is returned. The created notification has
+          no recipients — add them via `POST /notifications/{id}/recipients`.
   /v1/deployments/{deploymentId}/notifications/{id}:
     delete:
       operationId: deleteNotification
@@ -1104,11 +1199,12 @@ paths:
       x-mint:
         content: >-
           List the workspace items (folders, workbooks, reports) that have been shared with embed
-          users via the built-in `all_embed_users` group.
+          users via the built-in "All embed users" group or the caller's per-embed-tenant
+          `system:tenant:{embedTenantName}` group.
 
 
-          Unlike `GET /workspace`, this feed is not per-user: every valid embed caller for the
-          deployment sees the same set, scoped to what the built-in group has been granted. Owner
+          Unlike `GET /workspace`, this feed is not per-user: every valid embed caller from the same
+          embed tenant sees the same set, scoped to what those groups have been granted. Owner
           identities are blanked out so they are not exposed to embed users.
 
 
@@ -1334,6 +1430,13 @@ paths:
           required: true
           schema:
             type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DuplicateWorkbookInput'
+        description: DuplicateWorkbookInput
+        required: false
       responses:
         '200':
           content:
@@ -1358,6 +1461,16 @@ paths:
 
           Requires **read** access to the source workbook and the **AI BI User** role (or higher).
           The new workbook is owned by the calling user.
+
+
+          Creator-mode embed sessions can also clone a workbook from the **shared workspace** (the
+          items listed by `GET /shared-workspace`) by passing `{ "shared": true }` in the request
+          body — `workbookId` is then resolved against the shared workspace instead of the caller's
+          own. Such a clone is built from the workbook's **published dashboard**: a fresh report is
+          created per report snapshot, the dashboard is re-published onto the new workbook, and the
+          same config seeds the workbook's draft — the source's live reports and unpublished draft
+          are not copied. The clone is placed at the workspace root. Requires the workbook to have a
+          published dashboard (`400` otherwise); `403` for non-creator-mode callers.
 
 
           If the deployment's plan enforces a workbook limit and it has been reached, the request is
@@ -1777,6 +1890,79 @@ components:
       required:
         - recipients
       type: object
+    AppConfigResponse:
+      properties:
+        appTheme:
+          oneOf:
+            - $ref: '#/components/schemas/AppTheme'
+            - type: 'null'
+        applyThemeGlobally:
+          type: boolean
+        creatorMode:
+          oneOf:
+            - $ref: '#/components/schemas/CreatorMode'
+            - type: 'null'
+      required:
+        - applyThemeGlobally
+      type: object
+    AppTheme:
+      properties:
+        dark:
+          $ref: '#/components/schemas/AppThemeScheme'
+        light:
+          $ref: '#/components/schemas/AppThemeScheme'
+        typography:
+          oneOf:
+            - $ref: '#/components/schemas/AppThemeTypography'
+            - type: 'null'
+      required:
+        - light
+        - dark
+      type: object
+    AppThemeFontRef:
+      properties:
+        fontRef:
+          type: string
+        fontWeight:
+          type: number
+      required:
+        - fontRef
+        - fontWeight
+      type: object
+    AppThemeScheme:
+      properties:
+        accentColor:
+          type: string
+        backgroundColor:
+          type: string
+        contrast:
+          type: number
+        foregroundColor:
+          type: string
+        logoUrl:
+          type: string
+      required:
+        - accentColor
+        - backgroundColor
+        - foregroundColor
+        - contrast
+        - logoUrl
+      type: object
+    AppThemeTypography:
+      properties:
+        body:
+          $ref: '#/components/schemas/AppThemeFontRef'
+        fonts:
+          items:
+            $ref: '#/components/schemas/ThemeFont'
+          type: array
+        heading:
+          $ref: '#/components/schemas/AppThemeFontRef'
+      required:
+        - fonts
+        - body
+        - heading
+      type: object
     ColumnFormatOverride:
       properties:
         decimalPlaces:
@@ -1897,8 +2083,19 @@ components:
               description: Custom cron expression (required if scheduleType is CUSTOM)
             - type: 'null'
         dashboardId:
-          description: Dashboard to run on the schedule
-          type: integer
+          oneOf:
+            - type: integer
+              description: >-
+                Numeric id of the dashboard to run on the schedule. Provide this OR
+                dashboardPublicId (exactly one).
+            - type: 'null'
+        dashboardPublicId:
+          oneOf:
+            - type: string
+              description: >-
+                Public id of the dashboard to run on the schedule. Provide this OR dashboardId
+                (exactly one).
+            - type: 'null'
         dayOfMonth:
           oneOf:
             - type: integer
@@ -1908,6 +2105,15 @@ components:
           oneOf:
             - type: integer
               description: Day of week (0-6, Sunday=0)
+            - type: 'null'
+        filters:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardFilterInput'
+              type: array
+              description: >-
+                Dimension filters applied to the dashboard when the notification is rendered
+                (substituted into the screenshot/PDF for every recipient).
             - type: 'null'
         hour:
           oneOf:
@@ -1929,13 +2135,19 @@ components:
             - type: 'null'
         scheduleType:
           $ref: '#/components/schemas/CreateNotificationInputScheduleType'
+        timeGrains:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardTimeGrainInput'
+              type: array
+              description: Time-grain overrides applied to the dashboard when the notification is rendered.
+            - type: 'null'
         timezone:
           oneOf:
             - type: string
               description: Timezone for the schedule (e.g. "America/New_York")
             - type: 'null'
       required:
-        - dashboardId
         - scheduleType
       type: object
     CreateNotificationInputNotificationFormat:
@@ -2044,6 +2256,17 @@ components:
         - ready
         - demo
       type: string
+    CreatorMode:
+      properties:
+        showWorkspaceTitle:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        workspaceTitle:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
     Dashboard:
       properties:
         allowEmbed:
@@ -2059,6 +2282,10 @@ components:
         description:
           oneOf:
             - type: string
+            - type: 'null'
+        fromSharedWorkspace:
+          oneOf:
+            - type: boolean
             - type: 'null'
         id:
           type: integer
@@ -2255,6 +2482,113 @@ components:
         - published
         - archived
       type: string
+    DashboardFilter:
+      properties:
+        caseSensitive:
+          oneOf:
+            - {}
+            - type: 'null'
+        endInclusive:
+          oneOf:
+            - {}
+            - type: 'null'
+        member:
+          type: string
+        operator:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardFilterOperator'
+            - type: 'null'
+        startInclusive:
+          oneOf:
+            - {}
+            - type: 'null'
+        value:
+          oneOf:
+            - oneOf:
+                - type: string
+                - type: number
+                - type: boolean
+                - type: array
+                  items: {}
+            - type: 'null'
+      required:
+        - member
+      type: object
+    DashboardFilterInput:
+      properties:
+        caseSensitive:
+          oneOf:
+            - description: 'For string filters: whether matching is case-sensitive'
+            - type: 'null'
+        endInclusive:
+          oneOf:
+            - description: 'For between filters: whether the end bound is inclusive'
+            - type: 'null'
+        member:
+          description: Dimension path, e.g. "Orders.status"
+          pattern: .+\..+
+          type: string
+        operator:
+          oneOf:
+            - $ref: '#/components/schemas/DashboardFilterInputOperator'
+            - type: 'null'
+        startInclusive:
+          oneOf:
+            - description: 'For between filters: whether the start bound is inclusive'
+            - type: 'null'
+        value:
+          oneOf:
+            - description: >-
+                Filter value. Omit for is_null / is_not_null; provide a 2-element [start, end] array
+                for between.
+              oneOf:
+                - type: string
+                - type: number
+                - type: boolean
+                - type: array
+                  items: {}
+            - type: 'null'
+      required:
+        - member
+      type: object
+    DashboardFilterInputOperator:
+      enum:
+        - equals
+        - not_equals
+        - greater_than
+        - greater_than_or_equal
+        - less_than
+        - less_than_or_equal
+        - contains
+        - not_contains
+        - starts_with
+        - not_starts_with
+        - ends_with
+        - not_ends_with
+        - is_null
+        - is_not_null
+        - between
+        - custom
+      type: string
+    DashboardFilterOperator:
+      enum:
+        - equals
+        - not_equals
+        - greater_than
+        - greater_than_or_equal
+        - less_than
+        - less_than_or_equal
+        - contains
+        - not_contains
+        - starts_with
+        - not_starts_with
+        - ends_with
+        - not_ends_with
+        - is_null
+        - is_not_null
+        - between
+        - custom
+      type: string
     DashboardLayout:
       properties:
         breakpoints:
@@ -2396,6 +2730,29 @@ components:
           oneOf:
             - type: string
             - type: 'null'
+      type: object
+    DashboardTimeGrain:
+      properties:
+        grain:
+          type: string
+        member:
+          type: string
+      required:
+        - member
+        - grain
+      type: object
+    DashboardTimeGrainInput:
+      properties:
+        grain:
+          description: Granularity, e.g. "day", "week", "month"
+          type: string
+        member:
+          description: Time dimension path, e.g. "Orders.created_at"
+          pattern: .+\..+
+          type: string
+      required:
+        - member
+        - grain
       type: object
     DashboardWidget:
       properties:
@@ -2681,6 +3038,13 @@ components:
         - offset
         - limit
       type: object
+    DuplicateWorkbookInput:
+      properties:
+        shared:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+      type: object
     EmbedTheme:
       properties:
         analyticsChat:
@@ -2843,7 +3207,7 @@ components:
             - type: 'null'
         embedTenantName:
           oneOf:
-            - pattern: ^[a-z][a-z0-9-]{3,34}[a-z0-9]$
+            - pattern: ^[a-z][a-z0-9-]{0,34}[a-z0-9]$
               type: string
             - type: 'null'
         embedTheme:
@@ -2990,6 +3354,13 @@ components:
           type: integer
         deploymentId:
           type: integer
+        filters:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardFilter'
+              type: array
+              description: Dimension filters applied when the notification is rendered.
+            - type: 'null'
         humanReadableSchedule:
           description: Human-readable description of the cron schedule
           type: string
@@ -3001,6 +3372,13 @@ components:
           type: boolean
         notificationFormat:
           type: string
+        timeGrains:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardTimeGrain'
+              type: array
+              description: Time-grain overrides applied when the notification is rendered.
+            - type: 'null'
         timezone:
           type: string
       required:
@@ -3615,6 +3993,27 @@ components:
         - name
         - actions
       type: object
+    ThemeFont:
+      properties:
+        family:
+          oneOf:
+            - type: string
+            - type: 'null'
+        format:
+          type: string
+        id:
+          type: string
+        name:
+          oneOf:
+            - type: string
+            - type: 'null'
+        url:
+          type: string
+      required:
+        - id
+        - url
+        - format
+      type: object
     UpdateFolderInput:
       properties:
         name:
@@ -3641,6 +4040,15 @@ components:
           oneOf:
             - type: integer
             - type: 'null'
+        filters:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardFilterInput'
+              type: array
+              description: >-
+                Dimension filters applied to the dashboard when the notification is rendered.
+                Replaces the existing set when provided.
+            - type: 'null'
         hour:
           oneOf:
             - type: integer
@@ -3665,6 +4073,15 @@ components:
         scheduleType:
           oneOf:
             - $ref: '#/components/schemas/UpdateNotificationInputScheduleType'
+            - type: 'null'
+        timeGrains:
+          oneOf:
+            - items:
+                $ref: '#/components/schemas/DashboardTimeGrainInput'
+              type: array
+              description: >-
+                Time-grain overrides applied to the dashboard when the notification is rendered.
+                Replaces the existing set when provided.
             - type: 'null'
         timezone:
           oneOf:
@@ -4003,6 +4420,10 @@ components:
               type: string
             - format: date-time
               type: string
+        user:
+          oneOf:
+            - $ref: '#/components/schemas/ResourceOwner'
+            - type: 'null'
         userId:
           oneOf:
             - type: number

--- a/docs-mintlify/api-reference/authentication.mdx
+++ b/docs-mintlify/api-reference/authentication.mdx
@@ -19,6 +19,11 @@ Authorization: Bearer <YOUR_TOKEN>
 The token can be an API key generated in your Cube Cloud account settings, or an
 OAuth access token from Cube Cloud's OAuth flow — both are sent the same way.
 
+If the API key is [scoped to specific deployments](/admin/account-billing/api-keys#deployment-scope),
+it only authorizes requests for those deployments. A request targeting a
+deployment outside the key's scope returns `403 Forbidden`. Unscoped keys
+(**All deployments**) authorize requests for every deployment.
+
 ```bash
 curl --request GET \
   --url 'https://<tenant>.cubecloud.dev/api/v1/deployments' \
@@ -51,10 +56,12 @@ curl --request GET \
 
 <Warning>
 
-Treat API keys and SCIM tokens like passwords — they grant full access to your
-account's resources. Store them securely and rotate them if they are exposed.
+Treat API keys and SCIM tokens like passwords — unless an API key is scoped to
+specific deployments, they grant full access to your account's resources. Store
+them securely and rotate them if they are exposed.
 
 </Warning>
 
 A `401 Unauthorized` response means the credential is missing, malformed, or
-expired.
+expired. A `403 Forbidden` response means the credential is valid but not
+authorized for the target — for example, an API key scoped to other deployments.

--- a/docs-mintlify/api-reference/changelog.mdx
+++ b/docs-mintlify/api-reference/changelog.mdx
@@ -7,6 +7,39 @@ rss: true
 {/* GENERATED FILE — do not edit by hand. */}
 {/* Run scripts/extract-changelog.js against the platform client CHANGELOG.md. */}
 
+<Update label="2026-06-17" description="v0.1.2" tags={["Added","Changed"]}>
+  ### Added
+
+  - `GET /api/v1/app-config` operation (`AppThemePublicController.getAppConfig`) returning the deployment's app configuration — `appTheme`, `applyThemeGlobally`, and `creatorMode`. New schemas: `AppConfigResponse`, `AppTheme`, `CreatorMode`.
+  - Scheduled notifications can now carry dashboard `filters` and `timeGrains` that are applied when the dashboard is run. Available on `CreateNotificationInput`, `UpdateNotificationInput`, and the `Notification` response. New schemas: `DashboardFilter`, `DashboardFilterInput`, `DashboardFilterOperator`, `DashboardFilterInputOperator`, `DashboardTimeGrain`, `DashboardTimeGrainInput`.
+  - `CreateNotificationInput` accepts `dashboardPublicId` (string) as an alternative to the numeric `dashboardId` — supply exactly one.
+  - `GET /notifications` accepts new filter query parameters: `dashboardPublicId`, and recipient filters `recipientUserId` / `recipientEmail` (console user) or `recipientEmbedTenantName` + `recipientExternalId` (embed user).
+  - `POST /workbooks/{workbookId}/duplicate` accepts an optional `DuplicateWorkbookInput` body with a `shared` flag to clone a workbook from the shared workspace. New schema: `DuplicateWorkbookInput`.
+  - `Dashboard` now includes a `fromSharedWorkspace` field.
+  - `Workbook` now includes a `user` field (`ResourceOwner`).
+  - `InheritedUserPolicyDto` and `ResourceUserPolicyDto` now include `email`, `firstName`, and `picture` fields.
+
+  ### Changed
+
+  - `CreateNotificationInput.dashboardId` is now optional; identify the target dashboard with either `dashboardId` or the new `dashboardPublicId`.
+</Update>
+
+<Update label="2026-06-10" description="v0.1.1" tags={["Added","Changed","Deprecated"]}>
+  ### Added
+
+  - `GET /api/v1/deployments/{deploymentId}/reports` now supports cursor-based pagination via the `first` and `after` query parameters, and returns an `items` array alongside a `pageInfo` cursor block — matching the folders and other list endpoints. (Cursor pagination is not available when sorting by `lastViewedAt`.)
+  - The reports list now accepts `name` as a `sortBy` value, in addition to `createdAt`, `updatedAt`, and `lastViewedAt`.
+  - `NotificationRecipient` now includes an optional `username` field.
+
+  ### Changed
+
+  - **BREAKING:** The reports list response type `ReportsFindAllResult` is now `ReportsListResponse`.
+
+  ### Deprecated
+
+  - The `data` and `count` fields on the reports list response are deprecated in favor of `items` and `pageInfo`. They remain populated for backward compatibility.
+</Update>
+
 <Update label="2026-06-07" description="v0.1.0" tags={["Added","Changed","Deprecated"]}>
   ### Added
 

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -790,6 +790,13 @@
                 ]
               },
               {
+                "group": "App Theme",
+                "openapi": "/api-reference/api.yaml",
+                "pages": [
+                  "GET /v1/app-config"
+                ]
+              },
+              {
                 "group": "Embed",
                 "openapi": "/api-reference/api.yaml",
                 "pages": [

--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -13,7 +13,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 
 - **Natural language queries** – Ask questions in plain language without knowing SQL
 - **Multi-query reasoning** – The AI creates and synthesizes multiple queries for complex questions
-- **Semantic model integration** – All queries run against your semantic model with proper access control and security
+- **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
 - **Save to Workbook** – Export insights to [Workbooks](/docs/explore-analyze/workbooks) for further analysis
 

--- a/docs-mintlify/docs/explore-analyze/explore.mdx
+++ b/docs-mintlify/docs/explore-analyze/explore.mdx
@@ -43,6 +43,8 @@ The functionality in Explore is similar to when working with semantic views in w
 
 Explore state is also saved in the URL, making it easy to share your exploration with other users by simply copying and sharing the link.
 
+If you have developer or admin access, you can [apply a security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context) to an exploration to verify what a specific end user—or an AI agent querying on their behalf—would see.
+
 ## Saving explorations
 
 You can save an exploration so you can return to it later without

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -205,7 +205,7 @@ behaves as intended.
   loop
   playsInline
   className="w-full h-auto rounded-xl block dark:hidden"
-  src="https://lgo0ecceic.ucarecd.net/add0e872-e951-4d13-850b-991bf0e34c41/"
+  src="https://ucarecdn.com/0b8ed4a8-9072-4db6-95bb-8f4a40ebeff9/c67da299-light.mp4"
 ></video>
 <video
   autoPlay
@@ -213,7 +213,7 @@ behaves as intended.
   loop
   playsInline
   className="w-full h-auto rounded-xl hidden dark:block"
-  src="https://lgo0ecceic.ucarecd.net/d61efb90-809c-4247-aa00-efe3d0af2f6f/"
+  src="https://ucarecdn.com/172af2cd-920d-4443-aa17-41ff3f15bffb/103430ef-dark.mp4"
 ></video>
 
 [ref-core-data-apis]: /reference/core-data-apis

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -156,25 +156,48 @@ Currently, advanced semantic queries can be placed on dashboards, but dashboard 
 
 ## Applying a security context
 
-When you run a query in a workbook—or open a dashboard—Cube generates a token to
-execute it against the semantic layer. If you have developer access, you can
-attach a [security context][ref-security-context] to that token directly from
-the workbook or dashboard page. The values you provide are used when the token
-is generated, overriding the claims that would otherwise come from your session.
+When you run a query—in a workbook, on a dashboard, or in [Explore][ref-explore]—Cube
+generates a token to execute it against the semantic layer. If you have developer or
+admin access, you can attach a [security context][ref-security-context] to that token
+directly from the page you're working on. The values you provide are used when the
+token is generated, overriding the claims that would otherwise come from your session.
+
+The security context you set is also respected by [AI agents][ref-analytics-chat]:
+any query an agent runs on your behalf—whether in the workbook or in the IDE—executes
+under the same context. This lets you confirm an agent sees exactly the data a given
+end user would.
+
+### What you can override
+
+- **Groups** — choose **Inherit** to keep the Cube Cloud groups resolved from your
+  session, **Custom** to query as a specific set of groups, or **None** to query with
+  no groups at all.
+- **User attributes** — keep the attributes resolved from your session, or override
+  them with your own values.
 
 <Note>
 
-The security context control is only visible to developers. Other users always
-query with the security context derived from their own session.
+Setting a security context requires developer or admin access (deployment edit
+access). Overriding the Cube Cloud **groups** and **user attributes** specifically
+requires the admin role. Users without edit access always query with the security
+context derived from their own session.
 
 </Note>
 
-This is primarily a testing tool. It lets developers reproduce what a specific
-end user would see and verify [access control][ref-access-control] and
-multitenancy behavior without leaving Cube Cloud. It's especially useful when a
-query fails or returns no data because the data model expects security context
-values that aren't present in your session—you can supply them here and confirm
-the model behaves as intended.
+<Warning>
+
+You can't use a security context to impersonate another user. The `email` claim is
+never overridable—it's always taken from your own session—so you can't run queries on
+behalf of someone else.
+
+</Warning>
+
+This is primarily a testing tool. It lets you reproduce what a specific end user would
+see and verify [access control][ref-access-control] and multitenancy behavior without
+leaving Cube Cloud. It's especially useful when a query fails or returns no data
+because the data model expects security context values that aren't present in your
+session—you can supply them here and confirm the model (and any agent that queries it)
+behaves as intended.
 
 <video
   autoPlay
@@ -199,6 +222,8 @@ the model behaves as intended.
 [ref-configuration]: /docs/data-modeling/configuration
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-access-control]: /docs/data-modeling/access-control
+[ref-explore]: /docs/explore-analyze/explore
+[ref-analytics-chat]: /docs/explore-analyze/analytics-chat
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
 [ref-auto-run]: /reference/data-modeling/view#auto_run
 

--- a/docs-mintlify/reference/embed-apis/generate-session.mdx
+++ b/docs-mintlify/reference/embed-apis/generate-session.mdx
@@ -15,6 +15,8 @@ The Generate Session API is available on [Premium and Enterprise plans](https://
 
 The Generate Session API requires your [Cube Cloud API key][ref-api-keys] for authentication.
 
+If the API key is [scoped to specific deployments][ref-api-keys], the `deploymentId` in the request body must be within the key's scope; otherwise the request is rejected with `403 Forbidden`. Unscoped keys can mint sessions for any deployment.
+
 ## Endpoint
 
 ```text


### PR DESCRIPTION
## Summary

Documentation updates for the latest platform client release and two Cube Cloud feature changes.

### API reference — platform client v0.1.2
- Regenerated `changelog.mdx` and `api.yaml` from the platform client release (v0.1.1 + v0.1.2).
- New `GET /v1/app-config` endpoint and **App Theme** nav group; notification dashboard filters, workbook duplicate `shared` flag, and other additive schema changes.
- Verified all 45 spec endpoints are in sync with `docs.json` nav (no drift).

### Security context (expanded behavior)
- Overrides are now honored across workbooks, dashboards, Explore, and queries run by **AI agents** (in the workbook or the IDE).
- Documented the **Groups** (Inherit / Custom / None) and **user attribute** override options.
- Clarified permissions: setting a context requires developer or admin (deployment edit access); overriding Cube Cloud groups/attributes is admin-only.
- Documented that `email` is never overridable — no impersonation, no querying on another user's behalf.
- Cross-linked from Explore and Analytics Chat.

### Deployment-scoped API keys (CUB-2852)
- API keys can now be scoped to one or more deployments; default is unscoped (**All deployments**), backward compatible.
- Deployment-scoped endpoints require the key be scoped to that deployment or to all deployments; other endpoints are unaffected. Out-of-scope requests return `403`.
- Documented on the API keys page, with notes in the authentication and generate-session references.

## Notes / open questions
- **Security context permissions:** per the implementation, overriding Cube Cloud groups/attributes is admin-only (general overrides allow developers too). Documented both precisely — adjust if product intent differs.
- **API key scope editing:** documented scope as set at create/edit time per the source PR; narrow to creation-only if edit isn't shipping this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)