### PR TITLE
fix(schema-compiler): resolve multi-stage order_by against owning cube through views

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -3366,7 +3366,12 @@ export class BaseQuery {
           }
         }
         const primaryKeys = this.cubeEvaluator.primaryKeys[cubeName];
-        const orderBySql = (symbol.orderBy || []).map(o => ({ sql: this.evaluateSql(cubeName, o.sql), dir: o.dir }));
+        // order_by templates reference members of the measure's owning cube. When
+        // the measure is exposed through a view, those members may be absent or
+        // exposed only under an alias, so resolve them against the owning cube
+        // (from aliasMember, the underlying reference) instead of the view.
+        const orderByCubeName = symbol.aliasMember ? symbol.aliasMember.split('.')[0] : cubeName;
+        const orderBySql = (symbol.orderBy || []).map(o => ({ sql: this.evaluateSql(orderByCubeName, o.sql), dir: o.dir }));
         let sql;
         let patchedSymbol = symbol;
         if (symbol.type !== 'rank') {

--- a/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-order-by-view.test.ts
+++ b/packages/cubejs-schema-compiler/test/integration/postgres/multi-stage-order-by-view.test.ts
@@ -73,6 +73,17 @@ views:
           - created_at
           - volume_by_day_rank
           # num_parcels deliberately NOT exposed
+
+  - name: orders_view_alias
+    cubes:
+      - join_path: orders
+        includes:
+          - created_at
+          - volume_by_day_rank
+          # num_parcels exposed, but only under an alias, so the order_by
+          # template's bare {num_parcels} still does not resolve in the view.
+          - name: num_parcels
+            alias: total_parcels
     `);
 
   if (getEnv('nativeSqlPlanner')) {
@@ -102,9 +113,24 @@ views:
       { orders_view__created_at_day: '2024-01-01T00:00:00.000Z', orders_view__volume_by_day_rank: '2' },
       { orders_view__created_at_day: '2024-01-02T00:00:00.000Z', orders_view__volume_by_day_rank: '1' },
     ], { joinGraph, cubeEvaluator, compiler }));
+
+    // Repro: the same measure through a view that exposes num_parcels only under
+    // an alias (the order_by template still references it by its bare name).
+    it('view: rank order_by references a member exposed only under an alias', async () => dbRunner.runQueryTest({
+      measures: ['orders_view_alias.volume_by_day_rank'],
+      timeDimensions: [
+        { dimension: 'orders_view_alias.created_at', granularity: 'day' }
+      ],
+      order: [{ id: 'orders_view_alias.created_at' }],
+      timezone: 'UTC',
+    }, [
+      { orders_view_alias__created_at_day: '2024-01-01T00:00:00.000Z', orders_view_alias__volume_by_day_rank: '2' },
+      { orders_view_alias__created_at_day: '2024-01-02T00:00:00.000Z', orders_view_alias__volume_by_day_rank: '1' },
+    ], { joinGraph, cubeEvaluator, compiler }));
   } else {
     // Multi-stage rank is Tesseract-only.
     test.skip('base cube: rank order_by references a non-selected member', () => { expect(1).toBe(1); });
     test.skip('view: rank order_by references a member not exposed by the view', () => { expect(1).toBe(1); });
+    test.skip('view: rank order_by references a member exposed only under an alias', () => { expect(1).toBe(1); });
   }
 });

--- a/packages/cubejs-schema-compiler/test/unit/multi-stage-order-by-view.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/multi-stage-order-by-view.test.ts
@@ -1,0 +1,77 @@
+import { PostgresQuery } from '../../src/adapter/PostgresQuery';
+import { prepareYamlCompiler } from './PrepareCompiler';
+
+// A `rank` multi-stage measure whose `order_by` template references another
+// measure by its bare name (`{num_parcels}`) must resolve that reference against
+// the measure's owning cube, not against a view exposing the rank. Otherwise the
+// order_by template is evaluated in the view's context during the shared JS
+// member-collection pass and crashes with
+// `Cannot read properties of undefined (reading '_objectWithResolvedProperties')`
+// (the referenced member is absent from the view namespace, or present only under
+// an alias).
+describe('Multi-stage measure order_by through a view', () => {
+  const model = (viewIncludes: string) => `
+cubes:
+  - name: orders
+    sql: "SELECT 1 AS id, 10 AS parcels, '2024-01-01'::timestamptz AS created_at"
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: created_at
+        sql: created_at
+        type: time
+    measures:
+      - name: num_parcels
+        type: sum
+        sql: parcels
+      - name: volume_by_day_rank
+        type: rank
+        multi_stage: true
+        reduce_by:
+          - created_at
+        order_by:
+          - sql: "{num_parcels}"
+            dir: desc
+
+views:
+  - name: orders_view
+    cubes:
+      - join_path: orders
+        includes:
+${viewIncludes}
+  `;
+
+  const buildViewRankQuery = async (viewIncludes: string) => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareYamlCompiler(model(viewIncludes));
+    await compiler.compile();
+    const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+      measures: ['orders_view.volume_by_day_rank'],
+      timeDimensions: [{ dimension: 'orders_view.created_at', granularity: 'day' }],
+      order: [{ id: 'orders_view.created_at' }],
+      timezone: 'UTC',
+      // The crash is in the shared JS member-collection pass (query construction),
+      // which runs under both planners; pin the planner so the asserted SQL is
+      // deterministic and does not require the native addon to be built.
+      useNativeSqlPlanner: false,
+    });
+    return query.buildSqlAndParams();
+  };
+
+  it('resolves order_by against the owning cube when the member is not exposed by the view', async () => {
+    const [sql] = await buildViewRankQuery(
+      '          - created_at\n          - volume_by_day_rank'
+    );
+    expect(sql).toContain('rank() OVER (');
+    expect(sql).toContain('"orders__num_parcels" desc');
+  });
+
+  it('resolves order_by against the owning cube when the member is exposed under an alias', async () => {
+    const [sql] = await buildViewRankQuery(
+      '          - created_at\n          - volume_by_day_rank\n          - name: num_parcels\n            alias: total_parcels'
+    );
+    expect(sql).toContain('rank() OVER (');
+    expect(sql).toContain('"orders__num_parcels" desc');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a schema-compilation crash (issue #10856) when a `multi_stage` measure (e.g. `type: rank`) whose `order_by` template references another member by its bare name is queried **through a view**. The crash (`TypeError: Cannot read properties of undefined (reading '_objectWithResolvedProperties')`) happens in the shared JS member-collection pass **before** the query reaches the planner, so it reproduces with Tesseract enabled — #11214 fixed only the Rust side and does not help.

## Root cause

`order_by` templates reference members of the measure's **owning cube**. For a view-exposed measure, `evaluateSymbolSql` evaluated `order_by` against the **view** context, where the referenced member is absent (or exposed only under an alias), so `resolveSymbol` returned `undefined` and crashed. This occurs during query construction (member collection), independent of the planner.

## Changes

- `BaseQuery.js`: evaluate a measure's `order_by` against the owning cube derived from `aliasMember`, mirroring how `memberMaskSql` already resolves `mask.sql` for view members.
- Unit test covering both variants (referenced member not exposed / exposed only under an alias).
- Extended the Tesseract integration test with the aliased-member view case.

## Testing

- New unit test: red without the fix (exact crash), green with it.
- schema-compiler unit suite: no new regressions.
- Tesseract + Postgres integration test (3 cases incl. aliased): all pass, correct distinct ranks. This also turns the previously-red #11214 `view` case green.

Closes #10856