### PR TITLE
feat(cubestore): Support sending x-amz-server-side-encryption header on S3 requests (CUBESTORE_S3_SSE)

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1953,6 +1953,17 @@ The name of a bucket in AWS S3. Required when using AWS S3.
 | -------------------------------------- | ---------------------- | --------------------- |
 | [A valid AWS region][aws-docs-regions] | N/A                    | N/A                   |
 
+## `CUBESTORE_S3_SSE`
+
+When set, Cube Store sends the `x-amz-server-side-encryption` header with this
+value on every AWS S3 request. Optional. Useful when an AWS Organizations
+service control policy denies `s3:PutObject` requests that lack this header,
+even if the bucket has default encryption enabled.
+
+| Possible Values                   | Default in Development | Default in Production |
+| --------------------------------- | ---------------------- | --------------------- |
+| `AES256`, `aws:kms`, `aws:kms:dsse` | N/A                    | N/A                   |
+
 ## `CUBESTORE_S3_SUB_PATH`
 
 The path in a AWS S3 bucket to store pre-aggregations. Optional.

--- a/rust/cubestore/cubestore/src/remotefs/s3.rs
+++ b/rust/cubestore/cubestore/src/remotefs/s3.rs
@@ -33,6 +33,10 @@ pub struct S3RemoteFs {
     /// STS AssumeRoleWithWebIdentity with the JWT inside it.
     web_identity_token_file: Option<String>,
     web_identity_role_arn: Option<String>,
+    /// When set, every request carries `x-amz-server-side-encryption` with this
+    /// value. Some AWS Organizations SCPs deny `s3:PutObject` unless the header
+    /// is present, even when the bucket has default encryption.
+    server_side_encryption: Option<String>,
 }
 
 impl fmt::Debug for S3RemoteFs {
@@ -89,7 +93,13 @@ impl S3RemoteFs {
         let region = region.parse::<Region>().map_err(|e| {
             CubeError::internal(format!("Failed to parse Region '{}': {}", region, e))
         })?;
-        let bucket = Bucket::new(&bucket_name, region.clone(), credentials)?;
+        let server_side_encryption = server_side_encryption_from_env()?;
+        let bucket = new_bucket(
+            &bucket_name,
+            region.clone(),
+            credentials,
+            &server_side_encryption,
+        )?;
         let fs = Arc::new(Self {
             dir,
             bucket: arc_swap::ArcSwap::new(Arc::new(bucket)),
@@ -97,11 +107,45 @@ impl S3RemoteFs {
             delete_mut: Mutex::new(()),
             web_identity_token_file: token_file,
             web_identity_role_arn: role_arn,
+            server_side_encryption,
         });
         spawn_creds_refresh_loop(access_key, secret_key, bucket_name, region, &fs);
 
         Ok(fs)
     }
+}
+
+/// Values S3 accepts in `x-amz-server-side-encryption`.
+const ALLOWED_SSE_VALUES: &[&str] = &["AES256", "aws:kms", "aws:kms:dsse"];
+
+fn server_side_encryption_from_env() -> Result<Option<String>, CubeError> {
+    parse_sse_value(env::var("CUBESTORE_S3_SSE").ok())
+}
+
+fn parse_sse_value(value: Option<String>) -> Result<Option<String>, CubeError> {
+    match value {
+        None => Ok(None),
+        Some(v) if v.is_empty() => Ok(None),
+        Some(v) if ALLOWED_SSE_VALUES.contains(&v.as_str()) => Ok(Some(v)),
+        Some(v) => Err(CubeError::user(format!(
+            "Invalid CUBESTORE_S3_SSE value '{}'. Expected one of: {}",
+            v,
+            ALLOWED_SSE_VALUES.join(", ")
+        ))),
+    }
+}
+
+fn new_bucket(
+    bucket_name: &str,
+    region: Region,
+    credentials: Credentials,
+    server_side_encryption: &Option<String>,
+) -> Result<Bucket, CubeError> {
+    let mut bucket = Bucket::new(bucket_name, region, credentials)?;
+    if let Some(sse) = server_side_encryption {
+        bucket.add_header("x-amz-server-side-encryption", sse);
+    }
+    Ok(bucket)
 }
 
 fn spawn_creds_refresh_loop(
@@ -113,6 +157,7 @@ fn spawn_creds_refresh_loop(
 ) {
     let token_file = fs.web_identity_token_file.clone();
     let role_arn = fs.web_identity_role_arn.clone();
+    let server_side_encryption = fs.server_side_encryption.clone();
     let is_web_identity = token_file.is_some() && role_arn.is_some();
 
     // Web identity STS credentials expire in ~1 hour, so poll the token file
@@ -186,7 +231,7 @@ fn spawn_creds_refresh_loop(
                     continue;
                 }
             };
-            let b = match Bucket::new(&bucket_name, region.clone(), c) {
+            let b = match new_bucket(&bucket_name, region.clone(), c, &server_side_encryption) {
                 Ok(b) => b,
                 Err(e) => {
                     log::error!("Failed to refresh S3 credentials: {}", e);
@@ -511,5 +556,69 @@ impl S3RemoteFs {
                 .unwrap_or_else(|| "".to_string()),
             remote_path
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sse_value_accepts_allowed_values() {
+        assert_eq!(parse_sse_value(None).unwrap(), None);
+        assert_eq!(parse_sse_value(Some("".to_string())).unwrap(), None);
+        assert_eq!(
+            parse_sse_value(Some("AES256".to_string())).unwrap(),
+            Some("AES256".to_string())
+        );
+        assert_eq!(
+            parse_sse_value(Some("aws:kms".to_string())).unwrap(),
+            Some("aws:kms".to_string())
+        );
+        assert_eq!(
+            parse_sse_value(Some("aws:kms:dsse".to_string())).unwrap(),
+            Some("aws:kms:dsse".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_sse_value_rejects_unknown_values() {
+        assert!(parse_sse_value(Some("aes256".to_string())).is_err());
+        assert!(parse_sse_value(Some("true".to_string())).is_err());
+    }
+
+    #[test]
+    fn new_bucket_applies_sse_header() {
+        let credentials = Credentials::new(Some("key"), Some("secret"), None, None, None).unwrap();
+        let bucket = new_bucket(
+            "test-bucket",
+            "us-east-1".parse().unwrap(),
+            credentials,
+            &Some("AES256".to_string()),
+        )
+        .unwrap();
+        assert_eq!(
+            bucket
+                .extra_headers()
+                .get("x-amz-server-side-encryption")
+                .map(|v| v.to_str().unwrap()),
+            Some("AES256")
+        );
+    }
+
+    #[test]
+    fn new_bucket_without_sse_has_no_header() {
+        let credentials = Credentials::new(Some("key"), Some("secret"), None, None, None).unwrap();
+        let bucket = new_bucket(
+            "test-bucket",
+            "us-east-1".parse().unwrap(),
+            credentials,
+            &None,
+        )
+        .unwrap();
+        assert!(bucket
+            .extra_headers()
+            .get("x-amz-server-side-encryption")
+            .is_none());
     }
 }


### PR DESCRIPTION
## Motivation

Some AWS Organizations service control policies deny `s3:PutObject` requests that lack the `x-amz-server-side-encryption` header — even when the bucket has default encryption enabled (S3 encrypts all new objects by default since 2023, so the object would be encrypted either way). On such accounts every CubeStore upload (chunk parquet files, metastore snapshots, cachestore) fails with `AWS S3 error: Got HTTP 403`, breaking pre-aggregations entirely. Hit in production on a BYOC account on 2026-07-16.

## Change

New optional env var `CUBESTORE_S3_SSE` for the S3 remote FS:

- Accepted values: `AES256`, `aws:kms`, `aws:kms:dsse` (validated; anything else fails fast with a clear error). Unset/empty = current behavior, no header.
- When set, the value is sent as `x-amz-server-side-encryption` on every S3 request via rust-s3 `extra_headers` (merged into all commands, including `put_object_stream`).
- Applied both at initial `Bucket` construction and inside the credentials-refresh loop, which rebuilds the bucket — without re-applying there the header would silently disappear after the first refresh (30s in web-identity mode).

Scope: S3 remote FS only (`remotefs/s3.rs`). MinIO has a fully separate duplicated implementation and SCPs are AWS-specific, so it's intentionally untouched.

## Tests

- `parse_sse_value` unit tests: accepted values, empty/unset, rejects unknown values.
- `new_bucket` unit tests: header present with SSE configured, absent without (no network needed).
- `cargo check` + `cargo fmt --check` clean; docs entry added to `environment-variables.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)