### PR TITLE
docs: document language support for embedded surfaces

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -437,6 +437,7 @@
               "embedding/iframe/analytics-chat",
               "embedding/iframe/creator-mode",
               "embedding/iframe/customization",
+              "embedding/iframe/localization",
               "embedding/iframe/events",
               {
                 "group": "Authentication",

--- a/docs-mintlify/embedding/iframe/customization.mdx
+++ b/docs-mintlify/embedding/iframe/customization.mdx
@@ -13,6 +13,10 @@ You can customize the appearance of iframe-embedded Cube content in two ways:
 </Note>
 
 <Tip>
+  To set the language of embedded surfaces — account-wide, per embed, or at runtime — see [Localization](/embedding/iframe/localization).
+</Tip>
+
+<Tip>
   To brand the whole embedded experience — accent color, background, text, logo, and fonts — at the account level, configure the [app theme](/admin/customization/app-theme). It applies to all embedded surfaces automatically (and, optionally, to the entire Cube Cloud console).
 </Tip>
 

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -83,6 +83,18 @@ CSV is generated client-side from the data already loaded into the widget, so no
 additional query is issued. The parameter is opt-in — omit it (the default) to
 keep the download action hidden.
 
+## Set the language
+
+Embedded dashboards render their UI in the account's default language, which you can
+override per embed by adding the `?locale=` query parameter:
+
+```text
+https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&locale=es-MX
+```
+
+See [Localization](/embedding/iframe/localization) for the list of supported languages
+and the other ways to set the language.
+
 ## Customize appearance
 
 You can style an embedded dashboard — background, padding, widget borders, titles, and fonts — from the **Styling** panel in the Dashboard Builder. See [Dashboards → Styling](/docs/explore-analyze/dashboards/styling) for the full list of options.

--- a/docs-mintlify/embedding/iframe/events.mdx
+++ b/docs-mintlify/embedding/iframe/events.mdx
@@ -348,7 +348,8 @@ sendAction("cube:action:set-theme", {
 #### `cube:action:set-locale`
 
 Switch the embed's UI language. Accepts a full code (`es-ES`), a short code
-(`es`), or a regional variant.
+(`es`), or a regional variant. See [Localization](/embedding/iframe/localization)
+for the list of supported languages and the other ways to set the language.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/docs-mintlify/embedding/iframe/localization.mdx
+++ b/docs-mintlify/embedding/iframe/localization.mdx
@@ -1,0 +1,90 @@
+---
+title: Localization
+description: Set the language for embedded Cube surfaces — account-wide, per embed via URL, or at runtime.
+---
+
+Embedded Cube surfaces — dashboards, [Analytics Chat](/embedding/iframe/analytics-chat),
+and the full app in [Creator Mode](/embedding/iframe/creator-mode) — can render their
+UI in any of the supported languages. You can set a default language for the whole
+account, override it per embed with a URL parameter, or switch it at runtime from the
+host page.
+
+<Note>
+  Available on [Premium and Enterprise plans](https://cube.dev/pricing).
+</Note>
+
+## Supported languages
+
+| Language                   | Locale code |
+| -------------------------- | ----------- |
+| English (US)               | `en-US`     |
+| Deutsch (Deutschland)      | `de-DE`     |
+| Español (España)           | `es-ES`     |
+| Español (Latinoamérica)    | `es-MX`     |
+| Français (France)          | `fr-FR`     |
+| Italiano (Italia)          | `it-IT`     |
+| 日本語 (日本)               | `ja-JP`     |
+| Norsk bokmål (Norge)       | `nb-NO`     |
+| Português (Brasil)         | `pt-BR`     |
+| Português (Portugal)       | `pt-PT`     |
+| Svenska (Sverige)          | `sv-SE`     |
+| Tiếng Việt (Việt Nam)      | `vi-VN`     |
+
+English (`en-US`) is the default and the fallback when no language is configured.
+
+A locale value can be a full code (`es-ES`), a short language code (`es`), or a regional
+variant that isn't shipped (`es-AR`). Short codes and unsupported regional variants
+resolve to the first supported locale for that language — for example, both `es` and
+`es-AR` resolve to `es-ES`. A value that doesn't match any supported language is ignored.
+
+## How the language is resolved
+
+The language of an embedded surface is resolved from the following sources, highest
+priority first:
+
+1. **Runtime override** — a [`cube:action:set-locale`](/embedding/iframe/events#cube-action-set-locale)
+   message sent from the host page (see [At runtime](#at-runtime)).
+2. **URL parameter** — the `?locale=` query parameter on the embed URL (see
+   [Per embed via URL](#per-embed-via-url)).
+3. **Account default** — the language configured in **Embed → Settings** (see
+   [Account-wide default](#account-wide-default)).
+4. **Fallback** — `en-US`.
+
+## Account-wide default
+
+Set a default language for all embedded surfaces from the Cube Cloud console:
+
+1. Go to **Embed → Settings**.
+2. In the **Language** card, pick a language from the dropdown.
+
+The selected language applies to every embedded surface across the account, unless a
+specific embed overrides it with a `?locale=` URL parameter or a runtime
+`cube:action:set-locale` message.
+
+Clearing the setting removes the stored default, and embeds fall back to `en-US` (or to
+whatever a per-embed override specifies).
+
+## Per embed via URL
+
+Override the account default for an individual embed by adding the `?locale=` query
+parameter to the embed URL:
+
+```text
+https://your-tenant.cubecloud.dev/embed/dashboard/YOUR_DASHBOARD_PUBLIC_ID?session=YOUR_SESSION_ID&locale=es-MX
+```
+
+The parameter is read once when the embed loads and pinned for the session, so in-app
+navigation won't drop it.
+
+## At runtime
+
+Switch the language after the embed has loaded by sending a
+[`cube:action:set-locale`](/embedding/iframe/events#cube-action-set-locale) message from
+the host page. This takes precedence over both the URL parameter and the account default:
+
+```js
+sendAction("cube:action:set-locale", { locale: "es" });
+```
+
+See [Events and actions](/embedding/iframe/events) for the full host ↔ embed messaging
+contract.


### PR DESCRIPTION
## Summary

Documents the newly-shipped language/locale support for cloud-embedded surfaces (dashboards, Analytics Chat, and the Creator Mode app).

- **New page** `embedding/iframe/localization.mdx` — supported-languages table (12 locales), the precedence model, the account-wide default (**Embed → Settings → Language**), the per-embed `?locale=` URL parameter, and the runtime `cube:action:set-locale` override.
- **dashboards.mdx** — adds a "Set the language" section showing the `?locale=` parameter.
- **events.mdx** — links the existing `cube:action:set-locale` action to the new page.
- **customization.mdx** — adds a tip pointing to Localization.
- **docs.json** — registers the new page in the *Iframe embedding* group.

## Details

Language is resolved in this precedence order: runtime `cube:action:set-locale` → `?locale=` URL parameter → account default → `en-US` fallback. Supported locales: `en-US`, `de-DE`, `es-ES`, `es-MX`, `fr-FR`, `it-IT`, `ja-JP`, `nb-NO`, `pt-BR`, `pt-PT`, `sv-SE`, `vi-VN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)