### PR TITLE
docs: update Scheduled Tasks for GA and new capabilities

### DIFF
--- a/docs-mintlify/docs/explore-analyze/scheduled-tasks.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-tasks.mdx
@@ -1,25 +1,18 @@
 ---
 title: Scheduled Tasks
-description: Save a natural-language agent prompt and have Cube run it automatically on a schedule, producing an Analytics Chat thread for each run.
+description: Save a natural-language agent prompt and have Cube run it automatically on a schedule, producing a chat thread for each run.
 ---
 
-<Warning>
-
-Scheduled Tasks are currently in preview, and the user experience may still
-change. Reach out to the [Cube support team](/admin/account-billing/support)
-to activate this feature for your account.
-
-</Warning>
-
-Scheduled Tasks let you save a natural-language prompt for the
+Scheduled Tasks let you run tasks on a schedule — or whenever you need them.
+Save a natural-language prompt for the
 [agent](/docs/explore-analyze/analytics-chat) and have Cube run it
-automatically on a schedule — or on demand. Each run produces an
-[Analytics Chat](/docs/explore-analyze/analytics-chat) thread you can open
-later to read the agent's answer.
+automatically on a schedule or on demand. Each run produces a chat thread
+you can open later to read the agent's answer. You can also ask the agent to create a
+scheduled task for you from any of your chats.
 
 For example, you might schedule a task to *"every weekday at 9am, summarize
-yesterday's signups and flag anything anomalous"* and review the resulting
-chat each morning.
+yesterday's signups, flag anything anomalous, and email me the results"* and
+review the summary each morning.
 
 Scheduled Tasks are **scoped to a deployment** — each task belongs to the
 deployment it was created in.
@@ -30,7 +23,7 @@ In the deployment sidebar, open **Scheduled** (the clock icon, below
 **Explore**). The page lists the deployment's tasks with their name,
 schedule, status, and description, and is searchable.
 
-{/* TODO: screenshot — Scheduled Tasks list page in the deployment sidebar */}
+{/* TODO: screenshot — Scheduled Tasks list page in the deployment sidebar, showing the New task dropdown */}
 
 ## Anatomy of a task
 
@@ -62,37 +55,88 @@ the schedule fires; it is stored per task.
 
 From the list, you can:
 
