### PR TITLE
fix(tesseract): apply multi-stage filter directive through views

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/tree_ops.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/filter/tree_ops.rs
@@ -1,5 +1,32 @@
-use crate::planner::filter::{FilterGroup, FilterItem};
+use crate::planner::filter::{BaseSegment, FilterGroup, FilterItem};
+use crate::planner::MemberSymbol;
 use std::rc::Rc;
+
+/// True if any name in `member_names` matches the filter member or any member
+/// reachable from it via the reference chain. Matching the whole chain, not
+/// just the member's own name, lets `exclude`/`keep_only` — which list base
+/// members — also apply when the measure is queried through a view, where the
+/// carried filter names the view member that references that base.
+fn chain_contains(member_names: &[String], symbol: &Rc<MemberSymbol>) -> bool {
+    if member_names.contains(&symbol.full_name()) {
+        return true;
+    }
+    let mut current = symbol.reference_member();
+    while let Some(reference) = current {
+        if member_names.contains(&reference.full_name()) {
+            return true;
+        }
+        current = reference.reference_member();
+    }
+    false
+}
+
+/// Like `chain_contains`, but for a segment: its bare `full_name` matches the
+/// directive's plain path form, and its evaluator chain matches the view→base
+/// reference the same way as dimension filters.
+fn segment_matches(member_names: &[String], seg: &Rc<BaseSegment>) -> bool {
+    member_names.contains(&seg.full_name()) || chain_contains(member_names, &seg.member_evaluator())
+}
 
 pub fn exclude_members(member_names: &[String], filters: &[FilterItem]) -> Vec<FilterItem> {
     let mut result = Vec::new();
@@ -15,12 +42,12 @@ pub fn exclude_members(member_names: &[String], filters: &[FilterItem]) -> Vec<F
                 }
             }
             FilterItem::Item(itm) => {
-                if !member_names.contains(&itm.member_name()) {
+                if !chain_contains(member_names, &itm.member_evaluator()) {
                     result.push(FilterItem::Item(itm.clone()));
                 }
             }
             FilterItem::Segment(seg) => {
-                if !member_names.contains(&seg.full_name()) {
+                if !segment_matches(member_names, seg) {
                     result.push(FilterItem::Segment(seg.clone()));
                 }
             }
@@ -43,12 +70,12 @@ pub fn keep_only_members(member_names: &[String], filters: &[FilterItem]) -> Vec
                 }
             }
             FilterItem::Item(itm) => {
-                if member_names.contains(&itm.member_name()) {
+                if chain_contains(member_names, &itm.member_evaluator()) {
                     result.push(FilterItem::Item(itm.clone()));
                 }
             }
             FilterItem::Segment(seg) => {
-                if member_names.contains(&seg.full_name()) {
+                if segment_matches(member_names, seg) {
                     result.push(FilterItem::Segment(seg.clone()));
                 }
             }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -554,8 +554,14 @@ views:
           - join_path: orders
             includes:
                 - status
+                - category
                 - created_at
+                - completed_orders
                 - total_amount
+                - amount_exclude_status
+                - amount_keep_only_status
+                - amount_exclude_segment
+                - amount_keep_only_segment
                 - amount_prev_month
                 - mom_growth
                 - amount_reduce_time

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_exclude_drops_dim_filter_from_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_exclude_drops_dim_filter_from_leaf.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__category | orders_ms_view__total_amount | orders_ms_view__amount_exclude_status
+-------------------------+------------------------------+--------------------------------------
+books                    | 600.00                       | 880.00                               
+clothing                 | 300.00                       | 720.00                               
+electronics              | 500.00                       | 650.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_exclude_drops_segment_from_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_exclude_drops_segment_from_leaf.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__category | orders_ms_view__total_amount | orders_ms_view__amount_exclude_segment
+-------------------------+------------------------------+---------------------------------------
+books                    | 600.00                       | 880.00                                
+clothing                 | 300.00                       | 720.00                                
+electronics              | 500.00                       | 650.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_dim_filter_at_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_dim_filter_at_leaf.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__status | orders_ms_view__total_amount | orders_ms_view__amount_keep_only_status
+-----------------------+------------------------------+----------------------------------------
+completed              | 600.00                       | 1400.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_segment_at_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_keep_only_segment_at_leaf.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__category | orders_ms_view__total_amount | orders_ms_view__amount_keep_only_segment
+-------------------------+------------------------------+-----------------------------------------
+books                    | 600.00                       | 600.00                                  
+clothing                 | NULL                         | 300.00                                  
+electronics              | NULL                         | 500.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
@@ -79,6 +79,245 @@ async fn test_view_reduce_by_time_dimension() {
     }
 }
 
+// CORE-606: the `filter: exclude` directive must drop the query-level filter
+// from the measure's inner leaf CTE identically whether the measure is queried
+// on the cube directly or through a view. Regression: through the view the
+// status filter leaked into the exclude leaf, so amount_exclude_status collapsed
+// to total_amount (any derived percentage became 100%).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_exclude_drops_dim_filter_from_leaf() {
+    let ctx = create_context();
+
+    let cube_query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_exclude_status
+        dimensions:
+          - orders.category
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.category
+    "#};
+
+    let view_query = indoc! {r#"
+        measures:
+          - orders_ms_view.total_amount
+          - orders_ms_view.amount_exclude_status
+        dimensions:
+          - orders_ms_view.category
+        filters:
+          - dimension: orders_ms_view.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders_ms_view.category
+    "#};
+
+    // The status filter belongs only in the total_amount leaf, never in the
+    // amount_exclude_status leaf. Count its occurrences: querying the cube
+    // directly yields exactly one; through the view it must be the same.
+    let count_status_filter = |sql: &str| sql.matches("\"orders\".status =").count();
+    let cube_sql = ctx.build_sql(cube_query).unwrap();
+    let view_sql = ctx.build_sql(view_query).unwrap();
+    assert_eq!(
+        count_status_filter(&view_sql),
+        count_status_filter(&cube_sql),
+        "exclude(status) must drop the query filter from the leaf CTE through a \
+         view just as on the cube; the filter leaked into the exclude leaf.\n\
+         cube SQL:\n{}\nview SQL:\n{}",
+        cube_sql,
+        view_sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(view_query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// CORE-606 (segment variant): `filter: exclude` targeting a segment must drop
+// the query-level segment from the leaf CTE through a view, just as on the cube.
+// The segment renders as `"orders".status = 'completed'`; it belongs only in the
+// total_amount leaf, never in the amount_exclude_segment leaf.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_exclude_drops_segment_from_leaf() {
+    let ctx = create_context();
+
+    let cube_query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_exclude_segment
+        dimensions:
+          - orders.category
+        segments:
+          - orders.completed_orders
+        order:
+          - id: orders.category
+    "#};
+
+    let view_query = indoc! {r#"
+        measures:
+          - orders_ms_view.total_amount
+          - orders_ms_view.amount_exclude_segment
+        dimensions:
+          - orders_ms_view.category
+        segments:
+          - orders_ms_view.completed_orders
+        order:
+          - id: orders_ms_view.category
+    "#};
+
+    let count_segment = |sql: &str| sql.matches("\"orders\".status = 'completed'").count();
+    let cube_sql = ctx.build_sql(cube_query).unwrap();
+    let view_sql = ctx.build_sql(view_query).unwrap();
+    assert_eq!(
+        count_segment(&view_sql),
+        count_segment(&cube_sql),
+        "exclude(segment) must drop the query segment from the leaf CTE through a \
+         view just as on the cube; the segment leaked into the exclude leaf.\n\
+         cube SQL:\n{}\nview SQL:\n{}",
+        cube_sql,
+        view_sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(view_query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// CORE-606 (keep_only dimension variant): `filter: keep_only: [status]` must
+// keep the status filter and drop the category filter from the leaf CTE through
+// a view exactly as on the cube. Regression path would drop status too (its
+// view member name never matched the base `orders.status`), collapsing the leaf
+// to a grand total.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_keep_only_dim_filter_at_leaf() {
+    let ctx = create_context();
+
+    let cube_query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_keep_only_status
+        dimensions:
+          - orders.status
+        filters:
+          - dimension: orders.status
+            operator: equals
+            values: [completed]
+          - dimension: orders.category
+            operator: equals
+            values: [books]
+    "#};
+
+    let view_query = indoc! {r#"
+        measures:
+          - orders_ms_view.total_amount
+          - orders_ms_view.amount_keep_only_status
+        dimensions:
+          - orders_ms_view.status
+        filters:
+          - dimension: orders_ms_view.status
+            operator: equals
+            values: [completed]
+          - dimension: orders_ms_view.category
+            operator: equals
+            values: [books]
+    "#};
+
+    let count_status = |sql: &str| sql.matches("\"orders\".status =").count();
+    let count_category = |sql: &str| sql.matches("\"orders\".category =").count();
+    let cube_sql = ctx.build_sql(cube_query).unwrap();
+    let view_sql = ctx.build_sql(view_query).unwrap();
+    assert_eq!(
+        count_status(&view_sql),
+        count_status(&cube_sql),
+        "keep_only(status) must keep the status filter in the leaf CTE through a view.\n\
+         cube SQL:\n{}\nview SQL:\n{}",
+        cube_sql,
+        view_sql,
+    );
+    assert_eq!(
+        count_category(&view_sql),
+        count_category(&cube_sql),
+        "keep_only(status) must drop the category filter from the leaf CTE through a view.\n\
+         cube SQL:\n{}\nview SQL:\n{}",
+        cube_sql,
+        view_sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(view_query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// CORE-606 (keep_only segment variant): `filter: keep_only: [segment]` must keep
+// the segment and drop the category filter from the leaf CTE through a view.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_keep_only_segment_at_leaf() {
+    let ctx = create_context();
+
+    let cube_query = indoc! {r#"
+        measures:
+          - orders.total_amount
+          - orders.amount_keep_only_segment
+        dimensions:
+          - orders.category
+        segments:
+          - orders.completed_orders
+        filters:
+          - dimension: orders.category
+            operator: equals
+            values: [books]
+        order:
+          - id: orders.category
+    "#};
+
+    let view_query = indoc! {r#"
+        measures:
+          - orders_ms_view.total_amount
+          - orders_ms_view.amount_keep_only_segment
+        dimensions:
+          - orders_ms_view.category
+        segments:
+          - orders_ms_view.completed_orders
+        filters:
+          - dimension: orders_ms_view.category
+            operator: equals
+            values: [books]
+        order:
+          - id: orders_ms_view.category
+    "#};
+
+    let count_segment = |sql: &str| sql.matches("\"orders\".status = 'completed'").count();
+    let count_category = |sql: &str| sql.matches("\"orders\".category =").count();
+    let cube_sql = ctx.build_sql(cube_query).unwrap();
+    let view_sql = ctx.build_sql(view_query).unwrap();
+    assert_eq!(
+        count_segment(&view_sql),
+        count_segment(&cube_sql),
+        "keep_only(segment) must keep the segment in the leaf CTE through a view.\n\
+         cube SQL:\n{}\nview SQL:\n{}",
+        cube_sql,
+        view_sql,
+    );
+    assert_eq!(
+        count_category(&view_sql),
+        count_category(&cube_sql),
+        "keep_only(segment) must drop the category filter from the leaf CTE through a view.\n\
+         cube SQL:\n{}\nview SQL:\n{}",
+        cube_sql,
+        view_sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(view_query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_view_with_time_shift() {
     let ctx = create_context();


### PR DESCRIPTION
## Summary

A `multi_stage` measure's `filter: exclude` / `keep_only` directive was silently ignored when the measure was queried through a view. Directly on the cube the directive correctly reshapes the inner leaf CTE's filters; through a view the query filter leaked into (`exclude`) or was dropped from (`keep_only`) that leaf, collapsing the measure to the filtered total (e.g. a percentage-of-total measure always returned 100%).

## Root cause

The directive matched query filters by string `full_name` equality. Through a view the carried filter names the view member (e.g. `orders_ms_view.status`) while the directive lists the base member (`orders.status`), so the match failed. Same string-vs-reference-chain asymmetry previously fixed for `reduce_by` / `group_by` grain reshaping.

## Changes

- `tree_ops`: match dimension filters via `chain_contains`, which walks the member reference chain and resolves the view member down to its base; segments via `segment_matches` (bare `full_name` or evaluator chain). These functions are used exclusively by the filter-directive path, so no other filter handling is affected.
- Added integration guards in `multi_stage/views.rs` covering all four variants — `{exclude, keep_only}` × `{dimension, segment}` — as differential `build_sql` assertions (view predicate counts must equal the cube-direct query) plus Postgres result snapshots.
- Exposed the corresponding measures/segment through `orders_ms_view` in the test fixture.

## Testing

- `cubesqlplanner` lib suite: 1069 passed, 0 failed.
- `multi_stage::filter_directive` + `multi_stage::views` on real Postgres: 18 passed.
- Verified the new guards are real: stashing the `tree_ops` fix makes all four view tests fail; restoring it makes them pass.
- Result through a view now matches the cube-direct result (unfiltered denominator).