### PR TITLE
fix(cubestore): expose CUBESTORE_CACHESTORE_WAL_TTL_SECONDS to bound the cachestore WAL

### DIFF
--- a/docs/content/product/configuration/reference/environment-variables.mdx
+++ b/docs/content/product/configuration/reference/environment-variables.mdx
@@ -1553,6 +1553,19 @@ The address/port pair for Cube Store's MySQL-compatible interface.
 | ------------------------- | ---------------------- | --------------------- |
 | A valid address/port pair | `0.0.0.0:3306`         | `0.0.0.0:3306`        |
 
+## `CUBESTORE_CACHESTORE_WAL_TTL_SECONDS`
+
+How long, in seconds, Cube Store keeps an archived cachestore write-ahead log
+(WAL) file before deleting it; RocksDB checks on a `ttl / 2` cycle. Lower values
+keep less WAL on disk under sustained write load. When unset, it defaults to the
+cachestore snapshot interval plus the log-upload interval. Lower it only when
+cachestore log upload is disabled (the default), since that is the only consumer
+of the retained WAL. Minimum `2`.
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| A valid number  | N/A                    | N/A                   |
+
 ## `CUBESTORE_DATA_DIR`
 
 A path on the local filesystem to store a local replica of the data. Must be

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -96,10 +96,13 @@ impl RocksStoreDetails for RocksCacheStoreDetails {
         opts.set_compaction_filter_factory(compaction::MetaStoreCacheCompactionFactory::new(
             compaction_state,
         ));
-        // TODO(ovr): Decrease after additional fix for get_updates_since
-        opts.set_wal_ttl_seconds(
-            config.meta_store_snapshot_interval() + config.meta_store_log_upload_interval(),
-        );
+        // WAL retention for get_updates_since (log upload). Default = snapshot + log-upload
+        // interval; exposed via CUBESTORE_CACHESTORE_WAL_TTL_SECONDS so deployments that do not use
+        // cachestore log upload can lower it to bound the archived WAL on disk. RocksDB purges
+        // archived WAL older than this on a wal_ttl/2 cycle, so a lower value tightens the bound.
+        opts.set_wal_ttl_seconds(config.cachestore_wal_ttl_seconds().unwrap_or_else(|| {
+            config.meta_store_snapshot_interval() + config.meta_store_log_upload_interval()
+        }));
         // Disable automatic compaction before migration, will be enabled later in after_migration
         opts.set_disable_auto_compactions(true);
 

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -477,6 +477,8 @@ pub trait ConfigObj: DIService {
 
     fn cachestore_log_enabled(&self) -> bool;
 
+    fn cachestore_wal_ttl_seconds(&self) -> Option<u64>;
+
     fn cachestore_rocksdb_config(&self) -> &RocksStoreConfig;
 
     fn cachestore_gc_loop_interval(&self) -> u64;
@@ -707,6 +709,7 @@ pub struct ConfigObjImpl {
     pub metastore_rocks_store_config: RocksStoreConfig,
     pub cachestore_log_upload_interval: u64,
     pub cachestore_log_enabled: bool,
+    pub cachestore_wal_ttl_seconds: Option<u64>,
     pub cachestore_rocks_store_config: RocksStoreConfig,
     pub cachestore_gc_loop_interval: u64,
     pub cachestore_cache_eviction_loop_interval: u64,
@@ -950,6 +953,10 @@ impl ConfigObj for ConfigObjImpl {
 
     fn cachestore_log_enabled(&self) -> bool {
         self.cachestore_log_enabled
+    }
+
+    fn cachestore_wal_ttl_seconds(&self) -> Option<u64> {
+        self.cachestore_wal_ttl_seconds
     }
 
     fn cachestore_rocksdb_config(&self) -> &RocksStoreConfig {
@@ -1426,6 +1433,17 @@ where
     })
 }
 
+// Validates CUBESTORE_CACHESTORE_WAL_TTL_SECONDS. `None` means unset, in which case open_db
+// falls back to the upstream default (snapshot + log-upload interval). A value below 2 is
+// rejected: 0 disables RocksDB's WAL-ttl purge entirely (the archived WAL would grow unbounded),
+// and the purge runs on a ttl / 2 cycle.
+fn validate_cachestore_wal_ttl_seconds(ttl: Option<u64>) -> Option<u64> {
+    if matches!(ttl, Some(v) if v < 2) {
+        panic!("CUBESTORE_CACHESTORE_WAL_TTL_SECONDS must be >= 2 (0 disables WAL purge)");
+    }
+    ttl
+}
+
 // Unlike env_optparse, an unparseable value is not fatal: it logs a warning and falls
 // back to per_chunk, so a typo in the strategy env never takes the process down.
 fn env_repartition_strategy() -> RepartitionStrategy {
@@ -1648,6 +1666,9 @@ impl Config {
                     Some(15),
                 ),
                 cachestore_log_enabled: env_bool("CUBESTORE_CACHESTORE_LOG_ENABLED", false),
+                cachestore_wal_ttl_seconds: validate_cachestore_wal_ttl_seconds(env_optparse(
+                    "CUBESTORE_CACHESTORE_WAL_TTL_SECONDS",
+                )),
                 cachestore_rocks_store_config: RocksStoreConfig::cachestore_default(),
                 cachestore_gc_loop_interval: env_parse_duration(
                     "CUBESTORE_CACHESTORE_GC_LOOP",
@@ -1997,6 +2018,7 @@ impl Config {
                 metastore_rocks_store_config: RocksStoreConfig::metastore_default(),
                 cachestore_log_upload_interval: 30,
                 cachestore_log_enabled: true,
+                cachestore_wal_ttl_seconds: None,
                 cachestore_rocks_store_config: RocksStoreConfig::cachestore_default(),
                 cachestore_gc_loop_interval: 30,
                 cachestore_cache_eviction_loop_interval: 60,
@@ -2927,5 +2949,18 @@ mod tests {
             RepartitionStrategy::Range
         );
         assert!("nonsense".parse::<RepartitionStrategy>().is_err());
+    }
+
+    #[test]
+    fn cachestore_wal_ttl_seconds_validation() {
+        assert_eq!(validate_cachestore_wal_ttl_seconds(None), None);
+        assert_eq!(validate_cachestore_wal_ttl_seconds(Some(2)), Some(2));
+        assert_eq!(validate_cachestore_wal_ttl_seconds(Some(330)), Some(330));
+    }
+
+    #[test]
+    #[should_panic(expected = "must be >= 2")]
+    fn cachestore_wal_ttl_seconds_rejects_below_min() {
+        validate_cachestore_wal_ttl_seconds(Some(1));
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available (`cargo test -p cubestore cachestore` + the new config tests pass)
- [x] Linter has been run for changed code (`cargo fmt --check` clean; `cargo clippy` shows no new issues in the changed files)
- [x] Tests for the changes have been added if not covered yet (unit tests for the WAL ttl min-clamp validation)
- [x] Docs have been added / updated if required (added `CUBESTORE_CACHESTORE_WAL_TTL_SECONDS` to the environment variables reference)

**Issue Reference this PR resolves**

Fixes #11168

**Description of Changes Made**

The cachestore's RocksDB keeps old write-ahead-log (WAL) files for a retention time that is currently hardcoded (~330s).

- Under sustained write load these archived WAL files pile up and can fill the data volume (e.g. a Kubernetes `emptyDir`), which gets the pod evicted.
- This adds `CUBESTORE_CACHESTORE_WAL_TTL_SECONDS` to make that retention configurable:
  - **Unset** -> same value as today, so behavior is unchanged.
  - **Lower** -> RocksDB drops archived WAL sooner, keeping it smaller on disk. Useful when cachestore log upload is off (the default) -- that is the only thing that needs the WAL kept.
  - Minimum **2s** (`0` would turn WAL cleanup off entirely).
- `WAL_size_limit_MB` was deliberately not used: enabling it alongside the ttl makes RocksDB switch from the fast cleanup cycle to a 10-minute one, so it keeps *more* WAL, not less.
