### PR TITLE
docs: document relative date ranges in view-level default_ui_filters

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -43,15 +43,24 @@ views:
 
     meta:
       default_ui_filters:
+        - member: created_at
+          operator: between
+          values: ["7 days ago", "today"]
         - member: status
           operator: equals
-          values:
-            - completed
+          values: ["completed"]
 ```
 
 When you select such a view in a new tab, those filters are added to the query
 automatically. They behave exactly like filters you add yourself: you can
 change their values, switch operators, or remove them.
+
+Date range filters can use relative bounds like `7 days ago` or `this month`.
+A relative range resolves each time the query runs, so the window rolls
+forward day over day, and the filter's date editor opens on the **Relative**
+tab showing its bounds. See
+[`default_ui_filters`][ref-default-ui-filters] for the full list of accepted
+operators and values.
 
 Resetting the tab or going back to the view list clears default filters
 along with the rest of the query; they are seeded again the next time you

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -287,14 +287,13 @@ over the view's default. When `auto_run` is not set, auto-run is on.
 #### `default_ui_filters`
 
 In the Cube cloud platform, you can use the `default_ui_filters` key in a
-view's `meta` to define default filters for [workbooks][ref-workbook-filtering].
-When the view is selected in a new workbook tab, these filters are
-pre-populated as regular, fully editable filters — data consumers can change
-their values, switch operators, or remove them entirely.
+view's `meta` to define default filters for [workbooks][ref-workbook-filtering]
+and views embedded via the React Embed SDK. When the view is selected, these
+filters are pre-populated as regular, fully editable filters — data consumers
+can change their values, switch operators, or remove them entirely.
 
-Each entry has the same shape as a [`default_filters`](#default_filters) entry:
-a `member` (a dimension or measure exposed by the view), an `operator`, and a
-list of `values`.
+Each entry has a `member` (a dimension or measure exposed by the view), an
+`operator`, and a list of `values`.
 
 <Info>
 
@@ -315,15 +314,12 @@ views:
 
     meta:
       default_ui_filters:
+        - member: created_at
+          operator: between
+          values: ["7 days ago", "today"]
         - member: status
           operator: equals
-          values:
-            - completed
-        - member: created_at
-          operator: inDateRange
-          values:
-            - 2024-01-01
-            - 2024-12-31
+          values: ["completed", "shipped"]
 ```
 
 ```javascript title="JavaScript"
@@ -338,14 +334,14 @@ view(`orders_view`, {
   meta: {
     default_ui_filters: [
       {
-        member: `status`,
-        operator: `equals`,
-        values: [`completed`]
+        member: `created_at`,
+        operator: `between`,
+        values: [`7 days ago`, `today`]
       },
       {
-        member: `created_at`,
-        operator: `inDateRange`,
-        values: [`2024-01-01`, `2024-12-31`]
+        member: `status`,
+        operator: `equals`,
+        values: [`completed`, `shipped`]
       }
     ]
   }
@@ -353,6 +349,40 @@ view(`orders_view`, {
 ```
 
 </CodeGroup>
+
+##### Operators
+
+Operators use the same names data consumers see in the workbook filter bar:
+`equals`, `not_equals`, `between`, `greater_than`, `greater_than_or_equal`,
+`less_than`, `less_than_or_equal`, `contains`, `not_contains`, `starts_with`,
+`not_starts_with`, `ends_with`, `not_ends_with`, `is_null`, `is_not_null`.
+
+##### Relative date values
+
+A `between` filter always takes an explicit two-element `[start, end]` pair.
+Each bound is one of:
+
+- **A relative value**: `today`, `yesterday`,
+  `N days|weeks|months|quarters|years ago` (e.g. `7 days ago`),
+  `N ... from now` (e.g. `2 weeks from now`), or
+  `this week|month|quarter|year`. `now` is accepted as an alias for `today`.
+- **A fixed ISO date**: `"2026-01-15"`.
+- **A number**, for numeric members.
+
+Relative values also work with the open-ended comparison operators — for
+example, `greater_than` with `values: ["7 days ago"]`.
+
+Relative bounds resolve when a query runs, not when the filter is seeded:
+`["7 days ago", "today"]` produces SQL based on the current date (e.g.
+`BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE`), so the window
+rolls forward day over day. Both bounds are inclusive — `["7 days ago",
+"today"]` covers 8 calendar days for daily data. In the workbook, the seeded
+filter opens the date editor on the **Relative** tab showing its bounds.
+
+Values are case- and whitespace-insensitive. Bounds are validated: an
+unrecognized value, or a `between` filter with a single value, drops that
+filter entry with a browser-console warning — the remaining entries still
+apply, and view selection never breaks.
 
 Unlike [`default_filters`](#default_filters), which are enforced on every query
 against the view, `default_ui_filters` only provide a starting point for the


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Docs-only change for CUB-3018 (shipped in `cubejs-enterprise#12945` / `#12956`): view-level `meta.default_ui_filters` now supports relative date bounds, and its authoring vocabulary was finalized to mirror the workbook filter bar.

**`reference/data-modeling/view.mdx` — `default_ui_filters` section**
- Canonical example now uses `between` with `values: ["7 days ago", "today"]` (inline YAML arrays per house style), and the intro mentions views embedded via the React Embed SDK.
- New **Operators** subsection listing the UI operator names (`equals`, `not_equals`, `between`, `greater_than`, …, `is_null`, `is_not_null`).
- New **Relative date values** subsection: `between` takes an explicit two-element `[start, end]` pair; each bound is a relative value (`today`, `yesterday`, `N <unit>s ago`, `N <unit>s from now`, `this week|month|quarter|year`, `now` as alias for `today`), a fixed ISO date, or a number for numeric members. Covers relative values on open-ended comparisons (`greater_than: ["7 days ago"]`), query-time resolution (`CURRENT_DATE`-based SQL, rolls day over day), both-bounds inclusivity, the Relative-tab editor, case/whitespace-insensitivity, and validation (a bad bound or single-value `between` drops that entry with a console warning; view selection never breaks).

**`docs/explore-analyze/workbooks/querying-data.mdx`**
- Default filters example updated to the new syntax, plus a short paragraph on relative bounds linking to the reference.

**Notes for the reviewer**
- The REST API `inDateRange` docs and the `default_filters` section are deliberately untouched — their semantics are unchanged, and query-level relative support is a separate unshipped ticket (CUB-3129).
- Single-string range forms (`"last 7 days"`, `"from … to …"`) are intentionally not documented; they were never released as public syntax and are rejected.

Rendered locally with `mintlify dev` and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)