### PR TITLE
fix(tesseract): preserve FILTER_PARAMS pushdown with segments

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/sql-generation.test.ts
@@ -5770,4 +5770,62 @@ cubes:
       },
     ]);
   });
+
+  if (getEnv('nativeSqlPlanner')) {
+    describe('FILTER_PARAMS with segments under Tesseract', () => {
+      const fpCompilers = prepareJsCompiler(`
+        cube('orders_fp', {
+          sql: \`
+            SELECT * FROM orders
+            WHERE \${FILTER_PARAMS.orders_fp.created_at.filter('created_at')}
+              AND \${FILTER_PARAMS.orders_fp.status.filter('status')}
+          \`,
+          measures: {
+            count: { type: 'count' },
+          },
+          dimensions: {
+            id: { sql: 'id', type: 'number', primaryKey: true },
+            status: { sql: 'status', type: 'string' },
+            created_at: { sql: 'created_at', type: 'time' },
+          },
+          segments: {
+            completed: { sql: \`\${CUBE}.status = 'completed'\` },
+          },
+        });
+      `);
+
+      it('FILTER_PARAMS pushdown is preserved when a segment is present', async () => {
+        await fpCompilers.compiler.compile();
+        const query = new PostgresQuery(fpCompilers, {
+          measures: ['orders_fp.count'],
+          segments: ['orders_fp.completed'],
+          filters: [
+            { member: 'orders_fp.status', operator: 'equals', values: ['completed'] },
+          ],
+          timeDimensions: [{
+            dimension: 'orders_fp.created_at',
+            dateRange: ['2024-01-01', '2024-01-31'],
+          }],
+          timezone: 'UTC',
+        });
+
+        const [sql] = query.buildSqlAndParams();
+
+        // A dropped FILTER_PARAMS renders as `1 = 1` (always_true). The segment
+        // and the outer filters always render real predicates, so `1 = 1` can
+        // only come from a FILTER_PARAMS that failed to push down. Its absence
+        // proves both placeholders received their predicates (full or partial
+        // loss would leave at least one `1 = 1`).
+        expect(sql).not.toMatch(/1\s*=\s*1/);
+
+        // The predicates must land inside the cube's base subquery
+        // (`FROM orders WHERE ...`), before it is aliased as the cube — not
+        // only on the outer query, where they appear regardless of pushdown.
+        const innerStart = sql.indexOf('FROM orders');
+        const innerSql = sql.slice(innerStart, sql.indexOf('orders_fp', innerStart));
+        expect(innerSql).toMatch(/created_at\s*>=/);
+        expect(innerSql).toMatch(/status\s*=/);
+      });
+    });
+  }
 });

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/tree.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/tree.rs
@@ -42,6 +42,10 @@ pub enum FilterItem {
     Segment(Rc<BaseSegment>),
 }
 
+/// Whether a recursive `find_subtree_for_members` call matched every node
+/// without pruning anything (segments, non-matching items, etc.).
+type FullMatch = bool;
+
 /// Top-level filter tree of a query — its `items` are implicitly
 /// AND-joined.
 #[derive(Clone)]
@@ -105,39 +109,23 @@ impl FilterItem {
         }
     }
 
