### PR TITLE
docs: remove Upload file shortcut from the new tab page launchpad

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
@@ -14,8 +14,8 @@ Workbooks can contain one or more tabs, each providing a different way to query 
 
 When you open [Explore](/docs/explore-analyze/explore) or add a new tab in a workbook, Cube shows
 the **new tab page** — a single launchpad for starting a report. From here you can search across
-your data model, browse starting points by type, or jump straight to pasting a query, asking an AI
-agent, or uploading a file.
+your data model, browse starting points by type, or jump straight to pasting a query or asking an
+AI agent.
 
 ### Searching and browsing
 
@@ -37,7 +37,7 @@ The category selector lets you switch between starting-point types:
 Click through the list to drill down to an individual view, report, or table. Once you reach a
 starting point, the data model sidebar activates so you can continue building your query there.
 
-### Starting from a pasted query, an agent, or a file
+### Starting from a pasted query or an agent
 
 The launchpad also offers shortcuts at the bottom:
 
@@ -48,7 +48,6 @@ The launchpad also offers shortcuts at the bottom:
   converted to a semantic query for you.
 - **Ask Cube agent** — opens the chat sidebar so you can describe the report you want in natural
   language.
-- **Upload file** — opens the file upload flow.
 
 ### Configuring the launchpad
 


### PR DESCRIPTION
## Summary

The new tab page launchpad no longer has an **Upload file** shortcut, so this removes it from the docs: the bullet in the shortcut list, the "or uploading a file" phrase in the section intro, and "or a file" from the section heading. Pasting a query and asking the Cube agent remain.
