### PR TITLE
docs: document color scale (heat mapping) for table charts

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -121,9 +121,13 @@ To make a background transparent, open the color picker and clear the hex value.
 
 A **color scale** (heat map) tints each cell of a numeric column with a gradient based on where its value falls in the column's range. It is a rule type in the **Formatting** tab, alongside conditional formatting — switch a rule between **Conditional formatting** and **Color scale** with the **Type** selector inside the rule.
 
-To add one quickly, open the menu next to **Add rule** and pick a color-scale preset (for example, *White → green* or *Green · white · red*).
+To add one quickly, open the menu next to **Add rule** and pick a color-scale preset:
 
-A color scale requires a **numeric source column**. For non-numeric columns (strings, dates, booleans), the **Color scale** type is disabled — use conditional formatting instead.
+- **Outstanding values** — a two-color scale that highlights the highest values.
+- **Divergent values** — a three-color scale that distinguishes low, middle, and high values.
+- **Traffic light gradient** — a red–yellow–green three-color scale.
+
+A color scale requires a **numeric source column**. For non-numeric columns (strings, dates, booleans), the **Scale** type is disabled — use conditional formatting instead.
 
 Configure the gradient with three stops, laid out top-to-bottom to mirror the column:
 
@@ -131,7 +135,16 @@ Configure the gradient with three stops, laid out top-to-bottom to mirror the co
 - **Center** (optional middle) — **Disabled** by default, which produces a two-color gradient. Enable it for a three-color gradient anchored at the **Midpoint**, **Average**, **Median**, or a custom **Number** / **Percentile**.
 - **End** (high end) — anchored at the column **Maximum** by default, or a custom **Number** or **Percentile**.
 
-Each stop has its own color. Computed anchor modes (Minimum, Maximum, Midpoint, Average, Median) preview the resolved value from your data in the dropdown.
+Each stop has its own color. The anchor determines *which value* in the column the stop's color is pinned to:
+
+- **Minimum** / **Maximum** — the lowest / highest value in the column.
+- **Midpoint** — the halfway point of the range, i.e. `(minimum + maximum) / 2`. Independent of how the values are distributed.
+- **Average** — the mean of all values (sensitive to outliers).
+- **Median** — the middle value when sorted (robust to outliers).
+- **Number** — a fixed value you enter.
+- **Percentile** — a value at the given percentile (e.g. `90` = the 90th percentile).
+
+For the computed anchors (Minimum, Maximum, Midpoint, Average, Median), the dropdown previews the resolved value from your data.
 
 Use **Reverse color scale** to swap the Start and End colors. **Treat nulls as zero** is on by default, coloring null/blank cells as zero; turn it off to leave them uncolored.
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -117,17 +117,27 @@ To make a background transparent, open the color picker and clear the hex value.
 
 {/* TODO screenshot: conditional formatting panel with a condition configured (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-### Gradient color scale
+### Color scale
 
-The **Color scale** tab applies a gradient across a column based on value ranges. Configure a minimum color, a midpoint color (optional), and a maximum color. The gradient is applied across all visible rows.
+A **color scale** (heat map) tints each cell of a numeric column with a gradient based on where its value falls in the column's range. It is a rule type in the **Formatting** tab, alongside conditional formatting — switch a rule between **Conditional formatting** and **Color scale** with the **Type** selector inside the rule.
 
-<Warning>
-If you don't set a mapping value for the scale, the gradient applies across visible rows only. This can produce unexpected results when row limits or pagination are active.
-</Warning>
+To add one quickly, open the menu next to **Add rule** and pick a color-scale preset (for example, *White → green* or *Green · white · red*).
 
-Use the **Treat as zero** toggle to handle null values in the gradient calculation.
+A color scale requires a **numeric source column**. For non-numeric columns (strings, dates, booleans), the **Color scale** type is disabled — use conditional formatting instead.
 
-{/* TODO screenshot: table with gradient color scale applied to a numeric column (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+Configure the gradient with three stops, laid out top-to-bottom to mirror the column:
+
+- **Start** (low end) — anchored at the column **Minimum** by default, or a custom **Number** or **Percentile**.
+- **Center** (optional middle) — **Disabled** by default, which produces a two-color gradient. Enable it for a three-color gradient anchored at the **Midpoint**, **Average**, **Median**, or a custom **Number** / **Percentile**.
+- **End** (high end) — anchored at the column **Maximum** by default, or a custom **Number** or **Percentile**.
+
+Each stop has its own color. Computed anchor modes (Minimum, Maximum, Midpoint, Average, Median) preview the resolved value from your data in the dropdown.
+
+Use **Reverse scale** to swap the Start and End colors. Enable **Treat nulls as zero** to color null/blank cells as zero instead of leaving them uncolored.
+
+The scale is normalized **per column** — each targeted column uses its own value range.
+
+{/* TODO screenshot: table with a color scale applied to a numeric column (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ## Totals
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -133,7 +133,7 @@ Configure the gradient with three stops, laid out top-to-bottom to mirror the co
 
 Each stop has its own color. Computed anchor modes (Minimum, Maximum, Midpoint, Average, Median) preview the resolved value from your data in the dropdown.
 
-Use **Reverse scale** to swap the Start and End colors. Enable **Treat nulls as zero** to color null/blank cells as zero instead of leaving them uncolored.
+Use **Reverse color scale** to swap the Start and End colors. **Treat nulls as zero** is on by default, coloring null/blank cells as zero; turn it off to leave them uncolored.
 
 The scale is normalized **per column** — each targeted column uses its own value range.
 


### PR DESCRIPTION
## Summary

Documents the new **Color scale** option for the table visualization (a gradient/heat map that tints numeric cells by value range), alongside the existing conditional formatting docs. Covers: numeric-only requirement, Start/Center/End anchors (Minimum/Maximum/Midpoint/Average/Median/Number/Percentile), Center "Disabled" for 2- vs 3-color, presets, Reverse, Treat nulls as zero, and per-column normalization.

## Test plan

- [x] Section added under `docs/explore-analyze/charts/chart-types/table.mdx`
- [ ] Mintlify build/preview renders cleanly