### PR TITLE
fix(cubesql): Normalize date-only string literals in timestamp comparisons

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/optimizers/plan_normalize.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use datafusion::{
-    arrow::datatypes::DataType,
+    arrow::datatypes::{DataType, TimeUnit},
     error::{DataFusionError, Result},
     logical_expr::{BuiltinScalarFunction, Expr, GroupingSet, Like},
     logical_plan::{
@@ -22,7 +22,9 @@ use datafusion::{
     sql::planner::ContextProvider,
 };
 
-use crate::compile::{engine::CubeContext, rewrite::rules::utils::DatePartToken};
+use crate::compile::{
+    date_parser::parse_date_str, engine::CubeContext, rewrite::rules::utils::DatePartToken,
+};
 
 /// PlanNormalize optimizer rule walks through the query and applies transformations
 /// to normalize the logical plan structure and expressions.
@@ -1412,18 +1414,49 @@ fn binary_expr_normalize(
     };
 
     if literal_on_the_left {
-        Ok(Box::new(Expr::BinaryExpr {
-            left: evaluate_expr(optimizer, left.cast_to(&cast_type, schema)?)?,
-            op,
-            right,
-        }))
-    } else {
-        Ok(Box::new(Expr::BinaryExpr {
-            left,
-            op,
-            right: evaluate_expr(optimizer, right.cast_to(&cast_type, schema)?)?,
-        }))
+        if let Some(left) = cast_string_literal_expr(optimizer, &left, &cast_type, schema) {
+            return Ok(Box::new(Expr::BinaryExpr { left, op, right }));
+        }
+    } else if let Some(right) = cast_string_literal_expr(optimizer, &right, &cast_type, schema) {
+        return Ok(Box::new(Expr::BinaryExpr { left, op, right }));
     }
+
+    // The literal can't be casted to the target type; keep the expression as is
+    // instead of failing the whole plan normalization.
+    Ok(Box::new(Expr::BinaryExpr { left, op, right }))
+}
+
+/// Casts a string literal expression to the given type, evaluating it to a constant.
+/// Timestamp targets are parsed with Cube's date parser, which accepts date-only
+/// strings (e.g. `'2026-06-01'`) that the Arrow cast kernel rejects.
+/// Returns `None` when the literal can't be casted.
+fn cast_string_literal_expr(
+    optimizer: &PlanNormalize,
+    expr: &Expr,
+    cast_type: &DataType,
+    schema: &DFSchema,
+) -> Option<Box<Expr>> {
+    if let (Expr::Literal(ScalarValue::Utf8(Some(value))), DataType::Timestamp(unit, tz)) =
+        (expr, cast_type)
+    {
+        let parsed = parse_date_str(value).ok()?.and_utc();
+        let scalar = match unit {
+            TimeUnit::Second => ScalarValue::TimestampSecond(Some(parsed.timestamp()), tz.clone()),
+            TimeUnit::Millisecond => {
+                ScalarValue::TimestampMillisecond(Some(parsed.timestamp_millis()), tz.clone())
+            }
+            TimeUnit::Microsecond => {
+                ScalarValue::TimestampMicrosecond(Some(parsed.timestamp_micros()), tz.clone())
+            }
+            TimeUnit::Nanosecond => {
+                ScalarValue::TimestampNanosecond(Some(parsed.timestamp_nanos_opt()?), tz.clone())
+            }
+        };
+        return Some(Box::new(Expr::Literal(scalar)));
+    }
+
+    let casted = expr.clone().cast_to(cast_type, schema).ok()?;
+    evaluate_expr(optimizer, casted).ok()
 }
 
 /// Returns the type a literal string should be casted to based on the operator
@@ -1694,6 +1727,95 @@ mod tests {
 
             let optimizer = PlanNormalize::new(&cube_ctx);
             optimizer.optimize(&plan, &OptimizerConfig::new()).unwrap();
+        });
+
+        Ok(())
+    }
+
+    // Date-only strings (e.g. '2026-06-01') are rejected by the Arrow cast kernel,
+    // so they must be parsed with Cube's date parser instead.
+    #[test]
+    fn test_binary_expr_date_only_string_to_timestamp() -> Result<()> {
+        run_async_test(async move {
+            let meta = get_test_tenant_ctx();
+            let cube_ctx = create_test_postgresql_cube_context(meta)
+                .await
+                .expect("Failed to create cube context");
+
+            let schema = Schema::new(vec![Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            )]);
+
+            let table_scan = LogicalPlanBuilder::scan_empty(Some("test_table"), &schema, None)
+                .expect("Failed to create table scan")
+                .build()
+                .expect("Failed to build plan");
+
+            let plan = LogicalPlanBuilder::from(table_scan)
+                .filter(col("ts").gt_eq(lit("2026-06-01")))
+                .expect("Failed to add filter")
+                .build()
+                .expect("Failed to build plan");
+
+            let optimizer = PlanNormalize::new(&cube_ctx);
+            let optimized = optimizer.optimize(&plan, &OptimizerConfig::new()).unwrap();
+
+            let LogicalPlan::Filter(Filter { predicate, .. }) = &optimized else {
+                panic!("Expected Filter plan, got: {:?}", optimized);
+            };
+            let expected_nanos = parse_date_str("2026-06-01")
+                .unwrap()
+                .and_utc()
+                .timestamp_nanos_opt()
+                .unwrap();
+            assert_eq!(
+                *predicate,
+                col("test_table.ts").gt_eq(Expr::Literal(ScalarValue::TimestampNanosecond(
+                    Some(expected_nanos),
+                    None
+                )))
+            );
+        });
+
+        Ok(())
+    }
+
+    // A string literal that can't be casted must not fail the whole plan
+    // normalization; the expression is kept as is.
+    #[test]
+    fn test_binary_expr_uncastable_string_keeps_plan() -> Result<()> {
+        run_async_test(async move {
+            let meta = get_test_tenant_ctx();
+            let cube_ctx = create_test_postgresql_cube_context(meta)
+                .await
+                .expect("Failed to create cube context");
+
+            let schema = Schema::new(vec![Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            )]);
+
+            let table_scan = LogicalPlanBuilder::scan_empty(Some("test_table"), &schema, None)
+                .expect("Failed to create table scan")
+                .build()
+                .expect("Failed to build plan");
+
+            let plan = LogicalPlanBuilder::from(table_scan)
+                .filter(col("ts").gt_eq(lit("not-a-date")))
+                .expect("Failed to add filter")
+                .build()
+                .expect("Failed to build plan");
+
+            let optimizer = PlanNormalize::new(&cube_ctx);
+            let optimized = optimizer.optimize(&plan, &OptimizerConfig::new()).unwrap();
+
+            let LogicalPlan::Filter(Filter { predicate, .. }) = &optimized else {
+                panic!("Expected Filter plan, got: {:?}", optimized);
+            };
+            assert_eq!(*predicate, col("test_table.ts").gt_eq(lit("not-a-date")));
         });
 
         Ok(())

