### PR TITLE
fix(cubestore): Skip rolling rewrite for aggregates without aggregates

### DIFF
--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -210,6 +210,7 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
         ),
         t("rolling_window_offsets", rolling_window_offsets),
         t("rolling_window_filtered", rolling_window_filtered),
+        t("rolling_window_no_aggregates", rolling_window_no_aggregates),
         t("decimal_index", decimal_index),
         t("decimal_order", decimal_order),
         t("float_index", float_index),
@@ -5457,6 +5458,65 @@ LIMIT
     //     .exec_query("SELECT day, ROLLING(SUM(n) RANGE 2 PRECEDING) FROM s.Data ROLLING_WINDOW DIMENSION day FROM 10 to 0 EVERY 10")
     //     .await
     //     .unwrap_err();
+    Ok(())
+}
+
+async fn rolling_window_no_aggregates(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA s").await?;
+    service
+        .exec_query("CREATE TABLE s.Data(day int, name text, n int)")
+        .await?;
+    service
+        .exec_query(
+            "INSERT INTO s.Data(day, name, n) VALUES (1, 'john', 10), \
+                                                     (1, 'sara', 7), \
+                                                     (3, 'sara', 3), \
+                                                     (3, 'john', 9), \
+                                                     (3, 'john', 11), \
+                                                     (5, 'timmy', 5)",
+        )
+        .await?;
+
+    // Regression test for the rolling optimizer (commit 9481045): a grouped
+    // aggregate with no aggregate expressions — a `SELECT DISTINCT dim` key
+    // generator over the time series, as emitted for a multi-rolling-measure
+    // query — used to be rewritten into a RollingWindowAggregate with an empty
+    // `rolling_aggs` list, which panicked in the executor. It must instead run as
+    // a plain aggregate/range-join and return the series dimension keys.
+    let r = service
+        .exec_query(
+            r#"SELECT
+  q_0.`orders__created_at_day`
+FROM
+  (
+    SELECT
+      `orders.created_at_series`.`date_from` `orders__created_at_day`
+    FROM
+      (
+        SELECT
+          date_from as `date_from`,
+          date_from + 1 AS `date_to`
+        FROM (
+            select unnest(generate_series(1, 5, 1))
+        ) AS series(date_from)
+      ) AS `orders.created_at_series`
+      LEFT JOIN (
+        SELECT
+            day `orders__created_at_day`,
+            SUM(n) `orders__rolling_number`
+            FROM s.Data GROUP BY 1
+      ) AS `orders_rolling_number_cumulative__base` ON `orders_rolling_number_cumulative__base`.`orders__created_at_day` > `orders.created_at_series`.`date_to` - 1
+      AND `orders_rolling_number_cumulative__base`.`orders__created_at_day` <= `orders.created_at_series`.`date_to`
+    GROUP BY
+      1
+  ) as q_0
+ORDER BY
+  1 ASC
+LIMIT
+  5000"#,
+        )
+        .await?;
+    assert_eq!(to_rows(&r), rows(&[1i64, 2, 3, 4, 5]));
     Ok(())
 }
 

--- a/rust/cubestore/cubestore-sql-tests/tests/migration.rs
+++ b/rust/cubestore/cubestore-sql-tests/tests/migration.rs
@@ -22,12 +22,14 @@ fn main() {
             )).unwrap()
     };
 
-    // repartition_multi_node_consistency was added after the migration fixture
-    // tarball was recorded, so it has no pre-migration data directory to copy
-    // from. Skip it here; it still runs under in-process/cluster/multi-process.
+    // These tests were added after the migration fixture tarball was recorded, so
+    // they have no pre-migration data directory to copy from. Skip them here; they
+    // still run under in-process/cluster/multi-process.
     let extra_args = vec![
         "--skip".to_string(),
         "repartition_multi_node_consistency".to_string(),
+        "--skip".to_string(),
+        "rolling_window_no_aggregates".to_string(),
     ];
     run_sql_tests("migration", extra_args, move |test_name, test_fn| {
         let r = Builder::new_current_thread()

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
@@ -195,6 +195,17 @@ impl RollingOptimizerRule {
                     })
                     .collect::<Option<Vec<_>>>()?;
 
+                // A grouped aggregate with no aggregate expressions is a key generator
+                // (e.g. `SELECT DISTINCT dim` over the time series, used to assemble the
+                // dimension keys of a multi-measure rolling query), not a rolling window.
+                // Converting it to a RollingWindowAggregate yields an empty `rolling_aggs`,
+                // whose executor leaves the per-bucket `had_values` mask empty and then
+                // indexes out of bounds. Leave it as a plain aggregate/range-join, which
+                // produces the same dimension keys.
+                if rolling_aggs.is_empty() {
+                    return None;
+                }
+
                 let RollingWindowJoinExtractorResult {
                     input,
                     dimension,


### PR DESCRIPTION
A multi-rolling-measure query reads the rollup through a `SELECT DISTINCT dim` key-generator over the time series — a grouped Aggregate with no aggregate expressions. The rolling optimizer matched its shape and rewrote it into a RollingWindowAggregate with an empty `rolling_aggs` list. Its executor builds the per-bucket `had_values` mask only inside the rolling-aggregate loop, so an empty list leaves the mask empty and the output loop then indexes out of bounds: a panic on the current build, surfacing as "Sort expressions cannot be empty for streaming merge" on the DataFusion 46 executor.

Bail out of the rewrite when there are no rolling aggregates. The node runs as a plain aggregate/range-join instead, producing the same dimension keys.