### PR TITLE
fix(api-gateway): Accept timezone-suffixed timestamps in date filters

### DIFF
--- a/packages/cubejs-api-gateway/src/query.js
+++ b/packages/cubejs-api-gateway/src/query.js
@@ -250,8 +250,9 @@ const START_DATE_OPERATORS = ['beforeDate', 'afterOrOnDate'];
 const END_DATE_OPERATORS = ['beforeOrOnDate', 'afterDate'];
 
 // Absolute values must pass through byte-exact: bare dates keep each planner's
-// own day-boundary handling, timestamps keep their time component
-const AbsoluteDateTimeRegex = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?)?$/;
+// own day-boundary handling, timestamps keep their time component. Timestamps
+// may carry a UTC designator or offset (e.g. from the SQL API push-down).
+const AbsoluteDateTimeRegex = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?(Z|[+-]\d{2}(:?\d{2})?)?)?$/;
 
 // Resolve a dateRange input — a relative string ("last 2 weeks"), a single
 // absolute date, or a 2-element array — to a normalized [startISO, endISO]

--- a/packages/cubejs-api-gateway/test/normalize-query-filters-dates.test.js
+++ b/packages/cubejs-api-gateway/test/normalize-query-filters-dates.test.js
@@ -235,6 +235,34 @@ describe('normalizeDateFilterValues', () => {
     expect(result).toBe(filter);
   });
 
+  test('inDateRange with two absolute UTC-suffixed timestamps passes through unchanged', () => {
+    // Why: regression guard — the SQL API push-down produces ISO timestamps
+    // with a `Z` designator (e.g. "1999-12-30T00:00:00.000Z"). These are
+    // absolute values and must not be mistaken for relative-date strings.
+    const filter = {
+      member: 'Orders.createdAt',
+      operator: 'inDateRange',
+      values: ['1999-12-30T00:00:00.000Z', '1999-12-30T23:59:59.999Z'],
+    };
+
+    const result = normalizeDateFilterValues(filter, 'UTC');
+
+    expect(result).toBe(filter);
+  });
+
+  test('inDateRange with two absolute offset timestamps passes through unchanged', () => {
+    // Why: numeric UTC offsets are as absolute as `Z` and must be accepted.
+    const filter = {
+      member: 'Orders.createdAt',
+      operator: 'inDateRange',
+      values: ['2024-01-01T00:00:00+02:00', '2024-01-31T23:59:59-05:00'],
+    };
+
+    const result = normalizeDateFilterValues(filter, 'UTC');
+
+    expect(result).toBe(filter);
+  });
+
   test('invalid relative date string raises UserError', () => {
     // Why: failure must surface at the API boundary with a clear HTTP 400,
     // not as an opaque SQL error after the query reaches the database.


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes a v1.6.67 (#11167) regression where `inDateRange` filter values containing timezone-suffixed ISO timestamps (e.g. `1999-12-30T00:00:00.000Z`, as produced by the SQL API push-down) were misclassified as relative-date strings and rejected with a `UserError`. Related test is included.