--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -11,9 +11,9 @@ use datafusion::{
     arrow::{
         array::{
             new_null_array, Array, ArrayBuilder, ArrayRef, BooleanArray, BooleanBuilder,
-            Date32Array, Float64Array, Float64Builder, GenericStringArray, Int32Array,
-            Int32Builder, Int64Array, Int64Builder, IntervalMonthDayNanoArray, ListArray,
-            ListBuilder, PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
+            Date32Array, Date32Builder, Float64Array, Float64Builder, GenericStringArray,
+            Int32Array, Int32Builder, Int64Array, Int64Builder, IntervalMonthDayNanoArray,
+            ListArray, ListBuilder, PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
             StructBuilder, TimestampMicrosecondArray, TimestampMillisecondArray,
             TimestampNanosecondArray, TimestampNanosecondBuilder, TimestampSecondArray,
             UInt32Builder, UInt64Builder,
@@ -31,8 +31,7 @@ use datafusion::{
     logical_plan::create_udf,
     physical_plan::{
         functions::{
-            datetime_expressions::date_trunc, make_scalar_function, make_table_function, Signature,
-            TypeSignature, Volatility,
+            make_scalar_function, make_table_function, Signature, TypeSignature, Volatility,
         },
         udaf::AggregateUDF,
         udf::ScalarUDF,
@@ -47,10 +46,13 @@ use regex::Regex;
 use sha1_smol::Sha1;
 
 use crate::{
-    compile::engine::{
-        df::{coerce::common_type_coercion, columar::if_then_else},
-        information_schema::postgres::{PG_NAMESPACE_CATALOG_OID, PG_NAMESPACE_PUBLIC_OID},
-        udf::utils::*,
+    compile::{
+        date_parser::parse_date_str,
+        engine::{
+            df::{coerce::common_type_coercion, columar::if_then_else},
+            information_schema::postgres::{PG_NAMESPACE_CATALOG_OID, PG_NAMESPACE_PUBLIC_OID},
+            udf::utils::*,
+        },
     },
     sql::SessionState,
 };
@@ -786,24 +788,46 @@ pub fn create_ends_with_udf() -> ScalarUDF {
 
 pub fn create_to_date_udf() -> ScalarUDF {
     let fun = make_scalar_function(move |args: &[ArrayRef]| {
-        assert!(args.len() == 2 || args.len() == 3);
+        assert!(args.len() == 2);
 
-        return Err(DataFusionError::NotImplemented(format!(
-            "to_date is not implemented, it's stub"
-        )));
+        let dates = downcast_string_arg!(args[0], "date", i32);
+        let formats = downcast_string_arg!(args[1], "format", i32);
+
+        let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+        let mut builder = Date32Builder::new(dates.len());
+        for i in 0..dates.len() {
+            if dates.is_null(i) || formats.is_null(i) {
+                builder.append_null()?;
+                continue;
+            }
+
+            let chrono_format = match formats.value(i) {
+                "YYYY-MM-DD" | "yyyy-MM-dd" => "%Y-%m-%d",
+                format => {
+                    return Err(DataFusionError::NotImplemented(format!(
+                        "TO_DATE format is not supported: {}",
+                        format
+                    )))
+                }
+            };
+            let date = NaiveDate::parse_from_str(dates.value(i), chrono_format).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Error parsing {:?} in TO_DATE: {}",
+                    dates.value(i),
+                    e
+                ))
+            })?;
+            builder.append_value(date.signed_duration_since(epoch).num_days() as i32)?;
+        }
+
+        Ok(Arc::new(builder.finish()) as ArrayRef)
     });
 
     let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Date32)));
 
     ScalarUDF::new(
         "to_date",
-        &Signature::one_of(
-            vec![
-                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
-                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Boolean]),
-            ],
-            Volatility::Immutable,
-        ),
+        &Signature::exact(vec![DataType::Utf8, DataType::Utf8], Volatility::Immutable),
         &return_type,
         &fun,
     )
