### PR TITLE
docs: add Clay tracking script to Mintlify docs

### DIFF
--- a/docs-mintlify/clay.js
+++ b/docs-mintlify/clay.js
@@ -1,0 +1,6 @@
+(function () {
+  var script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://static.claydar.com/init.v1.js?id=c2dQN6r6rp';
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
## What

Adds `docs-mintlify/clay.js`, a small loader that injects the Clay tracking script (`https://static.claydar.com/init.v1.js?id=c2dQN6r6rp`). Mintlify includes any `.js` file in the content directory on every page — same mechanism as the existing `cube-tracking.js`.

## Why

Enable Clay visitor tracking on the new docs (docs.cube.dev), matching cube.dev and cube.dev/blog (cubedevinc/cubejs-landing#1147).

## Notes for reviewers

- Verified with `mintlify dev`: the loader is bundled into the page's custom-JS payload alongside `cube-tracking.js`.
- A dynamic loader is used because Mintlify custom JS doesn't support external `<script src>` tags directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)