### PR TITLE
docs: document data download controls

### DIFF
--- a/docs-mintlify/admin/users-and-permissions/custom-roles.mdx
+++ b/docs-mintlify/admin/users-and-permissions/custom-roles.mdx
@@ -119,6 +119,7 @@ Either grant **Full access** (a shortcut that enables every current and future d
 | Data Model  | Edit data model                     | Edit the data model on any branch, including the main/deploy branch. Allows committing and merging to main, force-syncing main, and starting dev mode against main.       |
 | Data Model  | Edit data model on dev branches     | Edit the data model only on non-default branches. Blocks any write that targets the main/deploy branch (including merging to main).                                       |
 | Monitoring  | Access query history                | View deployment query history, performance, and traces.                                                                                                                   |
+| Data Export | Download data                       | Download query results as CSV from workbooks, Analytics Chat, and published dashboards. Granted by default to the built-in Viewer, Explorer, and Developer roles. See [Data download controls][ref-data-download-controls]. |
 
 When **Full access** is checked, the granular checkboxes appear checked and disabled — granting Full access today also covers any deployment-scoped permissions added in the future.
 
@@ -126,9 +127,11 @@ When **Full access** is checked, the granular checkboxes appear checked and disa
 
 <Tip>
 
-**Access deployment** (`DeploymentRead`) is special. It's the only deployment action that does **not** auto-bump the Base Role to Developer, because Viewers also need it just to open a deployment.
+**Access deployment** (`DeploymentRead`) and **Download data** (`DownloadData`) are special. They are the only deployment actions that do **not** auto-bump the Base Role to Developer, because Viewers also need them just to open a deployment and download data from it.
 
 </Tip>
+
+[ref-data-download-controls]: /admin/users-and-permissions/roles-and-permissions#restricting-data-downloads
 
 ## Walkthroughs
 
@@ -252,3 +255,4 @@ This section lists every action a custom role can grant. The internal action nam
 | `SchemaUpdate`            | Edit data model                                             |
 | `SchemaUpdateDevBranches` | Edit data model on dev branches                             |
 | `APMRead`                 | Access query history                                        |
+| `DownloadData`            | Download data                                               |

--- a/docs-mintlify/admin/users-and-permissions/roles-and-permissions.mdx
+++ b/docs-mintlify/admin/users-and-permissions/roles-and-permissions.mdx
@@ -28,6 +28,17 @@ Admin roles are billed at the developer rate.
 
 </Info>
 
+## Restricting data downloads
+
+By default, all roles can download query results as CSV from workbooks, Analytics Chat, and published dashboards. Two controls restrict this:
+
+- **Account-wide** — the **Allow data downloads** switch on the **Admin → Settings** page. Turning it off hides export controls everywhere, for all users — including admins and embeds.
+- **Per user** — the **Download data** action in [custom roles][ref-custom-roles]. Built-in roles grant it by default; to remove download access for a group of users, assign them a custom role without it. Admins and anonymous embed viewers bypass it.
+
+The account-wide switch always wins; the permission applies only while downloads are allowed account-wide. Both govern the download button, not data access — query results are still rendered on screen.
+
+[ref-custom-roles]: /admin/users-and-permissions/custom-roles
+
 ## Agent Permissions
 
 Agents are connected to Semantic Model Deployments and inherit the permission level of the user they are operating under.


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required

**Description of Changes Made**

Documents the data download controls on the Roles & Permissions and Custom roles pages:

- New **Restricting data downloads** section on Roles & Permissions covering the account-wide **Allow data downloads** switch and the deployment-scoped **Download data** (`DownloadData`) custom-role action, and how they combine.
- Custom roles page: added **Data Export → Download data** to the deployment actions table and `DownloadData` to the action catalog; updated the auto-bump Tip since Download data doesn't force the Developer base role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)