### PR TITLE
docs: remove internal isDevMode param from public Chat API spec

### DIFF
--- a/docs-mintlify/api-reference/chat.yaml
+++ b/docs-mintlify/api-reference/chat.yaml
@@ -306,8 +306,6 @@ components:
         isDefaultBranch:
           description: Whether `activeBranchName` is the default branch. Defaults to `true` when not set.
           type: boolean
-        isDevMode:
-          type: boolean
         messageId:
           description: >-
             Client-provided identifier in the format `<timestamp>-message` (13+ digit Unix

--- a/docs-mintlify/scripts/extract-chat.js
+++ b/docs-mintlify/scripts/extract-chat.js
@@ -47,6 +47,7 @@ const INTERNAL_CHAT_REQUEST_FIELDS = [
   'context',
   'cubeCredentials',
   'dashboardContext',
+  'isDevMode',
   'workbookContext',
   'workbookId',
 ];


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Removes the internal `isDevMode` param from the public Chat API reference at [`/api-reference/chat/stream-chat-state`](https://docs.cube.dev/api-reference/chat/stream-chat-state):

- `docs-mintlify/api-reference/chat.yaml` — dropped the `isDevMode` property from the `ChatRequest` body schema in the committed OpenAPI spec that Mintlify renders.
- `docs-mintlify/scripts/extract-chat.js` — added `isDevMode` to `INTERNAL_CHAT_REQUEST_FIELDS` so regenerating the spec from the upstream source keeps the field stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bNvZME8DZLux1Wds7WvQv

---
_Generated by [Claude Code](https://claude.ai/code/session_016bNvZME8DZLux1Wds7WvQv)_