### PR TITLE
fix(tesseract): resolve FILTER_PARAMS callback-column placeholders in segments

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_call.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_call.rs
@@ -337,6 +337,26 @@ impl SqlCall {
             .collect::<Result<Vec<_>, _>>()?;
 
         let context_values = self.eval_security_context_values(&query_tools);
+
+        // A FILTER_PARAMS column can itself be a template referencing this
+        // call's members (e.g. `.filter(`${CUBE.col}`)`), so the rendered
+        // predicate may still carry `{arg:N}`/`{sv:N}` placeholders. Resolve
+        // them against the just-computed dependencies before the predicate is
+        // spliced into the outer template, which would otherwise leave them
+        // untouched (the outer pass never rescans substituted values).
+        let filter_params = filter_params
+            .iter()
+            .map(|s| {
+                Self::substitute_template(s, &deps, &filter_params, &filter_groups, &context_values)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let filter_groups = filter_groups
+            .iter()
+            .map(|s| {
+                Self::substitute_template(s, &deps, &filter_params, &filter_groups, &context_values)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
         Ok((filter_params, filter_groups, deps, context_values))
     }
 


### PR DESCRIPTION
## Summary

A `FILTER_PARAMS` column can itself be a template that references the cube's members (the callback-column form, e.g. `.filter(`${CUBE.col}`)`). When such a FILTER_PARAMS is pushed down — notably now that it reaches predicates inside segment SQL — its rendered predicate still carried unresolved `{arg:N}`/`{sv:N}` placeholders, which leaked into the base SQL (e.g. `{arg:1} = $2`) and broke the query.

This is the second, previously-deferred half of the segment/FILTER_PARAMS work (#11182): once segments stopped blocking pushdown, callback-column placeholders started reaching the base SQL and had to be resolved.

## Changes

- In `SqlCall::prepare_template_params`, after dependencies and security-context values are computed, re-run `substitute_template` over each rendered `FILTER_PARAMS` / `FILTER_GROUP` predicate to resolve leftover `{arg:N}`/`{sv:N}` before the predicate is spliced into the outer template (the outer pass never rescans substituted values).
- The second pass is given the real `filter_params`/`filter_groups` slices so a stray `{fp:N}`/`{fg:N}` is passed through rather than raising an out-of-bounds error.

## Testing

- Existing native-planner integration test `cube-views.test.ts › Cube Views › segment with filter params` now passes (it regressed after #11182 — the segment's `.filter(`${CUBE.productId}`)` leaked `{arg:1}`). Verified it fails on revert of this change and passes with it.
- Full Tesseract JS integration suites green: `cube-views`, `sql-generation`, `pre-aggregations*`, `sql-generation-logic`, `multi-stage-filter`.
- 1070 `cubesqlplanner` Rust unit tests pass; `cargo fmt` clean.

## Known limitation

`{arg:N}` inlined from a callback column skips paren-safety (`arg_paren_contexts` is computed from the outer template, which never contains that inner `{arg:N}`). A low-precedence member SQL used as a filter-param column could inline without parentheses. This is pre-existing (such filters produced invalid SQL before this fix) and out of scope here.