-- **Create** a new task.
+- **Create** a new task. The **New task** button is a dropdown with two
+  options:
+  - **Create with agent** — opens a new Analytics Chat pre-seeded with a
+    message asking the agent to explain scheduled tasks and interview you
+    about what the task should do and when it should run. The agent then
+    creates the task for you (see
+    [Managing tasks from chat](#managing-tasks-from-chat)).
+  - **Set up manually** — opens the create dialog where you fill in the
+    task's details yourself.
 - **Edit** an existing task's instructions, schedule, or details.
 - **Enable / Pause** a scheduled task to control whether it runs on schedule.
 - **Run now** — trigger a one-off run immediately. This works for both manual
-  and scheduled tasks.
+  and scheduled tasks. Triggering a run shows a notification with a **View**
+  link straight to the run's chat thread, and the thread appears in the
+  Recent Chats sidebar immediately.
 - **Delete** a task. Deleting removes its schedule and stops all future runs.
+
+{/* TODO: screenshot — New task dropdown with Create with agent and Set up manually options */}
+
+## Task detail page
+
+Clicking a task in the list opens its detail page. The header shows a
+breadcrumb back to Scheduled Tasks, the task name, a status tag (**Manual**,
+**Active**, or **Paused**), and the description, along with actions to
+**Edit** (pencil), **Delete** (trash), and a primary **Run now** button.
+
+The page shows:
+
+- **History** — the task's runs, newest first. Each entry is a timestamped
+  link that opens that run's chat thread. Currently-executing runs
+  show a **Running** tag, and failed runs a **Failed** tag. The list shows
+  the latest 50 runs; a "Showing the latest 50 runs" note appears once the
+  cap is hit.
+- **Instructions** — the task's prompt.
+- **Repeats** — the schedule in plain language.
+
+{/* TODO: screenshot — task detail page with History, Instructions, and Repeats */}
 
 ## Reading the output
 
-Each run creates an [Analytics Chat](/docs/explore-analyze/analytics-chat)
-thread containing the agent's response. Open the thread from the chat UI to
-read the full answer, ask follow-up questions, or
+Each run creates a chat thread containing the agent's response. Open the
+thread in [Analytics Chat](/docs/explore-analyze/analytics-chat) to read the
+full answer, ask follow-up questions, or
 [save results to a Workbook](/docs/explore-analyze/workbooks).
+Scheduled-run threads are marked in the Recent Chats sidebar with a clock
+icon (hover over it to see the "Scheduled task" tooltip).
+
+A run shows as **Running** while it executes, then completes or fails. A
+failed run's thread shows a failure notice instead of an empty thread.
 
 The task runs headlessly under the security context of the user who created
 it, so it sees exactly the data that user can access.
 
+### What the agent can do in a scheduled run
+
+Beyond querying the semantic model, the agent in a scheduled run can:
+
+- **Send email to workspace members** — for example, *"summarize yesterday's
+  signups and email the summary to me."* This requires the agent email tool
+  to be enabled for the workspace; recipients are restricted to workspace
+  members.
+- **Use web search**.
+- **Create and update reports, workbooks, and dashboards**, using the task
+  creator's permissions.
+
+Scheduled runs do not yet have data-model access — editing the semantic
+layer is currently available only in interactive chat.
+
 ## Managing tasks from chat
 
 You can also create and manage Scheduled Tasks conversationally in
-[Analytics Chat](/docs/explore-analyze/analytics-chat). Ask the agent to
-schedule, update, list, or delete tasks in plain language — for example,
-*"schedule a daily summary of yesterday's signups at 9am"* or *"list my
-scheduled tasks."*
+[Analytics Chat](/docs/explore-analyze/analytics-chat) — from any chat, not
+just ones started with **Create with agent** (that menu option simply opens
+a chat pre-seeded for this flow). Ask the agent to schedule, update, list,
+or delete tasks in plain language — for example, *"schedule a daily summary
+of yesterday's signups at 9am"* or *"list my scheduled tasks."*
 
-## Preview limitations
+The agent's actions render in the chat as labeled steps with a clock icon —
+*"Creating scheduled task…"* / *"Created scheduled task"*, *"Listed
+scheduled tasks"*, *"Updated scheduled task"*, and *"Deleted scheduled
+task"*.
 
-- Scheduled Tasks must be activated for your account by the
-  [Cube support team](/admin/account-billing/support).
-- Results are delivered only as Analytics Chat threads — there is no email or
-  Slack delivery.
-- Missed runs (for example, while a deployment is unavailable) are not caught
-  up automatically.
-- There is no in-app run-history view yet.
+The agent manages task definitions: when listing tasks, it can report each
+task's id, name, description, schedule, timezone, and enabled state. A
+task's run history lives on its [detail page](#task-detail-page).


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Updates the Scheduled Tasks page (`/docs/explore-analyze/scheduled-tasks`) now that the feature is generally available and has grown new capabilities. Docs-only change.

**Out of preview**
- Removed the preview `<Warning>` callout and all support-activation language.
- Removed the "Preview limitations" section (the remaining useful facts — the 50-run history cap and the data-model restriction — live in their relevant sections).

**New content**
- **Task detail page** section: header (status tag, Edit/Delete/Run now), run **History** (newest first, Running/Failed tags, latest-50 cap), Instructions, and Repeats.
- **Managing tasks**: `New task` is now a dropdown with **Create with agent** (pre-seeded chat) and **Set up manually**; Run now shows a notification with a **View** link to the run's thread.
- **Reading the output**: clock-icon marker in Recent Chats, run lifecycle (Running → completed/failed), and a new subsection on what the agent can do in a scheduled run — email to workspace members, web search, creating/updating reports, workbooks, and dashboards. Data-model access is noted as not available *yet* (planned follow-up).
- **Managing tasks from chat**: expanded with the labeled tool-call steps and cross-linked with the Create with agent flow.

**Notes for the reviewer**
- Run outputs are consistently called "chat threads"; "Analytics Chat" is used only when naming the feature/UI.
- Three screenshot `{/* TODO */}` placeholders remain (list page, New task menu, detail page) — screenshots to follow.

Rendered locally with `mintlify dev` and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)