### PR TITLE
fix(tesseract): Reject pre-agg when a measure is multiplied only in t…

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -2,6 +2,7 @@ use super::PreAggregationsCompiler;
 use super::*;
 use crate::logical_plan::visitor::{LogicalPlanRewriter, NodeRewriteResult};
 use crate::logical_plan::*;
+use crate::planner::collectors::has_multi_stage_members;
 use crate::planner::filter::FilterItem;
 use crate::planner::filter::FilterOp;
 use crate::planner::join_hints::JoinHints;
@@ -509,15 +510,54 @@ impl PreAggregationOptimizer {
             pre_aggregation,
             match_state == MatchState::Partial,
         )?;
-        if matched.is_none() {
+        let Some(matched_measures) = matched else {
             return Ok(None);
+        };
+
+        // Even when the query itself has no multiplied measures, a measure that
+        // is multiplied in the pre-aggregation (because the pre-agg groups by a
+        // multiplier dimension) stores a different value than the query expects,
+        // so the pre-aggregation can't serve it. This mirrors the leaf-measure
+        // additive check in the JS planner, which only applies when the query has
+        // no multiplied and no multi-stage measures: a multiplying filter (or a
+        // multi-stage measure) makes the multiplied pre-agg a legitimate match.
+        let pre_aggr_multiplied = pre_aggregation
+            .multi_fact_join_groups
+            .multiplied_measures()?;
+        if !pre_aggr_multiplied.is_empty() {
+            // Account for multiplying joins introduced by filters/segments — like
+            // the JS planner's `hasMultipliedMeasures`, this is filter-aware.
+            let query_groups_with_filters = MultiFactJoinGroups::try_new(
+                self.query_tools.clone(),
+                MeasuresJoinHints::builder(&JoinHints::new())
+                    .add_dimensions(&schema.dimensions)
+                    .add_dimensions(&schema.time_dimensions)
+                    .add_filters(&filters.dimensions_filters)
+                    .add_filters(&filters.time_dimensions_filters)
+                    .add_filters(&filters.segments)
+                    .build(&all_measures)?,
+            )?;
+            let query_has_multi_stage =
+                all_measures
+                    .iter()
+                    .try_fold(false, |acc, m| -> Result<bool, CubeError> {
+                        Ok(acc || has_multi_stage_members(m, false)?)
+                    })?;
+            if !query_groups_with_filters.has_multiplied_measures()?
+                && !query_has_multi_stage
+                && matched_measures
+                    .iter()
+                    .any(|m| pre_aggr_multiplied.contains(m))
+            {
+                return Ok(None);
+            }
         }
 
         if !self.are_join_paths_matching(schema, &all_measures, &query_groups, pre_aggregation)? {
             return Ok(None);
         }
 
-        Ok(matched)
+        Ok(Some(matched_measures))
     }
 
     fn query_join_groups(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -524,32 +524,38 @@ impl PreAggregationOptimizer {
         let pre_aggr_multiplied = pre_aggregation
             .multi_fact_join_groups
             .multiplied_measures()?;
-        if !pre_aggr_multiplied.is_empty() {
-            // Account for multiplying joins introduced by filters/segments — like
-            // the JS planner's `hasMultipliedMeasures`, this is filter-aware.
-            let query_groups_with_filters = MultiFactJoinGroups::try_new(
-                self.query_tools.clone(),
-                MeasuresJoinHints::builder(&JoinHints::new())
-                    .add_dimensions(&schema.dimensions)
-                    .add_dimensions(&schema.time_dimensions)
-                    .add_filters(&filters.dimensions_filters)
-                    .add_filters(&filters.time_dimensions_filters)
-                    .add_filters(&filters.segments)
-                    .build(&all_measures)?,
-            )?;
+        if matched_measures
+            .iter()
+            .any(|m| pre_aggr_multiplied.contains(m))
+        {
             let query_has_multi_stage =
                 all_measures
                     .iter()
                     .try_fold(false, |acc, m| -> Result<bool, CubeError> {
                         Ok(acc || has_multi_stage_members(m, false)?)
                     })?;
-            if !query_groups_with_filters.has_multiplied_measures()?
-                && !query_has_multi_stage
-                && matched_measures
-                    .iter()
-                    .any(|m| pre_aggr_multiplied.contains(m))
-            {
-                return Ok(None);
+            if !query_has_multi_stage {
+                let has_filters = !filters.dimensions_filters.is_empty()
+                    || !filters.time_dimensions_filters.is_empty()
+                    || !filters.segments.is_empty();
+                let query_has_multiplied = if has_filters {
+                    MultiFactJoinGroups::try_new(
+                        self.query_tools.clone(),
+                        MeasuresJoinHints::builder(&JoinHints::new())
+                            .add_dimensions(&schema.dimensions)
+                            .add_dimensions(&schema.time_dimensions)
+                            .add_filters(&filters.dimensions_filters)
+                            .add_filters(&filters.time_dimensions_filters)
+                            .add_filters(&filters.segments)
+                            .build(&all_measures)?,
+                    )?
+                    .has_multiplied_measures()?
+                } else {
+                    query_groups.has_multiplied_measures()?
+                };
+                if !query_has_multiplied {
+                    return Ok(None);
+                }
             }
         }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -517,10 +517,7 @@ impl PreAggregationOptimizer {
         // Even when the query itself has no multiplied measures, a measure that
         // is multiplied in the pre-aggregation (because the pre-agg groups by a
         // multiplier dimension) stores a different value than the query expects,
-        // so the pre-aggregation can't serve it. This mirrors the leaf-measure
-        // additive check in the JS planner, which only applies when the query has
-        // no multiplied and no multi-stage measures: a multiplying filter (or a
-        // multi-stage measure) makes the multiplied pre-agg a legitimate match.
+        // so the pre-aggregation can't serve it.
         let pre_aggr_multiplied = pre_aggregation
             .multi_fact_join_groups
             .multiplied_measures()?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/multi_fact_join_groups.rs
@@ -11,7 +11,7 @@ use crate::planner::JoinTree;
 use crate::planner::MemberSymbol;
 use cubenativeutils::CubeError;
 use itertools::Itertools;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 /// A single measure paired with the complete set of join hints it
@@ -284,6 +284,25 @@ impl MultiFactJoinGroups {
         Ok(false)
     }
 
+    /// Full names of the (leaf) measures that are multiplied — i.e. sit below a
+    /// one-to-many join — in these join groups. Like `has_multiplied_measures`,
+    /// but returns the concrete measures so callers can compare the
+    /// multiplicativity of a measure between two different groupings (e.g. the
+    /// query vs a pre-aggregation).
+    pub fn multiplied_measures(&self) -> Result<HashSet<String>, CubeError> {
+        let mut result = HashSet::new();
+        for (join, measures) in self.groups.iter() {
+            for measure in measures.iter() {
+                for item in collect_multiplied_measures(measure, join)? {
+                    if item.multiplied {
+                        result.insert(item.measure.full_name());
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+
     pub fn groups(&self) -> &[(Rc<JoinTree>, Vec<Rc<MemberSymbol>>)] {
         &self.groups
     }
@@ -445,6 +464,78 @@ mod tests {
         let groups = MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints).unwrap();
 
         assert!(!groups.has_multiplied_measures().unwrap());
+    }
+
+    #[test]
+    fn test_multiplied_measures_one_side_measure() -> Result<(), CubeError> {
+        // `customers` is the `one` side of a one_to_many join to `orders`.
+        // Grouping `customers.count` by an `orders` dimension multiplies it,
+        // so its full name is returned.
+        let schema = MockSchema::from_yaml_file("common/multi_fact.yaml");
+        let ctx = TestContext::new(schema)?;
+
+        let customers_count = ctx.create_symbol("customers.count")?;
+        let orders_status = ctx.create_symbol("orders.status")?;
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[orders_status])
+            .build(&[customers_count])?;
+
+        let groups = MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints)?;
+
+        assert_eq!(
+            groups.multiplied_measures()?,
+            HashSet::from(["customers.count".to_string()])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiplied_measures_many_side_measure() -> Result<(), CubeError> {
+        // `orders` is the `many` side, so joining the `customers` dimension
+        // does not multiply order rows: `orders.count` is not multiplied and
+        // the set is empty.
+        let schema = MockSchema::from_yaml_file("common/multi_fact.yaml");
+        let ctx = TestContext::new(schema)?;
+
+        let orders_count = ctx.create_symbol("orders.count")?;
+        let customers_name = ctx.create_symbol("customers.name")?;
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[customers_name])
+            .build(&[orders_count])?;
+
+        let groups = MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints)?;
+
+        assert!(groups.multiplied_measures()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiplied_measures_multi_fact_mixed() -> Result<(), CubeError> {
+        // Multi-fact query grouped by an `orders` dimension: `customers.count`
+        // is multiplied (one side), `orders.count` is not (many side). Only the
+        // multiplied measure is returned — discriminating per-measure where the
+        // boolean `has_multiplied_measures()` cannot.
+        let schema = MockSchema::from_yaml_file("common/multi_fact.yaml");
+        let ctx = TestContext::new(schema)?;
+
+        let customers_count = ctx.create_symbol("customers.count")?;
+        let orders_count = ctx.create_symbol("orders.count")?;
+        let orders_status = ctx.create_symbol("orders.status")?;
+
+        let hints = MeasuresJoinHints::builder(&JoinHints::new())
+            .add_dimensions(&[orders_status])
+            .build(&[customers_count, orders_count])?;
+
+        let groups = MultiFactJoinGroups::try_new(ctx.query_tools().clone(), hints)?;
+
+        assert!(groups.has_multiplied_measures()?);
+        assert_eq!(
+            groups.multiplied_measures()?,
+            HashSet::from(["customers.count".to_string()])
+        );
+        Ok(())
     }
 
     #[test]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
@@ -5,21 +5,18 @@ use std::rc::Rc;
 use cubenativeutils::CubeError;
 use typed_builder::TypedBuilder;
 
-use crate::{
-    cube_bridge::{
-        base_query_options::{
-            BaseQueryOptions, BaseQueryOptionsStatic, FilterItem, FilterValue, MaskedMemberItem,
-            OrderByItem, TimeDimension,
-        },
-        base_tools::BaseTools,
-        evaluator::CubeEvaluator,
-        join_graph::JoinGraph,
-        join_hints::JoinHintItem,
-        options_member::OptionsMember,
-        security_context::SecurityContext,
-        subquery_join::SubqueryJoin,
+use crate::cube_bridge::{
+    base_query_options::{
+        BaseQueryOptions, BaseQueryOptionsStatic, FilterItem, FilterValue, MaskedMemberItem,
+        OrderByItem, TimeDimension,
     },
-    impl_static_data,
+    base_tools::BaseTools,
+    evaluator::CubeEvaluator,
+    join_graph::JoinGraph,
+    join_hints::JoinHintItem,
+    options_member::OptionsMember,
+    security_context::SecurityContext,
+    subquery_join::SubqueryJoin,
 };
 
 /// Mock implementation of BaseQueryOptions for testing

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_case_switch_item.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_case_switch_item.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::case_switch_item::{CaseSwitchItem, CaseSwitchItemStatic};
 use crate::cube_bridge::member_sql::MemberSql;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::MockMemberSql;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_cube_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_cube_definition.rs
@@ -1,7 +1,6 @@
 use crate::cube_bridge::cube_definition::{CubeDefinition, CubeDefinitionStatic};
 use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::view_filter_definition::ViewFilterDefinition;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::{
     MockJoinItemDefinition, MockMemberSql, MockViewFilterDefinition,
 };

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_dimension_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_dimension_definition.rs
@@ -4,7 +4,6 @@ use crate::cube_bridge::geo_item::GeoItem;
 use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::multi_stage_filter::MultiStageFilterReferences;
 use crate::cube_bridge::timeshift_definition::TimeShiftDefinition;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::yaml::dimension::YamlDimensionDefinition;
 use crate::test_fixtures::cube_bridge::{
     MockGeoItem, MockMemberSql, MockMultiStageFilterReferences, MockTimeShiftDefinition,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_evaluator.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_evaluator.rs
@@ -6,7 +6,6 @@ use crate::cube_bridge::measure_definition::MeasureDefinition;
 use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::pre_aggregation_description::PreAggregationDescription;
 use crate::cube_bridge::segment_definition::SegmentDefinition;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::mock_schema::MockSchema;
 use crate::test_fixtures::cube_bridge::{mock_compiled, MockJoinGraph};
 use cubenativeutils::CubeError;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_expression_struct.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_expression_struct.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::member_expression::{ExpressionStruct, ExpressionStructStatic};
 use crate::cube_bridge::struct_with_sql_member::StructWithSqlMember;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::MockStructWithSqlMember;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_granularity_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_granularity_definition.rs
@@ -2,7 +2,6 @@ use crate::cube_bridge::granularity_definition::{
     GranularityDefinition, GranularityDefinitionStatic,
 };
 use crate::cube_bridge::member_sql::MemberSql;
-use crate::impl_static_data;
 use cubenativeutils::CubeError;
 use std::any::Any;
 use std::rc::Rc;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_join_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_join_definition.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::join_definition::{JoinDefinition, JoinDefinitionStatic};
 use crate::cube_bridge::join_item::JoinItem;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::MockJoinItem;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_join_item.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_join_item.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::join_item::{JoinItem, JoinItemStatic};
 use crate::cube_bridge::join_item_definition::JoinItemDefinition;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::MockJoinItemDefinition;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_join_item_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_join_item_definition.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::join_item_definition::{JoinItemDefinition, JoinItemDefinitionStatic};
 use crate::cube_bridge::member_sql::MemberSql;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::MockMemberSql;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_measure_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_measure_definition.rs
@@ -7,7 +7,6 @@ use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::multi_stage_filter::MultiStageFilterReferences;
 use crate::cube_bridge::multi_stage_grain::MultiStageGrainReferences;
 use crate::cube_bridge::struct_with_sql_member::StructWithSqlMember;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::yaml::measure::YamlMeasureDefinition;
 use crate::test_fixtures::cube_bridge::{
     MockMemberOrderBy, MockMemberSql, MockMultiStageFilterReferences,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_member_expression_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_member_expression_definition.rs
@@ -1,7 +1,6 @@
 use crate::cube_bridge::member_expression::{
     MemberExpressionDefinition, MemberExpressionDefinitionStatic, MemberExpressionExpressionDef,
 };
-use crate::impl_static_data;
 use cubenativeutils::CubeError;
 use std::any::Any;
 use std::rc::Rc;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_multi_stage_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_multi_stage_filter.rs
@@ -2,7 +2,6 @@ use crate::cube_bridge::base_query_options::FilterItem as NativeFilterItem;
 use crate::cube_bridge::multi_stage_filter::{
     MultiStageFilterReferences, MultiStageFilterReferencesStatic,
 };
-use crate::impl_static_data;
 use std::any::Any;
 use std::rc::Rc;
 use typed_builder::TypedBuilder;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_multi_stage_grain.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_multi_stage_grain.rs
@@ -1,7 +1,6 @@
 use crate::cube_bridge::multi_stage_grain::{
     MultiStageGrainReferences, MultiStageGrainReferencesStatic,
 };
-use crate::impl_static_data;
 use std::any::Any;
 use std::rc::Rc;
 use typed_builder::TypedBuilder;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_pre_aggregation_description.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_pre_aggregation_description.rs
@@ -3,7 +3,6 @@ use crate::cube_bridge::pre_aggregation_description::{
     PreAggregationDescription, PreAggregationDescriptionStatic,
 };
 use crate::cube_bridge::pre_aggregation_time_dimension::PreAggregationTimeDimension;
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::mock_pre_aggregation_time_dimension::MockPreAggregationTimeDimension;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_pre_aggregation_obj.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_pre_aggregation_obj.rs
@@ -1,5 +1,4 @@
 use crate::cube_bridge::pre_aggregation_obj::{PreAggregationObj, PreAggregationObjStatic};
-use crate::impl_static_data;
 use std::any::Any;
 use std::rc::Rc;
 use typed_builder::TypedBuilder;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_pre_aggregation_time_dimension.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_pre_aggregation_time_dimension.rs
@@ -2,7 +2,6 @@ use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::pre_aggregation_time_dimension::{
     PreAggregationTimeDimension, PreAggregationTimeDimensionStatic,
 };
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::MockMemberSql;
 use cubenativeutils::CubeError;
 use std::any::Any;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_segment_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_segment_definition.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::segment_definition::{SegmentDefinition, SegmentDefinitionStatic};
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::yaml::segment::YamlSegmentDefinition;
 use crate::test_fixtures::cube_bridge::MockMemberSql;
 use cubenativeutils::CubeError;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_subquery_join.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_subquery_join.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::member_expression::MemberExpressionDefinition;
 use crate::cube_bridge::subquery_join::{SubqueryJoin, SubqueryJoinStatic};
-use crate::impl_static_data;
 use cubenativeutils::CubeError;
 use std::any::Any;
 use std::rc::Rc;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_timeshift_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_timeshift_definition.rs
@@ -1,6 +1,5 @@
 use crate::cube_bridge::member_sql::MemberSql;
 use crate::cube_bridge::timeshift_definition::{TimeShiftDefinition, TimeShiftDefinitionStatic};
-use crate::impl_static_data;
 use crate::test_fixtures::cube_bridge::yaml::timeshift::YamlTimeShiftDefinition;
 use crate::test_fixtures::cube_bridge::MockMemberSql;
 use cubenativeutils::CubeError;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_view_filter_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_view_filter_definition.rs
@@ -1,7 +1,6 @@
 use crate::cube_bridge::view_filter_definition::{
     ViewFilterDefinition, ViewFilterDefinitionStatic,
 };
-use crate::impl_static_data;
 use std::any::Any;
 use std::rc::Rc;
 use typed_builder::TypedBuilder;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/multi_fact.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/multi_fact.rs
@@ -304,6 +304,48 @@ async fn test_regular_plus_two_multiplied_separate_pre_aggs() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unmultiplied_measure_rejects_multiplied_pre_agg(
+) -> Result<(), cubenativeutils::CubeError> {
+    // Regression for b07edca: a query for an unmultiplied measure must not match
+    // a pre-agg that multiplies it. `orders_by_addr_street` groups `orders.count`
+    // by `addresses.street`, and the orders → customers → addresses path crosses
+    // a one_to_many join, so `orders.count` is multiplied there and stores a
+    // different value. A plain `orders.count` query (no addresses.street) must
+    // fall back to the unmultiplied `orders_totals`, not roll up the multiplied
+    // pre-agg.
+    let schema = MockSchema::from_yaml_file("common/integration_multi_fact_pre_aggs.yaml")
+        .only_pre_aggregations(&["orders_totals", "orders_by_addr_street"]);
+    let ctx = TestContext::new(schema)?;
+
+    let query = indoc! {"
+        measures:
+          - orders.count
+    "};
+
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query)?;
+
+    let names: Vec<&str> = pre_aggrs.iter().map(|u| u.name().as_str()).collect();
+
+    assert_eq!(
+        pre_aggrs.len(),
+        1,
+        "Expected exactly one pre-aggregation usage; got {:?}",
+        names
+    );
+    assert_eq!(
+        pre_aggrs[0].name(),
+        "orders_totals",
+        "Expected unmultiplied orders_totals; multiplied orders_by_addr_street must be rejected; got {:?}",
+        names
+    );
+
+    if let Some(result) = ctx.try_execute(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+    Ok(())
+}
+
 // --- Filtered variants ---
 // Each test below uses the same query shape as its non-filtered counterpart
 // above but adds a filter on customers.name (not in projection) to verify

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__multi_fact__unmultiplied_measure_rejects_multiplied_pre_agg.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__multi_fact__unmultiplied_measure_rejects_multiplied_pre_agg.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/multi_fact.rs
+expression: result
+---
+orders__count
+-------------
+8


### PR DESCRIPTION
…he pre-agg

The native pre-aggregation matcher only rejected multiplied measures when the query itself was multiplied, so a query for an unmultiplied measure (e.g. `orders.total_qty`) wrongly matched a pre-aggregation that multiplies it by grouping on a joined cube's dimension — the stored value differs. This ports the JS planner's #9541 rejection.