### PR TITLE
fix(tesseract): honor rolling window offset without granularity

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/rolling-window-offset-no-granularity.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/rolling-window-offset-no-granularity.test.ts
@@ -1,0 +1,175 @@
+import { PostgresQuery } from '../../../src/adapter/PostgresQuery';
+import { prepareJsCompiler } from '../../unit/PrepareCompiler';
+import { dbRunner } from './PostgresDBRunner';
+
+// Rolling window measures queried WITHOUT a time dimension granularity (only a
+// dateRange). The window is anchored by `offset`: 'start' anchors at the period
+// start, 'end' anchors at the period end. With no granularity the result is a
+// single aggregate row.
+//
+// The seed visitors table has one row dated 2016-09-07 (before the queried
+// ranges) which distinguishes offset:'start' (accumulate everything before the
+// period start) from offset:'end' (accumulate everything up to the period end).
+describe('Rolling window offset without granularity', () => {
+  jest.setTimeout(200000);
+
+  const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+    cube(\`balances\`, {
+      sql: \`select * from visitors\`,
+
+      measures: {
+        // trailing: 'unbounded'
+        begBalance: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { trailing: 'unbounded', offset: 'start' }
+        },
+        endBalance: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { trailing: 'unbounded', offset: 'end' }
+        },
+
+        // leading: 'unbounded'
+        leadingStart: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { leading: 'unbounded', offset: 'start' }
+        },
+        leadingEnd: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { leading: 'unbounded', offset: 'end' }
+        },
+
+        // finite trailing interval
+        trailing5Start: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { trailing: '5 day', offset: 'start' }
+        },
+        trailing5End: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { trailing: '5 day', offset: 'end' }
+        },
+      },
+
+      dimensions: {
+        id: {
+          type: 'number',
+          sql: 'id',
+          primaryKey: true
+        },
+        createdAt: {
+          type: 'time',
+          sql: 'created_at'
+        },
+      },
+    })
+
+    cube(\`balances_fp\`, {
+      sql: \`select * from visitors WHERE \${FILTER_PARAMS.balances_fp.createdAt.filter('created_at')}\`,
+
+      measures: {
+        begBalance: {
+          type: 'sum',
+          sql: 'amount',
+          rollingWindow: { trailing: 'unbounded', offset: 'start' }
+        },
+      },
+
+      dimensions: {
+        id: {
+          type: 'number',
+          sql: 'id',
+          primaryKey: true
+        },
+        createdAt: {
+          type: 'time',
+          sql: 'created_at'
+        },
+      },
+    })
+  `);
+
+  const runQuery = async (measures: string[], dateRange: [string, string]) => {
+    const query = new PostgresQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      {
+        measures,
+        timeDimensions: [
+          {
+            dimension: 'balances.createdAt',
+            dateRange,
+          },
+        ],
+        timezone: 'UTC',
+      }
+    );
+
+    const queryAndParams = query.buildSqlAndParams();
+    return dbRunner.testQuery(queryAndParams);
+  };
+
+  it('trailing: unbounded — offset start vs end', () => compiler.compile().then(async () => {
+    // beg: amount where created_at < 2017-01-01  -> only the 2016-09-07 row (500)
+    // end: amount where created_at <= 2017-01-30 -> all rows (2000)
+    expect(await runQuery(
+      ['balances.begBalance', 'balances.endBalance'],
+      ['2017-01-01', '2017-01-30']
+    )).toEqual([
+      { balances__beg_balance: '500', balances__end_balance: '2000' },
+    ]);
+  }));
+
+  it('leading: unbounded — offset start vs end', () => compiler.compile().then(async () => {
+    // start: amount where created_at >= 2017-01-01 -> all 2017 rows in/after range (1500)
+    // end:   amount where created_at >  2017-01-30 -> none (null)
+    expect(await runQuery(
+      ['balances.leadingStart', 'balances.leadingEnd'],
+      ['2017-01-01', '2017-01-30']
+    )).toEqual([
+      { balances__leading_start: '1500', balances__leading_end: null },
+    ]);
+  }));
+
+  it('finite trailing interval — offset start vs end', () => compiler.compile().then(async () => {
+    // range 2017-01-06 .. 2017-01-10
+    // start: created_at in [from - 5d, from)  = [2017-01-01, 2017-01-06) -> 100 + 200 = 300
+    // end:   created_at in (to - 5d, to]      = (2017-01-05, 2017-01-10] -> 300 + 400 + 500 = 1200
+    expect(await runQuery(
+      ['balances.trailing5Start', 'balances.trailing5End'],
+      ['2017-01-06', '2017-01-10']
+    )).toEqual([
+      { balances__trailing5_start: '300', balances__trailing5_end: '1200' },
+    ]);
+  }));
+
+  // FILTER_PARAMS on the time dimension must receive the date-range bounds, not
+  // the rolling window config — the window's trailing/leading/offset must never
+  // leak into the filter as query parameters.
+  it('FILTER_PARAMS does not leak rolling window config into params', () => compiler.compile().then(async () => {
+    const query = new PostgresQuery(
+      { joinGraph, cubeEvaluator, compiler },
+      {
+        measures: ['balances_fp.begBalance'],
+        timeDimensions: [
+          {
+            dimension: 'balances_fp.createdAt',
+            dateRange: ['2017-01-01', '2017-01-30'],
+          },
+        ],
+        timezone: 'UTC',
+      }
+    );
+
+    const [, params] = query.buildSqlAndParams();
+    expect(params).not.toContain('unbounded');
+    expect(params).not.toContain('start');
+    expect(params).not.toContain('end');
+
+    // Sanity check: the query still executes.
+    await dbRunner.testQuery(query.buildSqlAndParams());
+  }));
+});

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/operators/rolling_window.rs
@@ -1,5 +1,7 @@
 use super::{FilterOperationSql, FilterSqlContext};
