### PR TITLE
fix(bigquery-driver): rethrow table listing errors

### DIFF
--- a/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
+++ b/packages/cubejs-bigquery-driver/src/BigQueryDriver.ts
@@ -299,7 +299,7 @@ export class BigQueryDriver extends BaseDriver implements DriverInterface {
       const [tables] = await this.bigquery.dataset(schemaName).getTables();
       return tables.map(t => ({ table_name: t.id }));
     } catch (e) {
-      if ((<any>e).toString().indexOf('Not found')) {
+      if ((<any>e).toString().indexOf('Not found') !== -1) {
         return [];
       }
       throw e;

--- a/packages/cubejs-bigquery-driver/test/unit/BigQueryDriver.test.ts
+++ b/packages/cubejs-bigquery-driver/test/unit/BigQueryDriver.test.ts
@@ -1,0 +1,18 @@
+import { BigQueryDriver } from '../../src';
+
+describe('BigQueryDriver', () => {
+  test('throws non-not found errors while fetching tables', async () => {
+    const driver = new BigQueryDriver({});
+    const error = new Error('Permission denied');
+
+    (driver as any).bigquery = {
+      dataset: () => ({
+        getTables: () => {
+          throw error;
+        },
+      }),
+    };
+
+    await expect(driver.getTablesQuery('schema')).rejects.toThrow(error);
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Fixes BigQueryDriver.getTablesQuery error handling so only "Not found" errors are treated as an empty table list.

Previously, the catch block checked:

`error.toString().indexOf('Not found')`

Because `indexOf()` returns `-1` when the substring is absent, and `-1` is truthy in JavaScript, non-"Not found" errors such as permission or API errors were incorrectly swallowed and returned as `[]`.

This change makes the check explicit with `!== -1`, allowing unexpected BigQuery table listing errors to be rethrown.

A focused unit regression test was added for the non-"Not found" case.