### PR TITLE
docs: document subtotals for pivoted tables

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -272,3 +272,7 @@ The scale is normalized **per column** — each targeted column uses its own val
 ## Totals
 
 Enable column totals and row totals from the **Table** configuration tab. Totals rows and columns are styled separately from body cells.
+
+### Subtotals
+
+When the table is pivoted by two or more dimensions, you can also enable **subtotals** — a bold **Total for ‹value›** column appended after each pivot group's columns, at every nesting level. Subtotals combine freely with column and row totals, work in workbooks and on dashboards, and — like the other totals — carry over from the results table when you switch the chart type to Table. See [Subtotals](/docs/explore-analyze/workbooks/querying-data#subtotals) for details and limitations.

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -72,6 +72,46 @@ You can add dimensions to the pivot by right-clicking on the left pane or in the
 
 Note that chart tables are different from results tables. You can configure pivots in chart tables separately.
 
+## Totals
+
+The totals menu (the **Σ** button) in the results toolbar adds summary rows
+and columns to the results table: **Column Totals** (a pinned row at the
+bottom with a total for each measure column), **Row Totals** (a total for
+each row across the pivoted columns), and **Subtotals** (see below). All
+three can be enabled at once; each setting is saved with the report and
+carries over when you switch the chart type to [Table][ref-table-chart].
+
+### Subtotals
+
+When the table is [pivoted](#pivoting) by two or more dimensions,
+**Subtotals** appends a bold **Total for ‹value›** column after each pivot
+group's columns, at every nesting level — for example, pivoting by year and
+then status adds a **Total for 2024** column after 2024's status columns.
+With fewer than two pivot dimensions the menu item is disabled, and if the
+query changes so the pivot no longer qualifies, subtotals switch off
+automatically.
+
+<Frame>
+  <img src="https://ucarecdn.com/61d36ecc-020f-4d04-b449-b7c983e269ea/92a1bd7f-light.png" alt="Pivoted results table with subtotal columns" />
+</Frame>
+
+Subtotal values are computed by the database — one extra query per pivot
+level — rather than by summing the visible cells, so they are correct for
+non-additive measures such as counts of distinct values and averages, and
+when the [row limit](#limiting) truncates the table. With **Column Totals**
+also enabled, the pinned totals row shows a grand total for each pivot group.
+
+<Note>
+
+- The toggle adds subtotals for all pivot levels at once; there is no
+  per-group control.
+- Subtotals are not available for flat (non-pivoted) tables or in the
+  values-as-rows table layout.
+- [Calculations][ref-calculated-fields] based on window functions, such as
+  **Running total**, are excluded — same as for row and column totals.
+
+</Note>
+
 ## Limiting
 
 Every query in a workbook returns at most a fixed number of rows. By
@@ -269,5 +309,7 @@ behaves as intended.
 [ref-explore]: /docs/explore-analyze/explore
 [ref-analytics-chat]: /docs/explore-analyze/analytics-chat
 [ref-default-ui-filters]: /reference/data-modeling/view#default_ui_filters
+[ref-table-chart]: /docs/explore-analyze/charts/chart-types/table
+[ref-calculated-fields]: /docs/explore-analyze/workbooks/calculated-fields
 [ref-auto-run]: /reference/data-modeling/view#auto_run
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Documents the new **Subtotals** option for pivoted tables in workbooks (docs-only change, `docs-mintlify`):

- `docs/explore-analyze/workbooks/querying-data.mdx` — adds a **Totals** section covering the results toolbar's Σ menu (Column Totals, Row Totals, Subtotals), with a **Subtotals** subsection: the "Total for ‹value›" columns per pivot group, the two-or-more-pivots requirement, database-computed values (correct for non-additive measures and under row-limit truncation), interplay with Column Totals, and limitations. Includes a screenshot.
- `docs/explore-analyze/charts/chart-types/table.mdx` — expands the Table chart's **Totals** section with a short Subtotals subsection that cross-links to the full write-up.

No navigation changes needed — both pages are already registered in `docs.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)