### PR TITLE
fix(duckdb-driver): Invalid SQL for custom granularities

### DIFF
--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -47,7 +47,7 @@ export class DuckDBQuery extends BaseQuery {
     const timeUnit = this.diffTimeUnitForInterval(interval);
     const beginOfTime = this.dateTimeCast('\'1970-01-01 00:00:00.000\'');
 
-    return `${this.dateTimeCast(`'${origin}'`)}' + INTERVAL '${interval}' *
+    return `${this.dateTimeCast(`'${origin}'`)} + INTERVAL '${interval}' *
       floor(
         date_diff('${timeUnit}', ${this.dateTimeCast(`'${origin}'`)}, ${source}) /
         date_diff('${timeUnit}', ${beginOfTime}, ${beginOfTime} + INTERVAL '${interval}')

--- a/packages/cubejs-testing/birdbox-fixtures/duckdb/schema/Orders.js
+++ b/packages/cubejs-testing/birdbox-fixtures/duckdb/schema/Orders.js
@@ -60,6 +60,12 @@ cube(`Orders`, {
     createdAt: {
       sql: `created_at`,
       type: `time`,
+      granularities: {
+        twoDayByOrigin: {
+          interval: `2 day`,
+          origin: `2020-01-01`,
+        },
+      },
     },
   },
 });

--- a/packages/cubejs-testing/test/smoke-duckdb.test.ts
+++ b/packages/cubejs-testing/test/smoke-duckdb.test.ts
@@ -51,11 +51,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // The HAVING clause applies after counting all records
     expect(response.rawData()[0]['Orders.count']).toBe('5');
   });
