### PR TITLE
docs: document Cube token authentication for the Chat API

### DIFF
--- a/docs-mintlify/api-reference/chat.yaml
+++ b/docs-mintlify/api-reference/chat.yaml
@@ -23,6 +23,7 @@ servers:
         description: AI agent identifier (Admin → Agents)
 security:
   - apiKey: []
+  - cubeToken: []
 tags:
   - name: Chat
 paths:
@@ -213,6 +214,7 @@ paths:
             `Content-Type: application/json`). Each line is a JSON object of the schema below.
       security:
         - apiKey: []
+        - cubeToken: []
       summary: Stream chat state
       tags:
         - Chat
@@ -223,6 +225,15 @@ components:
       in: header
       name: Authorization
       description: 'API key authentication. Send `Authorization: Api-Key <YOUR_API_KEY>`.'
+    cubeToken:
+      type: apiKey
+      in: header
+      name: X-Cube-Auth-Token
+      description: >-
+        Cube token authentication. Send your deployment's own Cube token (JWT) in the
+        `X-Cube-Auth-Token` header. The token must be valid for the agent's deployment and carry
+        the `chat` scope. Disabled by default — contact Cube support to enable it for your
+        deployment.
   schemas:
     ChatRequest:
       properties:

--- a/docs-mintlify/api-reference/chat.yaml
+++ b/docs-mintlify/api-reference/chat.yaml
@@ -232,8 +232,9 @@ components:
       description: >-
         Cube token authentication. Send your deployment's own Cube token (JWT) in the
         `X-Cube-Auth-Token` header. The token must be valid for the agent's deployment, include
-        an `externalId` claim identifying the external user, and carry the `chat` scope.
-        Disabled by default — enable it in your deployment settings.
+        an `externalId` (or `sub`) claim identifying the external user, and carry the `chat`
+        scope in its `scope` claim (an array). Disabled by default — enable it in your
+        deployment settings.
   schemas:
     ChatRequest:
       properties:

--- a/docs-mintlify/api-reference/chat.yaml
+++ b/docs-mintlify/api-reference/chat.yaml
@@ -231,8 +231,9 @@ components:
       name: X-Cube-Auth-Token
       description: >-
         Cube token authentication. Send your deployment's own Cube token (JWT) in the
-        `X-Cube-Auth-Token` header. The token must be valid for the agent's deployment and carry
-        the `chat` scope. Disabled by default — enable it in your deployment settings.
+        `X-Cube-Auth-Token` header. The token must be valid for the agent's deployment, include
+        an `externalId` claim identifying the external user, and carry the `chat` scope.
+        Disabled by default — enable it in your deployment settings.
   schemas:
     ChatRequest:
       properties:

--- a/docs-mintlify/api-reference/chat.yaml
+++ b/docs-mintlify/api-reference/chat.yaml
@@ -232,8 +232,7 @@ components:
       description: >-
         Cube token authentication. Send your deployment's own Cube token (JWT) in the
         `X-Cube-Auth-Token` header. The token must be valid for the agent's deployment and carry
-        the `chat` scope. Disabled by default — contact Cube support to enable it for your
-        deployment.
+        the `chat` scope. Disabled by default — enable it in your deployment settings.
   schemas:
     ChatRequest:
       properties:

