### PR TITLE
docs: remove preview label from Evals

### DIFF
--- a/docs-mintlify/admin/ai/evals.mdx
+++ b/docs-mintlify/admin/ai/evals.mdx
@@ -3,14 +3,6 @@ title: Evals
 description: Benchmark your agent's answers against a known-correct ground truth and track accuracy across data-model and agent changes.
 ---
 
-<Warning>
-
-Evals are currently in preview, and the user experience and file format may
-still change. Reach out to the [Cube support team](/admin/account-billing/support)
-to activate this feature for your account.
-
-</Warning>
-
 Evals let you benchmark your agent's answers against a known-correct ground
 truth, on any branch. You author a set of questions, each with the SQL or
 [certified query](/admin/ai/certified-queries) that represents the right
@@ -74,9 +66,9 @@ eval_questions:
 
 <Note>
 
-While in preview, the **Questions** tab is a read-only view of these files. To
-add or edit questions, edit the YAML in the IDE — there's no in-product
-question editor yet.
+The **Questions** tab is a read-only view of these files. To add or edit
+questions, edit the YAML in the IDE — there's no in-product question editor
+yet.
 
 </Note>
 
@@ -146,10 +138,8 @@ Verdicts:
 | **review** | Nothing to compare automatically — the question has no ground truth, or the agent didn't run a query. Compare manually. |
 | **error** | The agent run failed, the ground-truth query failed, or a referenced certified query wasn't found. |
 
-## Preview limitations
+## Limitations
 
-- Evals must be activated for your account by the
-  [Cube support team](/admin/account-billing/support).
 - Questions are authored as code only; the **Questions** tab is read-only.
 - Very large question sets can be slow to run.
 - Grading is execution-based on the result set; it does not semantically judge


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Evals is now generally available, so this removes the preview framing from the Evals docs page (`docs-mintlify/admin/ai/evals.mdx`):

- Removed the opening "in preview / may change / contact support to activate" `<Warning>` callout.
- Reworded the Questions-tab `<Note>` to drop "While in preview" (the read-only fact still stands).
- Renamed the "Preview limitations" section to "Limitations" and removed the support-activation bullet, since activation is no longer required for GA.

**Reviewer notes**

The activation requirement was dropped intentionally — Evals no longer needs to be activated by the support team now that it's GA. The remaining limitations (code-only authoring / read-only Questions tab, slow large question sets, execution-based grading) are persistent product behavior, not preview gating, so they're kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)