### PR TITLE
fix(tesseract): resolve multi_stage order_by against owning cube through views

### DIFF
--- a/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-order-by-view.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-order-by-view.test.ts
@@ -1,0 +1,110 @@
+import { getEnv } from '@cubejs-backend/shared';
+import { prepareYamlCompiler } from '../../unit/PrepareCompiler';
+import { dbRunner } from './PostgresDBRunner';
+
+// CORE-549: a `rank` multi-stage measure whose `order_by` template references a
+// member (`num_parcels`) that is NOT exposed by the view fails to compile: the
+// order_by template is resolved against the view's cube context instead of the
+// measure's owning cube, so `num_parcels` cannot be found.
+//
+// The ticket reported this as a JS crash (`Cannot read properties of undefined
+// (reading '_objectWithResolvedProperties')` in BaseQuery.js). On current master
+// order_by template compilation happens in the Tesseract planner, so it now
+// surfaces as `Cannot resolve: num_parcels` — same root cause, different surface.
+//
+// The base-cube control (querying `orders.*` directly) compiles and returns the
+// ranks; the view query (`orders_view.*`, with `num_parcels` deliberately not in
+// `includes`) reproduces the failure.
+//
+// Inline data (per-day sums so the two days rank distinctly):
+//   id parcels created_at
+//   1  10      2024-01-01   -> day 2024-01-01 total = 30
+//   2  20      2024-01-01
+//   3  30      2024-01-02   -> day 2024-01-02 total = 80
+//   4  50      2024-01-02
+//
+// volume_by_day_rank: reduce_by created_at removes the day from the window
+// partition, so the rank is global over days ordered by num_parcels desc:
+//   2024-01-02 (80) -> 1, 2024-01-01 (30) -> 2.
+describe('Multi-Stage rank order_by through a view (CORE-549)', () => {
+  jest.setTimeout(200000);
+
+  const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(`
+cubes:
+  - name: orders
+    sql: >
+      SELECT 1 AS id, 10 AS parcels, '2024-01-01T00:00:00.000Z'::timestamptz AS created_at
+      union all
+      SELECT 2 AS id, 20 AS parcels, '2024-01-01T00:00:00.000Z'::timestamptz AS created_at
+      union all
+      SELECT 3 AS id, 30 AS parcels, '2024-01-02T00:00:00.000Z'::timestamptz AS created_at
+      union all
+      SELECT 4 AS id, 50 AS parcels, '2024-01-02T00:00:00.000Z'::timestamptz AS created_at
+
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+
+      - name: created_at
+        sql: created_at
+        type: time
+
+    measures:
+      - name: num_parcels
+        type: sum
+        sql: parcels
+
+      - name: volume_by_day_rank
+        type: rank
+        multi_stage: true
+        reduce_by:
+          - created_at
+        order_by:
+          - sql: "{num_parcels}"
+            dir: desc
+
+views:
+  - name: orders_view
+    cubes:
+      - join_path: orders
+        includes:
+          - created_at
+          - volume_by_day_rank
+          # num_parcels deliberately NOT exposed
+    `);
+
+  if (getEnv('nativeSqlPlanner')) {
+    // Control: querying the base cube compiles cleanly (num_parcels resolves in
+    // the owning cube's context).
+    it('base cube: rank order_by references a non-selected member', async () => dbRunner.runQueryTest({
+      measures: ['orders.volume_by_day_rank'],
+      timeDimensions: [
+        { dimension: 'orders.created_at', granularity: 'day' }
+      ],
+      order: [{ id: 'orders.created_at' }],
+      timezone: 'UTC',
+    }, [
+      { orders__created_at_day: '2024-01-01T00:00:00.000Z', orders__volume_by_day_rank: '2' },
+      { orders__created_at_day: '2024-01-02T00:00:00.000Z', orders__volume_by_day_rank: '1' },
+    ], { joinGraph, cubeEvaluator, compiler }));
+
+    // Repro: the same measure through a view that does not expose num_parcels.
+    it('view: rank order_by references a member not exposed by the view', async () => dbRunner.runQueryTest({
+      measures: ['orders_view.volume_by_day_rank'],
+      timeDimensions: [
+        { dimension: 'orders_view.created_at', granularity: 'day' }
+      ],
+      order: [{ id: 'orders_view.created_at' }],
+      timezone: 'UTC',
+    }, [
+      { orders_view__created_at_day: '2024-01-01T00:00:00.000Z', orders_view__volume_by_day_rank: '2' },
+      { orders_view__created_at_day: '2024-01-02T00:00:00.000Z', orders_view__volume_by_day_rank: '1' },
+    ], { joinGraph, cubeEvaluator, compiler }));
+  } else {
+    // Multi-stage rank is Tesseract-only.
+    test.skip('base cube: rank order_by references a non-selected member', () => { expect(1).toBe(1); });
+    test.skip('view: rank order_by references a member not exposed by the view', () => { expect(1).toBe(1); });
+  }
+});

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
@@ -573,13 +573,6 @@ impl SymbolFactory for MeasureSymbolFactory {
             }
         }
 
