### PR TITLE
fix(cubesql): Push down `UTCTIMESTAMP` (`CURRENT_TIMESTAMP`)

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -168,6 +168,7 @@ export class DatabricksQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
+    templates.functions.UTCTIMESTAMP = 'TO_UTC_TIMESTAMP(CURRENT_TIMESTAMP(), CURRENT_TIMEZONE())';
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
     templates.functions.DATEPART = 'DATE_PART({{ args_concat }})';
     templates.functions.BTRIM = 'TRIM({% if args[1] is defined %}{{ args[1] }} FROM {% endif %}{{ args[0] }})';

--- a/packages/cubejs-druid-driver/src/DruidQuery.ts
+++ b/packages/cubejs-druid-driver/src/DruidQuery.ts
@@ -60,6 +60,9 @@ export class DruidQuery extends BaseQuery {
     delete templates.expressions.like_escape;
     templates.filters.like_pattern = 'CONCAT({% if start_wild %}\'%\'{% else %}\'\'{% endif %}, LOWER({{ value }}), {% if end_wild %}\'%\'{% else %}\'\'{% endif %})';
     templates.tesseract.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE {{ pattern }}';
+    // Druid evaluates CURRENT_TIMESTAMP in the sqlTimeZone query context, which
+    // defaults to UTC — assumes the connection does not override sqlTimeZone
+    templates.functions.UTCTIMESTAMP = 'CURRENT_TIMESTAMP';
 
     return templates;
   }

--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -61,6 +61,9 @@ export class DuckDBQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
+    // AT TIME ZONE on TIMESTAMPTZ yields a naive TIMESTAMP in UTC (requires the ICU
+    // extension, which is bundled and autoloaded in the DuckDB builds used by the driver)
+    templates.functions.UTCTIMESTAMP = '(NOW() AT TIME ZONE \'UTC\')';
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
     templates.functions.STRING_AGG = 'STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}, COALESCE({{ args[1] }}, \'\'))';

--- a/packages/cubejs-pinot-driver/src/PinotQuery.ts
+++ b/packages/cubejs-pinot-driver/src/PinotQuery.ts
@@ -141,6 +141,9 @@ export class PinotQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
+    // NOW() returns the current epoch millis (inherently UTC), matching the
+    // epoch-millis representation produced by the timestamp_literal template
+    templates.functions.UTCTIMESTAMP = 'NOW()';
     templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.statements.select = 'SELECT {{ select_concat | map(attribute=\'aliased\') | join(\', \') }} \n' +
       'FROM (\n  {{ from }}\n) AS {{ from_alias }} \n' +

