### PR TITLE
fix(cubesql): Reject `ORDER BY` over ungrouped columns with a clear error

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c7e685599fefdf0692d44ac7c2f6aebd6b927bc0#c7e685599fefdf0692d44ac7c2f6aebd6b927bc0"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "c7e685599fefdf0692d44ac7c2f6aebd6b927bc0", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "c4960447df1df72f9f66a7bbf23e9b0c19184d05", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -18928,6 +18928,36 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_order_by_ungrouped_column_returns_error() {
+        init_testing_logger();
+
+        // ORDER BY expression references a column consumed by the Aggregate and not
+        // present in GROUP BY — the query is invalid and must be rejected during
+        // planning instead of producing unresolvable SQL for the data source
+        let error = TestContext::new(DatabaseProtocol::PostgreSQL)
+            .await
+            .convert_sql_to_cube_query(
+                r#"
+                SELECT
+                    CASE
+                        WHEN order_date >= '2024-06-01' THEN 'recent'
+                        ELSE 'older'
+                    END AS time_period,
+                    MEASURE(count) AS cnt
+                FROM KibanaSampleDataEcommerce
+                GROUP BY 1
+                ORDER BY CASE WHEN order_date >= '2024-06-01' THEN 1 ELSE 2 END
+                "#,
+            )
+            .await
+            .expect_err("query with ORDER BY over ungrouped column should not plan");
+
+        assert!(error
+            .to_string()
+            .contains("must appear in the GROUP BY clause or be used in an aggregate function"));
+    }
+
+    #[tokio::test]
     async fn test_set_cache_mode() -> Result<(), CubeError> {
         if !Rewriter::sql_push_down_enabled() {
             return Ok(());


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@c496044, making queries with `ORDER BY` referencing a column absent from both `GROUP BY` and aggregate functions rejected at planning time with a PostgreSQL-style error instead of failing on the data source with an obscure one. Related test is included.