### PR TITLE
docs: remove Content Validator preview label, document Fill in missing rows

### DIFF
--- a/docs-mintlify/docs/data-modeling/content-validator.mdx
+++ b/docs-mintlify/docs/data-modeling/content-validator.mdx
@@ -3,14 +3,6 @@ title: Content Validator
 description: Find saved reports that reference data model fields or views that no longer exist, and fix or remove them before a model change breaks live dashboards.
 ---
 
-<Warning>
-
-Content Validator is currently in preview, and the user experience may still
-change. Reach out to the [Cube support team](/admin/account-billing/support)
-to activate this feature for your account.
-
-</Warning>
-
 The Content Validator finds saved reports whose queries reference data model
 members — individual fields or whole views — that no longer exist in your
 current data model. Use it to catch and fix broken content while you are

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -127,36 +127,20 @@ fill is active, an icon on the column header indicates it.
   <img src="https://ucarecdn.com/f32deed8-ae99-4582-820e-6d5742330a9e/55f9deba-light.png" alt="Results table column menu with the Fill in missing rows action" />
 </Frame>
 
-How the fill works:
+The fill works on time dimensions with a year, quarter, month, week, or day
+granularity. The date range comes from the date filters on that dimension, or
+from the earliest and latest dates in the data. In added rows, additive
+measures such as counts and sums are set to `0`; other measures are left
+empty.
 
-- It is available on time dimensions with a year, quarter, month, week, or
-  day granularity. Sub-day granularities (hour, minute, second) are not
-  supported.
-- The date range to fill comes from the date filters on that dimension —
-  including relative ranges like "this month" or "3 months ago", and
-  dashboard filters when the report is placed on a dashboard. Without a date
-  filter, the range spans from the earliest to the latest date present in
-  the data.
-- If the query includes other dimensions, each combination of their values
-  gets a complete series: rows are added for every combination × missing
-  date bucket.
-- In added rows, additive measures such as counts and sums are set to `0` —
-  a missing bucket genuinely means zero. Non-additive measures (averages,
-  distinct counts) are left empty.
-
-The fill is a display-time transform: it doesn't change the generated SQL or
-the underlying query result — the missing rows are synthesized when the
-report is rendered. It applies consistently everywhere the report appears:
-the results table, the chart, dashboards, and embedded content.
-
-The setting is saved with the report, so a filled report keeps its continuous
-time series when placed on a [dashboard][ref-dashboards].
+The fill doesn't change the query or the generated SQL — the missing rows are
+added when the report is rendered. It is saved with the report and applies
+everywhere it appears, including [dashboards][ref-dashboards].
 
 <Info>
 
-To keep results manageable, the fill is skipped when it would produce more
-than 10,000 rows. When that happens, the column header indicator warns you
-that missing rows were not filled.
+The fill is skipped when it would produce more than 10,000 rows. When that
+happens, the column header indicator warns you.
 
 </Info>
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -110,6 +110,56 @@ change the sort order for any member. Drag and drop members within the sorting c
 
 When a [pivot](#pivoting) is applied, an additional section with pivot dimensions appears.
 
+## Filling in missing rows
+
+A time-series query only returns rows for date buckets that actually contain
+data. If no orders were created in a given month, that month is simply absent
+from the result — which reads as a misleading gap in tables and charts. Fill
+in missing rows densifies the result so every date bucket in the range is
+present.
+
+To apply it, hover over the header of a time dimension column in the results
+table, expand the context menu, and select **Fill in missing rows**. To turn
+it off, select **Stop filling missing rows** from the same menu. While the
+fill is active, an icon on the column header indicates it.
+
+<Frame>
+  <img src="https://ucarecdn.com/f32deed8-ae99-4582-820e-6d5742330a9e/55f9deba-light.png" alt="Results table column menu with the Fill in missing rows action" />
+</Frame>
+
+How the fill works:
+
+- It is available on time dimensions with a year, quarter, month, week, or
+  day granularity. Sub-day granularities (hour, minute, second) are not
+  supported.
+- The date range to fill comes from the date filters on that dimension —
+  including relative ranges like "this month" or "3 months ago", and
+  dashboard filters when the report is placed on a dashboard. Without a date
+  filter, the range spans from the earliest to the latest date present in
+  the data.
+- If the query includes other dimensions, each combination of their values
+  gets a complete series: rows are added for every combination × missing
+  date bucket.
+- In added rows, additive measures such as counts and sums are set to `0` —
+  a missing bucket genuinely means zero. Non-additive measures (averages,
+  distinct counts) are left empty.
+
+The fill is a display-time transform: it doesn't change the generated SQL or
+the underlying query result — the missing rows are synthesized when the
+report is rendered. It applies consistently everywhere the report appears:
+the results table, the chart, dashboards, and embedded content.
+
+The setting is saved with the report, so a filled report keeps its continuous
+time series when placed on a [dashboard][ref-dashboards].
+
+<Info>
+
+To keep results manageable, the fill is skipped when it would produce more
+than 10,000 rows. When that happens, the column header indicator warns you
+that missing rows were not filled.
+
+</Info>
+
 ## Inspecting queries
 
 Every query in the Semantic Query tab can be inspected as code. Open the SQL panel via the **SQL** button in the top-right toolbar to see the query that the workbook generates, switch between representations, and copy it for use elsewhere.
@@ -222,6 +272,7 @@ behaves as intended.
 [ref-configuration]: /docs/data-modeling/configuration
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-access-control]: /docs/data-modeling/access-control
+[ref-dashboards]: /docs/explore-analyze/dashboards
 [ref-explore]: /docs/explore-analyze/explore
 [ref-analytics-chat]: /docs/explore-analyze/analytics-chat
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters


### PR DESCRIPTION
Two doc updates for features going live today:

- **Content Validator**: remove the in-preview `<Warning>` callout from its docs page — the feature is generally available now.
- **Fill in missing rows**: document the new results-table action in the workbook [Querying data](https://docs.cube.dev/docs/explore-analyze/workbooks/querying-data) page — what it does, supported granularities, how the date range is resolved, zero vs. empty values in synthesized rows, display-only semantics, and the 10,000-row cap. Based on cubedevinc/cubejs-enterprise#12786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)