### PR TITLE
fix(cubesql): Support type coercion in multi-branch `UNION ALL`

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=400af46a3f2cbc9f893021220af3fb5d6fcabd65#400af46a3f2cbc9f893021220af3fb5d6fcabd65"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "400af46a3f2cbc9f893021220af3fb5d6fcabd65", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "b01223b6454b0d72154d15a88aec76efc9da726d", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__union_all_ctes_with_type_coercion.snap
+++ b/rust/cubesql/cubesql/src/compile/test/snapshots/cubesql__compile__test__test_df_execution__union_all_ctes_with_type_coercion.snap
@@ -1,0 +1,11 @@
+---
+source: cubesql/src/compile/test/test_df_execution.rs
+expression: "execute_query(query.to_string(), DatabaseProtocol::PostgreSQL).await.unwrap()"
+---
++---+-----+
+| l | t   |
++---+-----+
+| A | 1   |
+| B | 2   |
+| C | 3.5 |
++---+-----+

--- a/rust/cubesql/cubesql/src/compile/test/test_df_execution.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_df_execution.rs
@@ -92,6 +92,34 @@ GROUP BY
     );
 }
 
+#[tokio::test]
+async fn union_all_ctes_with_type_coercion() {
+    init_testing_logger();
+
+    // language=PostgreSQL
+    let query = r#"
+WITH a AS (
+    SELECT 1::bigint AS t LIMIT 1
+), b AS (
+    SELECT 2::bigint AS t LIMIT 1
+), c AS (
+    SELECT 3.5::float8 AS t LIMIT 1
+)
+SELECT 'A' AS l, t FROM a
+UNION ALL
+SELECT 'B' AS l, t FROM b
+UNION ALL
+SELECT 'C' AS l, t FROM c
+;
+        "#;
+
+    insta::assert_snapshot!(
+        execute_query(query.to_string(), DatabaseProtocol::PostgreSQL)
+            .await
+            .unwrap()
+    );
+}
+
 /// See https://www.postgresql.org/docs/current/functions-math.html
 #[tokio::test]
 async fn test_round() {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@1e33a69, fixing `No field named '<cte>.<col>'` planning errors in `UNION ALL` queries with three or more branches where a later branch introduces a column type mismatch (e.g. an `Int64` count measure unioned with a `Float64` sum measure). Related test is included.