### PR TITLE
fix(tesseract): Support time series queries for MySQL 8+

### DIFF
--- a/.github/actions/integration/mysql.sh
+++ b/.github/actions/integration/mysql.sh
@@ -4,6 +4,11 @@ set -eo pipefail
 # Debug log for test containers
 export DEBUG=testcontainers
 
+# Recursive CTE based generated time series require MySQL 8.0+.
+# Keep it disabled for 5.6/5.7 (falls back to the portable VALUES series) and
+# enable it only for the 8.0.x run below.
+export CUBEJS_DB_MYSQL_USE_GENERATED_TIME_SERIES=false
+
 export TEST_MYSQL_VERSION=5.6
 
 echo "::group::MySQL ${TEST_MYSQL_VERSION}";
@@ -19,6 +24,7 @@ yarn lerna run --concurrency 1 --stream --no-prefix integration:mysql
 echo "::endgroup::"
 
 export TEST_MYSQL_VERSION=8.0.24
+export CUBEJS_DB_MYSQL_USE_GENERATED_TIME_SERIES=true
 
 echo "::group::MySQL ${TEST_MYSQL_VERSION}";
 docker pull mysql:${TEST_MYSQL_VERSION}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -416,6 +416,9 @@ jobs:
           - db: firebolt
             node-version: 22.x
             use_tesseract_sql_planner: true
+          - db: mysql
+            node-version: 22.x
+            use_tesseract_sql_planner: true
           - db: clickhouse
             node-version: 22.x
             use_tesseract_sql_planner: true

--- a/packages/cubejs-backend-shared/src/env.ts
+++ b/packages/cubejs-backend-shared/src/env.ts
@@ -1011,6 +1011,19 @@ const variables: Record<string, (...args: any) => any> = {
       .asBool()
   ),
 
