### PR TITLE
fix(cubesql): Reference window expressions by generated alias in `ORDER BY`

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -1635,9 +1635,33 @@ impl WrappedSelectNode {
         )
         .await?;
 
+        // Sort expressions can reference window expressions computed in this same select
+        // by their full DataFusion name. Those columns don't exist in the source SQL, so
+        // rewrite them to the generated window aliases, which ORDER BY can reference by name.
+        let order_expr = if window.is_empty() {
+            self.order_expr.clone()
+        } else {
+            let window_columns = self
+                .window_expr
+                .iter()
+                .zip(window.iter())
+                .map(|(window_expr, (aliased_column, _))| {
+                    Ok((
+                        Column::from_name(expr_name(window_expr, schema)?),
+                        Column::from_name(&aliased_column.alias),
+                    ))
+                })
+                .collect::<result::Result<HashMap<_, _>, CubeError>>()?;
+            let window_columns_ref = window_columns.iter().collect();
+            self.order_expr
+                .iter()
+                .map(|e| replace_col(e.clone(), &window_columns_ref))
+                .collect::<Result<Vec<_>>>()?
+        };
+
         let (order, sql) = Self::generate_column_expr(
             schema.clone(),
-            self.order_expr.iter().cloned(),
+            order_expr,
             sql,
             generator.clone(),
             column_remapping,
@@ -3763,13 +3787,15 @@ impl WrappedSelectNode {
                                 let aliased_column = find_column(&self.aggr_expr, &aggregate)
                                     .or_else(|| find_column(&self.projection_expr, &projection))
                                     .or_else(|| find_column(&flat_group_expr, &group_by))
+                                    .or_else(|| find_column(&self.window_expr, &window))
                                     .ok_or_else(|| {
                                         DataFusionError::Execution(format!(
-                                            "Can't find column {} in projection {:?} or aggregate {:?} or group {:?}",
+                                            "Can't find column {} in projection {:?} or aggregate {:?} or group {:?} or window {:?}",
                                             col_name,
                                             self.projection_expr,
                                             self.aggr_expr,
-                                            flat_group_expr
+                                            flat_group_expr,
+                                            self.window_expr
                                         ))
                                     })?;
                                 Ok(vec![

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -17415,6 +17415,56 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_sort_by_window_expr_sql_push_down() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        let query_plan = convert_select_to_query_plan(
+            r#"
+            WITH monthly AS (
+                SELECT
+                    customer_gender,
+                    DATE_TRUNC('month', order_date) AS order_date_month,
+                    MEASURE(sumPrice) AS monthly_spend
+                FROM KibanaSampleDataEcommerce
+                GROUP BY 1, 2
+                LIMIT 5000
+            )
+            SELECT
+                customer_gender,
+                order_date_month,
+                monthly_spend,
+                SUM(monthly_spend) OVER (PARTITION BY customer_gender) AS ytd_total
+            FROM monthly
+            ORDER BY ytd_total DESC, customer_gender, order_date_month
+            LIMIT 5000
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        // ORDER BY must reference the window expression by its generated alias,
+        // not by the raw DataFusion expression name
+        assert!(!sql.contains("PARTITION BY [#"));
+        let window_alias = &regex::Regex::new(r#"OVER \(PARTITION BY [^)]+\) "([^"]+)""#)
+            .unwrap()
+            .captures(&sql)
+            .expect("window expression with alias must be present in generated SQL")[1];
+        assert!(sql.contains(&format!(r#"ORDER BY "{window_alias}" DESC"#)));
+
+        let physical_plan = query_plan.as_physical_plan().await.unwrap();
+        println!(
+            "Physical plan: {}",
+            displayable(physical_plan.as_ref()).indent()
+        );
+    }
+
+    #[tokio::test]
     async fn test_date_filter_with_or_and() {
         init_testing_logger();
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes wrapped SQL generation for queries sorting by a window expression computed in the same select: `ORDER BY` now references the window expression's generated alias instead of its raw DataFusion expression name. Related test is included.