@@ -875,46 +899,39 @@ pub fn create_date_udf() -> ScalarUDF {
     let fun = make_scalar_function(move |args: &[ArrayRef]| {
         assert!(args.len() == 1);
 
-        let mut args = args
-            .iter()
-            .map(|i| -> Result<ColumnarValue> {
-                if let Some(strings) = i.as_any().downcast_ref::<StringArray>() {
-                    let mut builder = TimestampNanosecondArray::builder(strings.len());
-                    for i in 0..strings.len() {
-                        builder.append_value(
-                            NaiveDateTime::parse_from_str(strings.value(i), "%Y-%m-%d %H:%M:%S%.f")
-                                .map_err(|e| DataFusionError::Execution(e.to_string()))?
-                                .and_utc()
-                                .timestamp_nanos_opt()
-                                .unwrap(),
-                        )?;
-                    }
-                    Ok(ColumnarValue::Array(Arc::new(builder.finish())))
-                } else {
-                    assert!(i
-                        .as_any()
-                        .downcast_ref::<TimestampNanosecondArray>()
-                        .is_some());
-                    Ok(ColumnarValue::Array(i.clone()))
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-        args.insert(
-            0,
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some("day".to_string()))),
-        );
+        const NANOS_PER_DAY: i64 = 86_400_000_000_000;
+        let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
 
-        let res = date_trunc(args.as_slice())?;
-        match res {
-            ColumnarValue::Array(a) => Ok(a),
-            ColumnarValue::Scalar(_) => Err(DataFusionError::Internal(
-                "Date trunc returned scalar value for array input".to_string(),
-            )),
+        let mut builder = Date32Builder::new(args[0].len());
+        if let Some(strings) = args[0].as_any().downcast_ref::<StringArray>() {
+            for i in 0..strings.len() {
+                if strings.is_null(i) {
+                    builder.append_null()?;
+                } else {
+                    let date = parse_date_str(strings.value(i))?.date();
+                    builder.append_value(date.signed_duration_since(epoch).num_days() as i32)?;
+                }
+            }
+        } else if let Some(timestamps) = args[0].as_any().downcast_ref::<TimestampNanosecondArray>()
+        {
+            for i in 0..timestamps.len() {
+                if timestamps.is_null(i) {
+                    builder.append_null()?;
+                } else {
+                    builder.append_value(timestamps.value(i).div_euclid(NANOS_PER_DAY) as i32)?;
+                }
+            }
+        } else {
+            return Err(DataFusionError::Execution(format!(
+                "DATE expects a string or timestamp argument, actual: {}",
+                args[0].data_type()
+            )));
         }
+
+        Ok(Arc::new(builder.finish()) as ArrayRef)
     });
 
-    let return_type: ReturnTypeFunction =
-        Arc::new(move |_| Ok(Arc::new(DataType::Timestamp(TimeUnit::Nanosecond, None))));
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Date32)));
 
     ScalarUDF::new(
         "date",
@@ -934,8 +951,7 @@ pub fn create_date_udf() -> ScalarUDF {
 pub fn create_makedate_udf() -> ScalarUDF {
     let fun = make_scalar_function(move |_args: &[ArrayRef]| todo!("Not implemented"));
 
-    let return_type: ReturnTypeFunction =
-        Arc::new(move |_| Ok(Arc::new(DataType::Timestamp(TimeUnit::Millisecond, None))));
+    let return_type: ReturnTypeFunction = Arc::new(move |_| Ok(Arc::new(DataType::Date32)));
 
     ScalarUDF::new(
         "makedate",

--- a/rust/cubesql/cubesql/src/compile/engine/udf/redshift.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/redshift.rs
@@ -26,14 +26,16 @@ pub fn create_datediff_udf() -> ScalarUDF {
             DataType::Timestamp(TimeUnit::Nanosecond, None) => Arc::clone(&args[1]),
             DataType::Timestamp(TimeUnit::Microsecond, None)
             | DataType::Timestamp(TimeUnit::Millisecond, None)
-            | DataType::Timestamp(TimeUnit::Second, None) => cast_with_options(
+            | DataType::Timestamp(TimeUnit::Second, None)
+            | DataType::Date32
+            | DataType::Date64 => cast_with_options(
                 &args[1],
                 &DataType::Timestamp(TimeUnit::Nanosecond, None),
                 &CastOptions { safe: false },
             )?,
             t => {
                 return Err(DataFusionError::Execution(format!(
-                    "second datediff argument must be of type Timestamp actual: {}",
+                    "second datediff argument must be of type Timestamp or Date actual: {}",
                     t
                 )))
             }
@@ -43,14 +45,16 @@ pub fn create_datediff_udf() -> ScalarUDF {
             DataType::Timestamp(TimeUnit::Nanosecond, None) => Arc::clone(&args[2]),
             DataType::Timestamp(TimeUnit::Microsecond, None)
             | DataType::Timestamp(TimeUnit::Millisecond, None)
-            | DataType::Timestamp(TimeUnit::Second, None) => cast_with_options(
+            | DataType::Timestamp(TimeUnit::Second, None)
+            | DataType::Date32
+            | DataType::Date64 => cast_with_options(
                 &args[2],
                 &DataType::Timestamp(TimeUnit::Nanosecond, None),
                 &CastOptions { safe: false },
             )?,
             t => {
                 return Err(DataFusionError::Execution(format!(
-                    "third datediff argument must be of type Timestamp actual: {}",
+                    "third datediff argument must be of type Timestamp or Date actual: {}",
                     t
                 )))
             }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -16097,8 +16097,7 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
                     dimension: "KibanaSampleDataEcommerce.order_date".to_owned(),
                     granularity: Some("month".to_string()),
                     date_range: Some(json!(vec![
-                        // WHY NOT "2025-01-01T00:00:00.000Z".to_string(), ?
-                        "2025-01-01".to_string(),
+                        "2025-01-01T00:00:00.000Z".to_string(),
                         "2025-01-31T23:59:59.999Z".to_string()
                     ])),
                 }]),
@@ -17059,8 +17058,8 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
                     dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
                     granularity: None,
                     date_range: Some(json!(vec![
-                        "2024-01-01".to_string(),
-                        "2024-02-29".to_string()
+                        "2024-01-01T00:00:00.000Z".to_string(),
+                        "2024-02-29T00:00:00.000Z".to_string()
                     ]))
                 }]),
                 order: Some(vec![]),

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/dates.rs
@@ -376,16 +376,6 @@ impl RewriteRules for DateRules {
                     "?alias",
                 ),
             ),
-            // TODO: TO_DATE should return Date32, but Timestamp works for all supported cases
-            transforming_rewrite(
-                "thoughtspot-to-date-to-timestamp",
-                udf_expr(
-                    "to_date",
-                    vec![literal_expr("?date"), literal_expr("?format")],
-                ),
-                udf_expr("date_to_timestamp", vec![literal_expr("?date")]),
-                self.transform_to_date_to_timestamp("?format"),
-            ),
             // TODO turn this rule into generic DateTrunc merge
             transforming_rewrite(
                 "datastudio-dates",
@@ -613,25 +603,6 @@ impl DateRules {
                 },
                 _ => false,
             }
-        }
-    }
-
-    fn transform_to_date_to_timestamp(
-        &self,
-        format_var: &'static str,
-    ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
-        let format_var = var!(format_var);
-        move |egraph, subst| {
-            for format in var_iter!(egraph[subst[format_var]], LiteralExprValue) {
-                match format {
-                    ScalarValue::Utf8(Some(format)) => match format.as_str() {
-                        "YYYY-MM-DD" | "yyyy-MM-dd" => return true,
-                        _ => (),
-                    },
-                    _ => (),
-                }
-            }
-            false
         }
     }
 

