### PR TITLE
fix(tesseract): Drop order-by-only measures from pre-aggregation reads

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
@@ -197,8 +197,7 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
 
         // When reading from a pre-aggregation, drop ORDER BY keys on measures that
         // are not part of the selection. CubeStore cannot ORDER BY an aggregate of a
-        // rollup column that isn't projected, and the legacy planner likewise ignores
-        // such keys — matching that keeps results consistent across planners.
+        // rollup column that isn't projected.
         let order_by = if is_pre_aggregation {
             logical_plan
                 .modifers()

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/query.rs
@@ -195,9 +195,30 @@ impl<'a> LogicalNodeProcessor<'a, Query> for QueryProcessor<'a> {
             context_factory.set_ungrouped(true);
         }
 
+        // When reading from a pre-aggregation, drop ORDER BY keys on measures that
+        // are not part of the selection. CubeStore cannot ORDER BY an aggregate of a
+        // rollup column that isn't projected, and the legacy planner likewise ignores
+        // such keys — matching that keeps results consistent across planners.
+        let order_by = if is_pre_aggregation {
+            logical_plan
+                .modifers()
+                .order_by
+                .iter()
+                .filter(|o| {
+                    !(o.member_symbol().is_measure()
+                        && logical_plan
+                            .schema()
+                            .find_member_positions(&o.name())
+                            .is_empty())
+                })
+                .cloned()
+                .collect()
+        } else {
+            logical_plan.modifers().order_by.clone()
+        };
         select_builder.set_order_by(
             self.builder
-                .make_order_by(logical_plan.schema(), &logical_plan.modifers().order_by)?,
+                .make_order_by(logical_plan.schema(), &order_by)?,
         );
 
         let res = Rc::new(select_builder.build(query_tools.clone(), context_factory));

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__order_by_only_measure_dropped_from_pre_agg_cubestore_result.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__order_by_only_measure_dropped_from_pre_agg_cubestore_result.snap
@@ -1,0 +1,13 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+expression: result
+---
+orders__country | orders__created_at_day   | orders__count
+----------------+--------------------------+--------------
+New York        | 2025-01-10T00:00:00.000Z | 2            
+New York        | 2025-01-11T00:00:00.000Z | 1            
+Boston          | 2025-01-31T00:00:00.000Z | 1            
+Boston          | 2025-02-01T00:00:00.000Z | 2            
+Chicago         | 2025-02-15T00:00:00.000Z | 1            
+Chicago         | 2025-03-01T00:00:00.000Z | 2            
+New York        | 2025-03-02T00:00:00.000Z | 1

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
@@ -1368,3 +1368,60 @@ fn test_rollup_build_without_use_original_sql_pre_aggregations_in_pre_aggregatio
     );
     Ok(())
 }
