### PR TITLE
docs: document time-dimension drill-down in table charts

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -175,8 +175,8 @@ they apply, **Drill down** options.
   shows the four quarters of 2024. You can keep drilling, then close the view to
   return to the original table.
 
-Because a week can straddle two months or quarters, **Week** is only ever offered
-when a cell is already shown by week.
+Because a week can straddle two months or quarters, **Week** is never a drill
+target from a coarser granularity — a week cell drills only to **Day** and finer.
 
 ## Selecting and copying cells
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -165,28 +165,18 @@ dimension](/docs/data-modeling/dimensions#links) — drill into another dashboar
 (`dashboard:`) or open an external URL (`url:`) — plus **Copy value** and, where
 they apply, **Drill down** options.
 
-### Drill down on a measure
+**Drill down** works in two ways:
 
-On a measure cell whose data model defines drill members, **Drill down** opens
-the underlying rows behind that value.
+- On a **measure** cell whose data model defines drill members, it opens the
+  underlying rows behind that value.
+- On a **time-dimension** cell shown at a granularity, it opens a submenu of
+  finer granularities. Picking one re-buckets the **same measures** to that
+  granularity, scoped to the period you clicked — drilling `2024` to **Quarter**
+  shows the four quarters of 2024. You can keep drilling, then close the view to
+  return to the original table.
 
-### Drill down on a time dimension
-
-On a time-dimension cell that is displayed at a granularity (year, quarter,
-month, week, day, hour, or minute), **Drill down** opens a submenu of the finer
-granularities you can drill into. For example, a cell shown by year offers
-**Quarter**, **Month**, **Day**, and finer; a cell shown by quarter offers
-**Month**, **Day**, and finer.
-
-Choosing a finer granularity opens a view of the **same measures**, re-bucketed
-to that granularity and scoped to the period you clicked — clicking `2024` and
-drilling to **Quarter** shows the four quarters of 2024. You can keep drilling
-from that view (quarter → month → day) and close it to return to the original
-table.
-
-Granularities follow the calendar hierarchy: because a week can span two months
-or quarters, **Week** is never offered as a drill target from a coarser
-granularity. A cell already displayed by week drills down to **Day** and finer.
+Because a week can straddle two months or quarters, **Week** is only ever offered
+when a cell is already shown by week.
 
 ## Selecting and copying cells
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -162,8 +162,31 @@ Choose a reasonable granularity for the data's time span. An overly fine granula
 
 Left-clicking a table cell opens a context menu with any [`links` defined on the
 dimension](/docs/data-modeling/dimensions#links) — drill into another dashboard
-(`dashboard:`) or open an external URL (`url:`) — plus **Copy value** and, on
-measure cells that support it, **Drill down**.
+(`dashboard:`) or open an external URL (`url:`) — plus **Copy value** and, where
+they apply, **Drill down** options.
+
+### Drill down on a measure
+
+On a measure cell whose data model defines drill members, **Drill down** opens
+the underlying rows behind that value.
+
+### Drill down on a time dimension
+
+On a time-dimension cell that is displayed at a granularity (year, quarter,
+month, week, day, hour, or minute), **Drill down** opens a submenu of the finer
+granularities you can drill into. For example, a cell shown by year offers
+**Quarter**, **Month**, **Day**, and finer; a cell shown by quarter offers
+**Month**, **Day**, and finer.
+
+Choosing a finer granularity opens a view of the **same measures**, re-bucketed
+to that granularity and scoped to the period you clicked — clicking `2024` and
+drilling to **Quarter** shows the four quarters of 2024. You can keep drilling
+from that view (quarter → month → day) and close it to return to the original
+table.
+
+Granularities follow the calendar hierarchy: because a week can span two months
+or quarters, **Week** is never offered as a drill target from a coarser
+granularity. A cell already displayed by week drills down to **Day** and finer.
 
 ## Selecting and copying cells
 


### PR DESCRIPTION
## Summary

Documents the new time-dimension drill-down in table charts: clicking a time cell that's shown at a granularity offers **Drill down** to a finer granularity, re-viewing the same measures scoped to the clicked period. Adds it to the table chart's "Cell menu" section, alongside the existing measure drill-down.

## Test plan

- [x] Prose reconciled against the shipped UI (drill labels, granularity behavior, week handling).
- [ ] Docs build passes.