### PR TITLE
docs: reflect Tesseract SQL planner being the default since v1.7.0

### DIFF
--- a/docs-mintlify/docs/data-modeling/measures.mdx
+++ b/docs-mintlify/docs/data-modeling/measures.mdx
@@ -361,13 +361,6 @@ measures:
     format: percent
 ```
 
-<Note>
-
-The `filter` parameter requires the [Tesseract SQL planner][ref-tesseract-env]
-(`CUBEJS_TESSERACT_SQL_PLANNER=true`).
-
-</Note>
-
 ### Nested aggregates
 
 Use the [`grain`][ref-grain] parameter with `include` to compute an aggregate
@@ -477,7 +470,6 @@ measures:
 [ref-filter]: /reference/data-modeling/measures#filter
 [ref-case]: /reference/data-modeling/measures#case
 [ref-switch-dim]: /reference/data-modeling/dimensions#type
-[ref-tesseract-env]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
 [ref-calendar-cubes]: /docs/data-modeling/concepts/calendar-cubes
 [ref-pop-recipe]: /recipes/data-modeling/period-over-period
 [link-tesseract]: https://cube.dev/blog/introducing-next-generation-data-modeling-engine

--- a/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
+++ b/docs-mintlify/docs/data-modeling/multi-fact-views.mdx
@@ -336,8 +336,6 @@ separate-subquery-then-join strategy described
 
 This rewrite applies only when:
 
-- The Tesseract SQL planner is enabled via
-  [`CUBEJS_TESSERACT_SQL_PLANNER`][ref-tesseract-env].
 - Both sides of the join condition resolve to the **same underlying cube
   member** (a shared dimension), and the join key is composed only of
   dimensions.
@@ -540,5 +538,4 @@ to that fact's subquery.
 [ref-view-ref]: /reference/data-modeling/view
 [ref-segments]: /reference/data-modeling/segments
 [ref-sql-api]: /reference/core-data-apis/sql-api
-[ref-tesseract-env]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
 [link-tesseract]: https://cube.dev/blog/introducing-tesseract

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -159,5 +159,4 @@ configuration option.
 [ref-views]: /docs/data-modeling/views
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
 [ref-multi-stage]: /docs/data-modeling/measures#multi_stage
-[ref-tesseract-env]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
 [link-tesseract]: https://cube.dev/blog/introducing-tesseract

--- a/docs-mintlify/reference/core-data-apis/sql-api/joins.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/joins.mdx
@@ -227,8 +227,7 @@ GROUP BY 1
 ```
 
 The `JOIN` type (`INNER`, `LEFT`, `RIGHT`, `FULL`) controls which keys are
-kept. This requires the [Tesseract SQL planner][ref-tesseract-env] and only
-applies to grouped queries whose `GROUP BY` is the join key. See
+kept. This only applies to grouped queries whose `GROUP BY` is the join key. See
 [multi-fact views][ref-multi-fact-views] for the full explanation.
 
 
@@ -236,4 +235,3 @@ applies to grouped queries whose `GROUP BY` is the join key. See
 [ref-join-paths]: /docs/data-modeling/joins#join-paths
 [ref-join-hints]: /docs/data-modeling/joins#join-hints
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
-[ref-tesseract-env]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner

--- a/docs-mintlify/reference/data-modeling/measures.mdx
+++ b/docs-mintlify/reference/data-modeling/measures.mdx
@@ -722,13 +722,6 @@ This is commonly used for "share of total" calculations where the denominator
 must ignore a filter applied by the query — for example, computing each status's
 share of the per-category total while the query is filtered to a single status.
 
-<Note>
-
-The `filter` parameter requires the [Tesseract SQL planner][ref-tesseract-env]
-(`CUBEJS_TESSERACT_SQL_PLANNER=true`).
-
-</Note>
-
 <CodeGroup>
 
 ```yaml title="YAML"
@@ -1498,7 +1491,6 @@ cube(`orders`, {
 [ref-nested-aggregate]: /docs/data-modeling/measures#nested-aggregates
 [ref-calendar-cubes]: /docs/data-modeling/concepts/calendar-cubes
 [ref-switch-dimensions]: /reference/data-modeling/dimensions#type
-[ref-tesseract-env]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
 [ref-filters-query]: /reference/core-data-apis/rest-api/query-format#filters-format
 [ref-data-masking]: /docs/data-modeling/data-access-policies#data-masking
 [link-d3-format]: https://d3js.org/d3-format


### PR DESCRIPTION
## Description

Since v1.7.0, the Tesseract SQL planner is enabled by default (`CUBEJS_TESSERACT_SQL_PLANNER` defaults to `true`). Several docs pages still framed Tesseract as something the user must opt into, which now reads as misleading.

This PR reconciles that phrasing:

- **`docs/data-modeling/measures.mdx`** and **`reference/data-modeling/measures.mdx`** — remove the `<Note>` stating the `filter` parameter "requires the Tesseract SQL planner (`CUBEJS_TESSERACT_SQL_PLANNER=true`)"; it's the default now, so the caveat no longer adds value. Orphaned link definitions removed.
- **`docs/data-modeling/multi-fact-views.mdx`** — the join-key rewrite precondition is kept but reworded to note Tesseract is the default since v1.7.0.
- **`reference/core-data-apis/sql-api/joins.mdx`** — drop the "requires the Tesseract SQL planner" clause from the JOIN-type note, keeping the real precondition (grouped queries whose `GROUP BY` is the join key). Orphaned link definition removed.
- **`docs/pre-aggregations/matching-pre-aggregations.mdx`** — remove a pre-existing orphaned `ref-tesseract-env` link definition (cleanup).

Docs-only; no behavior changes.