### PR TITLE
fix(snowflake-driver): surface an actionable error when the connection fails

### DIFF
--- a/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
+++ b/packages/cubejs-snowflake-driver/src/SnowflakeDriver.ts
@@ -25,6 +25,7 @@ import crypto from 'crypto';
 import { S3ClientConfig } from '@aws-sdk/client-s3';
 import { HydrationMap, HydrationStream } from './HydrationStream';
 import { hydrators } from './type-parsers';
+import { ConnectionError } from './errors';
 
 const SUPPORTED_BUCKET_TYPES = ['s3', 'gcs', 'azure'];
 
@@ -435,7 +436,28 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
   private async createConnection() {
     const config = await this.prepareConnectOptions();
 
-    return snowflake.createConnection(config);
+    try {
+      return snowflake.createConnection(config);
+    } catch (e) {
+      // snowflake-sdk validates connection options synchronously here and can
+      // throw both clear errors (e.g. a missing account) and opaque ones. Wrap
+      // them so the operator always gets an actionable Snowflake message.
+      throw new ConnectionError(e);
+    }
+  }
+
+  /**
+   * Opens the SDK connection, wrapping any error the SDK throws (including its
+   * opaque internal `TypeError`s) into an actionable {@link ConnectionError}.
+   */
+  private async connect(connection: Connection): Promise<Connection> {
+    try {
+      return await new Promise<Connection>(
+        (resolve, reject) => connection.connect((err, conn) => (err ? reject(err) : resolve(conn)))
+      );
+    } catch (e) {
+      throw new ConnectionError(e);
+    }
   }
 
   /**
@@ -444,9 +466,7 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
   public async testConnection() {
     const connection = await this.createConnection();
 
-    await new Promise(
-      (resolve, reject) => connection.connect((err, conn) => (err ? reject(err) : resolve(conn)))
-    );
+    await this.connect(connection);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { password, ...rest } = this.config;
     if (!connection.isUp()) {
@@ -478,9 +498,7 @@ export class SnowflakeDriver extends BaseDriver implements DriverInterface {
     try {
       const connection = await this.createConnection();
 
-      await new Promise(
-        (resolve, reject) => connection.connect((err, conn) => (err ? reject(err) : resolve(conn)))
-      );
+      await this.connect(connection);
 
       await this.execute(
         connection,

--- a/packages/cubejs-snowflake-driver/src/errors.ts
+++ b/packages/cubejs-snowflake-driver/src/errors.ts
@@ -1,0 +1,139 @@
+const CREDENTIALS_HINT =
+  'This most commonly means the Snowflake credentials are wrong, expired or ' +
+  'revoked — verify the account, username and credentials (password / private ' +
+  'key / OAuth token)';
+
+/**
+ * Detects the opaque errors snowflake-sdk throws from inside its own
+ * error-formatting code (e.g. the OAuth `prepareError` path dereferencing a
+ * missing `error_description`) instead of a real authentication-failure
+ * message. These are `TypeError`s of the V8 undefined-property shape and carry
+ * no actionable information on their own — the operator has no way to tell the
+ * real cause is a bad Snowflake credential.
+ *
+ * Matched by shape rather than an exact string so it stays robust across
+ * snowflake-sdk versions and the different fields the SDK dereferences. Because
+ * the same shape can also come from an *unrelated* bug, we never discard the
+ * original message on a match — we only *append* the credentials hint to it
+ * (see `describeCause`), so a genuine null-deref keeps its pinpoint message.
+ */
+function isOpaqueSdkTypeError(cause: unknown): boolean {
+  if (cause instanceof AggregateError) {
+    return cause.errors.some((e: unknown) => isOpaqueSdkTypeError(e));
+  }
+  if (!(cause instanceof TypeError)) {
+    return false;
+  }
+  // Newer V8: "Cannot read properties of undefined (reading 'replace')"
+  // Older V8: "Cannot read property 'replace' of undefined"
+  return /Cannot read properties of undefined \(reading '.*'\)/.test(cause.message) ||
+    /Cannot read property '.*' of undefined/.test(cause.message);
+}
+
+/**
+ * Extracts the most useful message from anything that can be thrown/rejected —
+ * `Error`, `AggregateError` (flattened; falling back to the aggregate's own
+ * message), a plain object carrying a `message`, or a string. Returns an empty
+ * string when there is genuinely no usable text, so the caller can fall back to
+ * the hint.
+ *
+ * This runs on the error path, so it must never throw itself: a hostile or
+ * exotic `cause` (a cyclic `AggregateError`, a throwing `message` getter) is
+ * swallowed into the empty-string fallback rather than masking the real
+ * connection failure with a secondary error.
+ */
+function messageOf(cause: unknown): string {
+  try {
+    if (cause instanceof AggregateError) {
+      const flattened = cause.errors
+        .map((e: unknown) => messageOf(e))
+        .filter((m) => m.length > 0)
+        .join(', ');
+      // Fall back to the aggregate's own message (e.g. "All endpoints failed").
+      return flattened || (typeof cause.message === 'string' ? cause.message.trim() : '');
+    }
+
+    if (cause instanceof Error) {
+      return typeof cause.message === 'string' ? cause.message.trim() : '';
+    }
+
+    if (typeof cause === 'string') {
+      return cause.trim();
+    }
+
+    // Non-Error rejections/throws (e.g. snowflake-sdk's HTTP layer can reject
+    // with a plain `{ message, code }` object) still carry a real message.
+    if (cause && typeof cause === 'object' && 'message' in cause) {
+      const { message } = cause as { message: unknown };
+      if (typeof message === 'string') {
+        return message.trim();
+      }
+    }
+  } catch {
+    // A throwing getter / exotic object — treat as "no usable message".
+    return '';
+  }
+
+  return '';
+}
+
+function describeCause(cause: unknown): string {
+  const message = messageOf(cause);
+
+  // Opaque SDK internal TypeError: keep whatever message it has (in case it's
+  // actually a real deref bug) but append the credentials hint, which is the
+  // likely cause when the SDK crashes inside its own auth-error formatting.
+  if (isOpaqueSdkTypeError(cause)) {
+    if (!message) {
+      return CREDENTIALS_HINT;
+    }
+    // Avoid a doubled period when the message already ends with punctuation.
+    const separator = /[.!?]$/.test(message) ? ' ' : '. ';
+    return `${message}${separator}${CREDENTIALS_HINT}`;
+  }
+
+  // Any real message is preserved verbatim; only fall back to the hint when
+  // there is genuinely nothing usable to show.
+  return message || CREDENTIALS_HINT;
+}
+
+export class SnowflakeError extends Error {
+  public name = 'SnowflakeError';
+
+  public constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}
+
+/**
+ * Wraps errors thrown by `snowflake-sdk` while establishing a connection into
+ * an actionable message.
+ *
+ * The snowflake-sdk does not surface authentication/connection failures
+ * uniformly. Some failure shapes crash *inside the SDK's own error-formatting
+ * code* and throw an opaque `TypeError: Cannot read properties of undefined
+ * (reading 'replace')` that gives the operator no hint that the problem is
+ * with the Snowflake credentials (see CUB-1676 — reproducible on the OAuth
+ * path when an error response lacks `error_description`, at snowflake-sdk
+ * `authentication/authentication_util.js` `prepareError`). Even the SDK's
+ * "clean" errors (e.g. `RequestFailedError`) are not clearly attributed to
+ * Snowflake once they bubble up through the API.
+ *
+ * This attributes the failure to Snowflake, preserves the original message
+ * whenever there is one (adding the credentials hint only for the opaque case
+ * or when there is no message at all), and retains the original thrown value on
+ * `cause` — inspectable in a debugger or by a cause-aware logger (note that a
+ * bare `error.stack` does not include the cause's stack).
+ */
+export class ConnectionError extends SnowflakeError {
+  public readonly name = 'ConnectionError';
+
+  public constructor(cause: unknown) {
+    super(`Unable to connect to Snowflake: ${describeCause(cause)}`, {
+      // `Error`'s `cause` option accepts any value — retain the original
+      // (including a non-Error `{ message, code }` object) so its diagnostic
+      // fields are not lost.
+      ...(cause != null ? { cause } : {}),
+    });
+  }
+}

