### PR TITLE
fix(schema-compiler): Prevent alias gathering from polluting long-lived collector caches

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -5404,7 +5404,25 @@ export class BaseQuery {
       member => {
         const collectedMembers = query.evaluateSymbolSqlWithContext(
           () => query.collectFrom([member], query.collectMemberNamesFor.bind(query), 'collectMemberNamesFor'),
-          { aliasGathering: true }
+          {
+            aliasGathering: true,
+            // Alias gathering may be triggered in the middle of some collection
+            // (e.g. join hints collection for a member whose sql uses FILTER_PARAMS).
+            // Inherited collectors must be shadowed here, otherwise members of the
+            // current query traversed during alias gathering leak into the outer
+            // collection result. Some of those results are cached in the long-lived
+            // compilerCache and would poison unrelated queries (e.g. with extra joins).
+            cubeNames: undefined,
+            joinHints: undefined,
+            memberNames: undefined,
+            subQueryDimensions: undefined,
+            leafMeasures: undefined,
+            compositeCubeMeasures: undefined,
+            foundCompositeCubeMeasures: undefined,
+            memberChildren: undefined,
+            inlineWhereConditions: undefined,
+            collectOriginalSqlPreAggregations: undefined,
+          }
         );
         const memberPath = member.expressionPath();
         let nonAliasSeen = false;

--- a/packages/cubejs-schema-compiler/test/unit/join-hints-cache-pollution.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/join-hints-cache-pollution.test.ts
@@ -1,0 +1,109 @@
+import { PostgresQuery } from '../../src';
+import { prepareYamlCompiler } from './PrepareCompiler';
+import { createSchemaYaml } from './utils';
+
+// Regression test: cross-query pollution of compilerCache join hints
+// through a view. All view members report the view as their cube, so the
+// member-cubes cache namespacing added in #10084 cannot distinguish two
+// different queries against the same view. If a member's SQL uses
+// FILTER_PARAMS, collecting its join hints traverses ALL members of the
+// current query (via allBackAliasMembersExceptSegments), leaking their join
+// paths into the compilerCache entry of that member. A later query reusing
+// the poisoned entry gets an extra join.
+describe('Join hints compilerCache pollution through views', () => {
+  const schema = createSchemaYaml({
+    cubes: [
+      {
+        name: 'orders',
+        sql_table: 'orders_tbl',
+        joins: [{
+          name: 'layout',
+          sql: '1 = 1',
+          relationship: 'one_to_one',
+        }],
+        measures: [{ name: 'count', type: 'count' }],
+        dimensions: [
+          { name: 'id', sql: 'id', type: 'number', primary_key: true },
+          { name: 'category', sql: 'category', type: 'string' },
+          {
+            name: 'flag',
+            sql: 'CASE WHEN {FILTER_PARAMS.orders.category.filter(\'category\')} THEN 1 ELSE 0 END',
+            type: 'number',
+          },
+        ],
+      },
+      {
+        name: 'layout',
+        sql_table: 'layout_tbl',
+        measures: [],
+        dimensions: [
+          { name: 'id', sql: 'id', type: 'number', primary_key: true },
+          { name: 'bucket', sql: 'bucket', type: 'string' },
+        ],
+      },
+    ],
+    views: [{
+      name: 'v',
+      cubes: [
+        { join_path: 'orders', includes: ['count', 'id', 'category', 'flag'] },
+        { join_path: 'orders.layout', includes: ['bucket'] },
+      ],
+    }],
+  });
+
+  it('does not leak join hints from one query to another via compilerCache', async () => {
+    const compilers = prepareYamlCompiler(schema);
+    await compilers.compiler.compile();
+
+    // Query 1 (poisoner): legitimately joins `layout` because it filters on v.bucket
+    const poisoner = new PostgresQuery(compilers, {
+      dimensions: ['v.flag'],
+      filters: [{ member: 'v.bucket', operator: 'equals', values: ['x'] }],
+      timezone: 'UTC',
+    });
+    const poisonerSql = poisoner.buildSqlAndParams()[0];
+    expect(poisonerSql).toContain('layout_tbl');
+
+    // Query 2 (victim): does not reference layout at all — must not join it
+    const victim = new PostgresQuery(compilers, {
+      dimensions: ['v.flag'],
+      filters: [{ member: 'v.category', operator: 'equals', values: ['y'] }],
+      timezone: 'UTC',
+    });
+    const victimSql = victim.buildSqlAndParams()[0];
+    expect(victimSql).not.toContain('layout_tbl');
+  });
+
+  it('reverse order: query needing the join still gets it after a cached query without it', async () => {
+    const compilers = prepareYamlCompiler(schema);
+    await compilers.compiler.compile();
+
+    const victim = new PostgresQuery(compilers, {
+      dimensions: ['v.flag'],
+      filters: [{ member: 'v.category', operator: 'equals', values: ['y'] }],
+      timezone: 'UTC',
+    });
+    expect(victim.buildSqlAndParams()[0]).not.toContain('layout_tbl');
+
+    const poisoner = new PostgresQuery(compilers, {
+      dimensions: ['v.flag'],
+      filters: [{ member: 'v.bucket', operator: 'equals', values: ['x'] }],
+      timezone: 'UTC',
+    });
+    expect(poisoner.buildSqlAndParams()[0]).toContain('layout_tbl');
+  });
+
+  it('control: victim query alone does not join layout', async () => {
+    // Fresh compilers → fresh compilerCache → correct SQL
+    const compilers = prepareYamlCompiler(schema);
+    await compilers.compiler.compile();
+
+    const victim = new PostgresQuery(compilers, {
+      dimensions: ['v.flag'],
+      filters: [{ member: 'v.category', operator: 'equals', values: ['y'] }],
+      timezone: 'UTC',
+    });
+    const victimSql = victim.buildSqlAndParams()[0];
+    expect(victimSql).not.toContain('layout_tbl');
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR isolates the alias-gathering traversal in `backAliasMembers` from inherited evaluation-context collectors (`joinHints`, `cubeNames`, `leafMeasures`, `memberChildren`, etc.), which previously let members of one query leak into `compilerCache`-cached collection results for view members whose SQL uses `FILTER_PARAMS`, non-deterministically producing extra unreferenced joins (and thus multiplied measure values) in unrelated queries until the process restarted. Related tests are included.