+  /**
+   * Use the generated (recursive CTE based) time series for the Tesseract SQL
+   * planner instead of the portable VALUES/UNION ALL series. Defaults to TRUE.
+   * Recursive CTEs require MySQL 8.0+ — set this to FALSE for MySQL < 8.0,
+   * which has no CTE support. When disabled, time series are materialized as a
+   * VALUES list.
+   */
+  mysqlUseGeneratedTimeSeries: ({ dataSource, preAggregations }: DataSourceOpts) => (
+    get(keyByDataSource('CUBEJS_DB_MYSQL_USE_GENERATED_TIME_SERIES', dataSource, preAggregations))
+      .default('true')
+      .asBool()
+  ),
+
   /** ****************************************************************
    * MSSQL Driver                                                    *
    ***************************************************************** */

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4559,7 +4559,7 @@ export class BaseQuery {
         PERCENTILECONT: 'PERCENTILE_CONT({{ args_concat }})',
       },
       statements: {
-        select: '{% if ctes %} WITH \n' +
+        select: '{% if ctes %} WITH {% if recursive %}RECURSIVE {% endif %}\n' +
           '{{ ctes | join(\',\n\') }}\n' +
           '{% endif %}' +
           'SELECT {% if distinct %}DISTINCT {% endif %}' +

--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -27,10 +27,13 @@ class MysqlFilter extends BaseFilter {
 export class MysqlQuery extends BaseQuery {
   private readonly useNamedTimezones: boolean;
 
+  private readonly useGeneratedTimeSeries: boolean;
+
   public constructor(compilers: any, options: any) {
     super(compilers, options);
 
     this.useNamedTimezones = getEnv('mysqlUseNamedTimezones', { dataSource: this.dataSource });
+    this.useGeneratedTimeSeries = getEnv('mysqlUseGeneratedTimeSeries', { dataSource: this.dataSource });
   }
 
   public newFilter(filter) {
@@ -173,7 +176,7 @@ export class MysqlQuery extends BaseQuery {
   }
 
   public supportGeneratedSeriesForCustomTd(): boolean {
-    return true;
+    return this.useGeneratedTimeSeries;
   }
 
   public intervalString(interval: string): string {
@@ -211,31 +214,43 @@ export class MysqlQuery extends BaseQuery {
       '{% endfor %}' +
       ') AS dates';
 
-    templates.statements.generated_time_series_select =
-      'WITH RECURSIVE date_series AS (\n' +
-      '  SELECT TIMESTAMP({{ start }}) AS date_from\n' +
-      '  UNION ALL\n' +
-      '  SELECT DATE_ADD(date_from, INTERVAL {{ granularity }})\n' +
-      '  FROM date_series\n' +
-      '  WHERE DATE_ADD(date_from, INTERVAL {{ granularity }}) <= TIMESTAMP({{ end }})\n' +
-      ')\n' +
-      'SELECT CAST(date_from AS DATETIME) AS date_from,\n' +
-      '       CAST(DATE_SUB(DATE_ADD(date_from, INTERVAL {{ granularity }}), INTERVAL 1000 MICROSECOND) AS DATETIME) AS date_to\n' +
-      'FROM date_series';
+    // Generated (recursive CTE based) time series. Recursive CTEs require
+    // MySQL 8.0+, so they are only registered when explicitly enabled via
+    // CUBEJS_DB_MYSQL_USE_GENERATED_TIME_SERIES. When absent, the Tesseract
+    // planner falls back to the portable VALUES/UNION ALL `time_series_select`
+    // template, which also works on MySQL 5.6/5.7.
+    //
+    // The template body becomes the content of `time_series AS (...)` CTE, so
+    // it self-references `time_series` for recursion (no nested WITH). The
+    // outer WITH is emitted as `WITH RECURSIVE` because the
+    // `generated_time_series_recursive` marker below is present.
+    if (this.useGeneratedTimeSeries) {
+      templates.statements.generated_time_series_select =
+        'SELECT CAST(TIMESTAMP({{ start }}) AS DATETIME(6)) AS date_from,\n' +
+        '       CAST(DATE_SUB(DATE_ADD(TIMESTAMP({{ start }}), INTERVAL {{ granularity }}), INTERVAL 1000 MICROSECOND) AS DATETIME(6)) AS date_to\n' +
+        'UNION ALL\n' +
+        'SELECT DATE_ADD(date_from, INTERVAL {{ granularity }}),\n' +
+        '       CAST(DATE_SUB(DATE_ADD(DATE_ADD(date_from, INTERVAL {{ granularity }}), INTERVAL {{ granularity }}), INTERVAL 1000 MICROSECOND) AS DATETIME(6))\n' +
+        'FROM time_series\n' +
+        'WHERE DATE_ADD(date_from, INTERVAL {{ granularity }}) <= TIMESTAMP({{ end }})';
 
-    templates.statements.generated_time_series_with_cte_range_source =
-      'WITH RECURSIVE date_series AS (\n' +
-      '  SELECT {{ range_source }}.{{ min_name }} AS date_from,\n' +
-      '         {{ range_source }}.{{ max_name }} AS max_date\n' +
-      '  FROM {{ range_source }}\n' +
-      '  UNION ALL\n' +
-      '  SELECT DATE_ADD(date_from, INTERVAL {{ granularity }}), max_date\n' +
-      '  FROM date_series\n' +
-      '  WHERE DATE_ADD(date_from, INTERVAL {{ granularity }}) <= max_date\n' +
-      ')\n' +
-      'SELECT CAST(date_from AS DATETIME) AS date_from,\n' +
-      '       CAST(DATE_SUB(DATE_ADD(date_from, INTERVAL {{ granularity }}), INTERVAL 1000 MICROSECOND) AS DATETIME) AS date_to\n' +
-      'FROM date_series';
+      templates.statements.generated_time_series_with_cte_range_source =
+        'SELECT CAST({{ range_source }}.{{ min_name }} AS DATETIME(6)) AS date_from,\n' +
+        '       CAST(DATE_SUB(DATE_ADD({{ range_source }}.{{ min_name }}, INTERVAL {{ granularity }}), INTERVAL 1000 MICROSECOND) AS DATETIME(6)) AS date_to,\n' +
+        '       {{ range_source }}.{{ max_name }} AS max_date\n' +
+        'FROM {{ range_source }}\n' +
+        'UNION ALL\n' +
+        'SELECT DATE_ADD(date_from, INTERVAL {{ granularity }}),\n' +
+        '       CAST(DATE_SUB(DATE_ADD(DATE_ADD(date_from, INTERVAL {{ granularity }}), INTERVAL {{ granularity }}), INTERVAL 1000 MICROSECOND) AS DATETIME(6)),\n' +
+        '       max_date\n' +
+        'FROM time_series\n' +
+        'WHERE DATE_ADD(date_from, INTERVAL {{ granularity }}) <= max_date';
+
+      // Marker (presence-only) telling the Tesseract planner that the generated
+      // time series is a self-referencing recursive CTE and the outer WITH must
+      // be emitted as `WITH RECURSIVE`.
+      templates.statements.generated_time_series_recursive = 'true';
+    }
     templates.expressions.wrap_segment_select = 'IF({{ expr }}, 1, 0)';
     templates.expressions.wrap_segment_filter = '{{ expr }} = 1';
 

--- a/packages/cubejs-schema-compiler/test/integration/mysql/custom-granularities.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/mysql/custom-granularities.test.ts
@@ -1,5 +1,15 @@
+import { getEnv } from '@cubejs-backend/shared';
 import { prepareYamlCompiler } from '../../unit/PrepareCompiler';
 import { MySqlDbRunner } from './MySqlDbRunner';
+
+// Tesseract renders rolling-window queries using recursive CTEs, which require
+// MySQL 8.0+. That capability is controlled by mysqlUseGeneratedTimeSeries
+// (CUBEJS_DB_MYSQL_USE_GENERATED_TIME_SERIES), which is disabled for MySQL < 8.0.
+// The legacy planner does not use CTEs and works on all versions, so only skip
+// these cases when running under Tesseract with generated time series disabled.
+const nativeSqlPlanner = getEnv('nativeSqlPlanner');
+const useGeneratedTimeSeries = getEnv('mysqlUseGeneratedTimeSeries', { dataSource: 'default' });
+const itRollingWindow = nativeSqlPlanner && !useGeneratedTimeSeries ? it.skip : it;
 
 describe('Custom Granularities', () => {
   jest.setTimeout(200000);
@@ -387,7 +397,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year custom granularity w/o dimensions with unbounded rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year custom granularity w/o dimensions with unbounded rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByUnbounded'],
       timeDimensions: [{
@@ -420,7 +430,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year custom granularity with dimension with unbounded rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year custom granularity with dimension with unbounded rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByUnbounded'],
       timeDimensions: [{
@@ -498,7 +508,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year_by_1st_april custom granularity with dimension with unbounded rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year_by_1st_april custom granularity with dimension with unbounded rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByUnbounded'],
       timeDimensions: [{
@@ -591,7 +601,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year custom granularity w/o dimensions with trailing rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year custom granularity w/o dimensions with trailing rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByTrailing3Months'],
       timeDimensions: [{
@@ -624,7 +634,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year custom granularity with dimension with trailing rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year custom granularity with dimension with trailing rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByTrailing3Months'],
       timeDimensions: [{
@@ -702,7 +712,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year_by_1st_april custom granularity w/o dimensions with trailing rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year_by_1st_april custom granularity w/o dimensions with trailing rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByTrailing3Months'],
       timeDimensions: [{
@@ -739,7 +749,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year custom granularity w/o dimensions with leading rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year custom granularity w/o dimensions with leading rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByLeading4Months'],
       timeDimensions: [{
@@ -772,7 +782,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year custom granularity with dimension with leading rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year custom granularity with dimension with leading rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByLeading4Months'],
       timeDimensions: [{
@@ -850,7 +860,7 @@ describe('Custom Granularities', () => {
     { joinGraph, cubeEvaluator, compiler }
   ));
 
-  it('works with half_year_by_1st_april custom granularity w/o dimensions with leading rolling window query', async () => dbRunner.runQueryTest(
+  itRollingWindow('works with half_year_by_1st_april custom granularity w/o dimensions with leading rolling window query', async () => dbRunner.runQueryTest(
     {
       measures: ['orders.rollingCountByLeading4Months'],
       timeDimensions: [{

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/cte.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/cte.rs
@@ -8,17 +8,26 @@ use std::rc::Rc;
 pub struct Cte {
     query: Rc<QueryPlan>,
     name: String,
+    /// Whether this CTE is a self-referencing recursive CTE. When any CTE in a
+    /// `WITH` clause is recursive, dialects such as MySQL require the clause to
+    /// be emitted as `WITH RECURSIVE`.
+    is_recursive: bool,
 }
 
 impl Cte {
-    pub fn new(query: Rc<QueryPlan>, name: String) -> Self {
-        Self { query, name }
+    pub fn new(query: Rc<QueryPlan>, name: String, is_recursive: bool) -> Self {
+        Self {
+            query,
+            name,
+            is_recursive,
+        }
     }
 
     pub fn new_from_select(select: Rc<Select>, name: String) -> Self {
         Self {
             query: Rc::new(QueryPlan::Select(select)),
             name,
+            is_recursive: false,
         }
     }
 
@@ -28,6 +37,10 @@ impl Cte {
 
     pub fn name(&self) -> &String {
         &self.name
+    }
+
+    pub fn is_recursive(&self) -> bool {
+        self.is_recursive
     }
 
     pub fn to_sql(&self, templates: &PlanSqlTemplates) -> Result<String, CubeError> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/filter_sql_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/filter_sql_context.rs
@@ -172,6 +172,7 @@ impl<'a> FilterSqlContext<'a> {
             None,
             None,
             false,
+            false,
         )?;
         let to = self.plan_templates.select(
             vec![],
@@ -183,6 +184,7 @@ impl<'a> FilterSqlContext<'a> {
             vec![],
             None,
             None,
+            false,
             false,
         )?;
         Ok((format!("({})", from), format!("({})", to)))

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/select.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/select.rs
@@ -115,6 +115,10 @@ impl Select {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Dialects like MySQL require `WITH RECURSIVE` when any CTE is a
+        // self-referencing recursive CTE (e.g. a generated time series).
+        let recursive = self.ctes.iter().any(|cte| cte.is_recursive());
+
         let order_by = self
             .order_by
             .iter()
@@ -141,6 +145,7 @@ impl Select {
             self.limit,
             self.offset,
             self.is_distinct,
+            recursive,
         )?;
 
         /* let res = format!(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/root_query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/root_query.rs
@@ -44,7 +44,16 @@ impl<'a> LogicalNodeProcessor<'a, RootQuery> for RootQueryProcessor<'a> {
                     query.schema(),
                 );
             }
-            ctes.push(Rc::new(Cte::new(Rc::new(query), alias)));
+            // A generated time series is a self-referencing recursive CTE in
+            // some dialects (e.g. MySQL), which need the `WITH RECURSIVE` form.
+            let is_recursive = matches!(
+                &cte_member.member_type,
+                MultiStageMemberLogicalType::TimeSeries(_)
+            ) && self
+                .builder
+                .templates()
+                .generated_time_series_is_recursive();
+            ctes.push(Rc::new(Cte::new(Rc::new(query), alias, is_recursive)));
         }
 
         let select = self

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_templates/plan.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_templates/plan.rs
@@ -436,6 +436,7 @@ impl PlanSqlTemplates {
         limit: Option<usize>,
         offset: Option<usize>,
         distinct: bool,
+        recursive: bool,
     ) -> Result<String, CubeError> {
         self.render.render_template(
             "statements/select",
@@ -451,6 +452,7 @@ impl PlanSqlTemplates {
                 offset => offset,
                 distinct => distinct,
                 ctes => ctes,
+                recursive => recursive,
             },
         )
     }
@@ -539,6 +541,15 @@ impl PlanSqlTemplates {
                 || self
                     .driver_tools()
                     .support_generated_series_for_custom_td()?))
+    }
+
+    /// Whether the dialect's generated time series is a self-referencing
+    /// recursive CTE that must be wrapped in `WITH RECURSIVE` (e.g. MySQL).
+    /// MSSQL also uses a recursive CTE but relies on implicit recursion (plain
+    /// `WITH`), so it does not set this marker.
+    pub fn generated_time_series_is_recursive(&self) -> bool {
+        self.render
+            .contains_template("statements/generated_time_series_recursive")
     }
 
     pub fn generated_time_series_select(


### PR DESCRIPTION
Tesseract renders multi-stage / rolling-window queries with CTEs, which MySQL supports only from 8.0. The previous MySQL templates also emitted a complete `WITH RECURSIVE date_series AS (...) SELECT ...` statement that, once wrapped as a `time_series` CTE, produced an illegal nested `WITH` even on 8.0.