### PR TITLE
fix(tesseract): Per branch aliases in rollupLambda unions

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/compiled_pre_aggregation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/compiled_pre_aggregation.rs
@@ -20,7 +20,21 @@ pub struct PreAggregationJoin {
 
 #[derive(Clone, Debug)]
 pub struct PreAggregationUnion {
-    pub items: Vec<Rc<PreAggregationTable>>,
+    pub items: Vec<PreAggregationUnionItem>,
+}
+
+/// A single member rollup of a `rollupLambda` union, paired with the
+/// member symbols of *that* rollup. The lambda exposes the first member
+/// rollup's symbols, but each branch stores its columns under its own
+/// cube aliases (e.g. `requests_stream__tenant_id` vs `requests__tenant_id`),
+/// so the physical builder needs each branch's own symbols to read the
+/// right column while projecting the lambda's unified alias.
+#[derive(Clone, Debug)]
+pub struct PreAggregationUnionItem {
+    pub table: Rc<PreAggregationTable>,
+    pub measures: Vec<Rc<MemberSymbol>>,
+    pub dimensions: Vec<Rc<MemberSymbol>>,
+    pub time_dimensions: Vec<Rc<MemberSymbol>>,
 }
 
 #[derive(Clone, Debug)]

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/optimizer.rs
@@ -414,11 +414,14 @@ impl PreAggregationOptimizer {
                 let items = union
                     .items
                     .iter()
-                    .map(|t| {
-                        Rc::new(PreAggregationTable {
+                    .map(|item| PreAggregationUnionItem {
+                        table: Rc::new(PreAggregationTable {
                             usage_index: Some(usage_index),
-                            ..t.as_ref().clone()
-                        })
+                            ..item.table.as_ref().clone()
+                        }),
+                        measures: item.measures.clone(),
+                        dimensions: item.dimensions.clone(),
+                        time_dimensions: item.time_dimensions.clone(),
                     })
                     .collect();
                 Rc::new(PreAggregationSource::Union(PreAggregationUnion { items }))

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -7,6 +7,7 @@ use crate::logical_plan::PreAggregationJoin;
 use crate::logical_plan::PreAggregationJoinItem;
 use crate::logical_plan::PreAggregationTable;
 use crate::logical_plan::PreAggregationUnion;
+use crate::logical_plan::PreAggregationUnionItem;
 use crate::planner::join_hints::JoinHints;
 use crate::planner::multi_fact_join_groups::{MeasuresJoinHints, MultiFactJoinGroups};
 use crate::planner::planners::JoinPlanner;
@@ -302,13 +303,22 @@ impl PreAggregationsCompiler {
         for (i, rollup) in pre_aggrs_for_lambda.clone().iter().enumerate() {
             match rollup.source.as_ref() {
                 PreAggregationSource::Single(table) => {
-                    sources.push(Rc::new(table.clone()));
+                    // Carry this branch's own symbols: each member rollup stores its
+                    // columns under its own cube aliases, while the lambda exposes the
+                    // first rollup's symbols. The physical builder maps lambda members
+                    // to each branch's stored column through these.
+                    sources.push(PreAggregationUnionItem {
+                        table: Rc::new(table.clone()),
+                        measures: rollup.measures.clone(),
+                        dimensions: rollup.dimensions.clone(),
+                        time_dimensions: rollup.time_dimensions.clone(),
+                    });
                 }
                 _ => {
                     return Err(CubeError::user(format!("Rollup lambda can't be nested")));
                 }
             }
-            if i > 1 {
+            if i >= 1 {
                 Self::match_symbols(&rollup.measures, &pre_aggrs_for_lambda[0].measures)?;
                 Self::match_symbols(&rollup.dimensions, &pre_aggrs_for_lambda[0].dimensions)?;
                 Self::match_time_dimensions(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/pre_aggregation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/pre_aggregation.rs
@@ -178,7 +178,10 @@ impl PrettyPrint for PreAggregation {
                 result.println("Union:", &state);
                 let state = state.new_level();
                 for item in union.items.iter() {
-                    result.println(&format!("-{}.{}", item.cube_name, item.name), &state);
+                    result.println(
+                        &format!("-{}.{}", item.table.cube_name, item.table.name),
+                        &state,
+                    );
                 }
             }
         }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/pre_aggregation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/pre_aggregation.rs
@@ -11,6 +11,7 @@ use crate::physical_plan::{
 };
 use crate::physical_plan_builder::PhysicalPlanBuilder;
 use crate::planner::sql_templates::PlanSqlTemplates;
+use crate::planner::MemberSymbol;
 use crate::planner::SqlJoinCondition;
 use cubenativeutils::CubeError;
 use std::rc::Rc;
@@ -73,68 +74,110 @@ impl PreAggregationProcessor<'_> {
         Ok(from)
     }
 
+    /// Resolve the column a union branch stores a lambda member under. The
+    /// lambda exposes the first member rollup's symbols, but each branch keeps
+    /// its own cube aliases (e.g. `requests_stream__tenant_id` vs the lambda's
+    /// `requests__tenant_id`).
+    fn find_branch_member(
+        lambda_member: &Rc<MemberSymbol>,
+        branch_members: &[Rc<MemberSymbol>],
+        branch_cube_name: &str,
+    ) -> Result<Rc<MemberSymbol>, CubeError> {
+        if let Some(member) = branch_members
+            .iter()
+            .find(|m| m.full_name() == lambda_member.full_name())
+        {
+            return Ok(member.clone());
+        }
+        let short_name = lambda_member.name();
+        if let Some(member) = branch_members
+            .iter()
+            .find(|m| m.name() == short_name && m.cube_name() == branch_cube_name)
+        {
+            return Ok(member.clone());
+        }
+        Err(CubeError::internal(format!(
+            "Lambda pre-aggregation member '{}' has no match in union branch '{}'",
+            lambda_member.full_name(),
+            branch_cube_name
+        )))
+    }
+
     fn make_pre_aggregation_union_source(
         &self,
         pre_aggregation: &PreAggregation,
         union: &PreAggregationUnion,
     ) -> Result<Rc<From>, CubeError> {
         if union.items.len() == 1 {
-            let table_source = self.make_pre_aggregation_table_source(&union.items[0])?;
+            let table_source = self.make_pre_aggregation_table_source(&union.items[0].table)?;
             return Ok(From::new(FromSource::Single(table_source)));
         }
         let query_tools = self.builder.query_tools();
 
         let mut union_sources = Vec::new();
         for item in union.items.iter() {
-            let table_source = self.make_pre_aggregation_table_source(&item)?;
+            let branch_cube_name = &item.table.cube_name;
+            let table_source = self.make_pre_aggregation_table_source(&item.table)?;
             let from = From::new(FromSource::Single(table_source));
             let mut select_builder = SelectBuilder::new(from);
             for dim in pre_aggregation.dimensions().iter() {
-                let name_in_table =
-                    PlanSqlTemplates::member_alias_name(&item.cube_alias, &dim.name(), &None);
-                let alias = dim.alias();
+                // Read this branch's stored column for the lambda dimension and
+                // project it under the lambda's unified alias.
+                let branch_dim = Self::find_branch_member(dim, &item.dimensions, branch_cube_name)?;
+                select_builder.add_projection_reference_member(
+                    &dim,
+                    QualifiedColumnName::new(None, branch_dim.alias()),
+                    Some(dim.alias()),
+                );
+            }
+            // Match time dimensions on their base member so the granularity
+            // suffix is applied consistently on both the read and output sides.
+            let branch_time_bases = item
+                .time_dimensions
+                .iter()
+                .map(|td| {
+                    if let Ok(t) = td.as_time_dimension() {
+                        t.base_symbol().clone()
+                    } else {
+                        td.clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+            for dim in pre_aggregation.time_dimensions().iter() {
+                let (lambda_base, granularity) = if let Ok(td) = dim.as_time_dimension() {
+                    (td.base_symbol().clone(), td.granularity().clone())
+                } else {
+                    (dim.clone(), None)
+                };
+
+                let branch_base =
+                    Self::find_branch_member(&lambda_base, &branch_time_bases, branch_cube_name)?;
+
+                let read_suffix = if let Some(granularity) = &granularity {
+                    format!("_{}", granularity)
+                } else {
+                    String::new()
+                };
+                let name_in_table = format!("{}{}", branch_base.alias(), read_suffix);
+
+                let out_suffix = if let Some(granularity) = &granularity {
+                    format!("_{}", granularity)
+                } else {
+                    "_day".to_string()
+                };
+                let alias = format!("{}{}", lambda_base.alias(), out_suffix);
                 select_builder.add_projection_reference_member(
                     &dim,
                     QualifiedColumnName::new(None, name_in_table),
                     Some(alias),
                 );
             }
-            for dim in pre_aggregation.time_dimensions().iter() {
-                let (alias, granularity) = if let Ok(td) = dim.as_time_dimension() {
-                    (td.base_symbol().alias(), td.granularity().clone())
-                } else {
-                    (dim.alias(), None)
-                };
-
-                let name_in_table = PlanSqlTemplates::member_alias_name(
-                    &item.cube_alias,
-                    &dim.name(),
-                    &granularity,
-                );
-
-                let suffix = if let Some(granularity) = granularity {
-                    format!("_{}", granularity.clone())
-                } else {
-                    "_day".to_string()
-                };
-                let alias = format!("{}{}", alias, suffix);
-                select_builder.add_projection_reference_member(
-                    &dim,
-                    QualifiedColumnName::new(None, name_in_table.clone()),
-                    Some(alias),
-                );
-            }
             for meas in pre_aggregation.measures().iter() {
-                let name_in_table = PlanSqlTemplates::member_alias_name(
-                    &item.cube_alias,
-                    &meas.name(),
-                    &meas.alias_suffix(),
-                );
-                let alias = meas.alias();
+                let branch_meas = Self::find_branch_member(meas, &item.measures, branch_cube_name)?;
                 select_builder.add_projection_reference_member(
                     &meas,
-                    QualifiedColumnName::new(None, name_in_table.clone()),
-                    Some(alias),
+                    QualifiedColumnName::new(None, branch_meas.alias()),
+                    Some(meas.alias()),
                 );
             }
             let context = SqlNodesFactory::new();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/test_utils/test_context.rs
@@ -673,61 +673,108 @@ impl TestContext {
         for key in &order {
             let usages = &grouped[key];
             let pre_agg = &usages[0].pre_aggregation;
-            let tables = Self::collect_pre_agg_source_tables(pre_agg.source());
-            let mut union_measures: Vec<String> = Vec::new();
-            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-            for u in usages {
-                for m in u.pre_aggregation.measures() {
-                    let n = m.full_name();
-                    if seen.insert(n.clone()) {
-                        union_measures.push(n);
+
+            match pre_agg.source().as_ref() {
+                // A rollupLambda unions member rollups that may live in different
+                // cubes. Production refreshes each member rollup independently, so
+                // every stored table carries ITS OWN cube aliases (e.g.
+                // `visitor_checkins2__visitor_id`).
+                PreAggregationSource::Union(union) => {
+                    for item in &union.items {
+                        let yaml = Self::build_pre_agg_query_yaml_from_members(
+                            &item.measures,
+                            &item.dimensions,
+                            &item.time_dimensions,
+                        );
+                        let inlined_sql = self.build_pre_agg_table_sql(&yaml);
+                        let name = item
+                            .table
+                            .alias
+                            .clone()
+                            .unwrap_or_else(|| item.table.name.clone());
+                        let table_name = PlanSqlTemplates::alias_name(&format!(
+                            "{}.{}",
+                            item.table.cube_name, name
+                        ));
+                        Self::create_pg_pre_agg_table(client, &table_name, &inlined_sql).await;
+                    }
+                }
+                _ => {
+                    let tables = Self::collect_pre_agg_source_tables(pre_agg.source());
+                    // Dedup usages by (cube, name): the optimizer creates a separate
+                    // PreAggregationUsage per subquery with only the measures consumed
+                    // in that subquery; the physical pre-agg table must expose the union.
+                    let mut union_measures: Vec<String> = Vec::new();
+                    let mut seen: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
+                    for u in usages {
+                        for m in u.pre_aggregation.measures() {
+                            let n = m.full_name();
+                            if seen.insert(n.clone()) {
+                                union_measures.push(n);
+                            }
+                        }
+                    }
+                    let yaml = Self::build_pre_agg_query_yaml(pre_agg, &union_measures);
+                    let inlined_sql = self.build_pre_agg_table_sql(&yaml);
+
+                    for table in &tables {
+                        let name = table.alias.clone().unwrap_or_else(|| table.name.clone());
+                        let table_name =
+                            PlanSqlTemplates::alias_name(&format!("{}.{}", table.cube_name, name));
+                        Self::create_pg_pre_agg_table(client, &table_name, &inlined_sql).await;
                     }
                 }
             }
-            let yaml = Self::build_pre_agg_query_yaml(pre_agg, &union_measures);
-
-            let pa_ctx =
-                Self::new_with_options(self.schema.clone(), Tz::UTC, None, None, false, false)
-                    .expect("Failed to create pre-agg context");
-
-            let (raw_sql, _) = pa_ctx
-                .build_sql_with_used_pre_aggregations(&yaml)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Failed to build pre-agg SQL.\nQuery YAML:\n{}\nError: {}",
-                        yaml, e
-                    )
-                });
-
-            let templates = pa_ctx
-                .query_tools
-                .plan_sql_templates(false)
-                .expect("Failed to get SQL templates");
-            let (sql, params) = pa_ctx
-                .query_tools
-                .build_sql_and_params(&raw_sql, true, &templates)
-                .expect("Failed to build pre-agg SQL and params");
-            let inlined_sql = Self::inline_params(&sql, &params);
-
-            for table in &tables {
-                let name = table.alias.clone().unwrap_or_else(|| table.name.clone());
-                let table_name =
-                    PlanSqlTemplates::alias_name(&format!("{}.{}", table.cube_name, name));
-
-                client
-                    .batch_execute(&format!(
-                        "DROP TABLE IF EXISTS \"{table_name}\";\n\
-                         CREATE TABLE \"{table_name}\" AS ({inlined_sql})"
-                    ))
-                    .await
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "Failed to create pre-agg table {}: {}\nSQL: {}",
-                            table_name, e, inlined_sql
-                        )
-                    });
-            }
         }
+    }
+
+    /// Builds SQL that materializes a pre-aggregation table from a
+    /// `pre_aggregation_query: true` YAML (the rollup-defining SELECT), with
+    /// parameters inlined so it can run as `CREATE TABLE ... AS (...)`.
+    #[cfg(feature = "integration-postgres")]
+    fn build_pre_agg_table_sql(&self, yaml: &str) -> String {
+        let pa_ctx = Self::new_with_options(self.schema.clone(), Tz::UTC, None, None, false, false)
+            .expect("Failed to create pre-agg context");
+
+        let (raw_sql, _) = pa_ctx
+            .build_sql_with_used_pre_aggregations(yaml)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to build pre-agg SQL.\nQuery YAML:\n{}\nError: {}",
+                    yaml, e
+                )
+            });
+
+        let templates = pa_ctx
+            .query_tools
+            .plan_sql_templates(false)
+            .expect("Failed to get SQL templates");
+        let (sql, params) = pa_ctx
+            .query_tools
+            .build_sql_and_params(&raw_sql, true, &templates)
+            .expect("Failed to build pre-agg SQL and params");
+        Self::inline_params(&sql, &params)
+    }
+
+    #[cfg(feature = "integration-postgres")]
+    async fn create_pg_pre_agg_table(
+        client: &tokio_postgres::Client,
+        table_name: &str,
+        inlined_sql: &str,
+    ) {
+        client
+            .batch_execute(&format!(
+                "DROP TABLE IF EXISTS \"{table_name}\";\n\
+                 CREATE TABLE \"{table_name}\" AS ({inlined_sql})"
+            ))
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to create pre-agg table {}: {}\nSQL: {}",
+                    table_name, e, inlined_sql
+                )
+            });
     }
 
     #[cfg(feature = "integration-postgres")]
@@ -741,9 +788,11 @@ impl TestContext {
                 }
                 tables
             }
-            PreAggregationSource::Union(union) => {
-                union.items.iter().map(|t| t.as_ref().clone()).collect()
-            }
+            PreAggregationSource::Union(union) => union
+                .items
+                .iter()
+                .map(|item| item.table.as_ref().clone())
+                .collect(),
         }
     }
 
