### PR TITLE
fix(tesseract): read rollup column for ungrouped pre-aggregation measures

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/factory.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan/sql_nodes/factory.rs
@@ -255,6 +255,21 @@ impl SqlNodesFactory {
         );
         RenderReferencesSqlNode::new(root_node, self.render_references.clone())
     }
+
+    /// When an ungrouped query reads from a pre-aggregation, a measure must
+    /// resolve to its stored rollup column. Unlike the grouped case, the column
+    /// already holds the aggregated value and is returned as-is, so it's a plain
+    /// column reference with no `sum()` wrap. Wrapping the ungrouped node keeps
+    /// the reference outermost so the measure is intercepted before it would
+    /// otherwise re-render its base-table SQL.
+    fn wrap_ungrouped_pre_aggregation_measure(&self, node: Rc<dyn SqlNode>) -> Rc<dyn SqlNode> {
+        if !self.pre_aggregation_measures_references.is_empty() {
+            RenderReferencesSqlNode::new(node, self.pre_aggregation_measures_references.clone())
+        } else {
+            node
+        }
+    }
+
     fn add_ungrouped_measure_reference_if_needed(
         &self,
         default: Rc<dyn SqlNode>,
@@ -288,9 +303,11 @@ impl SqlNodesFactory {
 
     fn final_measure_node_processor(&self, input: Rc<dyn SqlNode>) -> Rc<dyn SqlNode> {
         if self.ungrouped_measure {
-            UngroupedMeasureSqlNode::new(input)
+            self.wrap_ungrouped_pre_aggregation_measure(UngroupedMeasureSqlNode::new(input))
         } else if self.ungrouped {
-            UngroupedQueryFinalMeasureSqlNode::new(input)
+            self.wrap_ungrouped_pre_aggregation_measure(UngroupedQueryFinalMeasureSqlNode::new(
+                input,
+            ))
         } else {
             let final_processor: Rc<dyn SqlNode> =
                 FinalMeasureSqlNode::new(input.clone(), self.count_approx_as_state);

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_pre_agg_measure_reads_rollup_column_cubestore_result.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__ungrouped_pre_agg_measure_reads_rollup_column_cubestore_result.snap
@@ -1,0 +1,13 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+expression: result
+---
+orders__status | orders__city | orders__total_amount
+---------------+--------------+---------------------
+cancelled      | Chicago      | 25                  
+completed      | Boston       | 375                 
+completed      | Chicago      | 400                 
+completed      | New York     | 150                 
+pending        | Boston       | 150                 
+pending        | Chicago      | 175                 
+pending        | New York     | 260

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
@@ -1432,3 +1432,49 @@ async fn test_order_by_only_measure_dropped_from_pre_agg() -> Result<(), CubeErr
 
     Ok(())
 }
+
+// An ungrouped query reading from a rollup must reference the stored measure
+// column as-is (no `sum()`), not re-render the measure's base-table SQL.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_pre_agg_measure_reads_rollup_column() -> Result<(), CubeError> {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregation_matching_test.yaml")
+        .only_pre_aggregations(&["main_rollup"]);
+    let ctx = TestContext::new(schema)?;
+
+    let query_yaml = indoc! {"
+        measures:
+          - orders.total_amount
+        dimensions:
+          - orders.status
+          - orders.city
+        ungrouped: true
+        order:
+          - id: orders.status
+          - id: orders.city
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(pre_aggrs.len(), 1);
+    assert_eq!(pre_aggrs[0].name(), "main_rollup");
+    assert!(
+        sql.contains("\"orders__total_amount\" \"orders__total_amount\""),
+        "ungrouped measure should project the rollup column, got:\n{sql}"
+    );
+    assert!(
+        !sql.contains("\"orders\".amount"),
+        "ungrouped measure must not reference the base-table column, got:\n{sql}"
+    );
+
+    if let Some(result) = ctx
+        .try_execute(query_yaml, "pre_aggregation_matching_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!(
+            "ungrouped_pre_agg_measure_reads_rollup_column_cubestore_result",
+            result
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required (N/A — internal SQL-planner fix)

**Description of Changes Made**

### Problem

When an **ungrouped** query (`ungrouped: true`) matched a pre-aggregation, the measure was rendered through the ungrouped measure nodes *without* the pre-aggregation reference substitution. The planner therefore emitted the measure's base-table SQL (e.g. the raw `amount` column) instead of the stored rollup column, and reading the rollup failed with a schema error such as `No field named big_e_commerce.sales`.

The dimensions were already substituted correctly — only the ungrouped **measure** node bypassed the pre-aggregation reference map.

### Fix

Wrap the ungrouped measure nodes (`UngroupedMeasureSqlNode` / `UngroupedQueryFinalMeasureSqlNode`) with the pre-aggregation reference map when reading from a rollup, so the measure resolves to its stored column. Unlike the grouped case, the stored column already holds the aggregated value and is returned as-is — a plain column reference, with no `sum()` wrap.

### Generated SQL (before / after)

For a query selecting `orders.total_amount` by `orders.status` / `orders.city` with `ungrouped: true`, matching `main_rollup`:

**Before** (broken — `"orders".amount` is not in scope; only the rollup is):
```sql
SELECT "orders__status" "orders__status",
       "orders__city" "orders__city",
       "orders".amount "orders__total_amount"
FROM orders__main_rollup__usage_0 AS "orders__main_rollup"
ORDER BY 1 ASC, 2 ASC
```

**After** (reads the stored rollup column):
```sql
SELECT "orders__status" "orders__status",
       "orders__city" "orders__city",
       "orders__total_amount" "orders__total_amount"
FROM orders__main_rollup__usage_0 AS "orders__main_rollup"
ORDER BY 1 ASC, 2 ASC
```

### Tests

Adds `test_ungrouped_pre_agg_measure_reads_rollup_column` to the cubesqlplanner pre-aggregation integration suite. It asserts the rollup column is projected (and the base-table column is not), and executes the query end-to-end against a **live CubeStore** instance (`--features cubesqlplanner/integration-cubestore`), snapshotting the result.