-        let mut measure_order_by = vec![];
-        if let Some(group_by) = definition.order_by()? {
-            for item in group_by.iter() {
-                let node = compiler.compile_sql_call(path.cube_name(), item.sql()?)?;
-                measure_order_by.push(MeasureOrderBy::new(node, item.dir()?));
-            }
-        }
         let sql = if let Some(sql) = sql {
             Some(compiler.compile_sql_call(path.cube_name(), sql)?)
         } else {
@@ -588,21 +581,34 @@ impl SymbolFactory for MeasureSymbolFactory {
 
         let is_sql_is_direct_ref = sql.as_ref().is_some_and(|s| s.is_direct_reference());
 
-        // mask.sql references are written in the context of the cube that
-        // owns the measure. When a measure is exposed through a view, the
-        // measure's sql is a direct reference to the underlying cube member;
-        // compile mask.sql against that referenced member's cube so CUBE /
-        // cross-cube references inside the mask resolve the same way as on
-        // the owning cube — and as they do on the legacy BaseQuery path,
-        // which routes mask compilation through aliasMember for the same
-        // reason.
-        let mask_sql_cube_name = sql
-            .as_ref()
-            .and_then(|s| s.resolve_direct_reference())
-            .map(|dep| dep.cube_name())
-            .unwrap_or_else(|| path.cube_name().clone());
+        // order_by and mask.sql are authored in the context of the cube that
+        // owns the measure and may reference members the exposing view does not
+        // re-export. When a measure is exposed through a view, its sql is a
+        // direct reference to the underlying cube member; resolve these
+        // templates against that referenced member's cube so CUBE / member
+        // references inside them resolve as they do on the owning cube. On a
+        // plain cube the owning cube is the measure's own cube.
+        let cube = cube_evaluator.cube_from_path(path.cube_name().clone())?;
+        let is_view = cube.static_data().is_view.unwrap_or(false);
+        let owning_cube_name = if is_view {
+            sql.as_ref()
+                .and_then(|s| s.resolve_direct_reference())
+                .map(|dep| dep.cube_name())
+                .unwrap_or_else(|| path.cube_name().clone())
+        } else {
+            path.cube_name().clone()
+        };
+
+        let mut measure_order_by = vec![];
+        if let Some(group_by) = definition.order_by()? {
+            for item in group_by.iter() {
+                let node = compiler.compile_sql_call(&owning_cube_name, item.sql()?)?;
+                measure_order_by.push(MeasureOrderBy::new(node, item.dir()?));
+            }
+        }
+
         let mask_sql = if let Some(mask_sql) = mask_sql {
-            Some(compiler.compile_sql_call(&mask_sql_cube_name, mask_sql)?)
+            Some(compiler.compile_sql_call(&owning_cube_name, mask_sql)?)
         } else {
             None
         };
@@ -727,7 +733,6 @@ impl SymbolFactory for MeasureSymbolFactory {
             owned
         };
 
-        let cube = cube_evaluator.cube_from_path(path.cube_name().clone())?;
         let alias = compiler
             .alias_for_member(path.full_name())
             .unwrap_or_else(|| {
@@ -737,8 +742,6 @@ impl SymbolFactory for MeasureSymbolFactory {
                     &None,
                 )
             });
-
-        let is_view = cube.static_data().is_view.unwrap_or(false);
 
         let is_reference = (is_view && is_sql_is_direct_ref)
             || (!owned_by_cube

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_measure_definition.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_measure_definition.rs
@@ -67,6 +67,10 @@ impl_static_data!(
 );
 
 impl MockMeasureDefinition {
+    pub fn raw_order_by(&self) -> Option<Vec<Rc<MockMemberOrderBy>>> {
+        self.order_by.clone()
+    }
+
     pub fn from_yaml(yaml: &str) -> Result<Rc<Self>, CubeError> {
         let yaml_def: YamlMeasureDefinition = serde_yaml::from_str(yaml)
             .map_err(|e| CubeError::user(format!("Failed to parse YAML: {}", e)))?;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/cube_bridge/mock_schema.rs
@@ -600,12 +600,19 @@ impl MockViewBuilder {
                             "number" | "string" | "time" | "boolean" => original_type.clone(),
                             _ => "number".to_string(),
                         };
+                        // A view member re-exports the source measure's
+                        // multi_stage flag and order_by, so order_by templates
+                        // are resolved in the view's cube context (where their
+                        // referenced members may be absent), matching how view
+                        // members are materialized in the schema compiler.
                         all_measures.insert(
                             view_name,
                             Rc::new(
                                 MockMeasureDefinition::builder()
                                     .measure_type(view_type)
                                     .sql(view_member_sql)
+                                    .multi_stage(measure.static_data().multi_stage)
+                                    .order_by(measure.raw_order_by())
                                     .build(),
                             ),
                         );

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -68,6 +68,20 @@ cubes:
             type: time
             sql: updated_at
 
+          # CORE-549 neighbor: a dimension `case` referencing a member
+          # (category) not exposed by orders_ms_view. Unlike order_by, `case`
+          # is not re-exported onto the view member, so it is reached through
+          # the view member's direct sql reference and resolves against the
+          # owning cube — it must keep building through the view.
+          - name: category_label
+            type: string
+            case:
+                when:
+                    - sql: "{CUBE.category} = 'books'"
+                      label: Literature
+                else:
+                    label: Other
+
           - name: customer_name
             type: string
             sql: "{customers.name}"
@@ -300,6 +314,30 @@ cubes:
             order_by:
                 - sql: "{CUBE.total_amount}"
                   dir: desc
+
+          # CORE-549: order_by references a measure (avg_amount) that
+          # orders_ms_view does not expose. Through the view the order_by
+          # SqlCall must resolve against the owning cube (orders), not the
+          # view — otherwise planning fails with "Cannot resolve: avg_amount".
+          - name: amount_rank_order_by_hidden
+            type: rank
+            multi_stage: true
+            reduce_by:
+                - orders.status
+            order_by:
+                - sql: "{CUBE.avg_amount}"
+                  dir: desc
+
+          # CORE-549 neighbor: a measure `filters` referencing a member
+          # (category) not exposed by orders_ms_view. `filters` is not
+          # re-exported onto the view member, so it is reached through the
+          # view member's direct sql reference and resolves against the
+          # owning cube — it must keep building through the view.
+          - name: amount_filtered_hidden
+            type: sum
+            sql: amount
+            filters:
+                - sql: "{CUBE.category} = 'books'"
 
           # Rank reduced by the time dimension (bare) while ordered by a
           # measure. With created_at selected at a granularity the partition
@@ -560,3 +598,6 @@ views:
                 - mom_growth
                 - amount_reduce_time
                 - amount_rank_reduce_time
+                - amount_rank_order_by_hidden
+                - amount_filtered_hidden
+                - category_label

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_case_dimension_hidden_ref.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_case_dimension_hidden_ref.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__category_label | orders_ms_view__total_amount
+-------------------------------+-----------------------------
+Literature                     | 880.00                      
+Other                          | 1370.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_filtered_measure_hidden_ref.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_filtered_measure_hidden_ref.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__status | orders_ms_view__amount_filtered_hidden
+-----------------------+---------------------------------------
+cancelled              | 100.00                                
+completed              | 600.00                                
+pending                | 180.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_order_by_hidden_member.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__views__view_order_by_hidden_member.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+expression: result
+---
+orders_ms_view__status | orders_ms_view__amount_rank_order_by_hidden
+-----------------------+--------------------------------------------
+cancelled              | 3                                          
+completed              | 1                                          
+pending                | 2

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/views.rs
@@ -150,3 +150,111 @@ async fn test_view_with_filter() {
         insta::assert_snapshot!(result);
     }
 }
+
+// CORE-549: a rank measure whose `order_by` references a member the view does
+// not expose (`avg_amount`). On the base cube the order_by resolves in the
+// owning cube's context and planning succeeds; through orders_ms_view the
+// order_by SqlCall was compiled against the view's cube context, where
+// `avg_amount` is not a member, so planning failed with
+// "Cannot resolve: avg_amount". Both queries must build and use a window fn.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_order_by_hidden_member() {
+    let ctx = create_context();
+
+    // Control: the base cube resolves the order_by member and plans fine.
+    let base_query = indoc! {r#"
+        measures:
+          - orders.amount_rank_order_by_hidden
+        dimensions:
+          - orders.status
+        order:
+          - id: orders.status
+    "#};
+    // reduce_by(status) empties the partition (status is the only selected
+    // dim), so the window is `rank() OVER (ORDER BY ...)` with no PARTITION BY.
+    let base_sql = ctx.build_sql(base_query).unwrap();
+    assert!(
+        base_sql.contains("rank() OVER ("),
+        "expected a rank window function, got:\n{}",
+        base_sql,
+    );
+
+    // Repro: the same measure through the view that does not expose avg_amount.
+    let view_query = indoc! {r#"
+        measures:
+          - orders_ms_view.amount_rank_order_by_hidden
+        dimensions:
+          - orders_ms_view.status
+        order:
+          - id: orders_ms_view.status
+    "#};
+    let view_sql = ctx.build_sql(view_query).unwrap();
+    assert!(
+        view_sql.contains("rank() OVER ("),
+        "expected a rank window function, got:\n{}",
+        view_sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(view_query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+// CORE-549 neighbors: `filters` and `case` reference members the same way
+// `order_by` does, but they are NOT re-exported onto the view member — they
+// stay on the base measure/dimension and are reached through the view
+// member's direct sql reference. So a filtered measure / case dimension whose
+// template references a member the view does not expose (`category`) must keep
+// building through the view. These guard that the neighbors don't regress into
+// the order_by failure mode.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_filtered_measure_hidden_ref() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders_ms_view.amount_filtered_hidden
+        dimensions:
+          - orders_ms_view.status
+        order:
+          - id: orders_ms_view.status
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert!(
+        sql.contains("category"),
+        "expected the measure filter on category to survive through the view,\n\
+         got:\n{}",
+        sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_view_case_dimension_hidden_ref() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders_ms_view.total_amount
+        dimensions:
+          - orders_ms_view.category_label
+        order:
+          - id: orders_ms_view.category_label
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert!(
+        sql.contains("CASE") && sql.contains("category"),
+        "expected the dimension CASE referencing category to survive through the view,\n\
+         got:\n{}",
+        sql,
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}


### PR DESCRIPTION
## Summary

A `rank`-type multi-stage measure whose `order_by` template references a member that a view does not re-export failed to compile when queried through that view (`Cannot resolve: <member>`). The `order_by` template was resolved in the view's cube context instead of the cube that owns the measure. Fixes cube-js/cube#10856.

## Changes

- `measure_symbol.rs`: resolve `order_by` (and `mask.sql`) against the measure's owning cube — derived from the view member's direct `sql` reference and guarded by `is_view`, so plain-cube behavior is unchanged.
- Neighbor audit: `filters` and `case` are not re-exported onto view members (they are reached through the member's direct `sql` reference and already resolve against the owning cube), so they are unaffected — covered with regression guards.
- Test-harness fidelity: `MockSchemaBuilder::finish_view` now copies `order_by` + `multi_stage` onto view members, mirroring how view members are materialized, so this class of bug is reproducible in the Rust planner harness.

## Testing

- Rust (`cubesqlplanner`): full lib suite green (1068 passed). New `multi_stage::views::test_view_order_by_hidden_member` reproduces the failure and now passes; neighbor guards `test_view_filtered_measure_hidden_ref` / `test_view_case_dimension_hidden_ref` confirm `filters`/`case` stay safe through views.
- JS integration (`multi-stage-order-by-view.test.ts`, under `CUBEJS_TESSERACT_SQL_PLANNER=true`): base cube + view queries both return correct ranks.
- `cargo fmt --check` clean.