-  
+
   test('numeric dimension filter - uses CAST', async () => {
     // This test verifies that the WHERE clause for numeric dimensions uses CAST(? AS DOUBLE)
     const response = await client.load({
@@ -70,11 +70,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // Only 3 orders have amount >= 300
     expect(response.rawData()[0]['Orders.count']).toBe('3');
   });
-  
+
   test('string filter - does NOT use CAST', async () => {
     // This test verifies that the WHERE clause for string dimensions does not use CAST
     const response = await client.load({
@@ -89,11 +89,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 2 'processed' orders
     expect(response.rawData()[0]['Orders.count']).toBe('2');
   });
-  
+
   test('numeric exact equality filter - also uses CAST', async () => {
     // This test verifies that even for equality comparisons on numeric values, CAST is used
     const response = await client.load({
@@ -108,11 +108,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // Only 1 order has amount exactly 300
     expect(response.rawData()[0]['Orders.count']).toBe('1');
   });
-  
+
   test('numeric string comparison - values are properly handled with CAST', async () => {
     // This test verifies that numeric strings are properly cast as numbers
     // This is important because '100' and 100 are different in string comparisons
@@ -129,11 +129,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // Only 1 order has amount 100
     expect(response.rawData()[0]['Orders.count']).toBe('1');
   });
-  
+
   test('multiple string values in filter - none use CAST', async () => {
     // This test verifies that IN (...) clauses for string dimensions don't use CAST
     const response = await client.load({
@@ -148,11 +148,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 4 orders with status 'new' or 'processed'
     expect(response.rawData()[0]['Orders.count']).toBe('4');
   });
-  
+
   test('string measure filter - should NOT use CAST', async () => {
     // This test verifies that filters on string measures don't use CAST
     const response = await client.load({
@@ -167,11 +167,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // Output should match the shipped orders
     expect(response.rawData()[0]['Orders.count']).toBe('5');
   });
-  
+
   test('boolean measure filter - should NOT use CAST', async () => {
     // This test verifies that filters on boolean measures don't use CAST
     const response = await client.load({
@@ -186,11 +186,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // Output should match all orders since there are unpaid orders
     expect(response.rawData()[0]['Orders.count']).toBe('5');
   });
-  
+
   test('time measure filter - afterDate operator', async () => {
     // This test verifies that filters on time measures don't use CAST
     const response = await client.load({
@@ -205,11 +205,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // Orders after 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('5');
   });
-  
+
   test('time measure filter - beforeDate operator', async () => {
     // This test verifies that beforeDate operator works correctly with time measures
     const response = await client.load({
@@ -350,11 +350,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 2 unpaid orders
     expect(response.rawData()[0]['Orders.count']).toBe('2');
   });
-  
+
   test('time dimension filter - should NOT use CAST', async () => {
     // This test verifies that filters on time types don't use CAST
     const response = await client.load({
@@ -369,11 +369,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 2 orders after 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('2');
   });
-  
+
   test('time dimension filter - beforeDate operator', async () => {
     // This test verifies that the beforeDate operator works correctly
     const response = await client.load({
@@ -388,11 +388,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 2 orders before 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('2');
   });
-  
+
   test('time dimension filter - beforeOrOnDate operator', async () => {
     // This test verifies that the beforeOrOnDate operator works correctly
     const response = await client.load({
@@ -407,11 +407,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 3 orders before or on 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('3');
   });
-  
+
   test('time dimension filter - afterOrOnDate operator', async () => {
     // This test verifies that the afterOrOnDate operator works correctly
     const response = await client.load({
@@ -426,11 +426,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 3 orders after or on 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('3');
   });
-  
+
   test('time dimension filter - inDateRange operator', async () => {
     // This test verifies that the inDateRange operator works correctly
     const response = await client.load({
@@ -445,11 +445,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 3 orders between 2020-01-02 and 2020-01-04 (inclusive)
     expect(response.rawData()[0]['Orders.count']).toBe('3');
   });
-  
+
   test('time dimension filter - notInDateRange operator', async () => {
     // This test verifies that the notInDateRange operator works correctly
     const response = await client.load({
@@ -464,11 +464,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 2 orders outside the range 2020-01-02 to 2020-01-04
     expect(response.rawData()[0]['Orders.count']).toBe('2');
   });
-  
+
   test('time dimension filter - set operator', async () => {
     // This test verifies that the set operator works correctly
     const response = await client.load({
@@ -482,11 +482,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // All 5 orders have createdAt set
     expect(response.rawData()[0]['Orders.count']).toBe('5');
   });
-  
+
   test('time measure filter - set operator', async () => {
     // This test verifies that the set operator works correctly with measures
     const response = await client.load({
@@ -500,11 +500,11 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // All 5 orders have maxCreatedAt set
     expect(response.rawData()[0]['Orders.count']).toBe('5');
   });
-  
+
   // We can't effectively test notSet with the current schema since all records have dates
   // This test is more for API completeness
   test('time dimension filter - notSet operator', async () => {
@@ -520,7 +520,7 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // No orders have createdAt as null
     expect(response.rawData()[0]['Orders.count']).toBe('0');
   });
@@ -539,7 +539,7 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There is 1 order on exactly 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('1');
   });
@@ -558,8 +558,37 @@ describe('duckdb', () => {
         }
       ]
     });
-    
+
     // There are 4 orders not on 2020-01-03
     expect(response.rawData()[0]['Orders.count']).toBe('4');
+  });
+
+  test('custom time granularity with origin', async () => {
+    const response = await client.load({
+      measures: [
+        'Orders.count'
+      ],
+      timeDimensions: [
+        {
+          dimension: 'Orders.createdAt',
+          granularity: 'twoDayByOrigin',
+        }
+      ],
+      order: {
+        'Orders.createdAt': 'asc'
+      }
+    });
+
+    // 2-day buckets aligned to origin 2020-01-01 over rows dated 2020-01-01..05:
+    //   [01-01, 01-02] -> 2, [01-03, 01-04] -> 2, [01-05] -> 1
+    const buckets = response.rawData().map((r) => ({
+      bucket: r['Orders.createdAt.twoDayByOrigin'],
+      count: r['Orders.count'],
+    }));
+    expect(buckets).toEqual([
+      { bucket: '2020-01-01T00:00:00.000', count: '2' },
+      { bucket: '2020-01-03T00:00:00.000', count: '2' },
+      { bucket: '2020-01-05T00:00:00.000', count: '1' },
+    ]);
   });
 });


### PR DESCRIPTION
DuckDBQuery.dateBin() emitted a stray single quote right after the origin's ::timestamp cast, e.g.

  '2024-01-01T00:00:00.000'::timestamp' + INTERVAL '6 month' * ...

which made DuckDB fail with a parser error for any custom granularity that uses a non-natural-aligned origin (half_year, two_mo_by_feb, ...). This affected both the legacy planner and Tesseract, since both render the bin expression through this method.