### PR TITLE
docs: clarify read-only permissions for Snowflake and Athena data sources

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/aws-athena.mdx
@@ -10,6 +10,20 @@ description: Give Cube IAM access to Athena, an S3 query-results path, region an
 - [The AWS region][aws-docs-regions]
 - [The S3 bucket][aws-s3] on AWS to [store query results][aws-docs-athena-query]
 
+<Info>
+
+**Read-only access to your source data is sufficient.** Cube reads it with
+`athena:*QueryExecution`/`GetQueryResults`/`GetWorkGroup`, `glue:Get*` metadata,
+and `s3:GetObject`/`ListBucket`. Athena also **always** writes query results to
+[`CUBEJS_AWS_S3_OUTPUT_LOCATION`](#environment-variables) — even for `SELECT`s —
+so that location needs `s3:PutObject` (plus the multipart actions), but this is
+Athena's own staging bucket, not your source data. Writes to source data are
+only needed for [pre-aggregations](#pre-aggregation-build-strategies) built
+inside Athena. For a ready-to-use IAM policy, see the
+[AWS OIDC guide][ref-oidc-aws-athena].
+
+</Info>
+
 ## Setup
 
 ### Manual
@@ -139,6 +153,14 @@ build pre-aggregations.
 
 No extra configuration is required to configure batching for AWS Athena.
 
+<Info>
+
+Batching builds pre-aggregations inside Athena via `CREATE TABLE AS SELECT`, the
+only case needing more than read-only access: `glue:CreateTable` on the
+pre-aggregations schema plus `s3:PutObject` on its S3 location.
+
+</Info>
+
 ### Export Bucket
 
 <Warning>
@@ -157,6 +179,10 @@ configuring Cube with the following environment variables:
 
 Ensure the AWS credentials are correctly configured in IAM to allow reads and
 writes to the export bucket in S3.
+
+The export bucket strategy uses Athena's `UNLOAD` to write directly to the
+bucket — no temporary tables, no Glue Data Catalog writes. The only extra
+permission beyond read-only querying is `s3:PutObject` on the export bucket.
 
 </Info>
 

--- a/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
@@ -10,15 +10,20 @@ description: "Snowflake is a popular cloud-based data platform."
 <Info>
 
 In order to connect Cube to Snowflake, you need to grant certain permissions to the Snowflake role
-used by Cube. Cube requires the role to have `USAGE` on databases and schemas
-and `SELECT` on tables. An example configuration:
+used by Cube. **Read-only access is sufficient to query data.** Cube requires the role to have
+`USAGE` on the warehouse, databases, and schemas, and `SELECT` on tables. An example configuration:
 ```sql
+GRANT USAGE ON WAREHOUSE MY_WAREHOUSE TO ROLE XYZ;
 GRANT USAGE ON DATABASE ABC TO ROLE XYZ;
 GRANT USAGE ON ALL SCHEMAS IN DATABASE ABC TO ROLE XYZ;
 GRANT USAGE ON FUTURE SCHEMAS IN DATABASE ABC TO ROLE XYZ;
 GRANT SELECT ON ALL TABLES IN DATABASE ABC TO ROLE XYZ;
 GRANT SELECT ON FUTURE TABLES IN DATABASE ABC TO ROLE XYZ;
 ```
+
+Write access is only needed for [pre-aggregations](#pre-aggregation-build-strategies) built inside
+Snowflake with the default [batching](#batching) strategy (`CREATE TABLE` on the pre-aggregations
+schema). The [export bucket](#export-bucket) strategy writes to the bucket, not the source.
 
 </Info>
 
@@ -263,6 +268,14 @@ No extra configuration is required to configure batching for Snowflake.
 
 Snowflake supports using both [AWS S3][aws-s3] and [Google Cloud
 Storage][google-cloud-storage] for export bucket functionality.
+
+<Info>
+
+The export bucket strategy unloads with `COPY INTO` directly from the query — no
+temporary tables. The role only needs the read-only grants above plus `USAGE` on
+the storage integration.
+
+</Info>
 
 #### AWS S3
 


### PR DESCRIPTION
## Summary

Clarifies that **read-only access to source data is sufficient** to query Snowflake and AWS Athena, addressing recurring confusion about whether these data sources need read-write permissions.

- **Snowflake**: adds the missing `GRANT USAGE ON WAREHOUSE` to the read-only grant example, and notes that write access (`CREATE TABLE`) is only needed for pre-aggregations built in-source via batching; the export-bucket strategy writes to the bucket, not the source, and creates no temporary tables.
- **Athena**: enumerates the least-privilege read-only IAM set (Athena query actions, `glue:Get*` metadata, `s3:GetObject`/`ListBucket` on source), and makes the key distinction explicit — Athena always writes query results to `CUBEJS_AWS_S3_OUTPUT_LOCATION` (its own staging bucket) even for plain `SELECT`s, which is **not** a write to source data. `UNLOAD` exports create no temporary tables and no Glue writes; only in-source pre-aggregations (CTAS) require write access.
- Both privilege claims verified against the driver source (`unloadWithoutTempTable`, `COPY INTO`/`UNLOAD` from query) and the official Snowflake and AWS Athena docs.

## Test plan

- [x] Verified all internal anchors and link references resolve
- [x] `docs.json` valid; both pages already registered in nav
- [ ] CI must pass