### PR TITLE
fix(tesseract): cast bound param on measure filters

### DIFF
--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -1106,6 +1106,20 @@ describe('SQL Generation', () => {
       );
     });
 
+    it('CORE-541: measure filter casts bound param - bigquery tesseract planner', async () => {
+      await compilers.compiler.compile();
+
+      const query = new BigqueryQuery(compilers, {
+        measures: ['cards.count'],
+        filters: [
+          { member: 'cards.count', operator: 'gt', values: ['10'] }
+        ],
+        useNativeSqlPlanner: true,
+      });
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toContain('CAST(? AS FLOAT64)');
+    });
+
     it('Test time series with different granularity - postgres', async () => {
       await compilers.compiler.compile();
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
@@ -158,7 +158,18 @@ impl TypedFilterBuilder {
         let symbol = resolve_base_symbol(member_evaluator);
         match symbol.as_ref() {
             MemberSymbol::Dimension(d) => Some(d.dimension_type().to_string()),
-            MemberSymbol::Measure(m) => Some(m.measure_type().to_string()),
+            // A measure filter compares against an aggregated expression, so its
+            // bound value needs the same numeric cast as a number member. The
+            // aggregation kind (count, sum, ...) is not a comparable scalar type,
+            // so map any non-boolean measure to "number" for cast purposes.
+            MemberSymbol::Measure(m) => {
+                let measure_type = m.measure_type();
+                if measure_type == "boolean" {
+                    Some("boolean".to_string())
+                } else {
+                    Some("number".to_string())
+                }
+            }
             _ => None,
         }
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/typed_filter.rs
@@ -158,18 +158,17 @@ impl TypedFilterBuilder {
         let symbol = resolve_base_symbol(member_evaluator);
         match symbol.as_ref() {
             MemberSymbol::Dimension(d) => Some(d.dimension_type().to_string()),
-            // A measure filter compares against an aggregated expression, so its
-            // bound value needs the same numeric cast as a number member. The
-            // aggregation kind (count, sum, ...) is not a comparable scalar type,
-            // so map any non-boolean measure to "number" for cast purposes.
-            MemberSymbol::Measure(m) => {
-                let measure_type = m.measure_type();
-                if measure_type == "boolean" {
-                    Some("boolean".to_string())
-                } else {
-                    Some("number".to_string())
-                }
-            }
+            // The cast type drives how a bound comparison value is wrapped.
+            // Aggregations (count, sum, ...) and number measures compare as
+            // numbers. String/time measures are non-numeric scalars and must
+            // not be coerced to a number; date comparisons take the dedicated
+            // date operators instead. min/max carry their operand type, which
+            // isn't known here, so they fall through to the numeric default.
+            MemberSymbol::Measure(m) => match m.measure_type() {
+                "boolean" => Some("boolean".to_string()),
+                "string" | "time" => None,
+                _ => Some("number".to_string()),
+            },
             _ => None,
         }
     }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/visitors.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/visitors.yaml
@@ -83,6 +83,9 @@ cubes:
           - name: total_revenue_per_count
             type: number
             sql: "{visitors.count} / {total_revenue}"
+          - name: source_label
+            type: string
+            sql: "MAX({CUBE}.source)"
       segments:
           - name: google
             sql: "{CUBE.source} = 'google'"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/filter/to_sql.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/filter/to_sql.rs
@@ -595,6 +595,36 @@ fn test_not_contains_with_null() {
     );
 }
 
+// ── measure filters (HAVING) ──────────────────────────────────────────────────
+
+#[test]
+fn test_measure_filter_count_gt_casts_param() {
+    let result = build(indoc! {"
+        filters:
+          - member: visitors.count
+            operator: gt
+            values:
+              - \"10\"
+    "});
+    assert_filter(&result, r#"(count(COUNT(*)) > $_0_$::numeric)"#, &["10"]);
+}
+
+#[test]
+fn test_measure_filter_sum_lt_casts_param() {
+    let result = build(indoc! {"
+        filters:
+          - member: visitors.total_revenue
+            operator: lt
+            values:
+              - \"100\"
+    "});
+    assert_filter(
+        &result,
+        r#"(sum("visitors".revenue) < $_0_$::numeric)"#,
+        &["100"],
+    );
+}
+
 // ── filter groups (OR / AND) ────────────────────────────────────────────────
 
 #[test]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/filter/to_sql.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/filter/to_sql.rs
@@ -625,6 +625,18 @@ fn test_measure_filter_sum_lt_casts_param() {
     );
 }
 
+#[test]
+fn test_measure_filter_string_no_cast() {
+    let result = build(indoc! {"
+        filters:
+          - member: visitors.source_label
+            operator: equals
+            values:
+              - google
+    "});
+    assert_filter(&result, r#"(MAX("visitors".source) = $_0_$)"#, &["google"]);
+}
+
 // ── filter groups (OR / AND) ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Under the Tesseract native SQL planner (`CUBEJS_TESSERACT_SQL_PLANNER=true`), filtering on an aggregate measure produced a `HAVING` comparison with a raw bound parameter and no numeric cast. On BigQuery the param stayed a string, so the engine rejected the comparison (`No matching signature for operator < for argument types: INT64, STRING`). The standard planner emits `CAST(? AS FLOAT64)` here; Tesseract did not. Fixes #11031.

## Changes

- Resolve a measure filter member to the `number` cast type (`boolean` for boolean measures), so the bound value is wrapped by the per-dialect cast template — e.g. `CAST(? AS FLOAT64)` on BigQuery, `CAST(? AS DOUBLE)` on Presto, and no cast where the dialect template is a no-op (Postgres).
- Derive the cast type from the measure type rather than casting every measure numerically: `string` and `time` measures are not numeric scalars and now render without a numeric cast (the standard planner coerces them to float). Aggregations, count, rank and number measures stay numeric; `min`/`max` fall through to the numeric default since their operand type isn't known at this point.

## Testing

- `cargo test -p cubesqlplanner` — 1057 passed. New filter tests in `tests/filter/to_sql.rs` cover a numeric measure filter (cast applied) and a string measure filter (no cast).
- Schema-compiler unit test asserting BigQuery measure filter renders `CAST(? AS FLOAT64)` under the native planner.
