### PR TITLE
feat(cubesql): Implement `STRING_AGG` aggregate function

### DIFF
--- a/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/udf/common.rs
@@ -1,5 +1,6 @@
 use std::{
     any::type_name,
+    collections::BTreeSet,
     convert::TryInto,
     mem::swap,
     sync::{Arc, LazyLock},
@@ -2247,6 +2248,177 @@ pub fn create_patch_measure_udaf() -> AggregateUDF {
         &accumulator,
         &state_type,
     )
+}
+
+pub fn create_string_agg_udaf() -> AggregateUDF {
+    // The bytea variant is advertised to match Postgres' signatures, but only
+    // text values are supported; the accumulator errors on binary input
+    let signature = Signature::one_of(
+        vec![
+            TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+            TypeSignature::Exact(vec![DataType::Binary, DataType::Binary]),
+        ],
+        Volatility::Immutable,
+    );
+    let return_type: ReturnTypeFunction =
+        Arc::new(|inputs| Ok(Arc::new(inputs.first().cloned().unwrap_or(DataType::Utf8))));
+    let accumulator: AccumulatorFunctionImplementation =
+        Arc::new(|distinct| Ok(Box::new(StringAggAccumulator::new(distinct))));
+    let state_type: StateTypeFunction = Arc::new(|_, _| {
+        Ok(Arc::new(vec![
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
+        ]))
+    });
+    AggregateUDF::new(
+        "string_agg",
+        &signature,
+        &return_type,
+        &accumulator,
+        &state_type,
+    )
+}
+
+#[derive(Debug)]
+struct StringAggAccumulator {
+    values: Vec<String>,
+    delimiter: Option<String>,
+    distinct: bool,
+}
+
+impl StringAggAccumulator {
+    fn new(distinct: bool) -> Self {
+        Self {
+            values: vec![],
+            delimiter: None,
+            distinct,
+        }
+    }
+}
+
+impl Accumulator for StringAggAccumulator {
+    fn state(&self) -> Result<Vec<ScalarValue>> {
+        let values = self
+            .values
+            .iter()
+            .map(|v| ScalarValue::Utf8(Some(v.clone())))
+            .collect::<Vec<_>>();
+        let delimiter = match &self.delimiter {
+            Some(delimiter) => vec![ScalarValue::Utf8(Some(delimiter.clone()))],
+            None => vec![],
+        };
+        Ok(vec![
+            ScalarValue::List(Some(Box::new(values)), Box::new(DataType::Utf8)),
+            ScalarValue::List(Some(Box::new(delimiter)), Box::new(DataType::Utf8)),
+        ])
+    }
+
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        if matches!(
+            values[0].data_type(),
+            DataType::Binary | DataType::LargeBinary
+        ) {
+            return Err(DataFusionError::NotImplemented(
+                "STRING_AGG over bytea values is not supported".to_string(),
+            ));
+        }
+        let value_array = cast(&values[0], &DataType::Utf8)?;
+        let value_array = value_array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("cast to Utf8 must produce a StringArray");
+        let delimiter_array = cast(&values[1], &DataType::Utf8)?;
+        let delimiter_array = delimiter_array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("cast to Utf8 must produce a StringArray");
+        for (value, delimiter) in value_array.iter().zip(delimiter_array.iter()) {
+            if self.delimiter.is_none() {
+                if let Some(delimiter) = delimiter {
+                    self.delimiter = Some(delimiter.to_string());
+                }
+            }
+            if let Some(value) = value {
+                self.values.push(value.to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        let values_list = states[0]
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(
+                    "STRING_AGG state `values` must be a ListArray".to_string(),
+                )
+            })?;
+        for i in 0..values_list.len() {
+            if values_list.is_null(i) {
+                continue;
+            }
+            let row = values_list.value(i);
+            let row = cast(&row, &DataType::Utf8)?;
+            let row = row
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("cast to Utf8 must produce a StringArray");
+            for value in row.iter().flatten() {
+                self.values.push(value.to_string());
+            }
+        }
+
+        let delimiters_list = states[1]
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(
+                    "STRING_AGG state `delimiter` must be a ListArray".to_string(),
+                )
+            })?;
+        for i in 0..delimiters_list.len() {
+            if self.delimiter.is_some() {
+                break;
+            }
+            if delimiters_list.is_null(i) {
+                continue;
+            }
+            let row = delimiters_list.value(i);
+            let row = cast(&row, &DataType::Utf8)?;
+            let row = row
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("cast to Utf8 must produce a StringArray");
+            if let Some(delimiter) = row.iter().flatten().next() {
+                self.delimiter = Some(delimiter.to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&self) -> Result<ScalarValue> {
+        if self.values.is_empty() {
+            return Ok(ScalarValue::Utf8(None));
+        }
+        let delimiter = self.delimiter.as_deref().unwrap_or("");
+        let result = if self.distinct {
+            self.values
+                .iter()
+                .map(|v| v.as_str())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join(delimiter)
+        } else {
+            self.values
+                .iter()
+                .map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(delimiter)
+        };
+        Ok(ScalarValue::Utf8(Some(result)))
+    }
 }
 
 macro_rules! generate_series_udtf {
@@ -5224,11 +5396,6 @@ pub fn register_fun_stubs(mut ctx: SessionContext) -> SessionContext {
     register_fun_stub!(udaf, "bit_xor", tsigs = [[Int16], [Int32], [Int64],]);
     register_fun_stub!(udaf, "every", tsig = [Boolean], rettyp = Boolean);
     register_fun_stub!(udaf, "median", argc = 1);
-    register_fun_stub!(
-        udaf,
-        "string_agg",
-        tsigs = [[Utf8, Utf8], [Binary, Binary],]
-    );
     register_fun_stub!(
         udaf,
         "regr_avgx",

--- a/rust/cubesql/cubesql/src/compile/query_engine.rs
+++ b/rust/cubesql/cubesql/src/compile/query_engine.rs
@@ -519,6 +519,7 @@ impl QueryEngine for SqlQueryEngine {
         ctx.register_udaf(create_measure_udaf());
         ctx.register_udaf(create_patch_measure_udaf());
         ctx.register_udaf(create_xirr_udaf());
+        ctx.register_udaf(create_string_agg_udaf());
 
         // udtf
         ctx.register_udtf(create_generate_series_udtf());

--- a/rust/cubesql/cubesql/src/compile/test/test_udfs.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_udfs.rs
@@ -1400,3 +1400,61 @@ async fn test_pg_tablespace_location() -> Result<(), CubeError> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_string_agg() -> Result<(), CubeError> {
+    init_testing_logger();
+
+    assert_eq!(
+        execute_query(
+            "SELECT
+                STRING_AGG(x, ', ') AS r1,
+                STRING_AGG(DISTINCT x, ', ') AS r2,
+                STRING_AGG(nothing, ', ') AS r3
+            FROM (
+                SELECT x, NULLIF(x, x) AS nothing
+                FROM (SELECT UNNEST(ARRAY['b', 'a', 'b', 'c']) AS x) t
+            ) t"
+            .to_string(),
+            DatabaseProtocol::PostgreSQL
+        )
+        .await?,
+        "+------------+---------+------+\n\
+            | r1         | r2      | r3   |\n\
+            +------------+---------+------+\n\
+            | b, a, b, c | a, b, c | NULL |\n\
+            +------------+---------+------+"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_string_agg_group_by() -> Result<(), CubeError> {
+    init_testing_logger();
+
+    // GROUP BY goes through the partial/final aggregate path, exercising
+    // per-group state merges
+    assert_eq!(
+        execute_query(
+            "SELECT k, STRING_AGG(DISTINCT x, ', ') AS r
+            FROM (
+                SELECT UNNEST(ARRAY[1, 1, 1, 2, 2]) AS k,
+                       UNNEST(ARRAY['b', 'a', 'b', 'c', 'a']) AS x
+            ) t
+            GROUP BY k
+            ORDER BY k"
+                .to_string(),
+            DatabaseProtocol::PostgreSQL
+        )
+        .await?,
+        "+---+------+\n\
+            | k | r    |\n\
+            +---+------+\n\
+            | 1 | a, b |\n\
+            | 2 | a, c |\n\
+            +---+------+"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR implements `STRING_AGG` as a real aggregate UDF so it can be executed in post-processing queries: previously it was a planning-only stub failing with `string_agg is not implemented, it's a stub` whenever it couldn't be pushed down to the data source. Related test is included.