### PR TITLE
fix(cubesql): Support `ORDER BY` over unprojected columns in CTEs

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=1c073dfa64c10949df15064aa7eb71ce513e725a#1c073dfa64c10949df15064aa7eb71ce513e725a"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b#ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "1c073dfa64c10949df15064aa7eb71ce513e725a", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "ed911e3d05215a4c97e6c977d5c3bd7f9cc33b8b", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -19007,6 +19007,61 @@ LIMIT {{ limit }}{% endif %}"#.to_string(),
     }
 
     #[tokio::test]
+    async fn test_cte_order_by_unprojected_column() {
+        init_testing_logger();
+
+        // The CTE's ORDER BY references `cnt`, which is not in the CTE's projection;
+        // the sort column must be resolved through the CTE's aliased projection
+        // during DF post-processing planning
+        let query_plan = convert_select_to_query_plan(
+            // language=PostgreSQL
+            r#"
+            WITH t1 AS (
+                SELECT
+                    customer_gender,
+                    taxful_total_price AS price,
+                    MEASURE(count) AS cnt
+                FROM KibanaSampleDataEcommerce
+                GROUP BY 1, 2
+            ),
+            t2 AS (
+                SELECT customer_gender, price
+                FROM t1
+                ORDER BY customer_gender, cnt DESC
+            )
+            SELECT * FROM t2
+            LIMIT 100
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let request = logical_plan.find_cube_scan().request;
+        assert_eq!(
+            request.dimensions,
+            Some(vec![
+                "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                "KibanaSampleDataEcommerce.taxful_total_price".to_string(),
+            ])
+        );
+        assert_eq!(
+            request.order,
+            Some(vec![
+                vec![
+                    "KibanaSampleDataEcommerce.customer_gender".to_string(),
+                    "asc".to_string(),
+                ],
+                vec![
+                    "KibanaSampleDataEcommerce.count".to_string(),
+                    "desc".to_string(),
+                ],
+            ])
+        );
+    }
+
+    #[tokio::test]
     async fn test_set_cache_mode() -> Result<(), CubeError> {
         if !Rewriter::sql_push_down_enabled() {
             return Ok(());


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@ed911e3 to pick up the fix for planning errors on queries where a CTE's `ORDER BY` references a column absent from the CTE's projection (`Initial planning error: ... column "..." must appear in the GROUP BY clause or be used in an aggregate function`). Related test is included.