### PR TITLE
docs: document single-file form for eval questions

### DIFF
--- a/docs-mintlify/admin/ai/evals.mdx
+++ b/docs-mintlify/admin/ai/evals.mdx
@@ -37,13 +37,19 @@ sub-tabs: **Evaluations** (runs) and **Questions** (the benchmark set).
 ## Authoring benchmark questions
 
 Questions live in your [data model repository](/admin/ai#agent-configuration),
-versioned and branched like the rest of it — under `agents/eval_questions/*.yml`.
+versioned and branched like the rest of it. You can keep them in a single
+top-level `agents/eval_questions.yml` file — the simplest place to start — or
+split them across any number of `agents/eval_questions/*.yml` files as your set
+grows. The parser picks up both and merges every file's `eval_questions` list
+into one set, so you can move from one file to many at any time without changing
+anything else.
+
 Each file has a top-level `eval_questions` list. A question needs a unique
 `name`, a `question`, and exactly one ground truth: a `certifiedQuery`
 reference **or** inline `sql`.
 
 ```yaml
-# agents/eval_questions/revenue.yml
+# agents/eval_questions.yml
 eval_questions:
   - name: revenue_by_quarter
     question: What was our revenue by quarter over the last two years?


### PR DESCRIPTION
## Summary

The [Evals docs page](https://docs.cube.dev/admin/ai/evals) documented eval-question authoring as only the directory form (`agents/eval_questions/*.yml`), implying a single file is not supported. That's inaccurate.

The cube-runtime agents-config parser picks up **both** a single top-level `agents/eval_questions.yml` file and any number of files under `agents/eval_questions/`, flattening every file's `eval_questions:` list into one set (verified on a live deployment).

## Changes

- Lead the "Authoring benchmark questions" section with the single-file `agents/eval_questions.yml` form (simplest entry point), then present the directory form as the way to split as the set grows.
- State that the parser merges both, so you can move from one file to many without changing anything else.
- Update the example snippet's path comment to `# agents/eval_questions.yml`.

Everything else (the `eval_questions:` list shape; `name` + `question` + exactly one of `sql`/`certifiedQuery`; optional `space:`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)