### PR TITLE
fix(cubesql): Resolve schema-qualified `pg_catalog` functions

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "arrow",
  "chrono",
@@ -868,7 +868,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -901,7 +901,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "arrow",
  "ordered-float 2.10.1",
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1a849d723be7a13dfe4cbb83a574d5da735e885f#1a849d723be7a13dfe4cbb83a574d5da735e885f"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "1a849d723be7a13dfe4cbb83a574d5da735e885f", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "c7e685599fefdf0692d44ac7c2f6aebd6b927bc0", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -17277,6 +17277,21 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_pg_catalog_array_agg() -> Result<(), CubeError> {
+        insta::assert_snapshot!(
+            "pg_catalog_array_agg",
+            execute_query(
+                r#"SELECT pg_catalog.array_agg(a) AS labels FROM (VALUES (1), (2), (3)) AS t(a)"#
+                    .to_string(),
+                DatabaseProtocol::PostgreSQL
+            )
+            .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_format_function() -> Result<(), CubeError> {
         // Test: Basic usage with a single string
         let result = execute_query(

--- a/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_catalog_array_agg.snap
+++ b/rust/cubesql/cubesql/src/compile/snapshots/cubesql__compile__tests__pg_catalog_array_agg.snap
@@ -1,0 +1,9 @@
+---
+source: cubesql/src/compile/mod.rs
+expression: "execute_query(r#\"SELECT pg_catalog.array_agg(a) AS labels FROM (VALUES (1), (2), (3)) AS t(a)\"#.to_string(),\nDatabaseProtocol::PostgreSQL).await?"
+---
++---------+
+| labels  |
++---------+
+| {1,2,3} |
++---------+


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@c7e6855, fixing a regression introduced with sqlparser bump where parsing `pg_catalog.array_agg` leads to parsing it as a compound function name. Related test is included.