-    // Extracts all member symbols from this filter tree.
-    // Returns None when the tree is invalid (e.g. an empty group, or
-    // anything below a Segment item), Some(members) otherwise.
-    fn extract_filter_members(&self) -> Option<Vec<Rc<MemberSymbol>>> {
-        match self {
-            FilterItem::Group(group) => {
-                // Empty groups are considered invalid
-                if group.items.is_empty() {
-                    return None;
-                }
-
-                let mut all_members = Vec::new();
-
-                // Recursively extract from all children
-                for child in &group.items {
-                    match child.extract_filter_members() {
-                        None => return None, // If any child is invalid, entire tree is invalid
-                        Some(mut members) => all_members.append(&mut members),
-                    }
-                }
-
-                Some(all_members)
-            }
-            FilterItem::Item(item) => Some(vec![item.member_evaluator().clone()]),
-            FilterItem::Segment(_) => None,
-        }
+    /// Returns the largest subtree that only references the given
+    /// `target_members`, or `None` if no such subtree exists.
+    ///
+    /// Partial matching is only supported for AND groups. OR groups are
+    /// preserved only when all of their children match the target members.
+    ///
+    /// `Segment` nodes are skipped during extraction — they do not prevent
+    /// sibling member filters from being collected in AND groups.
+    pub fn find_subtree_for_members(&self, target_members: &[&String]) -> Option<FilterItem> {
+        self.find_subtree_for_members_inner(target_members)
+            .map(|(filter_item, _)| filter_item)
     }
 
-    /// Returns the largest subtree that only references the given
-    /// `target_members`, or `None` if no such subtree exists. Only
-    /// AND groups are traversed for partial matching — OR groups
-    /// either match as a whole or are dropped.
-    pub fn find_subtree_for_members(&self, target_members: &[&String]) -> Option<FilterItem> {
+    fn find_subtree_for_members_inner(
+        &self,
+        target_members: &[&String],
+    ) -> Option<(FilterItem, FullMatch)> {
         match self {
             FilterItem::Group(group) => {
                 // Empty groups return None
@@ -145,47 +133,57 @@ impl FilterItem {
                     return None;
                 }
 
-                // Extract all members from this filter subtree
-                let filter_members = self.extract_filter_members()?;
+                match group.operator {
+                    FilterGroupOperator::And => {
+                        let mut matching_children = Vec::new();
+                        let mut all_children_fully_match = true;
 
-                // Check if all members in this filter are in the target set
-                let all_members_match = filter_members.iter().all(|member| {
-                    target_members.iter().any(|target| {
-                        &&member.clone().resolve_reference_chain().full_name() == target
-                    })
-                });
+                        for child in &group.items {
+                            match child.find_subtree_for_members_inner(target_members) {
+                                Some((matching_child, child_fully_matched)) => {
+                                    matching_children.push(matching_child);
+                                    all_children_fully_match &= child_fully_matched;
+                                }
+                                None => all_children_fully_match = false,
+                            }
+                        }
 
-                if all_members_match {
-                    // All members match - return this entire filter subtree
-                    return Some(self.clone());
-                }
+                        if matching_children.is_empty() {
+                            return None;
+                        }
 
-                // Only process AND groups for partial matching
-                if group.operator == FilterGroupOperator::And {
-                    let matching_children: Vec<FilterItem> = group
-                        .items
-                        .iter()
-                        .filter_map(|child| child.find_subtree_for_members(target_members))
-                        .collect();
+                        if all_children_fully_match {
+                            // Every child matches, so preserve the original group shape.
+                            return Some((self.clone(), true));
+                        }
 
-                    if matching_children.is_empty() {
-                        return None;
+                        if matching_children.len() == 1 {
+                            // Single match - return it directly without wrapping.
+                            return Some((matching_children.into_iter().next().unwrap(), false));
+                        }
+
+                        // Multiple matches - wrap in a new AND group.
+                        Some((
+                            FilterItem::Group(Rc::new(FilterGroup::new(
+                                FilterGroupOperator::And,
+                                matching_children,
+                            ))),
+                            false,
+                        ))
                     }
+                    FilterGroupOperator::Or => {
+                        // OR groups can only be preserved if every child matches.
+                        for child in &group.items {
+                            let (_, child_fully_matched) =
+                                child.find_subtree_for_members_inner(target_members)?;
+                            if !child_fully_matched {
+                                return None;
+                            }
+                        }
 
-                    if matching_children.len() == 1 {
-                        // Single match - return it directly without wrapping
-                        return Some(matching_children.into_iter().next().unwrap());
+                        Some((self.clone(), true))
                     }
-
-                    // Multiple matches - wrap in new AND group
-                    return Some(FilterItem::Group(Rc::new(FilterGroup::new(
-                        FilterGroupOperator::And,
-                        matching_children,
-                    ))));
                 }
-
-                // OR groups are not supported
-                None
             }
             FilterItem::Item(item) => {
                 let member = item.member_evaluator();
@@ -195,7 +193,7 @@ impl FilterItem {
                     .iter()
                     .any(|target| &&member.clone().resolve_reference_chain().full_name() == target)
                 {
-                    Some(self.clone())
+                    Some((self.clone(), true))
                 } else {
                     None
                 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/utils/debug.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/utils/debug.rs
@@ -6,6 +6,7 @@ use crate::planner::DebugSql;
 use crate::test_fixtures::cube_bridge::MockSchema;
 use crate::test_fixtures::test_utils::TestContext;
 use cubenativeutils::CubeError;
+use std::rc::Rc;
 
 #[test]
 fn test_dimension_basic() {
@@ -253,4 +254,217 @@ fn test_filter_group_and_collapsed() {
     let expected =
         "AND: [\n  {visitors.source} equals: ['google'],\n  {visitors.id} gt: ['100']\n]";
     assert_eq!(sql, expected);
+}
+
+#[test]
+fn test_find_subtree_for_members_excludes_segments_from_and_group() {
+    let schema = MockSchema::from_yaml_file("common/integration_basic.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+    let city_symbol = ctx.create_symbol("customers.city").unwrap();
+    let amount_symbol = ctx.create_symbol("orders.amount").unwrap();
+
+    let city_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        city_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Equal,
+        Some(vec![FilterValue::Str("New York".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let amount_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        amount_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Gte,
+        Some(vec![FilterValue::Str("100".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let completed_segment = ctx.create_segment("orders.completed_orders").unwrap();
+
+    let filter_tree = FilterItem::Group(Rc::new(FilterGroup::new(
+        FilterGroupOperator::And,
+        vec![
+            FilterItem::Item(city_filter),
+            FilterItem::Item(amount_filter),
+            FilterItem::Segment(completed_segment),
+        ],
+    )));
+
+    let city_member = city_symbol.clone().resolve_reference_chain().full_name();
+    let amount_member = amount_symbol.clone().resolve_reference_chain().full_name();
+    let targets = vec![&city_member, &amount_member];
+
+    let subtree = filter_tree
+        .find_subtree_for_members(&targets)
+        .expect("matching filters should still be extracted");
+
+    assert_eq!(
+        subtree.debug_sql(false),
+        "AND: [\n  {customers.city} equals: ['New York'],\n  {orders.amount} gte: ['100']\n]"
+    );
+}
+
+#[test]
+fn test_find_subtree_for_members_keeps_or_groups_all_or_nothing() {
+    let schema = MockSchema::from_yaml_file("common/integration_basic.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+    let city_symbol = ctx.create_symbol("customers.city").unwrap();
+
+    let city_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        city_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Equal,
+        Some(vec![FilterValue::Str("New York".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let completed_segment = ctx.create_segment("orders.completed_orders").unwrap();
+
+    let filter_tree = FilterItem::Group(Rc::new(FilterGroup::new(
+        FilterGroupOperator::Or,
+        vec![
+            FilterItem::Item(city_filter),
+            FilterItem::Segment(completed_segment),
+        ],
+    )));
+
+    let city_member = city_symbol.clone().resolve_reference_chain().full_name();
+    let targets = vec![&city_member];
+
+    assert!(
+        filter_tree.find_subtree_for_members(&targets).is_none(),
+        "partial matches should not be extracted from OR groups"
+    );
+}
+
+#[test]
+fn test_find_subtree_for_members_rejects_or_groups_with_partially_matching_children() {
+    let schema = MockSchema::from_yaml_file("common/integration_basic.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+    let city_symbol = ctx.create_symbol("customers.city").unwrap();
+    let amount_symbol = ctx.create_symbol("orders.amount").unwrap();
+
+    let city_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        city_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Equal,
+        Some(vec![FilterValue::Str("New York".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let amount_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        amount_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Gte,
+        Some(vec![FilterValue::Str("100".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let completed_segment = ctx.create_segment("orders.completed_orders").unwrap();
+
+    let partially_matching_branch = FilterItem::Group(Rc::new(FilterGroup::new(
+        FilterGroupOperator::And,
+        vec![
+            FilterItem::Item(city_filter),
+            FilterItem::Segment(completed_segment),
+        ],
+    )));
+
+    let filter_tree = FilterItem::Group(Rc::new(FilterGroup::new(
+        FilterGroupOperator::Or,
+        vec![partially_matching_branch, FilterItem::Item(amount_filter)],
+    )));
+
+    let city_member = city_symbol.clone().resolve_reference_chain().full_name();
+    let amount_member = amount_symbol.clone().resolve_reference_chain().full_name();
+    let targets = vec![&city_member, &amount_member];
+
+    assert!(
+        filter_tree.find_subtree_for_members(&targets).is_none(),
+        "OR groups should only match when every branch matches without pruning"
+    );
+}
+
+#[test]
+fn test_find_subtree_for_members_segment_only_and_group_returns_none() {
+    let schema = MockSchema::from_yaml_file("common/integration_basic.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+
+    let completed_segment = ctx.create_segment("orders.completed_orders").unwrap();
+
+    let filter_tree = FilterItem::Group(Rc::new(FilterGroup::new(
+        FilterGroupOperator::And,
+        vec![FilterItem::Segment(completed_segment)],
+    )));
+
+    let dummy_member = "orders.amount".to_string();
+    let targets = vec![&dummy_member];
+
+    assert!(
+        filter_tree.find_subtree_for_members(&targets).is_none(),
+        "AND group containing only segments should return None"
+    );
+}
+
+#[test]
+fn test_find_subtree_for_members_all_matching_and_group_preserves_group() {
+    let schema = MockSchema::from_yaml_file("common/integration_basic.yaml");
+    let ctx = TestContext::new(schema).unwrap();
+    let city_symbol = ctx.create_symbol("customers.city").unwrap();
+    let amount_symbol = ctx.create_symbol("orders.amount").unwrap();
+
+    let city_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        city_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Equal,
+        Some(vec![FilterValue::Str("New York".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let amount_filter = BaseFilter::try_new(
+        ctx.query_tools().query_tools().clone(),
+        amount_symbol.clone(),
+        crate::planner::filter::base_filter::FilterType::Dimension,
+        FilterOperator::Gte,
+        Some(vec![FilterValue::Str("100".to_string())]),
+        None,
+    )
+    .unwrap();
+
+    let filter_tree = FilterItem::Group(Rc::new(FilterGroup::new(
+        FilterGroupOperator::And,
+        vec![
+            FilterItem::Item(city_filter),
+            FilterItem::Item(amount_filter),
+        ],
+    )));
+
+    let city_member = city_symbol.clone().resolve_reference_chain().full_name();
+    let amount_member = amount_symbol.clone().resolve_reference_chain().full_name();
+    let targets = vec![&city_member, &amount_member];
+
+    let subtree = filter_tree
+        .find_subtree_for_members(&targets)
+        .expect("fully matching AND group should be returned");
+
+    let expected_sql =
+        "AND: [\n  {customers.city} equals: ['New York'],\n  {orders.amount} gte: ['100']\n]";
+    assert_eq!(subtree.debug_sql(false), expected_sql);
+
+    assert!(
+        subtree == filter_tree,
+        "fully matching group should be structurally identical to the original"
+    );
 }


### PR DESCRIPTION
## Summary

Under the native Tesseract planner, adding a **segment** to a query disabled `FILTER_PARAMS` pushdown into a cube's base `sql`: the placeholders rendered as `1 = 1` instead of the real predicates, so the inner subquery scanned everything and only the outer query filtered — a latency/scan-volume regression (results stayed correct).

Root cause: `find_subtree_for_members` called `extract_filter_members()?`, which returned `None` for any `Segment` node and short-circuited the entire AND group, falling back to `always_true()` (`1 = 1`).

This ports the customer-authored fix from #10608 (commit by **@hank-sq**, Hank Ditton) onto current `master` — a straight rebase wasn't viable since every Rust file the original PR touched has since been moved/renamed by intervening refactors. Huge thanks to @hank-sq for the diagnosis and the original fix.

## Changes

- Drop `extract_filter_members`; rewrite `find_subtree_for_members` via an inner helper returning `(FilterItem, FullMatch)`. AND groups now prune non-matching children and skip segments instead of bailing out; OR groups are preserved only when every child fully matches.
- Add 5 unit tests covering segment siblings in AND groups, all-or-nothing OR groups, partially-matching OR branches, segment-only groups, and fully-matching group preservation.
- Add an integration test asserting the predicates are pushed into the cube's base subquery (and that no `1 = 1` fallback leaks).

## Testing

- `cargo test -p cubesqlplanner` — 5 new unit tests green, full planner lib suite green.
- Schema-compiler integration test under `CUBEJS_TESSERACT_SQL_PLANNER=true` passes; verified it **fails** on the pre-fix planner (inner `WHERE 1 = 1 AND 1 = 1`) and passes after, with the real SQL confirming `FILTER_PARAMS` land inside the base subquery.

## Credits

Original fix and root-cause analysis by @hank-sq (Hank Ditton) in #10608 — thank you!
