### PR TITLE
docs: document multi-cell selection and copy in table charts

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -165,6 +165,20 @@ dimension](/docs/data-modeling/dimensions#links) — drill into another dashboar
 (`dashboard:`) or open an external URL (`url:`) — plus **Copy value** and, on
 measure cells that support it, **Drill down**.
 
+## Selecting and copying multiple cells
+
+To copy a block of cells, select a rectangular range and copy it as
+tab-separated values that paste straight into a spreadsheet:
+
+- **Shift+click** a second cell to extend the selection from the first into a
+  rectangle, or hold **Shift** and press the **arrow keys** to grow the selection
+  one cell at a time.
+- Press **Cmd/Ctrl+C** to copy the selected cells. The range menu also offers
+  **Copy** and **Copy with headers** — the latter prepends a row of column titles.
+
+Copied cells use the raw (unformatted) values and are joined by tabs across
+columns and newlines across rows.
+
 ## Style options
 
 The **Style** tab controls the visual appearance of the table:

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -165,19 +165,30 @@ dimension](/docs/data-modeling/dimensions#links) — drill into another dashboar
 (`dashboard:`) or open an external URL (`url:`) — plus **Copy value** and, on
 measure cells that support it, **Drill down**.
 
-## Selecting and copying multiple cells
+## Selecting and copying cells
 
-To copy a block of cells, select a rectangular range and copy it as
-tab-separated values that paste straight into a spreadsheet:
+You can copy a single cell or a rectangular block of cells straight out of the
+table — copied values paste cleanly into a spreadsheet or text editor.
+
+### Copy a single cell
+
+- **Click** the cell to select it, then press **Cmd/Ctrl+C**, or
+- Left-click the cell and choose **Copy value** from the [cell menu](#cell-menu).
+
+Either way copies that cell's raw (unformatted) value.
+
+### Select and copy a range
 
 - **Shift+click** a second cell to extend the selection from the first into a
   rectangle, or hold **Shift** and press the **arrow keys** to grow the selection
   one cell at a time.
-- Press **Cmd/Ctrl+C** to copy the selected cells. The range menu also offers
-  **Copy** and **Copy with headers** — the latter prepends a row of column titles.
+- Press **Cmd/Ctrl+C** to copy the selected cells. When more than one cell is
+  selected, the cell menu also offers **Copy** and **Copy with headers** — the
+  latter prepends a row of column titles.
 
-Copied cells use the raw (unformatted) values and are joined by tabs across
-columns and newlines across rows.
+Copied cells use the raw (unformatted) values. A range is joined by tabs across
+columns and newlines across rows, so it lands in a spreadsheet as a matching
+grid; a single cell copies as just its value.
 
 ## Style options
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -183,7 +183,7 @@ Either way copies that cell's raw (unformatted) value.
   rectangle, or hold **Shift** and press the **arrow keys** to grow the selection
   one cell at a time.
 - Press **Cmd/Ctrl+C** to copy the selected cells. When more than one cell is
-  selected, the cell menu also offers **Copy** and **Copy with headers** — the
+  selected, the cell menu also offers **Copy values** and **Copy values with headers** — the
   latter prepends a row of column titles.
 
 Copied cells use the raw (unformatted) values. A range is joined by tabs across

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -189,6 +189,9 @@ Copied cells use the raw (unformatted) values. A range is joined by tabs across
 columns and newlines across rows, so it lands in a spreadsheet as a matching
 grid; a single cell copies as just its value.
 
+The same single-cell and range selection works in the **Results** table on the query
+panel, not just the table visualization.
+
 ## Style options
 
 The **Style** tab controls the visual appearance of the table:

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -178,9 +178,9 @@ from the [cell menu](#cell-menu). Either way copies that cell's raw
 
 ### Select and copy a range
 
-- **Shift+click** a second cell to extend the selection from the first into a
-  rectangle, or hold **Shift** and press the **arrow keys** to grow the selection
-  one cell at a time.
+- **Click and drag** across the cells to sweep out a rectangle, or **Shift+click**
+  a second cell to extend the selection from the first, or hold **Shift** and press
+  the **arrow keys** to grow the selection one cell at a time.
 - Press **Cmd/Ctrl+C** to copy the selected cells. When more than one cell is
   selected, the cell menu also offers **Copy values** and **Copy values with headers** — the
   latter prepends a row of column titles.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -179,8 +179,7 @@ from the [cell menu](#cell-menu). Either way copies that cell's raw
 ### Select and copy a range
 
 - **Click and drag** across the cells to sweep out a rectangle, or **Shift+click**
-  a second cell to extend the selection from the first, or hold **Shift** and press
-  the **arrow keys** to grow the selection one cell at a time.
+  a second cell to extend the selection from the first.
 - Press **Cmd/Ctrl+C** to copy the selected cells. When more than one cell is
   selected, the cell menu also offers **Copy values** and **Copy values with headers** — the
   latter prepends a row of column titles.

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -172,10 +172,9 @@ table — copied values paste cleanly into a spreadsheet or text editor.
 
 ### Copy a single cell
 
-- **Click** the cell to select it, then press **Cmd/Ctrl+C**, or
-- Left-click the cell and choose **Copy value** from the [cell menu](#cell-menu).
-
-Either way copies that cell's raw (unformatted) value.
+Click the cell to select it, then press **Cmd/Ctrl+C** or choose **Copy value**
+from the [cell menu](#cell-menu). Either way copies that cell's raw
+(unformatted) value.
 
 ### Select and copy a range
 


### PR DESCRIPTION
## Summary

Documents the new multi-cell selection and copy behavior in table charts: Shift+click / Shift+Arrow to select a rectangular range, then Cmd/Ctrl+C or the cell menu's **Copy** / **Copy with headers** to copy it as tab-separated values that paste into a spreadsheet as a grid.

Adds a "Selecting and copying multiple cells" section to the table chart page, next to the existing "Cell menu" docs.
