### PR TITLE
docs: add Clay tracking script

### DIFF
--- a/docs/app/layout.jsx
+++ b/docs/app/layout.jsx
@@ -116,6 +116,9 @@ export default async function RootLayout({ children }) {
             })(window,document,'script','dataLayer','GTM-52W7VM2');
           `}} />
         )}
+        {process.env.NODE_ENV === 'production' && (
+          <script async src="https://static.claydar.com/init.v1.js?id=c2dQN6r6rp" />
+        )}
       </Head>
       <body>
         <SearchProviderWrapper>


### PR DESCRIPTION
## What

Adds the Clay tracking script (`https://static.claydar.com/init.v1.js?id=c2dQN6r6rp`) to the docs app layout, next to the existing GTM snippet and gated the same way to production builds (`NODE_ENV === 'production'`).

## Why

Enable Clay visitor tracking on the docs site, matching cube.dev and cube.dev/blog (cubedevinc/cubejs-landing#1147).

## Notes for reviewers

- The tag won't appear in dev — it's production-gated like GTM.
- Verified the layout compiles in the local dev server. (Local pages 500 on an unrelated pre-existing `lerna.json` module-resolution error in `LogoWithVersion` — present on master too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)