--- a/packages/cubejs-snowflake-driver/test/errors.test.ts
+++ b/packages/cubejs-snowflake-driver/test/errors.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'vitest';
+
+import { ConnectionError, SnowflakeError } from '../src/errors';
+
+describe('ConnectionError', () => {
+  test('turns the opaque snowflake-sdk `reading \'replace\'` TypeError into an actionable message', () => {
+    // This is exactly what snowflake-sdk throws from inside its own error
+    // formatting when authentication fails on some paths (CUB-1676) — an error
+    // that tells the operator nothing about the real cause.
+    const opaque = new TypeError("Cannot read properties of undefined (reading 'replace')");
+
+    const err = new ConnectionError(opaque);
+
+    expect(err).toBeInstanceOf(SnowflakeError);
+    expect(err.name).toBe('ConnectionError');
+    expect(err.message).toMatch(/^Unable to connect to Snowflake: /);
+    // The operator is pointed at the credentials.
+    expect(err.message).toMatch(/credential/i);
+    // The original error is preserved for logs.
+    expect(err.cause).toBe(opaque);
+  });
+
+  test('matches the opaque TypeError by shape, across SDK phrasings/fields', () => {
+    // Older V8 phrasing ("property", singular) and a different dereferenced
+    // field must both be caught — we match by shape, not an exact string.
+    for (const message of [
+      "Cannot read property 'replace' of undefined",
+      "Cannot read properties of undefined (reading 'substring')",
+    ]) {
+      expect(new ConnectionError(new TypeError(message)).message).toMatch(/credential/i);
+    }
+  });
+
+  test('keeps the original message for an opaque-shaped TypeError (so a real deref bug is not masked)', () => {
+    // A genuine null-deref bug happens to share V8's shape. We must NOT throw
+    // its pinpoint message away — append the hint, don't replace.
+    const realBug = new TypeError("Cannot read properties of undefined (reading 'toUpperCase')");
+
+    const err = new ConnectionError(realBug);
+
+    expect(err.message).toContain("reading 'toUpperCase'");
+    expect(err.message).toMatch(/credential/i);
+  });
+
+  test('preserves a real SDK error message (e.g. RequestFailedError / missing account)', () => {
+    const real = new Error('Incorrect username or password was specified.');
+
+    const err = new ConnectionError(real);
+
+    expect(err.message).toBe(
+      'Unable to connect to Snowflake: Incorrect username or password was specified.'
+    );
+    expect(err.cause).toBe(real);
+  });
+
+  test('does not swallow an unrelated TypeError that carries a real message', () => {
+    const real = new TypeError('privateKey must be a string');
+    const err = new ConnectionError(real);
+    expect(err.message).toBe('Unable to connect to Snowflake: privateKey must be a string');
+  });
+
+  test('flattens an AggregateError into its underlying messages', () => {
+    const aggregate = new AggregateError([
+      new Error('getaddrinfo ENOTFOUND acme.snowflakecomputing.com'),
+      new Error('connect ETIMEDOUT'),
+    ]);
+
+    const err = new ConnectionError(aggregate);
+
+    expect(err.message).toBe(
+      'Unable to connect to Snowflake: ' +
+      'getaddrinfo ENOTFOUND acme.snowflakecomputing.com, connect ETIMEDOUT'
+    );
+  });
+
+  test('falls back to the hint (no dangling colon) for an empty AggregateError', () => {
+    const err = new ConnectionError(new AggregateError([]));
+    expect(err.message).toMatch(/credential/i);
+    expect(err.message).not.toMatch(/Snowflake:\s*$/);
+  });
+
+  test('does not repeat the hint when AggregateError sub-errors have empty messages', () => {
+    const err = new ConnectionError(new AggregateError([new Error(''), new Error('')]));
+    // Empty sub-messages are dropped, so the hint appears exactly once.
+    expect(err.message.match(/verify the account/gi)?.length ?? 0).toBe(1);
+  });
+
+  test('extracts the message from a non-Error rejection object (SDK HTTP-layer shape)', () => {
+    // snowflake-sdk's transitive layers can reject with a plain object.
+    const err = new ConnectionError({ message: 'Incorrect username or password was specified.', code: 390144 });
+    expect(err.message).toBe(
+      'Unable to connect to Snowflake: Incorrect username or password was specified.'
+    );
+  });
+
+  test('falls back to the hint for an empty or non-descriptive cause', () => {
+    expect(new ConnectionError(undefined).message).toMatch(/credential/i);
+    expect(new ConnectionError(new Error('')).message).toMatch(/credential/i);
+    expect(new ConnectionError({ code: 390144 }).message).toMatch(/credential/i);
+  });
+
+  test('surfaces a plain string cause', () => {
+    const err = new ConnectionError('Browser action timed out after 60000 ms.');
+
+    expect(err.message).toBe(
+      'Unable to connect to Snowflake: Browser action timed out after 60000 ms.'
+    );
+  });
+
+  test('retains a non-Error cause object (so its diagnostic fields survive)', () => {
+    const raw = { message: 'Incorrect username or password was specified.', code: 390144 };
+    const err = new ConnectionError(raw);
+    expect(err.cause).toBe(raw);
+  });
+
+  test('uses an AggregateError own message when it has no sub-errors', () => {
+    const err = new ConnectionError(new AggregateError([], 'All Snowflake endpoints failed'));
+    expect(err.message).toBe('Unable to connect to Snowflake: All Snowflake endpoints failed');
+  });
+
+  test('appends the hint to an opaque TypeError nested inside an AggregateError', () => {
+    const aggregate = new AggregateError([
+      new TypeError("Cannot read properties of undefined (reading 'replace')"),
+    ]);
+    expect(new ConnectionError(aggregate).message).toMatch(/credential/i);
+  });
+
+  test('does not double punctuation when appending the hint', () => {
+    const err = new ConnectionError(
+      new TypeError("Cannot read properties of undefined (reading 'replace').")
+    );
+    expect(err.message).not.toContain("').. ");
+    expect(err.message).not.toMatch(/\.\s+\.\s/);
+  });
+
+  test('drops whitespace-only aggregate members without a dangling separator', () => {
+    const err = new ConnectionError(new AggregateError([new Error('   '), new Error('ETIMEDOUT')]));
+    expect(err.message).toBe('Unable to connect to Snowflake: ETIMEDOUT');
+  });
+
+  test('never throws itself when the cause is hostile (throwing message getter)', () => {
+    const hostile = {
+      get message(): string {
+        throw new Error('boom');
+      },
+    };
+    expect(() => new ConnectionError(hostile)).not.toThrow();
+    expect(new ConnectionError(hostile).message).toMatch(/credential/i);
+  });
+});