+
+// A measure referenced only in ORDER BY (not in the selected measures) is dropped
+// from the ORDER BY when reading a pre-aggregation. CubeStore cannot ORDER BY an
+// aggregate of a rollup column that isn't projected, and the legacy planner
+// likewise ignores such keys, so the remaining keys (here the time dimension and
+// the selected dimension) drive the order. Mirrors the driver-test "partitioned
+// pre-agg" queries that order by `created_at asc, <unselected measure> desc, <dim> asc`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_order_by_only_measure_dropped_from_pre_agg() {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
+        .only_pre_aggregations(&["daily_countries_rollup"]);
+    let ctx = TestContext::new(schema).unwrap();
+
+    let query_yaml = indoc! {"
+        measures:
+          - orders.count
+        dimensions:
+          - orders.country
+        time_dimensions:
+          - dimension: orders.created_at
+            granularity: day
+        order:
+          - id: orders.created_at
+            desc: false
+          - id: orders.total_amount
+            desc: true
+          - id: orders.country
+            desc: false
+    "};
+
+    let (sql, pre_aggrs) = ctx
+        .build_sql_with_used_pre_aggregations(query_yaml)
+        .unwrap();
+
+    assert_eq!(pre_aggrs.len(), 1);
+    assert_eq!(pre_aggrs[0].name(), "daily_countries_rollup");
+    // total_amount is neither selected nor projected by the rollup read, so it must
+    // not appear in ORDER BY — neither as the base column nor the rollup column.
+    assert!(
+        !sql.contains("\"orders\".amount"),
+        "ORDER BY must not reference the base-table column, got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("orders__total_amount"),
+        "order-by-only measure must be dropped, not reference the rollup column, got:\n{sql}"
+    );
+
+    if let Some(result) = ctx
+        .try_execute(query_yaml, "pre_aggregation_matching_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(
+            "order_by_only_measure_dropped_from_pre_agg_cubestore_result",
+            result
+        );
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
@@ -15,9 +15,9 @@ use indoc::indoc;
 use std::rc::Rc;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_basic_pre_agg_sql() {
+async fn test_basic_pre_agg_sql() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregations_test.yaml");
-    let test_context = TestContext::new(schema).unwrap();
+    let test_context = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -28,9 +28,7 @@ async fn test_basic_pre_agg_sql() {
           - id: visitors.source
     "};
 
-    let (_sql, pre_aggrs) = test_context
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .expect("Should generate SQL without pre-aggregations");
+    let (_sql, pre_aggrs) = test_context.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1, "Should use one pre-aggregation");
     assert_eq!(pre_aggrs[0].name(), "daily_rollup");
@@ -41,13 +39,15 @@ async fn test_basic_pre_agg_sql() {
     {
         insta::assert_snapshot!("basic_pre_agg_sql_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_full_match_main_rollup() {
+async fn test_full_match_main_rollup() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["main_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -61,9 +61,7 @@ async fn test_full_match_main_rollup() {
           - id: orders.city
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "main_rollup");
@@ -74,13 +72,15 @@ async fn test_full_match_main_rollup() {
     {
         insta::assert_snapshot!("full_match_main_rollup_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_partial_match_main_rollup() {
+async fn test_partial_match_main_rollup() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["main_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -91,9 +91,7 @@ async fn test_partial_match_main_rollup() {
           - id: orders.status
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "main_rollup");
@@ -104,13 +102,15 @@ async fn test_partial_match_main_rollup() {
     {
         insta::assert_snapshot!("partial_match_main_rollup_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_full_match_non_additive_measure() {
+async fn test_full_match_non_additive_measure() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["main_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -123,9 +123,7 @@ async fn test_full_match_non_additive_measure() {
           - id: orders.city
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "main_rollup");
@@ -136,31 +134,33 @@ async fn test_full_match_non_additive_measure() {
     {
         insta::assert_snapshot!("full_match_non_additive_measure_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_no_match_non_additive_measure_partial() {
+fn test_no_match_non_additive_measure_partial() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["main_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.avg_amount
             dimensions:
               - orders.status
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_daily_rollup_full_match() {
+async fn test_daily_rollup_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["daily_countries_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -175,9 +175,7 @@ async fn test_daily_rollup_full_match() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "daily_countries_rollup");
@@ -188,13 +186,15 @@ async fn test_daily_rollup_full_match() {
     {
         insta::assert_snapshot!("daily_rollup_full_match_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_daily_rollup_coarser_granularity() {
+async fn test_daily_rollup_coarser_granularity() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["daily_countries_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -209,9 +209,7 @@ async fn test_daily_rollup_coarser_granularity() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "daily_countries_rollup");
@@ -222,16 +220,17 @@ async fn test_daily_rollup_coarser_granularity() {
     {
         insta::assert_snapshot!("daily_rollup_coarser_granularity_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_daily_rollup_finer_granularity_no_match() {
+fn test_daily_rollup_finer_granularity_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["daily_countries_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.count
             dimensions:
@@ -239,17 +238,18 @@ fn test_daily_rollup_finer_granularity_no_match() {
             time_dimensions:
               - dimension: orders.created_at
                 granularity: hour
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_daily_rollup_non_additive_full_match() {
+async fn test_daily_rollup_non_additive_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["daily_countries_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -264,9 +264,7 @@ async fn test_daily_rollup_non_additive_full_match() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "daily_countries_rollup");
@@ -280,16 +278,17 @@ async fn test_daily_rollup_non_additive_full_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_daily_rollup_non_additive_coarser_granularity_no_match() {
+fn test_daily_rollup_non_additive_coarser_granularity_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["daily_countries_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.avg_amount
             dimensions:
@@ -297,19 +296,20 @@ fn test_daily_rollup_non_additive_coarser_granularity_no_match() {
             time_dimensions:
               - dimension: orders.created_at
                 granularity: month
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 // --- multi_level_measure across different pre-aggregations ---
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_level_all_base_measures_full_match() {
+async fn test_multi_level_all_base_measures_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["all_base_measures_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -322,9 +322,7 @@ async fn test_multi_level_all_base_measures_full_match() {
           - id: orders.city
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "all_base_measures_rollup");
@@ -338,13 +336,15 @@ async fn test_multi_level_all_base_measures_full_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_level_all_base_measures_partial_match() {
+async fn test_multi_level_all_base_measures_partial_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["all_base_measures_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -355,9 +355,7 @@ async fn test_multi_level_all_base_measures_partial_match() {
           - id: orders.status
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "all_base_measures_rollup");
@@ -371,31 +369,33 @@ async fn test_multi_level_all_base_measures_partial_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_multi_level_calculated_measure_no_match() {
+fn test_multi_level_calculated_measure_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["calculated_measure_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.multi_level_measure
             dimensions:
               - orders.status
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_level_calculated_measure_full_match() {
+async fn test_multi_level_calculated_measure_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["calculated_measure_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -408,9 +408,7 @@ async fn test_multi_level_calculated_measure_full_match() {
           - id: orders.city
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "calculated_measure_rollup");
@@ -424,13 +422,15 @@ async fn test_multi_level_calculated_measure_full_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_level_mixed_measure_full_match() {
+async fn test_multi_level_mixed_measure_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["mixed_measure_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -443,9 +443,7 @@ async fn test_multi_level_mixed_measure_full_match() {
           - id: orders.city
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "mixed_measure_rollup");
@@ -459,31 +457,33 @@ async fn test_multi_level_mixed_measure_full_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_multi_level_mixed_measure_partial_no_match() {
+fn test_multi_level_mixed_measure_partial_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["mixed_measure_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.multi_level_measure
             dimensions:
               - orders.status
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_base_and_calculated_measure_full_match() {
+async fn test_base_and_calculated_measure_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["base_and_calculated_measure_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -496,9 +496,7 @@ async fn test_base_and_calculated_measure_full_match() {
           - id: orders.city
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "base_and_calculated_measure_rollup");
@@ -512,13 +510,15 @@ async fn test_base_and_calculated_measure_full_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_base_and_calculated_measure_parital_match() {
+async fn test_base_and_calculated_measure_parital_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["base_and_calculated_measure_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -529,9 +529,7 @@ async fn test_base_and_calculated_measure_parital_match() {
           - id: orders.status
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "base_and_calculated_measure_rollup");
@@ -545,6 +543,8 @@ async fn test_base_and_calculated_measure_parital_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 // --- Segment matching tests ---
@@ -555,10 +555,10 @@ async fn test_base_and_calculated_measure_parital_match() {
 // references no members (empty dependencies), so it's a constant filter on top
 // of the rollup and must not disqualify pre-aggregation matching.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_constant_member_expression_segment_keeps_pre_aggregation() {
+async fn test_constant_member_expression_segment_keeps_pre_aggregation() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["main_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -568,7 +568,7 @@ async fn test_constant_member_expression_segment_keeps_pre_aggregation() {
     "};
 
     let access_denied_segment = {
-        let sql: Rc<dyn MemberSql> = Rc::new(MockMemberSql::new("1 = 0").unwrap());
+        let sql: Rc<dyn MemberSql> = Rc::new(MockMemberSql::new("1 = 0")?);
         let expr = MockMemberExpressionDefinition::builder()
             .expression_name(Some("rlsAccessDenied".to_string()))
             .cube_name(Some("orders".to_string()))
@@ -577,9 +577,10 @@ async fn test_constant_member_expression_segment_keeps_pre_aggregation() {
         OptionsMember::MemberExpression(Rc::new(expr))
     };
 
-    let (sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations_with_segments(query_yaml, vec![access_denied_segment])
-        .unwrap();
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations_with_segments(
+        query_yaml,
+        vec![access_denied_segment],
+    )?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "main_rollup");
@@ -587,13 +588,15 @@ async fn test_constant_member_expression_segment_keeps_pre_aggregation() {
         sql.contains("1 = 0"),
         "expected the constant access-denied segment in SQL, got:\n{sql}"
     );
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_segment_full_match() {
+async fn test_segment_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["segment_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -610,9 +613,7 @@ async fn test_segment_full_match() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "segment_rollup");
@@ -623,13 +624,15 @@ async fn test_segment_full_match() {
     {
         insta::assert_snapshot!("segment_full_match_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_segment_partial_match_unused_segment() {
+async fn test_segment_partial_match_unused_segment() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["segment_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -644,9 +647,7 @@ async fn test_segment_partial_match_unused_segment() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "segment_rollup");
@@ -660,16 +661,17 @@ async fn test_segment_partial_match_unused_segment() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_segment_no_match_missing_in_pre_agg() {
+fn test_segment_no_match_missing_in_pre_agg() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["main_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.count
             dimensions:
@@ -677,19 +679,20 @@ fn test_segment_no_match_missing_in_pre_agg() {
               - orders.city
             segments:
               - orders.high_priority
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 // --- Custom granularity pre-aggregation tests ---
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_custom_granularity_full_match() {
+async fn test_custom_granularity_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["custom_half_year_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -704,9 +707,7 @@ async fn test_custom_granularity_full_match() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "custom_half_year_rollup");
@@ -717,13 +718,15 @@ async fn test_custom_granularity_full_match() {
     {
         insta::assert_snapshot!("custom_granularity_full_match_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_standard_pre_agg_coarser_custom_query() {
+async fn test_standard_pre_agg_coarser_custom_query() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["daily_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -738,9 +741,7 @@ async fn test_standard_pre_agg_coarser_custom_query() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "daily_rollup");
@@ -754,16 +755,17 @@ async fn test_standard_pre_agg_coarser_custom_query() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_custom_pre_agg_finer_query_no_match() {
+fn test_custom_pre_agg_finer_query_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["custom_half_year_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.count
             dimensions:
@@ -771,20 +773,20 @@ fn test_custom_pre_agg_finer_query_no_match() {
             time_dimensions:
               - dimension: orders.created_at
                 granularity: day
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[test]
-fn test_custom_pre_agg_finer_standard_query_no_match() {
+fn test_custom_pre_agg_finer_standard_query_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["custom_half_year_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.count
             dimensions:
@@ -792,17 +794,18 @@ fn test_custom_pre_agg_finer_standard_query_no_match() {
             time_dimensions:
               - dimension: orders.created_at
                 granularity: month
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_custom_granularity_non_additive_full_match() {
+async fn test_custom_granularity_non_additive_full_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["custom_half_year_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -817,9 +820,7 @@ async fn test_custom_granularity_non_additive_full_match() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "custom_half_year_rollup");
@@ -833,16 +834,17 @@ async fn test_custom_granularity_non_additive_full_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[test]
-fn test_custom_granularity_non_additive_coarser_no_match() {
+fn test_custom_granularity_non_additive_coarser_no_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["daily_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - orders.avg_amount
             dimensions:
@@ -850,17 +852,18 @@ fn test_custom_granularity_non_additive_coarser_no_match() {
             time_dimensions:
               - dimension: orders.created_at
                 granularity: half_year
-        "})
-        .unwrap();
+        "})?;
 
     assert!(pre_aggrs.is_empty());
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_custom_granularity_non_strict_self_match() {
+async fn test_custom_granularity_non_strict_self_match() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/custom_granularity_test.yaml")
         .only_pre_aggregations(&["custom_half_year_non_strict"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -872,9 +875,7 @@ async fn test_custom_granularity_non_strict_self_match() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "custom_half_year_non_strict");
@@ -888,13 +889,15 @@ async fn test_custom_granularity_non_strict_self_match() {
             result
         );
     }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_segment_with_coarser_granularity() {
+async fn test_segment_with_coarser_granularity() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["segment_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -911,9 +914,7 @@ async fn test_segment_with_coarser_granularity() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "segment_rollup");
@@ -924,14 +925,17 @@ async fn test_segment_with_coarser_granularity() {
     {
         insta::assert_snapshot!("segment_with_coarser_granularity_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 // --- Multi-stage count_distinct sum by quarter with pre-aggregation ---
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_stage_count_distinct_sum_by_quarter_with_pre_aggregation() {
+async fn test_multi_stage_count_distinct_sum_by_quarter_with_pre_aggregation(
+) -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/multi_stage_sum_by_quarter_test.yaml");
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -939,9 +943,7 @@ async fn test_multi_stage_count_distinct_sum_by_quarter_with_pre_aggregation() {
         cubestoreSupportMultistage: true
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "main");
@@ -955,14 +957,16 @@ async fn test_multi_stage_count_distinct_sum_by_quarter_with_pre_aggregation() {
             result
         );
     }
+
+    Ok(())
 }
 
 // --- Multi-stage with separate pre-aggregations ---
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_stage_separate_pre_aggregations() {
+async fn test_multi_stage_separate_pre_aggregations() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/multi_stage_separate_pre_aggs_test.yaml");
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -971,9 +975,7 @@ async fn test_multi_stage_separate_pre_aggregations() {
         cubestoreSupportMultistage: true
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 2, "Expected 2 pre-aggregation usages");
 
@@ -998,14 +1000,16 @@ async fn test_multi_stage_separate_pre_aggregations() {
     {
         insta::assert_snapshot!("multi_stage_separate_pre_aggs_cubestore_result", result);
     }
+
+    Ok(())
 }
 
 // --- Multi-stage with separate pre-aggregations and time shift ---
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_multi_stage_separate_pre_aggs_with_time_shift() {
+async fn test_multi_stage_separate_pre_aggs_with_time_shift() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/multi_stage_pre_agg_time_shift_test.yaml");
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -1022,9 +1026,7 @@ async fn test_multi_stage_separate_pre_aggs_with_time_shift() {
           - id: orders.created_at
     "};
 
-    let (_sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 2, "Expected 2 pre-aggregation usages");
 
@@ -1067,24 +1069,24 @@ async fn test_multi_stage_separate_pre_aggs_with_time_shift() {
             result
         );
     }
+
+    Ok(())
 }
 
 // --- rollupJoin with calculated measures through view ---
 
 #[test]
-fn test_rollup_join_calculated_measures_through_view() {
+fn test_rollup_join_calculated_measures_through_view() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/rollup_join_calculated_measures.yaml");
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
-    let (sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(indoc! {"
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(indoc! {"
             measures:
               - my_view.facts_avg_cost
             time_dimensions:
               - dimension: my_view.facts_day
                 granularity: day
-        "})
-        .unwrap();
+        "})?;
 
     let pre_agg_names: Vec<_> = pre_aggrs
         .iter()
@@ -1113,6 +1115,8 @@ fn test_rollup_join_calculated_measures_through_view() {
         "SQL should reference li_rollup, got:\n{}",
         sql
     );
+
+    Ok(())
 }
 
 // A rolling-window count_distinct_approx whose pre-aggregation stores the
@@ -1121,11 +1125,10 @@ fn test_rollup_join_calculated_measures_through_view() {
 // across the window and finalize to a cardinality. This pins the state
 // branch — the read must NOT collapse the state to a cardinality too early.
 #[test]
-fn test_count_distinct_approx_rolling_pre_agg_keeps_state() {
+fn test_count_distinct_approx_rolling_pre_agg_keeps_state() -> Result<(), CubeError> {
     let ctx = TestContext::new(MockSchema::from_yaml_file(
         "common/integration_rolling_window.yaml",
-    ))
-    .unwrap();
+    ))?;
 
     let query = indoc! {r#"
         measures:
@@ -1141,7 +1144,7 @@ fn test_count_distinct_approx_rolling_pre_agg_keeps_state() {
         cubestoreSupportMultistage: true
     "#};
 
-    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query).unwrap();
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "approx_rolling");
@@ -1158,6 +1161,8 @@ fn test_count_distinct_approx_rolling_pre_agg_keeps_state() {
         "Rolling window should finalize merged states to a cardinality, got:\n{}",
         sql
     );
+
+    Ok(())
 }
 
 // --- HLL count_distinct_approx through a pre-aggregation ---
@@ -1175,10 +1180,10 @@ fn test_count_distinct_approx_rolling_pre_agg_keeps_state() {
 //   count_distinct_approx  -> round(hll_cardinality(hll_add_agg(hll_hash_any(x))))
 
 #[test]
-fn test_count_distinct_approx_pre_agg_read_merges_state() {
+fn test_count_distinct_approx_pre_agg_read_merges_state() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["approx_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -1188,9 +1193,7 @@ fn test_count_distinct_approx_pre_agg_read_merges_state() {
           - orders.city
     "};
 
-    let (sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "approx_rollup");
@@ -1208,13 +1211,15 @@ fn test_count_distinct_approx_pre_agg_read_merges_state() {
         "Read query should not re-init HLL from the state column, got:\n{}",
         sql
     );
+
+    Ok(())
 }
 
 #[test]
-fn test_count_distinct_approx_pre_agg_build_emits_state() {
+fn test_count_distinct_approx_pre_agg_build_emits_state() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["approx_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     // pre_aggregation_query: true renders the rollup build (load) SQL.
     let query_yaml = indoc! {"
@@ -1226,7 +1231,7 @@ fn test_count_distinct_approx_pre_agg_build_emits_state() {
         pre_aggregation_query: true
     "};
 
-    let sql = ctx.build_sql(query_yaml).unwrap();
+    let sql = ctx.build_sql(query_yaml)?;
 
     // The build must serialize the HLL state (hll_init) without merging
     // or taking its cardinality — that happens only on read.
@@ -1245,6 +1250,8 @@ fn test_count_distinct_approx_pre_agg_build_emits_state() {
         "Build SQL should not merge states, got:\n{}",
         sql
     );
+
+    Ok(())
 }
 
 // A multi-stage measure that sums a count_distinct_approx must read the
@@ -1252,9 +1259,9 @@ fn test_count_distinct_approx_pre_agg_build_emits_state() {
 // pre-aggregation — the outer `sum` aggregates counts, not raw HLL states.
 // This pins that the pre-agg read does not leak a bare merged state here.
 #[test]
-fn test_count_distinct_approx_multistage_pre_agg_reads_cardinality() {
+fn test_count_distinct_approx_multistage_pre_agg_reads_cardinality() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/multi_stage_sum_by_quarter_test.yaml");
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -1262,9 +1269,7 @@ fn test_count_distinct_approx_multistage_pre_agg_reads_cardinality() {
         cubestoreSupportMultistage: true
     "};
 
-    let (sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "main_approx");
@@ -1276,6 +1281,8 @@ fn test_count_distinct_approx_multistage_pre_agg_reads_cardinality() {
         "Multi-stage leaf should finalize HLL to cardinality, got:\n{}",
         sql
     );
+
+    Ok(())
 }
 
 // A cube `foo` whose `originalSql` pre-aggregation (`main`) materializes its base
@@ -1376,10 +1383,10 @@ fn test_rollup_build_without_use_original_sql_pre_aggregations_in_pre_aggregatio
 // the selected dimension) drive the order. Mirrors the driver-test "partitioned
 // pre-agg" queries that order by `created_at asc, <unselected measure> desc, <dim> asc`.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_order_by_only_measure_dropped_from_pre_agg() {
+async fn test_order_by_only_measure_dropped_from_pre_agg() -> Result<(), CubeError> {
     let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
         .only_pre_aggregations(&["daily_countries_rollup"]);
-    let ctx = TestContext::new(schema).unwrap();
+    let ctx = TestContext::new(schema)?;
 
     let query_yaml = indoc! {"
         measures:
@@ -1398,9 +1405,7 @@ async fn test_order_by_only_measure_dropped_from_pre_agg() {
             desc: false
     "};
 
-    let (sql, pre_aggrs) = ctx
-        .build_sql_with_used_pre_aggregations(query_yaml)
-        .unwrap();
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "daily_countries_rollup");
@@ -1424,4 +1429,6 @@ async fn test_order_by_only_measure_dropped_from_pre_agg() {
             result
         );
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Problem

A measure referenced only in `ORDER BY` (not in the selected measures) cannot be served from a pre-aggregation read: CubeStore's DataFusion rejects an `ORDER BY` that aggregates a rollup column which isn't in the `SELECT` projection, failing with e.g. `No field named e_commerce___t_a_external.ec__total_profit`.

## Fix

The legacy planner silently ignores order-by members that aren't selected, and the driver-test snapshots (shared between the legacy and Tesseract jobs) reflect that — they order by the remaining keys only. Match that behavior: when reading from a pre-aggregation, drop `ORDER BY` keys whose member is a measure not present in the selection, so the remaining dimensions/time dimensions drive the order.

This supersedes the previous attempt (reverted in the preceding commit) that matched the order-by measure into the pre-aggregation and referenced its rollup column — which both hit the CubeStore limitation above and would have diverged from the shared snapshots.

## Generated SQL

Example query reading the `daily_countries_rollup` pre-aggregation, ordered by `created_at asc, total_amount desc, country asc` — where `total_amount` is **not** in the selected measures:

**Before (broken):**

```sql
SELECT "orders__country" "orders__country",
       date_trunc('day', "orders__created_at_day") "orders__created_at_day",
       sum("orders__count") "orders__count"
FROM orders__daily_countries_rollup__usage_0 AS "orders__daily_countries_rollup"
GROUP BY 1, 2
ORDER BY 2 ASC, sum("orders".amount) DESC, 1 ASC
```

The middle key `sum("orders".amount)` is rendered from the measure's **base-table** SQL — a column (`orders.amount`) that does not exist on the rollup table `orders__daily_countries_rollup`. CubeStore rejects it with `No field named ...`.

**After (fixed):**

```sql
SELECT "orders__country" "orders__country",
       date_trunc('day', "orders__created_at_day") "orders__created_at_day",
       sum("orders__count") "orders__count"
FROM orders__daily_countries_rollup__usage_0 AS "orders__daily_countries_rollup"
GROUP BY 1, 2
ORDER BY 2 ASC, 1 ASC
```

The order-by-only measure is dropped; the remaining projected keys — `created_at_day` (position `2`) then `country` (position `1`) — drive the order, matching the legacy planner and the shared driver-test snapshots.

## Tests

Adds `test_order_by_only_measure_dropped_from_pre_agg`, which:

- asserts the dropped measure appears in the generated SQL neither as the base-table column (`"orders".amount`) nor as the rollup column (`orders__total_amount`), and
- validates execution against CubeStore via the `try_execute` integration path (`integration-cubestore`), with a snapshot of the result.
