### PR TITLE
docs: fix "Visual Modelerer" typo on Visual Modeler page

### DIFF
--- a/docs-mintlify/docs/data-modeling/visual-modeler.mdx
+++ b/docs-mintlify/docs/data-modeling/visual-modeler.mdx
@@ -1,5 +1,5 @@
 ---
-title: Visual Modelerer
+title: Visual Modeler
 description: Walks through Cube Cloud’s browser-based Visual Modeler for no-code modeling, including setup, workflow, and known limitations versus the code editor.
 ---
 


### PR DESCRIPTION
## Summary

- The Visual Modeler docs page had a typo in its frontmatter `title:` — "Visual Modelerer" instead of "Visual Modeler".
- Mintlify derives both the page heading and the sidebar label from `title:`, so this single edit fixes the typo in both places.

## Test plan

- [x] Verified no other occurrences of the typo remain under `docs-mintlify/`
- [ ] CI must pass