### PR DESCRIPTION
## Summary

Improves how the Snowflake driver surfaces connection failures. Previously it let the raw `snowflake-sdk` error bubble up unattributed (e.g. `RequestFailedError: Request to Snowflake failed.`), which isn't clearly tied to Snowflake once it reaches the API/logs and, on the startup connection check, can crashloop the pod.

Adds a `ConnectionError` (same pattern as the Postgres/Cubestore drivers) wrapping SDK connection failures into `Unable to connect to Snowflake: …`. It preserves the original message, keeps the original on `cause`, and defensively maps the opaque `TypeError: Cannot read properties of undefined (reading 'replace')` the SDK can throw from inside its own error formatting to a credentials hint (kept alongside the original message, not replacing it). Wired into `createConnection()` + a new `connect()` helper used by `testConnection()` and `initConnection()`. Non-breaking: error surface only.

Note on scope: the opaque `reading 'replace'` TypeError originally reported lives in the SDK's interactive browser/OAuth-authorization-code flow, which this server-side driver does not use — on the driver's actual paths, invalid creds already surface as a structured `OperationFailedError`/`RequestFailedError`. This change is defensive attribution of any connection failure, not a repro-driven fix of that specific SDK path.

## Test plan

- [x] 17 unit tests (`test/errors.test.ts`), no live Snowflake
- [x] `tsc` / `eslint` / `yarn build` green
- [x] Verified before→after against the real driver with a bogus account (`RequestFailedError` → `Unable to connect to Snowflake: …`)
- [ ] CI