--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -332,6 +332,7 @@ export class BigqueryQuery extends BaseQuery {
     // DATEADD is being rewritten to DATE_ADD
     templates.functions.DATE_ADD = 'DATETIME_ADD(DATETIME({{ args[0] }}), INTERVAL {{ interval }} {{ date_part }})';
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
+    templates.functions.UTCTIMESTAMP = 'CURRENT_TIMESTAMP()';
     delete templates.functions.TO_CHAR;
     delete templates.functions.PERCENTILECONT;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -263,6 +263,7 @@ export class ClickHouseQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DATETRUNC = 'DATE_TRUNC({{ args_concat }})';
+    templates.functions.UTCTIMESTAMP = 'now(\'UTC\')';
     templates.functions.STRING_AGG = 'arrayStringConcat(group{% if distinct %}Uniq{% endif %}Array({{ args[0] }}), {{ args[1] }})';
     // TODO: Introduce additional filter in jinja? or parseDateTimeBestEffort?
     // https://github.com/ClickHouse/ClickHouse/issues/19351

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -268,6 +268,7 @@ export class MssqlQuery extends BaseQuery {
     const templates = super.sqlTemplates();
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
+    templates.functions.UTCTIMESTAMP = 'GETUTCDATE()';
     // MSSQL ROUND requires 2 arguments: ROUND(number, length)
     templates.functions.ROUND = 'ROUND({{ args_concat }}{% if args | length < 2 %}, 0{% endif %})';
     // NOTE: MSSQL does not support DISTINCT clause. No workaround is available

--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -186,6 +186,7 @@ export class MysqlQuery extends BaseQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.STRING_AGG = 'GROUP_CONCAT({% if distinct %}DISTINCT {% endif %}{{ args[0] }} SEPARATOR {{ args[1] }})';
+    templates.functions.UTCTIMESTAMP = 'UTC_TIMESTAMP()';
     // PERCENTILE_CONT works but requires PARTITION BY
     delete templates.functions.PERCENTILECONT;
     templates.quotes.identifiers = '`';

--- a/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
@@ -215,6 +215,7 @@ export class OracleQuery extends BaseQuery {
 
   public sqlTemplates() {
     const templates = super.sqlTemplates();
+    templates.functions.UTCTIMESTAMP = 'SYS_EXTRACT_UTC(SYSTIMESTAMP)';
     // Oracle forbids `AS` before a table/subquery alias.
     templates.expressions.query_aliased = '{{ query }} {{ quoted_alias }}';
     // Oracle does not support positional GROUP BY — group by expressions.

--- a/packages/cubejs-schema-compiler/src/adapter/PostgresQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PostgresQuery.ts
@@ -86,6 +86,7 @@ export class PostgresQuery extends BaseQuery {
     templates.functions.LEAST = 'LEAST({{ args_concat }})';
     templates.functions.GREATEST = 'GREATEST({{ args_concat }})';
     templates.functions.NOW = 'NOW({{ args_concat }})';
+    templates.functions.UTCTIMESTAMP = '(NOW() AT TIME ZONE \'UTC\')';
     // DATEADD is being rewritten to DATE_ADD
     // templates.functions.DATEADD = '({{ args[2] }} + \'{{ interval }} {{ date_part }}\'::interval)';
     // TODO: is DATEDIFF expr worth documenting?

--- a/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PrestodbQuery.ts
@@ -141,6 +141,7 @@ export class PrestodbQuery extends BaseQuery {
     templates.functions.DATEPART = 'DATE_PART({{ args_concat }})';
     templates.functions.DATEDIFF = 'DATE_DIFF(\'{{ date_part }}\', {{ args[1] }}, {{ args[2] }})';
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
+    templates.functions.UTCTIMESTAMP = 'CAST(NOW() AT TIME ZONE \'UTC\' AS TIMESTAMP)';
     templates.functions.TRUNC = 'TRUNCATE({{ args_concat }})';
     templates.functions.STRING_AGG = 'ARRAY_JOIN(ARRAY_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}), COALESCE({{ args[1] }}, \'\'))';
     delete templates.functions.PERCENTILECONT;

--- a/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/RedshiftQuery.ts
@@ -84,6 +84,9 @@ export class RedshiftQuery extends PostgresQuery {
   public sqlTemplates() {
     const templates = super.sqlTemplates();
     templates.functions.DLOG10 = 'LOG(10, {{ args_concat }})';
+    // Redshift clusters always run in UTC and GETDATE() is supported on compute
+    // nodes, unlike NOW(), which is a leader node–only function.
+    templates.functions.UTCTIMESTAMP = 'GETDATE()';
     templates.functions.DATEDIFF = 'DATEDIFF({{ date_part }}, {{ args[1] }}, {{ args[2] }})';
     templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.statements.time_series_select = 'SELECT dates.f::timestamp date_from, dates.t::timestamp date_to \n' +

--- a/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
@@ -108,6 +108,7 @@ export class SnowflakeQuery extends BaseQuery {
     templates.functions.DATEPART = 'DATE_PART({{ args_concat }})';
     templates.functions.CURRENTDATE = 'CURRENT_DATE';
     templates.functions.NOW = 'CURRENT_TIMESTAMP';
+    templates.functions.UTCTIMESTAMP = 'SYSDATE()';
     templates.functions.LOG = 'LOG({% if args[1] is undefined %}10, {% endif %}{{ args_concat }})';
     templates.functions.DLOG10 = 'LOG(10, {{ args_concat }})';
     templates.functions.CHARACTERLENGTH = 'LENGTH({{ args[0] }})';

--- a/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
+++ b/packages/cubejs-testing/test/__snapshots__/smoke-cubesql.test.ts.snap
@@ -545,6 +545,14 @@ Array [
 ]
 `;
 
+exports[`SQL API Postgres (Data) current_timestamp subquery filter push down: current_timestamp_push_down 1`] = `
+Array [
+  Object {
+    "cn": "5",
+  },
+]
+`;
+
 exports[`SQL API Postgres (Data) date/string measures in view: date case 1`] = `
 Array [
   Object {

--- a/packages/cubejs-testing/test/smoke-cubesql.test.ts
+++ b/packages/cubejs-testing/test/smoke-cubesql.test.ts
@@ -530,6 +530,18 @@ describe('SQL API', () => {
       expect(res.rows).toMatchSnapshot('powerbi_min_max_push_down');
     });
 
+    test('current_timestamp subquery filter push down', async () => {
+      // CURRENT_TIMESTAMP-based bounds wrapped in scalar subqueries force
+      // SQL push down and require the functions/UTCTIMESTAMP template.
+      // All fixture rows are in the past, so the result is stable over time.
+      const res = await connection.query(`
+        SELECT COUNT(*) as cn
+        FROM "public"."Orders" "orders"
+        WHERE ("orders"."createdAt" < ((SELECT DATE_TRUNC('year', DATE_TRUNC('day', CURRENT_TIMESTAMP)))))
+      `);
+      expect(res.rows).toMatchSnapshot('current_timestamp_push_down');
+    });
+
     test('no limit for non matching count push down', async () => {
       const res = await connection.query(`
       select

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -694,6 +694,7 @@ pub fn sql_generator(
                     ("functions/DATEDIFF".to_string(), "DATEDIFF({{ date_part }}, {{ args[1] }}, {{ args[2] }})".to_string()),
                     ("functions/CURRENTDATE".to_string(), "CURRENT_DATE({{ args_concat }})".to_string()),
                     ("functions/NOW".to_string(), "NOW({{ args_concat }})".to_string()),
+                    ("functions/UTCTIMESTAMP".to_string(), "(NOW() AT TIME ZONE 'UTC')".to_string()),
                     ("functions/DATE_ADD".to_string(), "DATE_ADD({{ args_concat }})".to_string()),
                     ("functions/CONCAT".to_string(), "CONCAT({{ args_concat }})".to_string()),
                     ("functions/DATE".to_string(), "DATE({{ args_concat }})".to_string()),

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -286,6 +286,32 @@ async fn test_simple_subquery_wrapper_filter_empty_source() {
 }
 
 #[tokio::test]
+async fn test_wrapper_filter_subquery_current_timestamp() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        SELECT customer_gender, AVG(avgPrice) mp
+        FROM KibanaSampleDataEcommerce a
+        WHERE order_date >= (SELECT DATE_TRUNC('year', DATE_TRUNC('day', CURRENT_TIMESTAMP)))
+        GROUP BY 1
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(sql.contains("NOW() AT TIME ZONE 'UTC'"));
+
+    let _physical_plan = query_plan.as_physical_plan().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_simple_subquery_wrapper_projection_aggregate_empty_source() {
     if !Rewriter::sql_push_down_enabled() {
         return;


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR adds `UTCTIMESTAMP` SQL push down templates so `CURRENT_TIMESTAMP` can use SQL push down when needed. Related test is included.