--- a/docs-mintlify/reference/embed-apis/chat-api.mdx
+++ b/docs-mintlify/reference/embed-apis/chat-api.mdx
@@ -126,13 +126,18 @@ const response = await fetch(
 ```
 
 To be accepted by the Chat API, the token must be valid for the agent's
-deployment and carry the `chat` scope:
+deployment and include the following claims in its payload:
+
+- `externalId` (required) — unique identifier for the external user,
+  lowercase and without spaces.
+- `scopes` (required) — must include the `chat` scope.
 
 ```javascript
 const jwt = require("jsonwebtoken")
 
 const cubeToken = jwt.sign(
   {
+    externalId: "user@example.com",
     scopes: ["chat"],
     // Security context claims, e.g.:
     tenant_id: "acme"
@@ -144,14 +149,15 @@ const cubeToken = jwt.sign(
 
 When Cube token authentication is used:
 
-- The external user and their security context are resolved from the token
-  claims, so you don't need to pass identity fields in `sessionSettings` —
-  users are provisioned automatically from the token.
+- The external user is identified by the `externalId` claim, and their
+  security context is resolved from the token claims — so you don't need to
+  pass identity fields in `sessionSettings`; users are provisioned
+  automatically from the token.
 - The agent queries the deployment with the same token you sent, so
   row-level security and any other security-context-based access controls
   apply to the conversation exactly as they apply to your direct API queries.
-- Tokens that are invalid for the deployment or don't carry the `chat` scope
-  are rejected.
+- Tokens that are invalid for the deployment, miss the `externalId` claim,
+  or don't carry the `chat` scope are rejected.
 
 **Request Body Fields:**
 

--- a/docs-mintlify/reference/embed-apis/chat-api.mdx
+++ b/docs-mintlify/reference/embed-apis/chat-api.mdx
@@ -88,7 +88,8 @@ while (true) {
 <Note>
 
 Cube token authentication for the Chat API is disabled by default. You can
-enable it in your deployment settings.
+enable it in your deployment settings: **Settings** → **Configuration** →
+**Use Cube authentication for Chat and embedding APIs**.
 
 </Note>
 
@@ -125,12 +126,23 @@ const response = await fetch(
 );
 ```
 
+<Warning>
+
+If the request also carries an `Authorization` header, it takes precedence
+and the `X-Cube-Auth-Token` header is ignored. Send exactly one of the two.
+
+</Warning>
+
 To be accepted by the Chat API, the token must be valid for the agent's
 deployment and include the following claims in its payload:
 
-- `externalId` (required) — unique identifier for the external user,
-  lowercase and without spaces.
-- `scopes` (required) — must include the `chat` scope.
+- `externalId` (required) — unique identifier for the external user.
+  Normalized to lowercase, so ids that differ only in casing map to the same
+  user. When `externalId` is not present, the standard JWT `sub` claim is
+  used instead.
+- `scope` (required) — an array of scopes that must include `chat`.
+- `email` (optional) — email address to store on the provisioned external
+  user.
 
 ```javascript
 const jwt = require("jsonwebtoken")
@@ -138,7 +150,7 @@ const jwt = require("jsonwebtoken")
 const cubeToken = jwt.sign(
   {
     externalId: "user@example.com",
-    scopes: ["chat"],
+    scope: ["chat"],
     // Security context claims, e.g.:
     tenant_id: "acme"
   },
@@ -147,17 +159,29 @@ const cubeToken = jwt.sign(
 )
 ```
 
+<Info>
+
+The `chat` scope is asserted on the token's *resolved security context*.
+With the default JWT authentication the security context is simply the
+token payload, so including `scope: ["chat"]` in the token is enough. If
+your deployment uses a custom [`check_auth`][ref-config-check-auth]
+implementation that rewrites the security context, make sure the resolved
+security context carries `scope: ["chat"]` for tokens that should be
+allowed to use the Chat API.
+
+</Info>
+
 When Cube token authentication is used:
 
-- The external user is identified by the `externalId` claim, and their
-  security context is resolved from the token claims — so you don't need to
-  pass identity fields in `sessionSettings`; users are provisioned
+- The external user is identified by the `externalId` (or `sub`) claim, and
+  their security context is resolved from the token claims — so you don't
+  need to pass identity fields in `sessionSettings`; users are provisioned
   automatically from the token.
 - The agent queries the deployment with the same token you sent, so
   row-level security and any other security-context-based access controls
   apply to the conversation exactly as they apply to your direct API queries.
-- Tokens that are invalid for the deployment, miss the `externalId` claim,
-  or don't carry the `chat` scope are rejected.
+- Tokens that are invalid for the deployment, miss the `externalId` (or
+  `sub`) claim, or don't carry the `chat` scope are rejected.
 
 **Request Body Fields:**
 
@@ -241,7 +265,9 @@ Copy the complete Chat API URL from your agent settings (**Chat API URL** field)
 - **`input`** (string): User message or query to send to the AI agent, e.g. "What is our revenue last month?". If omitted, returns current state of thread with provided `chatId`.
 - **`chatId`** (string): Chat thread ID. If omitted, a new thread is created automatically. If provided, it should match the previously returned `chatId` from a message with id `__cutoff__`.
 - **`messageId`** (string): Client-provided identifier for the user message. Must match the format `<timestamp>-message` (a 13+ digit Unix timestamp in milliseconds followed by `-message`), e.g. `1717500000000-message`. Used to make requests idempotent — see [Idempotency](#idempotency).
-- **`sessionSettings`** (object, required): Session configuration for the user
+- **`sessionSettings`** (object, required for API key authentication; ignored
+  with Cube token authentication, where identity comes from the token claims):
+  Session configuration for the user
   - **`externalId`** (string): Unique identifier for the external user. Either `externalId` or `internalId` should be provided.
   - **`internalId`** (string): Email address of an internal Cube Cloud user. The user must already exist. Either `externalId` or `internalId` should be provided.
   - **`email`** (string): User's email address
@@ -1113,7 +1139,11 @@ while (true) {
 
 - **204 No Content**: (Abort endpoint only) Chat streaming was aborted successfully.
 - **400 Bad Request**: Invalid request body or parameters. Check required fields and data types.
-- **401 Unauthorized**: Invalid or missing credentials. Verify your API key is correct and has the necessary permissions. For Cube token authentication, verify the token is valid for the agent's deployment and carries the `chat` scope.
+- **Authentication errors**: Returned as a JSON-RPC error object in an HTTP 200
+  response. Verify your API key is correct and has the necessary permissions.
+  For Cube token authentication, verify the token is valid for the agent's
+  deployment, identifies a user via `externalId` (or `sub`), and carries the
+  `chat` scope.
 - **403 Forbidden**: (Abort endpoint only) The authenticated user does not own the specified chat thread.
 - **404 Not Found**: Agent, tenant, or chat thread not found. Verify the Chat API URL from your agent settings and the `chatId`.
 - **500 Internal Server Error**: Server processing error. Contact support if the issue persists.

--- a/docs-mintlify/reference/embed-apis/chat-api.mdx
+++ b/docs-mintlify/reference/embed-apis/chat-api.mdx
@@ -35,6 +35,13 @@ Accounts are limited to 10,000 non-ephemeral external users. To increase this li
 All users created using this API are ephemeral by default and will be removed after `sessionSettings.ephemeralTtlSeconds` (1 week by default). If users need to be persisted, pass `isEphemeral: false` in `sessionSettings`. Ephemeral users are guaranteed to not live longer than `sessionSettings.ephemeralTtlSeconds`.
 </Info>
 
+The Chat API supports two authentication methods:
+
+- [API key authentication](#api-key-authentication) — pass a Cube [API key][ref-api-keys] in the `Authorization` header.
+- [Cube token authentication](#cube-token-authentication) — pass your deployment's own [Cube token][ref-jwt-auth] (JWT) in the `X-Cube-Auth-Token` header.
+
+### API key authentication
+
 Pass your [API key][ref-api-keys] directly to the Chat API endpoint. The session will be created automatically based on the `externalId` provided:
 
 ```javascript
@@ -75,6 +82,77 @@ while (true) {
   console.log(decoder.decode(value));
 }
 ```
+
+### Cube token authentication
+
+<Note>
+
+Cube token authentication for the Chat API is disabled by default. Reach out
+to the [Cube support team](/admin/account-billing/support) to enable it for
+your deployment.
+
+</Note>
+
+Instead of an API key, the Chat API can authenticate requests with your
+deployment's own [Cube authentication][ref-jwt-auth] — the same JSON Web
+Tokens (JWTs) your application already uses with the Core Data APIs. Cube
+validates the token using the deployment's existing authentication
+configuration: the API secret, JWKS, or a custom
+[`check_auth`][ref-config-check-auth] implementation.
+
+This is useful for [headless embedding][ref-headless-embedding]: your
+application issues a single kind of token, and the same token works for both
+data queries and AI-powered conversations.
+
+Pass the token in the `X-Cube-Auth-Token` header instead of the
+`Authorization` header:
+
+```javascript
+// Copy the Chat API URL from your agent settings (Admin → Agents → Chat API URL field)
+const CHAT_API_URL = 'YOUR_CHAT_API_URL';
+
+const response = await fetch(
+  CHAT_API_URL,
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Cube-Auth-Token': CUBE_TOKEN,
+    },
+    body: JSON.stringify({
+      input: 'What were the total sales last month?'
+    }),
+  }
+);
+```
+
+To be accepted by the Chat API, the token must be valid for the agent's
+deployment and carry the `chat` scope:
+
+```javascript
+const jwt = require("jsonwebtoken")
+
+const cubeToken = jwt.sign(
+  {
+    scopes: ["chat"],
+    // Security context claims, e.g.:
+    tenant_id: "acme"
+  },
+  process.env.CUBEJS_API_SECRET,
+  { expiresIn: "1h" }
+)
+```
+
+When Cube token authentication is used:
+
+- The external user and their security context are resolved from the token
+  claims, so you don't need to pass identity fields in `sessionSettings` —
+  users are provisioned automatically from the token.
+- The agent queries the deployment with the same token you sent, so
+  row-level security and any other security-context-based access controls
+  apply to the conversation exactly as they apply to your direct API queries.
+- Tokens that are invalid for the deployment or don't carry the `chat` scope
+  are rejected.
 
 **Request Body Fields:**
 
@@ -829,7 +907,9 @@ with `/abort`.
 
 ### Authentication
 
-Uses the same API key authentication as the Chat API.
+Supports the same authentication methods as the Chat API: an
+[API key](#api-key-authentication) or, when enabled for your deployment, a
+[Cube token](#cube-token-authentication).
 
 ### Request Body
 
@@ -1028,10 +1108,13 @@ while (true) {
 
 - **204 No Content**: (Abort endpoint only) Chat streaming was aborted successfully.
 - **400 Bad Request**: Invalid request body or parameters. Check required fields and data types.
-- **401 Unauthorized**: Invalid or missing API key. Verify your API key is correct and has the necessary permissions.
+- **401 Unauthorized**: Invalid or missing credentials. Verify your API key is correct and has the necessary permissions. For Cube token authentication, verify the token is valid for the agent's deployment and carries the `chat` scope.
 - **403 Forbidden**: (Abort endpoint only) The authenticated user does not own the specified chat thread.
 - **404 Not Found**: Agent, tenant, or chat thread not found. Verify the Chat API URL from your agent settings and the `chatId`.
 - **500 Internal Server Error**: Server processing error. Contact support if the issue persists.
 
 
 [ref-api-keys]: /admin/account-billing/api-keys
+[ref-jwt-auth]: /embedding/authentication/jwt
+[ref-config-check-auth]: /reference/configuration/config#check_auth
+[ref-headless-embedding]: /embedding#headless-embedding

--- a/docs-mintlify/reference/embed-apis/chat-api.mdx
+++ b/docs-mintlify/reference/embed-apis/chat-api.mdx
@@ -87,9 +87,8 @@ while (true) {
 
 <Note>
 
-Cube token authentication for the Chat API is disabled by default. Reach out
-to the [Cube support team](/admin/account-billing/support) to enable it for
-your deployment.
+Cube token authentication for the Chat API is disabled by default. You can
+enable it in your deployment settings.
 
 </Note>
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Documents the recently added ability to authenticate Chat API requests with the deployment's own Cube token (JWT), as an alternative to API keys (implemented in cubedevinc/cubejs-enterprise#12808). Details verified against the enterprise implementation.

- `docs-mintlify/reference/embed-apis/chat-api.mdx`: splits the Authentication section into **API key authentication** (existing content) and a new **Cube token authentication** subsection — the deployment's Cube JWT (validated via the API secret, JWKS, or custom `check_auth`) passed in the `X-Cube-Auth-Token` header, with a required `externalId` claim (falling back to `sub`), a `scope` claim including `chat`, and an optional `email` claim. Covers `Authorization` header precedence, how the `chat` scope is asserted on the resolved security context with custom `check_auth`, that the caller's token is used as query credentials (so row-level security applies unchanged), how to enable the feature in deployment settings, and that `sessionSettings` is ignored with Cube token authentication. Also updates the abort endpoint's authentication note and the error-handling section (auth failures are returned as a JSON-RPC error object in an HTTP 200 response).
- `docs-mintlify/api-reference/chat.yaml`: registers a `cubeToken` security scheme (`X-Cube-Auth-Token` header) as an alternative to `apiKey` in the Chat API OpenAPI spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfzMYkSrtEBV9ViFCyrePL