### PR TITLE
fix(tesseract): resolve shared rank reference to its inode, not the bare-grid leaf

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/planners/multi_stage/multi_stage_query_planner.rs
@@ -475,10 +475,14 @@ impl MultiStageQueryPlanner {
         };
 
         let member_name = member.full_name();
-        if let Some(exists) = descriptions
-            .iter()
-            .find(|q| q.is_match_member_and_state(&member, &state))
-        {
+        // Skip without-member leaves: they carry the rank/similar member's
+        // own name only to select its dimension grid, so `(member, state)`
+        // alone can't tell them apart from the member's real inode CTE. A
+        // `{member}` reference must always resolve to the computing inode,
+        // never to the bare-grid leaf.
+        if let Some(exists) = descriptions.iter().find(|q| {
+            !q.member().is_without_member_leaf() && q.is_match_member_and_state(&member, &state)
+        }) {
             return Ok(exists.clone());
         };
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -358,6 +358,45 @@ cubes:
             add_group_by:
                 - orders.created_at
 
+          # CORE-602: end-of-period rank shared by two sibling consumers.
+          # `eop_rank` keeps the last snapshot per status; both consumers
+          # filter on `{eop_rank} = 1`, so a query selecting both must plan
+          # the rank stage once and join both consumers to it.
+          - name: eop_rank
+            type: rank
+            multi_stage: true
+            order_by:
+                - sql: "{CUBE.created_at}"
+                  dir: desc
+            grain:
+                include:
+                    - orders.status
+                    - orders.created_at
+                keep_only:
+                    - orders.status
+
+          - name: balance_eop_a
+            type: sum
+            multi_stage: true
+            sql: "{CUBE.total_amount}"
+            grain:
+                include:
+                    - orders.status
+                    - orders.created_at
+            filters:
+                - sql: "{CUBE.eop_rank} = 1"
+
+          - name: balance_eop_b
+            type: sum
+            multi_stage: true
+            sql: "{CUBE.total_amount}"
+            grain:
+                include:
+                    - orders.status
+                    - orders.created_at
+            filters:
+                - sql: "{CUBE.eop_rank} = 1"
+
           - name: status_weighted_amount
             type: sum
             multi_stage: true

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rank.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rank.rs
@@ -163,6 +163,45 @@ async fn test_rank_no_granularity() {
     }
 }
 
+// CORE-602: two multi-stage consumers of the same rank measure in one query.
+// A single consumer of `eop_rank` plans fine, but selecting both `balance_eop_a`
+// and `balance_eop_b` (identical consumers filtering on `{eop_rank} = 1`) made
+// the planner reach `to_sql` on the shared rank symbol instead of resolving it
+// through its multi-stage sub-query ref, failing with
+// "Rank measure doesn't support direct evaluation".
+#[tokio::test(flavor = "multi_thread")]
+async fn test_two_consumers_of_same_rank() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.balance_eop_a
+          - orders.balance_eop_b
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_single_consumer_of_rank() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.balance_eop_a
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rank_with_filter() {
     let ctx = create_context();

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__rank__single_consumer_of_rank.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__rank__single_consumer_of_rank.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rank.rs
+expression: result
+---
+orders__balance_eop_a
+---------------------
+350.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__rank__two_consumers_of_same_rank.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__rank__two_consumers_of_same_rank.snap
@@ -1,0 +1,7 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/rank.rs
+expression: result
+---
+orders__balance_eop_a | orders__balance_eop_b
+----------------------+----------------------
+350.00                | 350.00


### PR DESCRIPTION
## Summary

Fixes a hard error in the Tesseract SQL planner when a query selects two (or more) multi-stage measures that both consume the same `rank` measure via a `filters: [{ sql: "{rank} = 1" }]` dependency (the natural end-of-period / ratio pattern). Such a query failed with `Rank measure doesn't support direct evaluation`, while a single consumer worked.

## Changes

- A `rank` measure expands into two CTEs: a *without-member leaf* that selects only the dimension grid, and the *rank inode* that computes `RANK()` over it. Both descriptions carried the rank member's own name, so the `(member, state)` dedup in `make_queries_descriptions` could not tell them apart.
- The first consumer built the rank fresh and got the inode; any subsequent consumer hit the dedup and matched the leaf (registered first), whose filter then evaluated the rank symbol directly and errored.
- Fix: skip without-member leaves when deduping — a `{member}` reference must always resolve to the computing inode, never to the bare-grid leaf. The leaf is still built exactly once as a child of the inode (guaranteed by the inode dedup).

## Testing

- New Rust integration guards in `multi_stage/rank.rs`: `test_two_consumers_of_same_rank` (was the red repro) and `test_single_consumer_of_rank`, backed by fixture measures `eop_rank` / `balance_eop_a` / `balance_eop_b`.
- Verified against real Postgres: both consumers return `350` (sum over the last snapshot per group — `200 + 50 + 100`), not the grand total `2250`, confirming the rank filter is actually applied.
- Full `cubesqlplanner` suite (1067 tests) green; all `rank` and `multiple_measures` integration-postgres tests green — no data-snapshot regressions.
