### PR TITLE
fix(schema-compiler): Thread memberToAlias through multi-stage CTEs

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -1790,6 +1790,11 @@ export class BaseQuery {
       multiStageDimensions: withQuery.multiStageDimensions,
       multiStageTimeDimensions: withQuery.multiStageTimeDimensions,
       filters: withQuery.filters,
+      // Propagate SQL API member aliases so dimension columns produced by this stage
+      // match how the outer aggregate (and renderedReference) reference them. Without it
+      // the stage names columns with full internal aliases while the consumer references
+      // them by memberToAlias, producing `invalid identifier` errors.
+      memberToAlias: this.options.memberToAlias,
       // TODO do we need it?
       multiStageQuery: true, // !!fromDimensions.find(d => this.newDimension(d).isMultiStage())
       disableExternalPreAggregations: true,
@@ -1812,6 +1817,8 @@ export class BaseQuery {
       multiStageTimeDimensions: withQuery.multiStageTimeDimensions,
       filters: withQuery.filters,
       segments: withQuery.segments,
+      // See note above: keep member aliases consistent across multi-stage CTEs.
+      memberToAlias: this.options.memberToAlias,
       from: fromSql && {
         sql: fromSql,
         alias: `${withQuery.alias}_join`,

--- a/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-member-to-alias.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-member-to-alias.test.ts
@@ -1,0 +1,118 @@
+import { SnowflakeQuery } from '../../../src/adapter/SnowflakeQuery';
+import { prepareYamlCompiler } from '../../unit/PrepareCompiler';
+
+// Multi-stage ratio measure in a cube whose name is >= the 16-char alias truncation limit.
+// The SQL API (cubesql) sends `memberToAlias` where every selected member truncates to the
+// same 16-char prefix (deduped with _1/_2 suffixes). This previously produced
+// `invalid identifier '"kibanasampledata"'` from the warehouse.
+describe('multi_stage member_to_alias', () => {
+  jest.setTimeout(60000);
+
+  const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(`
+cubes:
+  - name: KibanaSampleDataEcommerce
+    sql_table: public.kibana_sample_data_ecommerce
+    dimensions:
+      - name: id
+        sql: "{CUBE}.id"
+        type: number
+        primary_key: true
+      - name: customer_gender
+        sql: "{CUBE}.customer_gender"
+        type: string
+      - name: notes
+        sql: "{CUBE}.notes"
+        type: string
+      - name: status
+        sql: "{CUBE}.status"
+        type: string
+    measures:
+      - name: sumPrice
+        sql: "{CUBE}.price"
+        type: sum
+      - name: sumPriceTotal
+        sql: "{sumPrice}"
+        type: sum
+        multi_stage: true
+        group_by:
+          - notes
+          - status
+      - name: pricePercent
+        sql: "coalesce(100 * {sumPrice} / nullif({sumPriceTotal}, 0), 0)"
+        type: number
+        multi_stage: true
+`);
+
+  // What cubesql sends: the cube name alone is >= 16 chars, so every member truncates to the
+  // same `kibanasampledata` prefix and is deduped with _N suffixes.
+  const queryOptions = {
+    measures: [
+      'KibanaSampleDataEcommerce.pricePercent',
+    ],
+    dimensions: [
+      'KibanaSampleDataEcommerce.customer_gender',
+      'KibanaSampleDataEcommerce.notes',
+      'KibanaSampleDataEcommerce.status',
+    ],
+    memberToAlias: {
+      'KibanaSampleDataEcommerce.customer_gender': 'kibanasampledata',
+      'KibanaSampleDataEcommerce.notes': 'kibanasampledata_1',
+      'KibanaSampleDataEcommerce.status': 'kibanasampledata_2',
+      'KibanaSampleDataEcommerce.pricePercent': 'kibanasampledata_3',
+    },
+    timezone: 'UTC',
+    order: [],
+  };
+
+  it('grouped multi_stage ratio with colliding truncated memberToAlias', async () => {
+    await compiler.compile();
+
+    const query = new SnowflakeQuery({ joinGraph, cubeEvaluator, compiler }, queryOptions);
+
+    const [sql] = query.buildSqlAndParams();
+
+    // The leaf scan over the real table must project each selected dimension under its
+    // memberToAlias, so every downstream multi-stage CTE that references the dimension by
+    // that alias resolves. Before the fix the leaf projected the full internal name
+    // (`kibana_sample_data_ecommerce__customer_gender`) while the stages referenced
+    // `"kibanasampledata"`, producing `invalid identifier "kibanasampledata"`.
+    expect(sql).toMatch(/\.customer_gender\s+"kibanasampledata"/);
+    expect(sql).toMatch(/\.notes\s+"kibanasampledata_1"/);
+    expect(sql).toMatch(/\.status\s+"kibanasampledata_2"/);
+
+    // And the inverted aliasing (reference truncated alias, output full internal name) that
+    // characterised the bug must not appear anywhere.
+    expect(sql).not.toMatch(/"kibanasampledata(?:_\d+)?"\s+"kibana_sample_data_ecommerce__/);
+  });
+
+  // Same scenario through the native (Tesseract) SQL planner, which generates SQL itself
+  // rather than via BaseQuery. It bakes memberToAlias into each member symbol and resolves
+  // references through a shared references builder, so define/reference stay consistent.
+  it('grouped multi_stage ratio with colliding truncated memberToAlias (Tesseract)', async () => {
+    await compiler.compile();
+
+    const query = new SnowflakeQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      { ...queryOptions, useNativeSqlPlanner: true },
+    );
+
+    const [sql] = query.buildSqlAndParams();
+
+    // Final output must expose all four members under their memberToAlias values.
+    expect(sql).toMatch(/"kibanasampledata"/);
+    expect(sql).toMatch(/"kibanasampledata_1"/);
+    expect(sql).toMatch(/"kibanasampledata_2"/);
+    expect(sql).toMatch(/"kibanasampledata_3"/);
+
+    // Every qualified reference must resolve to a projected column; a reference to a truncated
+    // alias that no sub-select defines is the failure mode we are guarding against.
+    const referenced = new Set(
+      [...sql.matchAll(/\b\w+\."(kibanasampledata(?:_\d+)?)"/g)].map((m) => m[1]),
+    );
+    const defined = new Set(
+      [...sql.matchAll(/"(kibanasampledata(?:_\d+)?)"(?=\s*(?:,|\)|$|\sAS|\sFROM))/gim)].map((m) => m[1]),
+    );
+    const dangling = [...referenced].filter((r) => !defined.has(r));
+    expect(dangling).toEqual([]);
+  });
+});

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -1396,6 +1396,57 @@ async fn test_grouped_join_wrapper_full_outer_without_template() {
     );
 }
 
+/// FULL OUTER JOIN between grouped CTEs from two *different* cubes (no join relationship
+/// defined between them). Both sides are standalone grouped subqueries joined in SQL
+/// (non-push-to-Cube path), so FULL should be supported and pushed down.
+#[tokio::test]
+async fn test_grouped_join_wrapper_full_outer_cross_cube() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        WITH m1 AS (
+            SELECT
+                id,
+                sum(sumPrice) AS first_price
+            FROM KibanaSampleDataEcommerce
+            GROUP BY 1
+        ),
+        m2 AS (
+            SELECT
+                dim0,
+                MEASURE(WideCube.count) AS cnt
+            FROM WideCube
+            GROUP BY 1
+        )
+        SELECT
+            COALESCE(m1.id, m2.dim0) AS id,
+            m1.first_price,
+            m2.cnt
+        FROM m1
+        FULL OUTER JOIN m2 ON m1.id = m2.dim0
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    // Whole query must be pushed down to a single wrapped SQL with a FULL JOIN
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("FULL JOIN"),
+        "wrapped SQL is missing FULL JOIN:\n{}",
+        sql
+    );
+}
+
 /// Regression test for smoke test "select __user and literal grouped under wrapper".
 /// Inner CTE has unaliased DATE_TRUNC expressions; outer query references those columns
 /// through the SubqueryAlias qualifier (`cube_scan_subq`). The CTE-level Remapper must


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

This PR fixes `invalid identifier` errors on SQL API queries that select a multi-stage measure, caused by stage CTEs referencing dimension columns by their `memberToAlias` value while defining them under the full internal alias. Related tests are included.
