### PR TITLE
fix(schema-compiler): Throw UserError for unknown granularity so API returns 400 instead of 500

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/Granularity.ts
@@ -10,6 +10,7 @@ import {
   timeSeriesFromCustomInterval,
   TimeSeriesOptions
 } from '@cubejs-backend/shared';
+import { UserError } from '../compiler/UserError';
 import { BaseQuery } from './BaseQuery';
 
 export class Granularity {
@@ -44,7 +45,7 @@ export class Granularity {
       );
 
       if (!customGranularity) {
-        throw new Error(`Granularity "${timeDimension.granularity}" does not exist in dimension ${timeDimension.dimension}`);
+        throw new UserError(`Granularity "${timeDimension.granularity}" does not exist in dimension ${timeDimension.dimension}`);
       }
 
       this.granularityInterval = customGranularity.interval;

--- a/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/base-query.test.ts
@@ -863,6 +863,27 @@ describe('SQL Generation', () => {
       }
     });
 
+    it('throws UserError for unknown granularity', async () => {
+      await compilers.compiler.compile();
+
+      const buildQuery = () => new PostgresQuery(compilers, {
+        measures: ['orders.count'],
+        timeDimensions: [
+          {
+            dimension: 'orders.createdAt',
+            granularity: 'all',
+            dateRange: ['2020-01-01', '2021-12-31']
+          }
+        ],
+        dimensions: [],
+        filters: [],
+        timezone: 'Europe/Kyiv'
+      });
+
+      expect(buildQuery).toThrow(UserError);
+      expect(buildQuery).toThrow('Granularity "all" does not exist in dimension orders.createdAt');
+    });
+
     describe('via PostgresQuery', () => {
       beforeAll(async () => {
         await compilers.compiler.compile();


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Querying a time dimension with an unknown granularity (for example `granularity: "all"`, which some older clients send) throws a plain `Error` from `Granularity`'s constructor. The API gateway only classifies `UserError` as a client error, so the REST API responds with `500 Internal Server Error` for what is really invalid client input:

```
Error: Granularity "all" does not exist in dimension Sales.local_reporting_timestamp
```

This change throws `UserError` instead, so `/v1/load` returns `400` for unknown granularities, consistent with other invalid-query errors (unknown members, malformed filters, etc.).

Added a unit test in `base-query.test.ts` covering the unknown-granularity case; ran the full `Custom granularities` suite (35 tests) and the schema-compiler linter (0 errors).