### PR TITLE
fix(cubesql): Support `HAVING` on a measure combined with `ORDER BY` on the same measure

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=c4960447df1df72f9f66a7bbf23e9b0c19184d05#c4960447df1df72f9f66a7bbf23e9b0c19184d05"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "c4960447df1df72f9f66a7bbf23e9b0c19184d05", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "1c073dfa64c10949df15064aa7eb71ce513e725a", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/test/test_filters.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_filters.rs
@@ -1,4 +1,6 @@
-use cubeclient::models::{V1LoadRequestQuery, V1LoadRequestQueryFilterItem};
+use cubeclient::models::{
+    V1LoadRequestQuery, V1LoadRequestQueryFilterItem, V1LoadRequestQueryTimeDimension,
+};
 use datafusion::physical_plan::displayable;
 use pretty_assertions::assert_eq;
 
@@ -185,6 +187,100 @@ WHERE
             segments: Some(vec![]),
             order: Some(vec![]),
             filters: None,
+            ..Default::default()
+        }
+    );
+}
+
+/// HAVING on a measure combined with ORDER BY on the same measure used to leave
+/// a raw `measure()` aggregate in the Sort above the rewritten CubeScan
+/// ("Physical plan does not support logical expression measure(...)").
+#[tokio::test]
+async fn test_measure_having_and_order_by_measure() {
+    if !Rewriter::sql_push_down_enabled() {
+        return;
+    }
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+SELECT
+    customer_gender,
+    notes,
+    DATE_TRUNC('month', order_date) AS order_date_month,
+    MEASURE(sumPrice)
+FROM KibanaSampleDataEcommerce
+WHERE
+    order_date >= '2026-01-01'
+    AND order_date <= '2026-06-26'
+    AND customer_gender IN ('male', 'female')
+GROUP BY 1, 2, 3
+HAVING
+    MEASURE(sumPrice) IS NOT NULL
+    AND MEASURE(sumPrice) != 0
+ORDER BY MEASURE(sumPrice) DESC
+LIMIT 5000
+;
+"#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    // The whole query must be pushed to a single CubeScan; before the fix
+    // physical planning failed on the leftover Sort node.
+    let physical_plan = query_plan.as_physical_plan().await.unwrap();
+    println!(
+        "Physical plan: {}",
+        displayable(physical_plan.as_ref()).indent()
+    );
+
+    assert_eq!(
+        query_plan.as_logical_plan().find_cube_scan().request,
+        V1LoadRequestQuery {
+            measures: Some(vec!["KibanaSampleDataEcommerce.sumPrice".to_string()]),
+            dimensions: Some(vec![
+                "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                "KibanaSampleDataEcommerce.notes".to_string(),
+            ]),
+            segments: Some(vec![]),
+            time_dimensions: Some(vec![V1LoadRequestQueryTimeDimension {
+                dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                granularity: Some("month".to_string()),
+                date_range: Some(serde_json::json!(vec![
+                    "2026-01-01T00:00:00.000Z".to_string(),
+                    "2026-06-26T00:00:00.000Z".to_string(),
+                ])),
+            }]),
+            order: Some(vec![vec![
+                "KibanaSampleDataEcommerce.sumPrice".to_string(),
+                "desc".to_string(),
+            ]]),
+            limit: Some(5000),
+            filters: Some(vec![
+                V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                    operator: Some("equals".to_string()),
+                    values: Some(vec!["male".to_string(), "female".to_string()]),
+                    or: None,
+                    and: None,
+                },
+                V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.sumPrice".to_string()),
+                    operator: Some("set".to_string()),
+                    values: None,
+                    or: None,
+                    and: None,
+                },
+                V1LoadRequestQueryFilterItem {
+                    member: Some("KibanaSampleDataEcommerce.sumPrice".to_string()),
+                    operator: Some("notEquals".to_string()),
+                    values: Some(vec!["0".to_string()]),
+                    or: None,
+                    and: None,
+                },
+            ]),
             ..Default::default()
         }
     );


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@1c073df, fixing queries combining a `HAVING` filter on a measure with `ORDER BY` on the same measure failing with "Physical plan does not support logical expression measure(...)". Related test is included.
