### PR TITLE
fix(druid-driver): Emulate ILIKE for Tesseract and SQL API push down

### DIFF
--- a/packages/cubejs-druid-driver/src/DruidQuery.ts
+++ b/packages/cubejs-druid-driver/src/DruidQuery.ts
@@ -51,4 +51,16 @@ export class DruidQuery extends BaseQuery {
   public nowTimestampSql(): string {
     return 'CURRENT_TIMESTAMP';
   }
+
+  public sqlTemplates() {
+    const templates = super.sqlTemplates();
+
+    // Druid doesn't support ILIKE, so case-insensitive matching is emulated with LOWER(...) LIKE CONCAT(...)
+    templates.expressions.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE LOWER({{ pattern }})';
+    delete templates.expressions.like_escape;
+    templates.filters.like_pattern = 'CONCAT({% if start_wild %}\'%\'{% else %}\'\'{% endif %}, LOWER({{ value }}), {% if end_wild %}\'%\'{% else %}\'\'{% endif %})';
+    templates.tesseract.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE {{ pattern }}';
+
+    return templates;
+  }
 }


### PR DESCRIPTION
Druid does not support ILIKE. The driver overrode DruidFilter.likeIgnoreCase for the legacy query path only, so the Tesseract (native SQL planner) and SQL API push-down paths fell back to the default ILIKE templates and produced SQL Druid cannot run (the contains filter rendered `name ILIKE '%' || ? || '%'`).