### PR TITLE
feat(databricks-jdbc-driver): Upgrade driver to 1.0.11 (to fix out of sequence response: expected N but got N-1)

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/installer.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/installer.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { downloadAndExtractFile, getEnv } from '@cubejs-backend/shared';
 
-export const OSS_DRIVER_VERSION = '1.0.6';
+export const OSS_DRIVER_VERSION = '1.0.11';
 
 /**
  * In the beginning of 2025 Databricks released their open-source version of JDBC driver and encourage


### PR DESCRIPTION
Includes databricks/databricks-jdbc#999 "Fix race condition in thrift client", which fixes TCLIService.Client state leakage where a failed prior server call corrupted the shared Thrift client and leaked into the next operation on a reused pooled connection, surfacing as "out of sequence response: expected N but got N-1" during pre-aggregation builds (CUB-3050).