@@ -781,6 +830,52 @@ impl TestContext {
         if !pre_agg.time_dimensions().is_empty() {
             yaml.push_str("time_dimensions:\n");
             for td in pre_agg.time_dimensions() {
+                if let Ok(td_sym) = td.as_time_dimension() {
+                    yaml.push_str(&format!(
+                        "  - dimension: {}\n",
+                        td_sym.base_symbol().full_name()
+                    ));
+                    if let Some(gran) = td_sym.granularity() {
+                        yaml.push_str(&format!("    granularity: {}\n", gran));
+                    }
+                } else {
+                    yaml.push_str(&format!("  - dimension: {}\n", td.full_name()));
+                }
+            }
+        }
+
+        yaml.push_str("pre_aggregation_query: true\n");
+        yaml
+    }
+
+    /// Same as `build_pre_agg_query_yaml` but driven by explicit member symbols
+    /// instead of a `PreAggregation`. Used to materialize each rollupLambda union
+    /// member from its own cube's members.
+    #[cfg(feature = "integration-postgres")]
+    fn build_pre_agg_query_yaml_from_members(
+        measures: &[Rc<MemberSymbol>],
+        dimensions: &[Rc<MemberSymbol>],
+        time_dimensions: &[Rc<MemberSymbol>],
+    ) -> String {
+        let mut yaml = String::new();
+
+        if !measures.is_empty() {
+            yaml.push_str("measures:\n");
+            for m in measures {
+                yaml.push_str(&format!("  - {}\n", m.full_name()));
+            }
+        }
+
+        if !dimensions.is_empty() {
+            yaml.push_str("dimensions:\n");
+            for d in dimensions {
+                yaml.push_str(&format!("  - {}\n", d.full_name()));
+            }
+        }
+
+        if !time_dimensions.is_empty() {
+            yaml.push_str("time_dimensions:\n");
+            for td in time_dimensions {
                 if let Ok(td_sym) = td.as_time_dimension() {
                     yaml.push_str(&format!(
                         "  - dimension: {}\n",

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__rollup_lambda_cross_cube_union_cubestore_result.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/snapshots/cubesqlplanner__tests__integration__pre_aggregations__sql_generation__rollup_lambda_cross_cube_union_cubestore_result.snap
@@ -1,0 +1,14 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+expression: result
+---
+visitor_checkins__visitor_id | visitor_checkins__created_at_day | visitor_checkins__count
+-----------------------------+----------------------------------+------------------------
+1                            | 2025-01-10T00:00:00.000Z         | 4                      
+1                            | 2025-01-11T00:00:00.000Z         | 2                      
+4                            | 2025-01-31T00:00:00.000Z         | 2                      
+4                            | 2025-02-01T00:00:00.000Z         | 2                      
+5                            | 2025-02-01T00:00:00.000Z         | 2                      
+6                            | 2025-02-15T00:00:00.000Z         | 2                      
+7                            | 2025-02-16T00:00:00.000Z         | 2                      
+8                            | 2025-03-01T00:00:00.000Z         | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
@@ -1506,7 +1506,7 @@ async fn test_rollup_lambda_cross_cube_union_aliases() -> Result<(), CubeError> 
         pre_aggregation_id: visitor_checkins.lambda_union
     "};
 
-    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+    let (_sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
 
     assert_eq!(pre_aggrs.len(), 1);
     assert_eq!(pre_aggrs[0].name(), "lambda_union");

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/pre_aggregations/sql_generation.rs
@@ -1478,3 +1478,45 @@ async fn test_ungrouped_pre_agg_measure_reads_rollup_column() -> Result<(), Cube
 
     Ok(())
 }
+
+// `lambda_union` UNIONs `visitor_checkins.for_lambda` with
+// `visitor_checkins2.for_lambda`. The lambda exposes the first member
+// rollup's symbols, so the dimension's unified output alias is
+// `visitor_checkins__visitor_id`, but the second branch stores it as
+// `visitor_checkins2__visitor_id`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rollup_lambda_cross_cube_union_aliases() -> Result<(), CubeError> {
+    let schema = MockSchema::from_yaml_file("common/pre_aggregations_test.yaml");
+    let ctx = TestContext::new(schema)?;
+
+    // Force the lambda; otherwise the matcher would pick the plain `for_lambda`
+    // rollup that the lambda is built from (it is declared first). The total
+    // `order:` pins row order so the CubeStore result snapshot is stable.
+    let query_yaml = indoc! {"
+        measures:
+          - visitor_checkins.count
+        dimensions:
+          - visitor_checkins.visitor_id
+        time_dimensions:
+          - dimension: visitor_checkins.created_at
+            granularity: day
+        order:
+          - id: visitor_checkins.visitor_id
+          - id: visitor_checkins.created_at
+        pre_aggregation_id: visitor_checkins.lambda_union
+    "};
+
+    let (sql, pre_aggrs) = ctx.build_sql_with_used_pre_aggregations(query_yaml)?;
+
+    assert_eq!(pre_aggrs.len(), 1);
+    assert_eq!(pre_aggrs[0].name(), "lambda_union");
+
+    if let Some(result) = ctx
+        .try_execute(query_yaml, "pre_aggregation_tables.sql")
+        .await
+    {
+        insta::assert_snapshot!("rollup_lambda_cross_cube_union_cubestore_result", result);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
A rollupLambda UNIONs member rollups that can belong to different cubes (e.g. `Requests.batch` ∪ `RequestsStream.stream`, `Orders.*` ∪ `RealTimeOrders.AOrdersByCompletedByHour`). The lambda exposes the first member rollup's symbols, so every member alias is the first cube's (`requests__tenant_id`, `orders__status`). The physical union builder read each branch's dimension columns through `dim.alias()` for all branches, which only holds for same-cube branches — the streaming/real-time branch stores `requests_stream__tenant_id` / `real_time_orders__status`, so the per-branch SELECT referenced a missing column and DataFusion rejected it ("No field named requests__tenant_id …").

Carry each union branch's own member symbols on the union item and resolve every lambda member to that branch's equivalent member, reading through the branch member's alias while projecting under the lambda's unified alias. Matching mirrors the legacy planner's `columnsFor`: exact full-name match first (a dimension from a joined cube is identical across branches, keeping the previous cross-cube-dimension fix), then the short member name within the branch's own cube (a cross-cube union member). Applied uniformly to dimensions, time dimensions and measures; for same-cube branches the read and output aliases coincide, so behavior there is unchanged. 