### PR TITLE
fix(tesseract): match rolling pre-aggregations without a date range v…

### DIFF
--- a/packages/cubejs-backend-native/test/bridge/object-bridges-coverage.test.ts
+++ b/packages/cubejs-backend-native/test/bridge/object-bridges-coverage.test.ts
@@ -54,6 +54,7 @@ const BRIDGES: BridgeSpec[] = [
       'order',
       'pre_aggregation_id',
       'pre_aggregation_query',
+      'pre_aggregations_match_only',
       'row_limit',
       'security_context',
       'segments',

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -1009,6 +1009,11 @@ export class BaseQuery {
       ungrouped: this.options.ungrouped,
       exportAnnotatedSql: false,
       preAggregationQuery: this.options.preAggregationQuery,
+      // We only consume the pre-aggregation match result here (sql/params are discarded
+      // below), so tell the native planner to skip building the outer query SQL. Otherwise
+      // a rolling-window measure without a date range would throw while rendering its time
+      // series, even though matching itself doesn't need it.
+      preAggregationsMatchOnly: true,
       preAggregationId: this.options.preAggregationId || null,
       securityContext: this.contextSymbols.securityContext,
       cubestoreSupportMultistage: this.options.cubestoreSupportMultistage ?? getEnv('cubeStoreRollingWindowJoin'),

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { prepareJsCompiler, prepareYamlCompiler } from './PrepareCompiler';
 import { createECommerceSchema, createSchemaYaml } from './utils';
 import { PostgresQuery, queryClass, QueryFactory } from '../../src';
+import { RedshiftQuery } from '../../src/adapter/RedshiftQuery';
 
 describe('pre-aggregations', () => {
   it('rollupJoin scheduledRefresh', async () => {
@@ -977,6 +978,84 @@ describe('pre-aggregations', () => {
       expect(originalSqlDesc.sql[0]).toMatch(/SELECT \* FROM public\.orders/);
       expect(originalSqlDesc.loadSql[0]).toMatch(/CREATE TABLE/);
       expect(originalSqlDesc.loadSql[0]).toMatch(/SELECT \* FROM public\.orders/);
+    });
+  });
+
+  // Regression for the pre-aggregation refresh/metadata path: it builds a query from a
+  // rolling pre-agg's references (rolling measure + a time dimension with granularity, but
+  // NO date range) just to find the matching pre-aggregation. Matching must succeed without
+  // building the outer query's rolling-window time series — which can't render without a date
+  // range on dialects that lack generated time series (e.g. Redshift). Pure matching, no DB.
+  describe('rolling pre-aggregation matching without a date range', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(`
+      cube(\`visitors\`, {
+        sql: \`SELECT * FROM visitors\`,
+
+        measures: {
+          count: {
+            type: \`count\`,
+          },
+          rollingCount: {
+            type: \`count\`,
+            rollingWindow: {
+              trailing: \`unbounded\`,
+            },
+          },
+        },
+
+        dimensions: {
+          id: {
+            sql: \`id\`,
+            type: \`number\`,
+            primaryKey: true,
+          },
+          source: {
+            sql: \`source\`,
+            type: \`string\`,
+          },
+          createdAt: {
+            sql: \`created_at\`,
+            type: \`time\`,
+          },
+        },
+
+        preAggregations: {
+          partitionedRolling: {
+            type: \`rollup\`,
+            measures: [CUBE.rollingCount],
+            dimensions: [CUBE.source],
+            timeDimension: CUBE.createdAt,
+            granularity: \`hour\`,
+            partitionGranularity: \`month\`,
+          },
+        },
+      });
+    `);
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    [PostgresQuery, RedshiftQuery].forEach((QueryClass) => {
+      it(`matches the rolling pre-aggregation (${QueryClass.name})`, async () => {
+        const query = new QueryClass({ joinGraph, cubeEvaluator, compiler }, {
+          measures: ['visitors.rollingCount'],
+          dimensions: ['visitors.source'],
+          timeDimensions: [{
+            dimension: 'visitors.createdAt',
+            granularity: 'day',
+            // no dateRange — the shape the refresh/metadata path builds
+          }],
+          timezone: 'UTC',
+          preAggregationsSchema: '',
+        });
+
+        // Must not throw while determining the matching pre-aggregation.
+        const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+        const ids = (preAggregationsDescription || []).map((d: any) => d.preAggregationId);
+        expect(ids).toContain('visitors.partitionedRolling');
+        expect(query.preAggregations?.preAggregationForQuery?.canUsePreAggregation).toEqual(true);
+      });
     });
   });
 });

--- a/packages/cubejs-server-core/src/core/CompilerApi.ts
+++ b/packages/cubejs-server-core/src/core/CompilerApi.ts
@@ -58,6 +58,11 @@ export interface GetSqlOptions {
   includeDebugInfo?: boolean;
   exportAnnotatedSql?: boolean;
   requestId?: string;
+  // Build only the pre-aggregation descriptions, skipping the outer query SQL.
+  // Used by the refresh/metadata path, which consumes `preAggregations` but not `sql`.
+  // Avoids building a rolling-window time series that would require a date range the
+  // refresh path doesn't provide.
+  preAggregationsOnly?: boolean;
 }
 
 export interface SqlResult {
@@ -347,13 +352,13 @@ export class CompilerApi {
   }
 
   public async getSql(query: NormalizedQuery, options: GetSqlOptions = {}): Promise<SqlResult> {
-    const { includeDebugInfo, exportAnnotatedSql } = options;
+    const { includeDebugInfo, exportAnnotatedSql, preAggregationsOnly } = options;
     const { sqlGenerator, compilers } = await this.getSqlGenerator(query);
 
     const getSqlFn = () => compilers.compiler.withQuery(sqlGenerator, () => ({
       external: sqlGenerator.externalPreAggregationQuery(),
-      sql: sqlGenerator.buildSqlAndParams(exportAnnotatedSql),
-      lambdaQueries: sqlGenerator.buildLambdaQuery(),
+      sql: preAggregationsOnly ? null : sqlGenerator.buildSqlAndParams(exportAnnotatedSql),
+      lambdaQueries: preAggregationsOnly ? [] : sqlGenerator.buildLambdaQuery(),
       timeDimensionAlias: sqlGenerator.timeDimensions[0]?.unescapedAliasName(),
       timeDimensionField: sqlGenerator.timeDimensions[0]?.dimension,
       order: sqlGenerator.order,

--- a/packages/cubejs-server-core/src/core/RefreshScheduler.ts
+++ b/packages/cubejs-server-core/src/core/RefreshScheduler.ts
@@ -146,7 +146,7 @@ export class RefreshScheduler {
     queryingOptions: ScheduledRefreshQueryingOptions
   ): Promise<RefreshQueries> {
     const baseQuery = await this.baseQueryForPreAggregation(compilerApi, preAggregation, queryingOptions);
-    const baseQuerySql = await compilerApi.getSql(baseQuery);
+    const baseQuerySql = await compilerApi.getSql(baseQuery, { preAggregationsOnly: true });
     const preAggregationDescriptionList = baseQuerySql.preAggregations;
     const preAggregationDescription = preAggregationDescriptionList.find(p => p.preAggregationId === preAggregation.id);
     const orchestratorApi = await this.serverCore.getOrchestratorApi(context);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/cube_bridge/base_query_options.rs
@@ -206,6 +206,8 @@ pub struct BaseQueryOptionsStatic {
     pub export_annotated_sql: bool,
     #[serde(rename = "preAggregationQuery")]
     pub pre_aggregation_query: Option<bool>,
+    #[serde(rename = "preAggregationsMatchOnly")]
+    pub pre_aggregations_match_only: Option<bool>,
     #[serde(rename = "useOriginalSqlPreAggregationsInPreAggregation")]
     pub use_original_sql_pre_aggregations_in_pre_aggregation: Option<bool>,
     #[serde(rename = "totalQuery")]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties.rs
@@ -167,6 +167,13 @@ pub struct QueryProperties {
     ungrouped: bool,
     #[builder(default)]
     pre_aggregation_query: bool,
+    /// Pre-aggregation matching only: run the pre-aggregation optimizer to determine
+    /// which pre-aggregation a query would use, but skip building the outer query's
+    /// physical SQL. Used by the refresh/metadata path, which needs the match (and the
+    /// pre-agg's own load SQL) but not the outer query — that outer query may include a
+    /// rolling-window time series which requires a date range the refresh path doesn't have.
+    #[builder(default)]
+    pre_aggregations_match_only: bool,
     /// When building a rollup pre-aggregation, source it from the cube's
     /// `originalSql` pre-aggregation table instead of the raw cube SQL.
     #[builder(default)]
@@ -356,6 +363,10 @@ impl QueryProperties {
 
     pub fn is_pre_aggregation_query(&self) -> bool {
         self.pre_aggregation_query
+    }
+
+    pub fn is_pre_aggregations_match_only(&self) -> bool {
+        self.pre_aggregations_match_only
     }
 
     pub fn use_original_sql_pre_aggregations_in_pre_aggregation(&self) -> bool {
@@ -1115,6 +1126,7 @@ impl PartialEq for QueryProperties {
             ungrouped,
             ignore_cumulative,
             pre_aggregation_query,
+            pre_aggregations_match_only,
             use_original_sql_pre_aggregations_in_pre_aggregation,
             total_query,
             allow_multi_stage,
@@ -1141,6 +1153,7 @@ impl PartialEq for QueryProperties {
             && *ungrouped == other.ungrouped
             && *ignore_cumulative == other.ignore_cumulative
             && *pre_aggregation_query == other.pre_aggregation_query
+            && *pre_aggregations_match_only == other.pre_aggregations_match_only
             && *use_original_sql_pre_aggregations_in_pre_aggregation
                 == other.use_original_sql_pre_aggregations_in_pre_aggregation
             && *total_query == other.total_query

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/query_properties_compiler.rs
@@ -84,6 +84,10 @@ impl QueryPropertiesCompiler {
             .and_then(|v| v.parse::<usize>().ok());
         let ungrouped = options.static_data().ungrouped.unwrap_or(false);
         let pre_aggregation_query = options.static_data().pre_aggregation_query.unwrap_or(false);
+        let pre_aggregations_match_only = options
+            .static_data()
+            .pre_aggregations_match_only
+            .unwrap_or(false);
         let use_original_sql_pre_aggregations_in_pre_aggregation = options
             .static_data()
             .use_original_sql_pre_aggregations_in_pre_aggregation
@@ -113,6 +117,7 @@ impl QueryPropertiesCompiler {
             .offset(offset)
             .ungrouped(ungrouped)
             .pre_aggregation_query(pre_aggregation_query)
+            .pre_aggregations_match_only(pre_aggregations_match_only)
             .use_original_sql_pre_aggregations_in_pre_aggregation(
                 use_original_sql_pre_aggregations_in_pre_aggregation,
             )

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/top_level_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/top_level_planner.rs
@@ -43,6 +43,15 @@ impl TopLevelPlanner {
 
         let (optimized_plan, usages) = self.try_pre_aggregations(logical_plan.clone())?;
 
+        // Match-only mode (refresh/metadata path): the caller only needs the matched
+        // pre-aggregation(s), not the outer query SQL. Skip the physical build, which for a
+        // rolling-window measure would render a time series that requires a date range the
+        // refresh path doesn't provide (and which non-generated-time-series dialects can't
+        // build without one). The pre-agg's own load SQL is built separately on the JS side.
+        if self.request.is_pre_aggregations_match_only() {
+            return Ok((String::new(), usages));
+        }
+
         let is_external = if !usages.is_empty() {
             usages.iter().all(|usage| usage.pre_aggregation.external())
         } else {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/base_query_options.rs
@@ -62,6 +62,8 @@ pub struct MockBaseQueryOptions {
     #[builder(default)]
     pre_aggregation_query: Option<bool>,
     #[builder(default)]
+    pre_aggregations_match_only: Option<bool>,
+    #[builder(default)]
     use_original_sql_pre_aggregations_in_pre_aggregation: Option<bool>,
     #[builder(default)]
     total_query: Option<bool>,
@@ -92,6 +94,7 @@ impl_static_data!(
     ungrouped,
     export_annotated_sql,
     pre_aggregation_query,
+    pre_aggregations_match_only,
     use_original_sql_pre_aggregations_in_pre_aggregation,
     total_query,
     cubestore_support_multistage,


### PR DESCRIPTION
…ia match-only mode

The pre-aggregation refresh/metadata path (e.g. the `/cubejs-system/v1/pre-aggregations` API) builds a query from a rolling pre-agg's references (rolling measure + a time dimension with granularity, but no date range) and calls `CompilerApi.getSql()`, which 500s. `getSql()` eagerly builds both `.sql` (`buildSqlAndParams`, discarded by the refresh path) and `.preAggregations`; on dialects without generated time series the native matching itself also throws, because `findPreAggregationForQueryRust` builds the full outer SQL — including the rolling-window time series, which requires a date range — just to compute the match.

Let the refresh/metadata path skip the outer-query builds it never needs while pre-aggregation matching still runs:

- Native planner: add a `preAggregationsMatchOnly` request option. `TopLevelPlanner::plan` runs the pre-aggregation optimizer and returns the matched usages without building the outer physical SQL. Setting `preAggregationQuery: true` is not an option here — that mode skips matching entirely, so the pre-agg would never refresh.
- `findPreAggregationForQueryRust` requests match-only unconditionally (it already discards the sql/params), so matching no longer renders a time series.
- `CompilerApi.getSql({ preAggregationsOnly })` skips `.sql`/`.lambdaQueries`; `RefreshScheduler.refreshQueriesForPreAggregation` passes it (it consumes only `.preAggregations`). The pre-agg's own load SQL is built separately and never needs the outer time series.ce this PR resolves**