--- a/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rules/filters.rs
@@ -44,7 +44,7 @@ use cubeclient::models::V1CubeMeta;
 use datafusion::{
     arrow::{
         array::{Date32Array, Date64Array, TimestampNanosecondArray},
-        datatypes::{DataType, IntervalDayTimeType},
+        datatypes::DataType,
     },
     logical_plan::{Column, Expr, Operator},
     scalar::ScalarValue,
@@ -2780,16 +2780,13 @@ impl RewriteRules for FilterRules {
                             vec![literal_string("day"), column_expr("?column")],
                         ),
                         "?op",
-                        udf_expr(
-                            "to_date",
-                            vec![literal_expr("?literal"), literal_string("yyyy-MM-dd")],
-                        ),
+                        literal_expr("?timestamp"),
                     ),
                     "?alias_to_cube",
                     "?members",
                     "?filter_aliases",
                 ),
-                self.transform_date_column_compare_date_str("?op", "?literal"),
+                self.transform_date_column_compare_date_str("?op", "?literal", "?timestamp"),
             ),
             rewrite(
                 "filter-domo-date-column-between",
@@ -2825,33 +2822,19 @@ impl RewriteRules for FilterRules {
                 ),
                 filter_replacer(
                     binary_expr(
-                        binary_expr(
-                            column_expr("?column"),
-                            "<",
-                            udf_expr(
-                                "to_date",
-                                vec![literal_expr("?literal"), literal_string("yyyy-MM-dd")],
-                            ),
-                        ),
+                        binary_expr(column_expr("?column"), "<", literal_expr("?day_start")),
                         "OR",
                         binary_expr(
                             column_expr("?column"),
                             ">=",
-                            binary_expr(
-                                udf_expr(
-                                    "to_date",
-                                    vec![literal_expr("?literal"), literal_string("yyyy-MM-dd")],
-                                ),
-                                "+",
-                                literal_expr("?one_day"),
-                            ),
+                            literal_expr("?next_day_start"),
                         ),
                     ),
                     "?alias_to_cube",
                     "?members",
                     "?filter_aliases",
                 ),
-                self.transform_not_column_equals_date("?literal", "?one_day"),
+                self.transform_not_column_equals_date("?literal", "?day_start", "?next_day_start"),
             ),
             rewrite(
                 "filter-tableau-case-when-not-null",
@@ -5778,13 +5761,30 @@ impl FilterRules {
         }
     }
 
