### PR TITLE
fix(trino-driver): Use SSL options in testConnection

### DIFF
--- a/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
+++ b/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
@@ -53,7 +53,7 @@ export type PrestoDriverConfiguration = PrestoDriverExportBucket & PrestoDriverI
   custom_auth?: string;
   // eslint-disable-next-line camelcase
   basic_auth?: { user: string, password: string };
-  ssl?: string | TLSConnectionOptions;
+  ssl?: TLSConnectionOptions;
   dataSource?: string;
   queryTimeout?: number;
   preAggregations?: boolean;

--- a/packages/cubejs-trino-driver/src/TrinoDriver.ts
+++ b/packages/cubejs-trino-driver/src/TrinoDriver.ts
@@ -1,4 +1,5 @@
-import fetch from 'node-fetch';
+import fetch, { RequestInit } from 'node-fetch';
+import { Agent as HttpsAgent } from 'https';
 import { PrestoDriver, PrestoDriverConfiguration } from '@cubejs-backend/prestodb-driver';
 import { PrestodbQuery } from '@cubejs-backend/schema-compiler';
 
@@ -32,7 +33,13 @@ export class TrinoDriver extends PrestoDriver {
       headers.Authorization = `Basic ${encoded}`;
     }
 
-    const response = await fetch(url, { method: 'GET', headers });
+    const requestInit: RequestInit = { method: 'GET', headers };
+
+    if (ssl) {
+      requestInit.agent = new HttpsAgent({ ...ssl });
+    }
+
+    const response = await fetch(url, requestInit);
 
     if (!response.ok) {
       const text = await response.text();

--- a/packages/cubejs-trino-driver/test/unit/headers.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/headers.test.ts
@@ -1,4 +1,4 @@
-import { TrinoDriver } from '../../src/TrinoDriver';
+import { TrinoDriver } from '../../src';
 
 const mockFetch: jest.Mock = jest.fn();
 const mockExecute: jest.Mock = jest.fn();

--- a/packages/cubejs-trino-driver/test/unit/ssl.test.ts
+++ b/packages/cubejs-trino-driver/test/unit/ssl.test.ts
@@ -1,0 +1,66 @@
+import { Agent as HttpsAgent } from 'https';
+import { TrinoDriver } from '../../src';
+
+const mockFetch: jest.Mock = jest.fn();
+
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockFetch(...args),
+}));
+
+jest.mock('@cubejs-backend/schema-compiler', () => ({
+  PrestodbQuery: class { },
+}));
+
+jest.mock('presto-client', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    execute: jest.fn(),
+    nodes: jest.fn(),
+  })),
+}));
+
+describe('TrinoDriver SSL', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '',
+    });
+  });
+
+  it('passes SSL options to fetch via an https agent on testConnection()', async () => {
+    const ca = '-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----';
+    const driver = new TrinoDriver({
+      host: 'trino.local',
+      port: '8443',
+      ssl: { ca, rejectUnauthorized: false },
+    });
+
+    await driver.testConnection();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://trino.local:8443/v1/info');
+    expect(options.agent).toBeInstanceOf(HttpsAgent);
+    expect(options.agent.options).toMatchObject({
+      ca,
+      rejectUnauthorized: false,
+    });
+  });
+
+  it('does not pass an agent when SSL is disabled', async () => {
+    const driver = new TrinoDriver({
+      host: 'trino.local',
+      port: '8080',
+    });
+
+    await driver.testConnection();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://trino.local:8080/v1/info');
+    expect(options.agent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
testConnection() issued its GET /v1/info probe via node-fetch without passing the TLS material the driver already resolves from CUBEJS_DB_SSL_* env vars (BaseDriver.getSslOptions). Queries through presto-client honored those options, but the connection test fell back to node-fetch defaults (system CA store, rejectUnauthorized: true) and failed against clusters with custom CAs, self-signed certs, or mTLS.