-use crate::planner::filter::operators::rolling_window::RegularRollingWindowOp;
+use crate::planner::filter::operators::rolling_window::{
+    RegularRollingWindowOp, RollingWindowOffsetOp,
+};
 use cubenativeutils::CubeError;
 
 impl FilterOperationSql for RegularRollingWindowOp {
@@ -19,6 +21,54 @@ impl FilterOperationSql for RegularRollingWindowOp {
             (Some(from), None) => ctx.plan_templates.gte(date_field, from.clone()),
             (None, Some(to)) => ctx.plan_templates.lte(date_field, to.clone()),
             (None, None) => ctx.plan_templates.always_true(),
+        }
+    }
+}
+
+impl FilterOperationSql for RollingWindowOffsetOp {
+    fn to_sql(&self, ctx: &FilterSqlContext) -> Result<String, CubeError> {
+        let from_start = self.offset == "start";
+        let member = ctx.member_sql.to_string();
+
+        // Anchor: range start (formatted to start-of-day) for offset 'start',
+        // range end (formatted to end-of-day) for 'end'. Both bounds share it.
+        let anchor = if from_start {
+            let from = self.from.as_deref().ok_or_else(|| {
+                CubeError::internal("Rolling window date range is missing its start".to_string())
+            })?;
+            ctx.format_and_allocate_from_date(from)?
+        } else {
+            let to = self.to.as_deref().ok_or_else(|| {
+                CubeError::internal("Rolling window date range is missing its end".to_string())
+            })?;
+            ctx.format_and_allocate_to_date(to)?
+        };
+
+        let mut conditions = Vec::new();
+
+        // trailing side -> lower bound (shifted back by the trailing interval;
+        // `unbounded` drops the bound, `None` keeps the anchor unshifted).
+        if let Some(bound) = ctx.extend_date_range_bound(anchor.clone(), &self.trailing, true)? {
+            conditions.push(if from_start {
+                ctx.plan_templates.gte(member.clone(), bound)?
+            } else {
+                ctx.plan_templates.gt(member.clone(), bound)?
+            });
+        }
+
+        // leading side -> upper bound (shifted forward by the leading interval).
+        if let Some(bound) = ctx.extend_date_range_bound(anchor.clone(), &self.leading, false)? {
+            conditions.push(if from_start {
+                ctx.plan_templates.lt(member.clone(), bound)?
+            } else {
+                ctx.plan_templates.lte(member.clone(), bound)?
+            });
+        }
+
+        if conditions.is_empty() {
+            ctx.plan_templates.always_true()
+        } else {
+            Ok(conditions.join(" AND "))
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/filter/typed_filter.rs
@@ -67,7 +67,11 @@ impl TypedFilter {
             }
             FilterParamsColumn::Callback(callback) => {
                 let args = match self.operation() {
-                    FilterOp::DateRange(_) | FilterOp::DateSingle(_) => {
+                    // RollingWindowOffset carries [from, to, trailing, leading, offset];
+                    // only the from/to dates are filter-param args for the callback.
+                    FilterOp::DateRange(_)
+                    | FilterOp::DateSingle(_)
+                    | FilterOp::RollingWindowOffset(_) => {
                         let ctx = FilterSqlContext {
                             member_sql: "",
                             query_tools,
@@ -115,6 +119,7 @@ fn dispatch_to_sql(op: &FilterOp, ctx: &FilterSqlContext) -> Result<String, Cube
         }
         FilterOp::Nullability(op) => op.to_sql(ctx),
         FilterOp::RegularRollingWindow(op) => op.to_sql(ctx),
+        FilterOp::RollingWindowOffset(op) => op.to_sql(ctx),
         FilterOp::ToDateRollingWindow(op) => op.to_sql(ctx),
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/filter_operator.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/filter_operator.rs
@@ -2,9 +2,10 @@ use cubenativeutils::CubeError;
 use std::str::FromStr;
 
 /// Filter operator declared in the data model (`equals`, `in`,
-/// `gt`, `inDateRange`, ...). `RegularRollingWindowDateRange` and
-/// `ToDateRollingWindowDateRange` are synthetic — manufactured by
-/// the rolling-window planner, never coming from a query.
+/// `gt`, `inDateRange`, ...). `RegularRollingWindowDateRange`,
+/// `RollingWindowOffsetDateRange` and `ToDateRollingWindowDateRange`
+/// are synthetic — manufactured by the rolling-window planner, never
+/// coming from a query.
 #[derive(Clone, PartialEq, Debug)]
 pub enum FilterOperator {
     Equal,
@@ -16,6 +17,7 @@ pub enum FilterOperator {
     AfterDate,
     AfterOrOnDate,
     RegularRollingWindowDateRange,
+    RollingWindowOffsetDateRange,
     ToDateRollingWindowDateRange,
     In,
     NotIn,
@@ -81,6 +83,7 @@ impl ToString for FilterOperator {
             FilterOperator::AfterDate => "afterDate",
             FilterOperator::AfterOrOnDate => "afterOrOnDate",
             FilterOperator::RegularRollingWindowDateRange => "inDateRange",
+            FilterOperator::RollingWindowOffsetDateRange => "inDateRange",
             FilterOperator::ToDateRollingWindowDateRange => "inDateRange",
             FilterOperator::In => "in",
             FilterOperator::NotIn => "notIn",

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/operators/rolling_window.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/operators/rolling_window.rs
@@ -12,3 +12,35 @@ impl RegularRollingWindowOp {
         Self { trailing, leading }
     }
 }
+
+/// `RollingWindowOffset` filter operation: a rolling window over a single date
+/// range `[from, to]` (no time series / granularity). The window is anchored by
+/// `offset` ('start' → `from`, 'end' → `to`); the trailing side is the lower
+/// bound, the leading side the upper bound. An `unbounded` side drops its bound,
+/// a finite interval shifts it (trailing subtracts, leading adds).
+#[derive(Clone, Debug)]
+pub struct RollingWindowOffsetOp {
+    pub(crate) from: Option<String>,
+    pub(crate) to: Option<String>,
+    pub(crate) trailing: Option<String>,
+    pub(crate) leading: Option<String>,
+    pub(crate) offset: String,
+}
+
+impl RollingWindowOffsetOp {
+    pub fn new(
+        from: Option<String>,
+        to: Option<String>,
+        trailing: Option<String>,
+        leading: Option<String>,
+        offset: String,
+    ) -> Self {
+        Self {
+            from,
+            to,
+            trailing,
+            leading,
+            offset,
+        }
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
@@ -277,7 +277,7 @@ impl TypedFilterBuilder {
                     FilterOp::RegularRollingWindow(RegularRollingWindowOp::new(trailing, leading))
                 }
                 FilterOperator::RollingWindowOffsetDateRange => {
-                    let from = values.get(0).and_then(|v| v.to_param_string());
+                    let from = values.first().and_then(|v| v.to_param_string());
                     let to = values.get(1).and_then(|v| v.to_param_string());
                     let trailing = values.get(2).and_then(|v| v.to_param_string());
                     let leading = values.get(3).and_then(|v| v.to_param_string());

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
@@ -14,7 +14,7 @@ use super::operators::in_list::InListOp;
 use super::operators::like::LikeOp;
 use super::operators::measure_filter::MeasureFilterOp;
 use super::operators::nullability::NullabilityOp;
-use super::operators::rolling_window::RegularRollingWindowOp;
+use super::operators::rolling_window::{RegularRollingWindowOp, RollingWindowOffsetOp};
 use super::operators::to_date_rolling_window::ToDateRollingWindowOp;
 use super::FilterOperator;
 use crate::planner::GranularityHelper;
@@ -43,6 +43,7 @@ pub enum FilterOp {
     MeasureFilter(MeasureFilterOp),
     Nullability(NullabilityOp),
     RegularRollingWindow(RegularRollingWindowOp),
+    RollingWindowOffset(RollingWindowOffsetOp),
     ToDateRollingWindow(ToDateRollingWindowOp),
 }
 
@@ -274,6 +275,19 @@ impl TypedFilterBuilder {
                     let trailing = values.get(2).and_then(|v| v.to_param_string());
                     let leading = values.get(3).and_then(|v| v.to_param_string());
                     FilterOp::RegularRollingWindow(RegularRollingWindowOp::new(trailing, leading))
+                }
+                FilterOperator::RollingWindowOffsetDateRange => {
+                    let from = values.get(0).and_then(|v| v.to_param_string());
+                    let to = values.get(1).and_then(|v| v.to_param_string());
+                    let trailing = values.get(2).and_then(|v| v.to_param_string());
+                    let leading = values.get(3).and_then(|v| v.to_param_string());
+                    let offset = values
+                        .get(4)
+                        .and_then(|v| v.to_param_string())
+                        .unwrap_or_else(|| "end".to_string());
+                    FilterOp::RollingWindowOffset(RollingWindowOffsetOp::new(
+                        from, to, trailing, leading, offset,
+                    ))
                 }
                 FilterOperator::ToDateRollingWindowDateRange => {
                     let granularity_name = values

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -956,8 +956,9 @@ impl MultiStageQueryPlanner {
     }
 
     /// Adjust date range filters for rolling window when there's no granularity.
-    /// Without granularity there's no time_series CTE, so we replace InDateRange
-    /// with BeforeOrOnDate/AfterOrOnDate that use parameters directly.
+    /// Without granularity there's no time_series CTE, so the InDateRange filter
+    /// is rewritten into the rolling-window bounds (anchored by the window offset)
+    /// applied directly to the base measure.
     fn replace_date_range_for_rolling_window(
         &self,
         rolling_window: &RollingWindow,
@@ -971,6 +972,7 @@ impl MultiStageQueryPlanner {
                         &filter.member_name(),
                         &rolling_window.trailing,
                         &rolling_window.leading,
+                        rolling_window.offset.as_deref().unwrap_or("end"),
                     )?;
                 }
             }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -885,26 +885,25 @@ impl QueryProperties {
         false
     }
 
-    /// Rewrite an `InDateRange` filter on `member_name` according to the
-    /// trailing/leading bounds: both `unbounded` removes the filter entirely;
-    /// trailing-`unbounded` rewrites to `BeforeOrOnDate(to)`; leading-
-    /// `unbounded` rewrites to `AfterOrOnDate(from)`. Other inputs are
-    /// no-ops.
+    /// Rewrite an `InDateRange(from, to)` filter on `member_name` into a single
+    /// rolling-window-over-date-range filter anchored by `offset`. The window is
+    /// rendered by `RollingWindowOffsetOp`; here we only carry the inputs
+    /// (`from`, `to`, `trailing`, `leading`, `offset`). No rolling interval on
+    /// either side (e.g. running total, to_date) keeps the filter as-is; both
+    /// sides `unbounded` drops it entirely.
     pub fn replace_date_range_for_rolling_window_without_granularity(
         &mut self,
         member_name: &str,
         trailing: &Option<String>,
         leading: &Option<String>,
+        offset: &str,
     ) -> Result<(), CubeError> {
-        let trailing_unbounded = trailing.as_deref() == Some("unbounded");
-        let leading_unbounded = leading.as_deref() == Some("unbounded");
-
-        if !trailing_unbounded && !leading_unbounded {
+        if trailing.is_none() && leading.is_none() {
             return Ok(());
         }
 
-        if trailing_unbounded && leading_unbounded {
-            // Both unbounded — remove the date range filter entirely
+        // Both sides unbounded: the window spans everything, drop the date filter.
+        if trailing.as_deref() == Some("unbounded") && leading.as_deref() == Some("unbounded") {
             self.time_dimensions_filters.retain(|item| match item {
                 FilterItem::Item(itm) => {
                     !(itm.member_name() == member_name
@@ -912,61 +911,25 @@ impl QueryProperties {
                 }
                 _ => true,
             });
-        } else if trailing_unbounded {
-            // Remove lower bound: InDateRange(from, to) → BeforeOrOnDate(to)
-            let mut new_filters = Vec::new();
-            for item in self.time_dimensions_filters.iter() {
-                match item {
-                    FilterItem::Item(itm)
-                        if itm.member_name() == member_name
-                            && matches!(itm.filter_operator(), FilterOperator::InDateRange) =>
-                    {
-                        let values = itm.values();
-                        let to_value = if values.len() >= 2 {
-                            vec![values[1].clone()]
-                        } else {
-                            values.clone()
-                        };
-                        new_filters.push(FilterItem::Item(itm.change_operator(
-                            FilterOperator::BeforeOrOnDate,
-                            to_value,
-                            itm.use_raw_values(),
-                            self.query_tools.query_tools().clone(),
-                            None,
-                        )?));
-                    }
-                    other => new_filters.push(other.clone()),
-                }
-            }
-            self.time_dimensions_filters = new_filters;
-        } else {
-            // leading unbounded: remove upper bound: InDateRange(from, to) → AfterOrOnDate(from)
-            let mut new_filters = Vec::new();
-            for item in self.time_dimensions_filters.iter() {
-                match item {
-                    FilterItem::Item(itm)
-                        if itm.member_name() == member_name
-                            && matches!(itm.filter_operator(), FilterOperator::InDateRange) =>
-                    {
-                        let values = itm.values();
-                        let from_value = if !values.is_empty() {
-                            vec![values[0].clone()]
-                        } else {
-                            values.clone()
-                        };
-                        new_filters.push(FilterItem::Item(itm.change_operator(
-                            FilterOperator::AfterOrOnDate,
-                            from_value,
-                            itm.use_raw_values(),
-                            self.query_tools.query_tools().clone(),
-                            None,
-                        )?));
-                    }
-                    other => new_filters.push(other.clone()),
-                }
-            }
-            self.time_dimensions_filters = new_filters;
+            self.invalidate_join_groups_cache();
+            return Ok(());
         }
+
+        // Keep the original [from, to] values and append the window inputs, so
+        // the filter carries [from, to, trailing, leading, offset].
+        let additional_values = vec![
+            FilterValue::from(trailing.clone()),
+            FilterValue::from(leading.clone()),
+            FilterValue::Str(offset.to_string()),
+        ];
+        self.time_dimensions_filters = self.change_date_range_filter_impl(
+            member_name,
+            &self.time_dimensions_filters,
+            &FilterOperator::RollingWindowOffsetDateRange,
+            None,
+            &additional_values,
+            &None,
+        )?;
         self.invalidate_join_groups_cache();
         Ok(())
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_rolling_window.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_rolling_window.yaml
@@ -177,6 +177,30 @@ cubes:
                 trailing: 3 day
                 leading: 1 day
                 offset: end
+          - name: rolling_sum_trailing_offset_start
+            type: sum
+            sql: amount
+            rolling_window:
+                trailing: unbounded
+                offset: start
+          - name: rolling_sum_trailing_offset_end
+            type: sum
+            sql: amount
+            rolling_window:
+                trailing: unbounded
+                offset: end
+          - name: rolling_sum_leading_offset_start
+            type: sum
+            sql: amount
+            rolling_window:
+                leading: unbounded
+                offset: start
+          - name: rolling_sum_leading_offset_end
+            type: sum
+            sql: amount
+            rolling_window:
+                leading: unbounded
+                offset: end
           # Cat 15 — running total
           - name: running_total
             type: runningTotal

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/basic_types.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/basic_types.rs
@@ -63,13 +63,19 @@ async fn test_leading_unbounded_no_granularity() {
         .build_sql(query)
         .expect("Should generate SQL for leading unbounded");
 
+    // Default offset is 'end', so the window anchors at the range end: everything
+    // strictly after `to`.
     assert!(
-        sql.contains(r#""orders".created_at >= $_0_$::timestamptz"#),
-        "Leading unbounded should have lower time bound (>=), got: {sql}"
+        sql.contains(r#""orders".created_at > $_0_$::timestamptz"#),
+        "Leading unbounded should have strict lower time bound (> to), got: {sql}"
     );
     assert!(
-        !sql.contains(r#"created_at <= $_"#),
-        "Leading unbounded should not have an upper time bound (<=), got: {sql}"
+        !sql.contains("created_at >= "),
+        "Leading unbounded (offset end) should not use inclusive lower bound, got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at <"),
+        "Leading unbounded should not have an upper time bound, got: {sql}"
     );
 
     if let Some(result) = ctx.try_execute_pg(query, SEED).await {
@@ -142,15 +148,6 @@ async fn test_trailing_unbounded_with_granularity() {
     }
 }
 
-// FIXME: Bounded rolling window (trailing: 3 day, leading: 1 day) without granularity
-// currently ignores the trailing/leading intervals entirely and uses the raw dateRange
-// as a plain WHERE filter: created_at >= Jan 10 AND created_at <= Jan 20, producing 830.
-// Expected behavior: the intervals should expand the date range, so the effective window
-// becomes [Jan 10 - 3d .. Jan 20 + 1d] = [Jan 7 .. Jan 21], which would include
-// order ID4 (200, Jan 8) and produce a larger result.
-// The correct expected value depends on the chosen anchor semantics (start-of-range vs
-// end-of-range), but the current behavior of silently discarding the intervals is wrong.
-#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bounded_no_granularity() {
     let ctx = create_context();
@@ -169,14 +166,28 @@ async fn test_bounded_no_granularity() {
         .build_sql(query)
         .expect("Should generate SQL for bounded rolling window");
 
+    // Default offset 'end' anchors at the range end: the trailing interval shifts
+    // the (strict) lower bound back, the leading interval shifts the (inclusive)
+    // upper bound forward.
     assert!(
         !sql.contains("time_series"),
         "Without granularity should not reference time_series CTE, got: {sql}"
     );
     assert!(
-        sql.contains(r#"created_at >= $_0_$::timestamptz"#)
-            && sql.contains(r#"created_at <= $_1_$::timestamptz"#),
-        "Should use parameterized date range on created_at, got: {sql}"
+        sql.contains("- interval '3 day'"),
+        "Should subtract trailing interval '3 day', got: {sql}"
+    );
+    assert!(
+        sql.contains("+ interval '1 day'"),
+        "Should add leading interval '1 day', got: {sql}"
+    );
+    assert!(
+        sql.contains("created_at > ") && !sql.contains("created_at >= "),
+        "Should have strict lower bound (> to - trailing), got: {sql}"
+    );
+    assert!(
+        sql.contains("created_at <= "),
+        "Should have inclusive upper bound (<= to + leading), got: {sql}"
     );
 
     if let Some(result) = ctx.try_execute_pg(query, SEED).await {
@@ -221,15 +232,6 @@ async fn test_bounded_with_granularity() {
     }
 }
 
-// FIXME: Trailing bounded rolling window (trailing: 7 day) without granularity currently
-// ignores the trailing interval and uses the raw dateRange as a plain WHERE filter:
-// created_at >= Jan 10 AND created_at <= Jan 20, producing 830 (sum of orders in
-// [Jan 10..Jan 20]).
-// Expected behavior: the trailing interval should expand the lower bound of the date
-// range, so the effective window becomes [Jan 10 - 7d .. Jan 20] = [Jan 3 .. Jan 20],
-// which would include orders ID2 (45, Jan 3), ID3 (75, Jan 4), ID4 (200, Jan 8) and
-// produce 1150 (830 + 45 + 75 + 200).
-#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_trailing_bounded_no_granularity() {
     let ctx = create_context();
@@ -248,18 +250,27 @@ async fn test_trailing_bounded_no_granularity() {
         .build_sql(query)
         .expect("Should generate SQL for trailing bounded rolling window");
 
+    // Default offset 'end' anchors at the range end: trailing shifts the (strict)
+    // lower bound back; with no leading the upper bound is the inclusive range end.
     assert!(
-        sql.contains(r#"created_at >= $_0_$::timestamptz"#)
-            && sql.contains(r#"created_at <= $_1_$::timestamptz"#),
-        "Should use parameterized date range on created_at, got: {sql}"
+        sql.contains("- interval '7 day'"),
+        "Should subtract trailing interval '7 day', got: {sql}"
+    );
+    assert!(
+        !sql.contains("+ interval"),
+        "Should not have a leading interval, got: {sql}"
+    );
+    assert!(
+        sql.contains("created_at > ") && !sql.contains("created_at >= "),
+        "Should have strict lower bound (> to - trailing), got: {sql}"
+    );
+    assert!(
+        sql.contains("created_at <= "),
+        "Should have inclusive upper bound (<= to), got: {sql}"
     );
     assert!(
         !sql.contains("time_series"),
         "Without granularity should not reference time_series CTE, got: {sql}"
-    );
-    assert!(
-        !sql.contains("interval"),
-        "Without granularity should not have interval arithmetic, got: {sql}"
     );
 
     if let Some(result) = ctx.try_execute_pg(query, SEED).await {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/mod.rs
@@ -9,6 +9,7 @@ mod filtered_rolling_measures;
 mod mixed_measures;
 mod multi_fact;
 mod multiple_rolling;
+mod offset_no_granularity;
 mod offset_variations;
 mod order_and_limit;
 mod running_total;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
@@ -1,0 +1,228 @@
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use indoc::indoc;
+
+fn create_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/integration_rolling_window.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+const SEED: &str = "integration_rolling_window_tables.sql";
+
+// Rolling window measures queried without a granularity (dateRange only). The
+// whole range is a single window anchored by `offset`: 'start' anchors at the
+// range start (`from`), 'end' at the range end (`to`). The seed has orders before
+// (January) and after (March) the queried February range, which is what makes the
+// start/end anchors produce different aggregates.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trailing_unbounded_offset_start_no_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_trailing_offset_start
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-02-01"
+              - "2024-02-29"
+    "#};
+
+    let sql = ctx.build_sql(query).expect("Should generate SQL");
+
+    // offset start + trailing unbounded => everything strictly before the range start.
+    assert!(
+        sql.contains(r#""orders".created_at < $_0_$::timestamptz"#),
+        "Should have strict upper bound at range start (< from), got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at <= "),
+        "Should not use inclusive upper bound, got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at >"),
+        "Should not have a lower bound, got: {sql}"
+    );
+    assert!(
+        !sql.contains("time_series"),
+        "Without granularity should not reference time_series CTE, got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trailing_unbounded_offset_end_no_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_trailing_offset_end
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-02-01"
+              - "2024-02-29"
+    "#};
+
+    let sql = ctx.build_sql(query).expect("Should generate SQL");
+
+    // offset end + trailing unbounded => everything up to and including the range end.
+    assert!(
+        sql.contains(r#""orders".created_at <= $_0_$::timestamptz"#),
+        "Should have inclusive upper bound at range end (<= to), got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at >"),
+        "Should not have a lower bound, got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_leading_unbounded_offset_start_no_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_leading_offset_start
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-02-01"
+              - "2024-02-29"
+    "#};
+
+    let sql = ctx.build_sql(query).expect("Should generate SQL");
+
+    // offset start + leading unbounded => everything from the range start onward.
+    assert!(
+        sql.contains(r#""orders".created_at >= $_0_$::timestamptz"#),
+        "Should have inclusive lower bound at range start (>= from), got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at <"),
+        "Should not have an upper bound, got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_leading_unbounded_offset_end_no_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_leading_offset_end
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-02-01"
+              - "2024-02-29"
+    "#};
+
+    let sql = ctx.build_sql(query).expect("Should generate SQL");
+
+    // offset end + leading unbounded => everything strictly after the range end.
+    assert!(
+        sql.contains(r#""orders".created_at > $_0_$::timestamptz"#),
+        "Should have strict lower bound at range end (> to), got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at >= "),
+        "Should not use inclusive lower bound, got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at <"),
+        "Should not have an upper bound, got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trailing_finite_offset_start_no_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_7d_offset_start
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-01-10"
+              - "2024-01-16"
+    "#};
+
+    let sql = ctx.build_sql(query).expect("Should generate SQL");
+
+    // offset start + trailing 7 day => [from - 7 day, from): the trailing interval
+    // shifts the lower bound; the upper bound is the strict range start.
+    assert!(
+        sql.contains("7 day"),
+        "Should apply the trailing interval, got: {sql}"
+    );
+    assert!(
+        sql.contains(r#""orders".created_at < $"#),
+        "Should have strict upper bound at range start (< from), got: {sql}"
+    );
+    assert!(
+        !sql.contains("created_at <= "),
+        "Should not use inclusive upper bound, got: {sql}"
+    );
+    assert!(
+        !sql.contains("time_series"),
+        "Without granularity should not reference time_series CTE, got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trailing_finite_offset_end_no_granularity() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.rolling_sum_7d_offset_end
+        time_dimensions:
+          - dimension: orders.created_at
+            dateRange:
+              - "2024-01-10"
+              - "2024-01-16"
+    "#};
+
+    let sql = ctx.build_sql(query).expect("Should generate SQL");
+
+    // offset end + trailing 7 day => (to - 7 day, to]: the trailing interval shifts
+    // the lower bound (strict); the upper bound is the inclusive range end.
+    assert!(
+        sql.contains("7 day"),
+        "Should apply the trailing interval, got: {sql}"
+    );
+    assert!(
+        sql.contains(r#""orders".created_at <= $"#),
+        "Should have inclusive upper bound at range end (<= to), got: {sql}"
+    );
+    assert!(
+        sql.contains("created_at > ") && !sql.contains("created_at >= "),
+        "Should have strict lower bound (> to - interval), got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__basic_types__bounded_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__basic_types__bounded_no_granularity.snap
@@ -1,8 +1,8 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/basic_types.rs
-assertion_line: 82
+assertion_line: 194
 expression: result
 ---
-orders__rolling_sum_leading
+orders__rolling_sum_bounded
 ---------------------------
-1455.00
+180.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__basic_types__trailing_bounded_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__basic_types__trailing_bounded_no_granularity.snap
@@ -1,8 +1,8 @@
 ---
 source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/basic_types.rs
-assertion_line: 82
+assertion_line: 277
 expression: result
 ---
-orders__rolling_sum_leading
----------------------------
-1455.00
+orders__rolling_sum_trailing_7d
+-------------------------------
+450.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__leading_unbounded_offset_end_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__leading_unbounded_offset_end_no_granularity.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+assertion_line: 150
+expression: result
+---
+orders__rolling_sum_leading_offset_end
+--------------------------------------
+480.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__leading_unbounded_offset_start_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__leading_unbounded_offset_start_no_granularity.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+assertion_line: 115
+expression: result
+---
+orders__rolling_sum_leading_offset_start
+----------------------------------------
+1205.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_finite_offset_end_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_finite_offset_end_no_granularity.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+assertion_line: 226
+expression: result
+---
+orders__rolling_sum_7d_offset_end
+---------------------------------
+650.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_finite_offset_start_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_finite_offset_start_no_granularity.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+assertion_line: 190
+expression: result
+---
+orders__rolling_sum_7d_offset_start
+-----------------------------------
+320.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_unbounded_offset_end_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_unbounded_offset_end_no_granularity.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+assertion_line: 84
+expression: result
+---
+orders__rolling_sum_trailing_offset_end
+---------------------------------------
+2275.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_unbounded_offset_start_no_granularity.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/snapshots/cubesqlplanner__tests__integration__rolling_window__offset_no_granularity__trailing_unbounded_offset_start_no_granularity.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/rolling_window/offset_no_granularity.rs
+assertion_line: 53
+expression: result
+---
+orders__rolling_sum_trailing_offset_start
+-----------------------------------------
+1550.00


### PR DESCRIPTION
## Summary

Fixes #11162. Under the Tesseract SQL planner, rolling window measures queried with only a `dateRange` (no granularity) ignored the `offset` and dropped finite trailing/leading intervals, producing wrong results — e.g. a `trailing: unbounded, offset: start` "beginning balance" measure returned the same value as `offset: end`.

## Why

Without granularity there is no `time_series` CTE, so the window is emulated by rewriting the `InDateRange` filter on the base measure. That rewrite only handled `unbounded` sides and discarded `offset` entirely:

- `trailing: unbounded` + `offset: start` filtered by `<= to` instead of `< from`
- `leading: unbounded` + `offset: end` filtered by `>= from` instead of `> to`
- finite `trailing`/`leading` without granularity fell back to the raw date range (interval ignored)

The correct semantics are taken from the authoritative with-granularity path (`physical_plan/join.rs`): treat the whole range as a single window anchored by `offset` (`start` → range start `from`, `end` → range end `to`); the trailing side is the lower bound, the leading side the upper bound; an `unbounded` side drops its bound, a finite interval shifts it.

## Changes

- New synthetic `RollingWindowOffsetDateRange` filter operator + `RollingWindowOffsetOp` renderer that emits the offset-anchored bounds over the literal date range (reuses `extend_date_range_bound`).
- `replace_date_range_for_rolling_window_without_granularity` now threads `offset` and rewrites via the shared `change_date_range_filter_impl` (recurses into filter groups, single pass).
- `FILTER_PARAMS` callbacks on the time dimension now receive the `from`/`to` dates, never the window config (`unbounded`/`offset`).
- User-facing `beforeDate`/`afterDate` operators left untouched (no value overloading).
- Behavior change: bare `leading: unbounded` without an explicit `offset` (no granularity) now anchors at the range end (`> to`) per the default `offset: end`, instead of `>= from`.

## Testing

- New Rust integration tests `offset_no_granularity.rs` (SQL assertions + real-Postgres snapshots) covering trailing/leading × unbounded/finite × offset start/end; un-ignored the two finite no-granularity FIXME tests.
- New JS schema-compiler integration test verifying correct results under both planners and that `FILTER_PARAMS` does not leak window config into params.
- `cubesqlplanner`: 1052 passed; rolling_window with Postgres: 125 passed; JS tests green under both BaseQuery and Tesseract; `cargo fmt` clean.