### PR TITLE
docs: combining multi-stage measures at a shared grain

### DIFF
--- a/docs-mintlify/docs/data-modeling/measures.mdx
+++ b/docs-mintlify/docs/data-modeling/measures.mdx
@@ -396,6 +396,8 @@ measures:
     sql: id
     type: count
 
+  # Intermediate multi-stage measures — the grain is set on the combining
+  # measure below, so these inherit it and are joined on the shared grain.
   - name: daily_amount
     multi_stage: true
     sql: "{total_amount}"

--- a/docs-mintlify/docs/data-modeling/measures.mdx
+++ b/docs-mintlify/docs/data-modeling/measures.mdx
@@ -381,6 +381,52 @@ measures:
         - customer_id
 ```
 
+When a nested aggregate combines two or more other multi-stage measures that
+share the same grain, set [`grain`][ref-grain] on the **combining** measure —
+not on each of its inputs. For example, to average a per-day ratio, group the
+per-day components by day through the combining measure:
+
+```yaml
+measures:
+  - name: total_amount
+    sql: amount
+    type: sum
+
+  - name: total_count
+    sql: id
+    type: count
+
+  - name: daily_amount
+    multi_stage: true
+    sql: "{total_amount}"
+    type: number
+
+  - name: daily_count
+    multi_stage: true
+    sql: "{total_count}"
+    type: number
+
+  - name: avg_daily_order_value
+    multi_stage: true
+    sql: "1.0 * {daily_amount} / NULLIF({daily_count}, 0)"
+    type: avg
+    grain:
+      include:
+        - created_at
+```
+
+<Warning>
+
+`grain` fixes the inner grain of the measure it's declared on and does not
+expose the added dimension to a measure built on top of it. If each input
+measure declares the same `grain.include` (rather than the combining measure),
+the inputs no longer carry a shared grouping key, so they are combined with a
+cross join instead of being joined on that key — producing incorrect results.
+Declare `grain` on the combining measure so its inputs are joined on the shared
+grain.
+
+</Warning>
+
 ### Ranking
 
 Use the [`grain`][ref-grain] parameter with `exclude` to rank items within

--- a/docs-mintlify/reference/data-modeling/measures.mdx
+++ b/docs-mintlify/reference/data-modeling/measures.mdx
@@ -686,6 +686,11 @@ measures: {
 | `exclude` | Query dimensions minus listed | Query dimensions |
 | `include` | Query dimensions plus listed | Query dimensions |
 
+`grain` applies to the measure it's declared on and does not expose the added
+dimension to a measure built on top of it. When a measure combines several
+other multi-stage measures at a shared grain, declare `grain` on the
+combining measure — see [nested aggregates][ref-nested-aggregate].
+
 <Note>
 
 `grain` replaces the standalone `group_by`, `reduce_by`, and `add_group_by` parameters,


### PR DESCRIPTION
## Summary

- Documents how to combine two or more multi-stage measures that share the same grain (e.g. averaging a per-day ratio). `grain` applies to the measure it is declared on and does not expose the added dimension to a measure built on top of it, so the grain must be set on the **combining** measure, not on each input.
- Adds a worked example plus a `<Warning>` to the *Nested aggregates* section of the measures guide: declaring the same `grain.include` on each input drops the shared grouping key, so the inputs are combined with a cross join instead of being joined on that key — producing incorrect results.
- Adds a short note to the `grain` reference pointing back to the guide.

## Test plan

- [x] Examples verified to compile and generate the expected SQL (key join on the shared grain when the grain is on the combining measure; cross join when it is on the inputs), confirmed end-to-end against a real Postgres dataset — matched-day ground truth vs. the cross-join result.
- [x] Pages render without MDX errors in `mint dev`; `mint broken-links` clean.
- [ ] CI