+    /// Converts a date/time literal to a timestamp in nanoseconds.
+    /// String literals are parsed with Cube's date parser to also support
+    /// date-only strings (e.g. `'2019-01-01'`).
+    fn filter_scalar_to_timestamp_nanos(literal: &ScalarValue) -> Option<i64> {
+        match literal {
+            ScalarValue::Utf8(Some(value)) => {
+                parse_date_str(value).ok()?.and_utc().timestamp_nanos_opt()
+            }
+            _ => Self::scalar_to_native_datetime(literal)
+                .ok()??
+                .and_utc()
+                .timestamp_nanos_opt(),
+        }
+    }
+
     fn transform_date_column_compare_date_str(
         &self,
         op_var: &'static str,
         literal_var: &'static str,
+        timestamp_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let op_var = var!(op_var);
         let literal_var = var!(literal_var);
+        let timestamp_var = var!(timestamp_var);
         move |egraph, subst| {
             for op in var_iter!(egraph[subst[op_var]], BinaryExprOp) {
                 match op {
@@ -5797,9 +5797,17 @@ impl FilterRules {
                 };
 
                 for literal in var_iter!(egraph[subst[literal_var]], LiteralExprValue) {
-                    if let ScalarValue::Utf8(_) = literal {
-                        return true;
-                    }
+                    let Some(timestamp) = Self::filter_scalar_to_timestamp_nanos(literal) else {
+                        continue;
+                    };
+
+                    subst.insert(
+                        timestamp_var,
+                        egraph.add(LogicalPlanLanguage::LiteralExprValue(LiteralExprValue(
+                            ScalarValue::TimestampNanosecond(Some(timestamp), None),
+                        ))),
+                    );
+                    return true;
                 }
             }
 
@@ -5810,23 +5818,32 @@ impl FilterRules {
     fn transform_not_column_equals_date(
         &self,
         literal_var: &'static str,
-        one_day_var: &'static str,
+        day_start_var: &'static str,
+        next_day_start_var: &'static str,
     ) -> impl Fn(&mut CubeEGraph, &mut Subst) -> bool {
         let literal_var = var!(literal_var);
-        let one_day_var = var!(one_day_var);
+        let day_start_var = var!(day_start_var);
+        let next_day_start_var = var!(next_day_start_var);
         move |egraph, subst| {
+            const ONE_DAY_NANOS: i64 = 86_400_000_000_000;
             for literal in var_iter!(egraph[subst[literal_var]], LiteralExprValue) {
-                if let ScalarValue::Utf8(_) = literal {
-                    subst.insert(
-                        one_day_var,
-                        egraph.add(LogicalPlanLanguage::LiteralExprValue(LiteralExprValue(
-                            ScalarValue::IntervalDayTime(Some(IntervalDayTimeType::make_value(
-                                1, 0,
-                            ))),
-                        ))),
-                    );
-                    return true;
-                }
+                let Some(timestamp) = Self::filter_scalar_to_timestamp_nanos(literal) else {
+                    continue;
+                };
+
+                subst.insert(
+                    day_start_var,
+                    egraph.add(LogicalPlanLanguage::LiteralExprValue(LiteralExprValue(
+                        ScalarValue::TimestampNanosecond(Some(timestamp), None),
+                    ))),
+                );
+                subst.insert(
+                    next_day_start_var,
+                    egraph.add(LogicalPlanLanguage::LiteralExprValue(LiteralExprValue(
+                        ScalarValue::TimestampNanosecond(Some(timestamp + ONE_DAY_NANOS), None),
+                    ))),
+                );
+                return true;
             }
 
             false

--- a/rust/cubesql/cubesql/src/compile/test/test_udfs.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_udfs.rs
@@ -50,6 +50,51 @@ async fn test_ends_with() -> Result<(), CubeError> {
 }
 
 #[tokio::test]
+async fn test_date() -> Result<(), CubeError> {
+    assert_eq!(
+        execute_query(
+            "select \
+                    DATE('2019-01-15 10:30:35.5') as r1,
+                    DATE('2019-01-15') as r2,
+                    DATE(CAST('2019-01-15 10:30:35' AS TIMESTAMP)) as r3;
+                "
+            .to_string(),
+            DatabaseProtocol::PostgreSQL
+        )
+        .await?,
+        "+------------+------------+------------+\n\
+            | r1         | r2         | r3         |\n\
+            +------------+------------+------------+\n\
+            | 2019-01-15 | 2019-01-15 | 2019-01-15 |\n\
+            +------------+------------+------------+"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_to_date() -> Result<(), CubeError> {
+    assert_eq!(
+        execute_query(
+            "select \
+                    TO_DATE('2020-02-20', 'YYYY-MM-DD') as r1,
+                    TO_DATE('2020-02-20', 'yyyy-MM-dd') as r2;
+                "
+            .to_string(),
+            DatabaseProtocol::PostgreSQL
+        )
+        .await?,
+        "+------------+------------+\n\
+            | r1         | r2         |\n\
+            +------------+------------+\n\
+            | 2020-02-20 | 2020-02-20 |\n\
+            +------------+------------+"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_locate() -> Result<(), CubeError> {
     assert_eq!(
         execute_query(

--- a/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_wrapper.rs
@@ -2179,6 +2179,7 @@ FROM MultiTypeCube
 WHERE
     DATE_TRUNC('day', CAST(dim_date0 AS TIMESTAMP)) >=
      '2025-01-01'
+    AND LOWER(dim_str0) = 'some value'
 GROUP BY
     1
 ;
@@ -2609,5 +2610,50 @@ GROUP BY 1
     assert_eq!(
         params_in_sql_order,
         vec!["sub_notes", "male_notes", "female_notes", "other_notes"]
+    );
+}
+
+/// Date-only string literals (e.g. `'2026-06-24'`) compared to a timestamp column
+/// inside an aggregated CASE expression must be normalized to timestamps
+/// so the whole query can be pushed down to the wrapper.
+#[tokio::test]
+async fn test_case_wrapper_sum_case_date_only_string() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        r#"
+        SELECT
+            customer_gender,
+            SUM(CASE WHEN order_date >= '2026-06-24' AND order_date < '2026-06-25' THEN sumPrice END) AS today_amount,
+            MEASURE(sumPrice) AS mtd_amount
+        FROM KibanaSampleDataEcommerce
+        WHERE customer_gender = 'female'
+            AND order_date >= '2026-06-01'
+            AND order_date <= '2026-06-24'
+        GROUP BY 1
+        HAVING MEASURE(sumPrice) != 0
+        ORDER BY 3 DESC
+        LIMIT 100
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+    assert!(
+        sql.contains("2026-06-24T00:00:00.000Z"),
+        "expected date-only string normalized to timestamp, got: {}",
+        sql
+    );
+
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
     );
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR fixes SQL pushdown failing with a coercion error when a timestamp is compared to a date-only string literal (e.g. in an aggregated `CASE` expression) by normalizing such literals to timestamps, in PostgreSQL semantics. Related tests are included.