### PR TITLE
fix(tesseract): Deduplicate cube names for dimension-only measure expressions

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/member-expression.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/member-expression.test.ts
@@ -310,6 +310,26 @@ views:
   },
 
   [{ count: 1, city: 'New York', cubejoinfield: 'NULL' }, { count: 1, city: 'New York', cubejoinfield: 'NULL' }]));
+
+  it('dimension-only measure expression over multiple dimensions of the same cube', async () => runQueryTest({
+    measures: [
+      {
+        // eslint-disable-next-line no-new-func
+        expression: new Function(
+          'customers',
+          // eslint-disable-next-line no-template-curly-in-string
+          'return `SUM(CASE WHEN ${customers.state} = ${customers.city} THEN 1 ELSE 0 END)`'
+        ),
+        // eslint-disable-next-line no-template-curly-in-string
+        definition: 'SUM(CASE WHEN ${customers.state} = ${customers.city} THEN 1 ELSE 0 END)',
+        expressionName: 'same_state_city_count',
+        cubeName: 'customers',
+      },
+    ],
+  },
+
+  [{ same_state_city_count: '0' }]));
+
   if (getEnv('nativeSqlPlanner')) {
     it('member expression multi stage', async () => runQueryTest({
       measures: [

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_expression_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_expression_symbol.rs
@@ -182,9 +182,12 @@ impl MemberExpressionSymbol {
         if childs.iter().any(|s| !s.is_dimension()) {
             Ok(None)
         } else {
+            // Single member expression can reference multiple dimensions from
+            // the same cube
             let cube_names = childs
                 .into_iter()
                 .map(|child| child.cube_name())
+                .unique()
                 .collect_vec();
             Ok(Some(cube_names))
         }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes an issue with Tesseract where cube names could be duplicated for dimension-only measure expressions, leading to an error like this: `Expected single cube for dimension-only measure expr:Calcs.sum_datepart_utf, got ["Calcs", "Calcs", "Calcs"]`. Related test is included.