### PR TITLE
docs: fix broken internal links across docs-mintlify

### DIFF
--- a/docs-mintlify/admin/account-billing/ai-tokens.mdx
+++ b/docs-mintlify/admin/account-billing/ai-tokens.mdx
@@ -118,5 +118,5 @@ Token usage can vary between identical prompts due to differences in
 conversation context (earlier messages in the session) or the AI choosing a
 different reasoning path.
 
-[ref-ai-overview]: /admin/ai/index
+[ref-ai-overview]: /admin/ai
 [ref-byom]: /admin/ai/bring-your-own-model

--- a/docs-mintlify/admin/account-billing/distribution.mdx
+++ b/docs-mintlify/admin/account-billing/distribution.mdx
@@ -124,4 +124,4 @@ open http://localhost:3000
 [ref-infrastructure]: /admin/deployment/infrastructure
 [ref-workspace]: /admin/workspace
 [ref-deployment]: /admin/deployment
-[ref-update-channels]: /admin/deployment/index#update-channels
+[ref-update-channels]: /admin/deployment#update-channels

--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -308,7 +308,7 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 [ref-cloud-deployment-dev-instance]: /admin/deployment/deployment-types#shared
 [ref-cloud-deployment-prod-cluster]: /admin/deployment/deployment-types#dedicated
 [ref-cloud-limits]: /admin/deployment/limits
-[ref-monitoring-integrations]: /docs/monitoring/integrations
+[ref-monitoring-integrations]: /admin/monitoring/monitoring-integrations
 [ref-cloud-acl]: /admin/users-and-permissions/custom-roles
 [ref-cloud-deployment-prod-multicluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-cloud-custom-domains]: /admin/deployment/custom-domains
@@ -327,8 +327,8 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 [ref-production-cluster]: /admin/deployment/deployment-types#dedicated
 [ref-development-instance]: /admin/deployment/deployment-types#shared
 [ref-apis]: /reference
-[ref-mdx-api]: /reference/mdx-api
-[ref-dax-api]: /reference/dax-api
+[ref-mdx-api]: /reference/core-data-apis/mdx-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-cube-store-architecture]: /docs/pre-aggregations/running-in-production#architecture
 [ref-data-at-rest-encryption]: /docs/pre-aggregations/running-in-production#data-at-rest-encryption
 [ref-customer-managed-keys]: /admin/deployment/encryption-keys

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
@@ -49,7 +49,7 @@ To find your MDX API credentials, go to the [Integrations][ref-integrations-apis
 Follow the instructions to [install][ref-cube-cloud-for-excel-installation] the
 add-in and [authenticate][ref-cube-cloud-for-excel-authentication] to Cube Cloud.
 
-[ref-mdx-api]: /reference/mdx-api
+[ref-mdx-api]: /reference/core-data-apis/mdx-api
 [link-pivottable]: https://support.microsoft.com/en-us/office/create-a-pivottable-to-analyze-worksheet-data-a9a84538-bfe9-40a9-a8e9-f99134456576
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel
 [ref-cube-cloud-for-excel-pivot]: /docs/integrations/microsoft-excel#create-reports-via-pivot-table

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/powerbi.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/powerbi.mdx
@@ -72,7 +72,7 @@ than the DAX API. However, this is the only option when using Cube Core.
 [link-powerbi]: https://www.microsoft.com/en-gb/power-platform/products/power-bi/
 [link-powerbi-desktop-vs-service]: https://learn.microsoft.com/en-us/power-bi/fundamentals/service-service-vs-desktop
 [link-powerbi-gateway]: https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-sls]: /docs/integrations/semantic-layer-sync

--- a/docs-mintlify/admin/customization/chart-palettes.mdx
+++ b/docs-mintlify/admin/customization/chart-palettes.mdx
@@ -7,8 +7,8 @@ Chart palettes control the colors used in chart visualizations across [workbooks
 
 Custom palettes are managed centrally and are available across every deployment in the account.
 
-[ref-workbooks]: /workbooks
-[ref-dashboards]: /workbooks/dashboards
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-dashboards]: /docs/explore-analyze/dashboards
 
 ## Requirements
 

--- a/docs-mintlify/admin/customization/dashboard-themes.mdx
+++ b/docs-mintlify/admin/customization/dashboard-themes.mdx
@@ -7,7 +7,7 @@ Dashboard themes control the look and feel of [dashboards][ref-dashboards] — i
 
 Themes are designed and saved from the dashboard builder, then managed centrally in the admin area.
 
-[ref-dashboards]: /workbooks/dashboards
+[ref-dashboards]: /docs/explore-analyze/dashboards
 
 ## Requirements
 

--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -124,4 +124,4 @@ response times to be significantly longer than usual.
 [self-effects]: #effects-on-experience
 [ref-refresh-worker]: /cube-core/architecture#refresh-worker
 [ref-sls]: /docs/integrations/semantic-layer-sync#on-schedule
-[ref-cube-version]: /admin/deployment/index#cube-version
+[ref-cube-version]: /admin/deployment#cube-version

--- a/docs-mintlify/admin/deployment/core.mdx
+++ b/docs-mintlify/admin/deployment/core.mdx
@@ -523,7 +523,7 @@ data source usage.
 [link-cubejs-dev-vs-prod]: /docs/data-modeling/dev-mode
 [link-k8s-healthcheck-api]:
   https://kubernetes.io/docs/reference/using-api/health-checks/
-[ref-config-connect-db]: /connecting-to-the-database
+[ref-config-connect-db]: /admin/connect-to-data/data-sources
 [ref-caching-cubestore]: /docs/pre-aggregations/running-in-production
 [ref-conf-preaggs-schema]: /reference/configuration/config#pre_aggregations_schema
 [ref-env-vars]: /reference/configuration/environment-variables

--- a/docs-mintlify/admin/deployment/environments.mdx
+++ b/docs-mintlify/admin/deployment/environments.mdx
@@ -114,5 +114,5 @@ credentials**][ref-credentials].
 [ref-suspend]: /admin/deployment/auto-suspension
 [ref-overview]: /admin/connect-to-data/visualization-tools
 [ref-credentials]: /admin/connect-to-data/visualization-tools
-[ref-version]: /admin/deployment/index#cube-version
-[ref-version-channel]: /admin/deployment/index#update-channels
+[ref-version]: /admin/deployment#cube-version
+[ref-version-channel]: /admin/deployment#update-channels

--- a/docs-mintlify/admin/deployment/index.mdx
+++ b/docs-mintlify/admin/deployment/index.mdx
@@ -198,8 +198,8 @@ resource consumption in different scenarios.
 [ref-playground]: /docs/explore-analyze/playground
 [ref-environments]: /admin/deployment/environments
 [ref-environments-prod]: /admin/deployment/environments#production-environment
-[ref-lts]: /docs/distribution#long-term-support
+[ref-lts]: /admin/account-billing/distribution#long-term-support
 [link-semver]: https://semver.org
 [ref-data-sources]: /admin/connect-to-data/data-sources
 [ref-audit-log]: /admin/monitoring/audit-log
-[ref-distribution-versions]: /docs/distribution#versions
+[ref-distribution-versions]: /admin/account-billing/distribution#versions

--- a/docs-mintlify/admin/deployment/providers/azure.mdx
+++ b/docs-mintlify/admin/deployment/providers/azure.mdx
@@ -55,6 +55,6 @@ Cube Cloud integrates with the following [data visualization tools](/admin/conne
 
 
 [ref-powerbi]: /admin/connect-to-data/visualization-tools/powerbi
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel

--- a/docs-mintlify/admin/index.mdx
+++ b/docs-mintlify/admin/index.mdx
@@ -196,13 +196,13 @@ mode does the following:
 - Logs incorrect/invalid configuration for `externalRefresh` /`waitForRenew`
   instead of throwing errors.
 
-[ref-folder-structure]: /docs/data-modeling/syntax#folder-structure
+[ref-folder-structure]: /docs/data-modeling/concepts/syntax#folder-structure
 [link-config]: /reference/configuration/config
 [link-dev-playground]: /docs/explore-analyze/playground
 [link-env-vars]: /reference/configuration/environment-variables
 [link-scheduled-refresh]: /reference/data-modeling/pre-aggregations#scheduled_refresh
 [ref-dynamic-data-models]: /docs/data-modeling/dynamic
-[ref-custom-docker-image]: /docs/deployment/core#extend-the-docker-image
+[ref-custom-docker-image]: /admin/deployment/core#extend-the-docker-image
 [link-docker-env-vars]: https://docs.docker.com/compose/environment-variables/set-environment-variables/
 [ref-mls]: /docs/data-modeling/access-control/member-level-security
 [link-current-python-version]: https://github.com/cube-js/cube/blob/master/packages/cubejs-docker/latest.Dockerfile#L13

--- a/docs-mintlify/cube-core/deployment.mdx
+++ b/docs-mintlify/cube-core/deployment.mdx
@@ -523,7 +523,7 @@ data source usage.
 [link-cubejs-dev-vs-prod]: /docs/data-modeling/dev-mode
 [link-k8s-healthcheck-api]:
   https://kubernetes.io/docs/reference/using-api/health-checks/
-[ref-config-connect-db]: /connecting-to-the-database
+[ref-config-connect-db]: /admin/connect-to-data/data-sources
 [ref-caching-cubestore]: /docs/pre-aggregations/running-in-production
 [ref-conf-preaggs-schema]: /reference/configuration/config#pre_aggregations_schema
 [ref-env-vars]: /reference/configuration/environment-variables

--- a/docs-mintlify/cube-core/getting-started/learn-more.mdx
+++ b/docs-mintlify/cube-core/getting-started/learn-more.mdx
@@ -5,7 +5,7 @@ description: Now that you've set up your first project, learn more about what el
 
 ## Data Modeling
 
-Learn more about [data modeling](/docs/data-modeling/concepts)
+Learn more about [data modeling](/docs/data-modeling/overview)
 and how to effectively define metrics in your data models.
 
 ## Querying

--- a/docs-mintlify/cube-core/migrate-from-core/upload-with-cli.mdx
+++ b/docs-mintlify/cube-core/migrate-from-core/upload-with-cli.mdx
@@ -99,4 +99,4 @@ queries or connect your application to Cube Cloud API.
 </div>
 
 [ref-cloud-connecting-to-databases]: /admin/connect-to-data/data-sources
-[ref-cloud-playground]: /cloud/dev-tools/dev-playground
+[ref-cloud-playground]: /docs/explore-analyze/playground

--- a/docs-mintlify/docs/data-modeling/access-control/member-level-security.mdx
+++ b/docs-mintlify/docs/data-modeling/access-control/member-level-security.mdx
@@ -143,7 +143,7 @@ them entirely, see [data masking][ref-data-masking] in access policies.
 </Info>
 
 
-[ref-data-modeling-concepts]: /docs/data-modeling/concepts
+[ref-data-modeling-concepts]: /docs/data-modeling/overview
 [ref-apis]: /reference
 [ref-cubes]: /docs/data-modeling/cubes
 [ref-views]: /docs/data-modeling/views

--- a/docs-mintlify/docs/data-modeling/access-control/row-level-security.mdx
+++ b/docs-mintlify/docs/data-modeling/access-control/row-level-security.mdx
@@ -63,7 +63,7 @@ cube(`orders`, {
 
 
 
-[ref-data-modeling-concepts]: /docs/data-modeling/concepts
+[ref-data-modeling-concepts]: /docs/data-modeling/overview
 [ref-apis]: /reference
 [ref-cubes]: /docs/data-modeling/cubes
 [ref-views]: /docs/data-modeling/views

--- a/docs-mintlify/docs/data-modeling/concepts/syntax.mdx
+++ b/docs-mintlify/docs/data-modeling/concepts/syntax.mdx
@@ -1014,7 +1014,7 @@ string values in time dimensions.
 [ref-data-blending]: /docs/data-modeling/concepts/data-blending
 [link-js-template-literals]: https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Strings#embedding_javascript
 [link-python-reserved-words]: https://docs.python.org/3/reference/lexical_analysis.html#keywords
-[ref-dax-api-date-hierarchies]: /reference/dax-api#date-hierarchies
+[ref-dax-api-date-hierarchies]: /reference/core-data-apis/dax-api#date-hierarchies
 [ref-time-dimension]: /docs/data-modeling/dimensions#time-dimensions
 [ref-recipe-string-time-dimensions]: /recipes/data-modeling/string-time-dimensions
 [ref-view-groups]: /reference/data-modeling/view-group

--- a/docs-mintlify/docs/data-modeling/dimensions.mdx
+++ b/docs-mintlify/docs/data-modeling/dimensions.mdx
@@ -563,7 +563,7 @@ cubes:
 
 [ref-dimensions-ref]: /reference/data-modeling/dimensions
 [ref-workbooks]: /docs/explore-analyze/workbooks
-[ref-references]: /docs/data-modeling/syntax#references
+[ref-references]: /docs/data-modeling/concepts/syntax#references
 [link-tabler]: https://tabler.io/icons
 [ref-measures-page]: /docs/data-modeling/measures
 [ref-joins]: /docs/data-modeling/joins

--- a/docs-mintlify/docs/data-modeling/dynamic/jinja.mdx
+++ b/docs-mintlify/docs/data-modeling/dynamic/jinja.mdx
@@ -385,7 +385,7 @@ image][ref-docker-image-extension].
 [jinja-docs-filters-safe]: https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.safe
 [ref-cube-dbt]: /reference/data-modeling/cube_dbt
 [ref-visual-model]: /docs/data-modeling/visual-modeler
-[ref-docker-image-extension]: /docs/deployment/core#extend-the-docker-image
+[ref-docker-image-extension]: /admin/deployment/core#extend-the-docker-image
 [ref-cube-package]: /reference/data-modeling/cube-package
 [ref-cube-template-context]: /reference/data-modeling/cube-package#templatecontext-class
 [ref-cube-dbt-package]: /reference/data-modeling/cube_dbt

--- a/docs-mintlify/docs/data-modeling/extending-cubes.mdx
+++ b/docs-mintlify/docs/data-modeling/extending-cubes.mdx
@@ -207,4 +207,4 @@ cube(`base_events`, {
 [ref-cube-extends]: /reference/data-modeling/cube#extends
 [ref-view-extends]: /reference/data-modeling/view#extends
 [ref-schema-ref-cube-filter-params]: /reference/data-modeling/context-variables#filter_params
-[ref-cube-variable]: /docs/data-modeling/syntax#cube-variable
+[ref-cube-variable]: /docs/data-modeling/concepts/syntax#cube-variable

--- a/docs-mintlify/docs/data-modeling/overview.mdx
+++ b/docs-mintlify/docs/data-modeling/overview.mdx
@@ -338,5 +338,5 @@ model.
 [ref-apis]: /reference
 [ref-calculated-measures]: /docs/data-modeling/measures#calculated-measures
 [ref-views]: /reference/data-modeling/view
-[ref-explore]: /analytics/explore
-[ref-workbooks]: /analytics/workbooks
+[ref-explore]: /docs/explore-analyze/explore
+[ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/docs/data-modeling/views.mdx
+++ b/docs-mintlify/docs/data-modeling/views.mdx
@@ -454,9 +454,9 @@ parameters.
 [ref-access-policies]: /reference/data-modeling/data-access-policies
 [ref-ai-context]: /docs/data-modeling/ai-context
 [ref-compile-context]: /docs/data-modeling/access-control/context
-[ref-explore]: /analytics/explore
-[ref-workbooks]: /analytics/workbooks
-[ref-embedding]: /docs/embedding
+[ref-explore]: /docs/explore-analyze/explore
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-embedding]: /embedding
 [ref-ide]: /docs/data-modeling/data-model-ide
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools
 [ref-apis-support]: /reference#data-modeling

--- a/docs-mintlify/docs/data-modeling/visual-modeler.mdx
+++ b/docs-mintlify/docs/data-modeling/visual-modeler.mdx
@@ -161,7 +161,7 @@ allow editing of [dynamic data models][ref-dynamic-data-models] or models which 
 [ref-dynamic-data-models]: /docs/data-modeling/dynamic
 [ref-jinja]: /docs/data-modeling/dynamic/jinja
 [ref-continuous-deployment]: /admin/deployment/continuous-deployment
-[ref-yaml-syntax]: /docs/data-modeling/syntax#model-syntax
+[ref-yaml-syntax]: /docs/data-modeling/concepts/syntax#model-syntax
 [ref-dev-mode]: /docs/data-modeling/dev-mode
 [ref-environments]: /admin/deployment/environments
 [ref-playground]: /docs/explore-analyze/playground

--- a/docs-mintlify/docs/explore-analyze/notifications.mdx
+++ b/docs-mintlify/docs/explore-analyze/notifications.mdx
@@ -73,4 +73,4 @@ This is a one-time setup. Once connected, you can select any channel your Slack
 workspace has access to.
 
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
-[ref-scheduled-refreshes]: /analytics/scheduled-refreshes
+[ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes

--- a/docs-mintlify/docs/explore-analyze/playground.mdx
+++ b/docs-mintlify/docs/explore-analyze/playground.mdx
@@ -198,7 +198,7 @@ manually.
 [ref-js-sdk]: /reference/javascript-sdk
 [ref-data-model]: /docs/data-modeling/data-model-ide#generating-data-model-files
 [ref-multiple-data-sources]: /admin/connect-to-data/multiple-data-sources
-[ref-queries]: /reference/queries
+[ref-queries]: /reference/core-data-apis/queries
 [ref-data-modeling]: /docs/data-modeling/overview
 [ref-data-model-title]: /reference/data-modeling/measures#title
 [ref-data-model-description]: /reference/data-modeling/measures#description

--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -95,4 +95,4 @@ When a scheduled refresh runs, it progresses through these phases:
 The sidebar shows real-time status updates during execution.
 
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
-[ref-notifications]: /analytics/notifications
+[ref-notifications]: /docs/explore-analyze/notifications

--- a/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/index.mdx
@@ -32,7 +32,7 @@ The category selector lets you switch between starting-point types:
   as the starting point for the new report. The workbook you are currently in and empty tabs
   (which have no query to reuse) appear disabled.
 - **Source tables** — raw tables from your connected
-  [data sources](/admin/connect-to-data/data-sources/index), browsable by data source and schema.
+  [data sources](/admin/connect-to-data/data-sources), browsable by data source and schema.
 
 Click through the list to drill down to an individual view, report, or table. Once you reach a
 starting point, the data model sidebar activates so you can continue building your query there.

--- a/docs-mintlify/docs/getting-started/cloud/create-data-model.mdx
+++ b/docs-mintlify/docs/getting-started/cloud/create-data-model.mdx
@@ -212,5 +212,5 @@ After saving, you can experiment with your newly created view in the Playground.
 In the next section, we will learn how to query our `orders_view` using a BI
 tool.
 
-[ref-member-references]: /docs/data-modeling/syntax#references
+[ref-member-references]: /docs/data-modeling/concepts/syntax#references
 [ref-visual-model]: /docs/data-modeling/visual-modeler

--- a/docs-mintlify/docs/getting-started/create-workbooks-and-dashboards.mdx
+++ b/docs-mintlify/docs/getting-started/create-workbooks-and-dashboards.mdx
@@ -25,4 +25,4 @@ Once you're ready to share your work, you can turn workbooks into [dashboards][r
 
 Dashboards can be published to make them accessible to your team. Published dashboards provide stakeholders with direct access to the insights that matter most.
 
-[ref-dashboards]: /analytics/dashboards
+[ref-dashboards]: /docs/explore-analyze/dashboards

--- a/docs-mintlify/docs/getting-started/databricks/create-data-model.mdx
+++ b/docs-mintlify/docs/getting-started/databricks/create-data-model.mdx
@@ -212,5 +212,5 @@ After saving, you can experiment with your newly created view in the Playground.
 In the next section, we will learn how to query our `orders_view` using a BI
 tool.
 
-[ref-member-references]: /docs/data-modeling/syntax#references
+[ref-member-references]: /docs/data-modeling/concepts/syntax#references
 [ref-visual-model]: /docs/data-modeling/visual-modeler

--- a/docs-mintlify/docs/getting-started/embed-analytics.mdx
+++ b/docs-mintlify/docs/getting-started/embed-analytics.mdx
@@ -17,8 +17,8 @@ For more control over the conversational analytics experience, you can use the [
 
 If you want complete control over visualizations and user interfaces, you can use [Cube's core APIs][ref-core-apis]—including REST (JSON), GraphQL, and SQL APIs—directly. This headless approach enables you to build fully custom visualization, reporting, and dashboarding experiences tailored to your specific needs.
 
-[ref-dashboards]: /analytics/dashboards
-[ref-analytics-chat]: /analytics/analytics-chat
+[ref-dashboards]: /docs/explore-analyze/dashboards
+[ref-analytics-chat]: /docs/explore-analyze/analytics-chat
 [ref-chat-api]: /reference/embed-apis/chat-api
 [ref-core-apis]: /reference/core-data-apis
 [ref-private-embedding]: /embedding/iframe/auth/private

--- a/docs-mintlify/docs/getting-started/index.mdx
+++ b/docs-mintlify/docs/getting-started/index.mdx
@@ -34,6 +34,6 @@ Cube Cloud supports several ways to import existing Cube projects:
 - [Import a local project with CLI](/docs/getting-started/migrate-from-core/upload-with-cli)
 
 [cube-cloud]: https://cube.dev/cloud/
-[ref-infrastructure]: /docs/deployment/cloud
+[ref-infrastructure]: /admin/deployment/infrastructure
 [ref-workspace]: /docs/workspace
 [ref-data-sources]: /admin/connect-to-data/data-sources

--- a/docs-mintlify/docs/getting-started/migrate-from-core/upload-with-cli.mdx
+++ b/docs-mintlify/docs/getting-started/migrate-from-core/upload-with-cli.mdx
@@ -99,4 +99,4 @@ queries or connect your application to Cube Cloud API.
 </div>
 
 [ref-cloud-connecting-to-databases]: /admin/connect-to-data/data-sources
-[ref-cloud-playground]: /cloud/dev-tools/dev-playground
+[ref-cloud-playground]: /docs/explore-analyze/playground

--- a/docs-mintlify/docs/integrations/power-bi/index.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/index.mdx
@@ -65,7 +65,7 @@ than the DAX API. However, this is the only option when using Cube Core.
 [link-powerbi]: https://www.microsoft.com/en-gb/power-platform/products/power-bi/
 [link-powerbi-desktop-vs-service]: https://learn.microsoft.com/en-us/power-bi/fundamentals/service-service-vs-desktop
 [link-powerbi-gateway]: https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-sls]: /docs/integrations/semantic-layer-sync

--- a/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
@@ -194,6 +194,6 @@ receives is just a string — what you map to it is your decision.
 [link-ktpass]: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/ktpass
 [ref-power-bi]: /admin/connect-to-data/visualization-tools/powerbi#connecting-from-power-bi
 [link-kerberos]: https://en.wikipedia.org/wiki/Kerberos_(protocol)#Microsoft_Windows
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-config-check-sql-auth]: /reference/configuration/config#check_sql_auth
 [ref-scim]: /admin/sso/microsoft-entra-id/scim

--- a/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
@@ -96,7 +96,7 @@ of the master user account were passed.
 
 
 [link-ntlm]: https://en.wikipedia.org/wiki/NTLM
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [link-power-bi-opdg]: https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
 [ref-kerberos]: /docs/integrations/power-bi/kerberos
 [ref-config-check-sql-auth]: /reference/configuration/config#check_sql_auth

--- a/docs-mintlify/docs/integrations/slack.mdx
+++ b/docs-mintlify/docs/integrations/slack.mdx
@@ -102,5 +102,5 @@ Slack Agent is in active development. The following limitations apply:
 
 [ref-analytics-chat]: /docs/explore-analyze/analytics-chat
 [ref-notifications]: /docs/explore-analyze/notifications
-[ref-scheduled-refreshes]: /analytics/scheduled-refreshes
+[ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes
 [ref-rules]: /admin/ai/rules

--- a/docs-mintlify/docs/integrations/tableau.mdx
+++ b/docs-mintlify/docs/integrations/tableau.mdx
@@ -132,7 +132,7 @@ You can use [user attributes][ref-user-attributes] and
 [ref-sls]: /docs/integrations/semantic-layer-sync
 [ref-scim]: /admin/sso/microsoft-entra-id/scim
 [ref-entra]: /admin/sso/microsoft-entra-id
-[ref-okta]: /admin/sso/okta
+[ref-okta]: /admin/sso/okta/saml
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
 [ref-user-groups]: /admin/users-and-permissions/user-groups
 [ref-dap]: /docs/data-modeling/data-access-policies

--- a/docs-mintlify/recipes/configuration/environment-variables.mdx
+++ b/docs-mintlify/recipes/configuration/environment-variables.mdx
@@ -157,9 +157,9 @@ cube(`my_cube`, {
 ```
 
 
-[ref-data-model-syntax]: /docs/data-modeling/syntax
+[ref-data-model-syntax]: /docs/data-modeling/concepts/syntax
 [ref-config-files]: /admin/connect-to-data#cubepy-and-cubejs-files
-[ref-docker-compose-config]: /docs/deployment/core#configuration
+[ref-docker-compose-config]: /admin/deployment/core#configuration
 [ref-python-globals]: /docs/data-modeling/dynamic/jinja#python
 [ref-template-context]: /reference/data-modeling/cube-package#templatecontext-class
 [ref-nodejs-globals]: /docs/data-modeling/dynamic/schema-execution-environment#nodejs-globals-processenv-consolelog-and-others

--- a/docs-mintlify/recipes/core-data-api/sorting.mdx
+++ b/docs-mintlify/recipes/core-data-api/sorting.mdx
@@ -152,5 +152,5 @@ As you can see, now `NULL` values of the `value` dimension appear first in the
 result set.
 
 
-[ref-queries]: /reference/queries
+[ref-queries]: /reference/core-data-apis/queries
 [ref-data-apis]: /reference#data-apis

--- a/docs-mintlify/recipes/data-modeling/custom-order.mdx
+++ b/docs-mintlify/recipes/data-modeling/custom-order.mdx
@@ -183,4 +183,4 @@ stable business rule that should be available to all consumers.
 [ref-data-apis]: /reference#data-apis
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-custom-sorting]: /recipes/core-data-api/sorting
-[ref-workbooks]: /docs/workspace/workbooks
+[ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/recipes/data-modeling/funnels.mdx
+++ b/docs-mintlify/recipes/data-modeling/funnels.mdx
@@ -328,6 +328,6 @@ cube(`PurchaseFunnel`, {
 })
 ```
 
-[ref-modeling-syntax]: /docs/data-modeling/syntax
+[ref-modeling-syntax]: /docs/data-modeling/concepts/syntax
 [ref-partitioned-rollups]: /docs/pre-aggregations/using-pre-aggregations#time-partitioning
 [ref-schema-ref-preaggs-origsql]: /reference/data-modeling/pre-aggregations#original_sql

--- a/docs-mintlify/recipes/data-modeling/style-guide.mdx
+++ b/docs-mintlify/recipes/data-modeling/style-guide.mdx
@@ -327,9 +327,9 @@ This style guide was inspired in part by:
 - [LAMS Style Guide](https://looker-open-source.github.io/look-at-me-sideways/rules.html)
 
 [cpn]: https://cube.dev/consulting/cube-partner-network
-[ref-syntax-model]: /docs/data-modeling/syntax#model-syntax
-[ref-syntax-naming]: /docs/data-modeling/syntax#naming
-[ref-syntax-folder-structure]: /docs/data-modeling/syntax#folder-structure
+[ref-syntax-model]: /docs/data-modeling/concepts/syntax#model-syntax
+[ref-syntax-naming]: /docs/data-modeling/concepts/syntax#naming
+[ref-syntax-folder-structure]: /docs/data-modeling/concepts/syntax#folder-structure
 [ref-public]: /reference/data-modeling/cube#public
 [ref-sql-table]: /reference/data-modeling/cube#sql_table
 [ref-join-rel]: /reference/data-modeling/joins#relationship

--- a/docs-mintlify/recipes/data-modeling/xirr.mdx
+++ b/docs-mintlify/recipes/data-modeling/xirr.mdx
@@ -183,7 +183,7 @@ All queries above would yield the same result:
 
 
 [ref-sql-api]: /reference/core-data-apis/sql-api/reference#custom-functions
-[ref-dax-api]: /reference/dax-api/reference#financial-functions
+[ref-dax-api]: /reference/core-data-apis/dax-api/reference#financial-functions
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-query-wpp]: /reference/core-data-apis/queries#query-with-post-processing
 [ref-query-regular]: /reference/core-data-apis/queries#regular-query

--- a/docs-mintlify/recipes/pre-aggregations/incrementally-building-pre-aggregations-for-a-date-range.mdx
+++ b/docs-mintlify/recipes/pre-aggregations/incrementally-building-pre-aggregations-for-a-date-range.mdx
@@ -254,5 +254,5 @@ used to apply the build ranges as defined by `build_range_start` and
 
 [ref-schema-ref-preagg-buildrange]: /reference/data-modeling/pre-aggregations#build_range_start-and-build_range_end
 [ref-schema-ref-cube-filterparam]: /reference/data-modeling/context-variables#filter_params
-[self-config-aws-athena]: /config/databases/aws-athena/
+[self-config-aws-athena]: /admin/connect-to-data/data-sources/aws-athena
 [self-config-google-bigquery]: /admin/connect-to-data/data-sources/google-bigquery

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -1512,7 +1512,7 @@ module.exports = {
 [ref-config-options]: /admin/connect-to-data#configuration-options
 [self-orchestrator-id]: #context_to_orchestrator_id
 [ref-multiple-data-sources]: /admin/connect-to-data/multiple-data-sources
-[ref-websockets]: /reference/core-data-apis/rest-api/real-time-data-fetch
+[ref-websockets]: /recipes/core-data-api/real-time-data-fetch
 [ref-matching-preaggs]: /docs/pre-aggregations/matching-pre-aggregations
 [link-snake-case]: https://en.wikipedia.org/wiki/Snake_case
 [link-camel-case]: https://en.wikipedia.org/wiki/Camel_case
@@ -1521,6 +1521,6 @@ module.exports = {
 [ref-dap]: /docs/data-modeling/data-access-policies
 [ref-dap-roles]: /docs/data-modeling/data-access-policies#data-access-roles
 [ref-auth-integration]: /docs/data-modeling/access-control#authentication-integration
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-ntlm]: /docs/integrations/power-bi/ntlm
 [ref-environments]: /admin/deployment/environments

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -191,7 +191,7 @@ from [**Settings → Data Sources**][ref-config-multiple-ds-cloud]. The page
 writes, updates, and removes it as you add or delete named sources — you
 only need to hand-edit it when configuring Cube Core or when overriding
 the UI from
-[**Settings → Environment Variables**](/admin/index#environment-variables).
+[**Settings → Environment Variables**](/admin#environment-variables).
 
 </Info>
 
@@ -2125,8 +2125,8 @@ The port for a Cube deployment to listen to API connections on.
 [ref-context-to-app-id]: /reference/configuration/config#context_to_app_id
 [ref-environments]: /admin/deployment/environments
 [ref-databricks-m2m-oauth]: https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m
-[ref-mdx-api]: /reference/mdx-api
-[ref-mdx-api-locale]: /reference/mdx-api#measure-format
+[ref-mdx-api]: /reference/core-data-apis/mdx-api
+[ref-mdx-api-locale]: /reference/core-data-apis/mdx-api#measure-format
 [ref-time-dimensions]: /reference/data-modeling/dimensions#type
 [ref-time-zone]: /reference/core-data-apis/queries#time-zone
 [link-tzdb]: https://en.wikipedia.org/wiki/Tz_database

--- a/docs-mintlify/reference/control-plane-api.mdx
+++ b/docs-mintlify/reference/control-plane-api.mdx
@@ -260,8 +260,8 @@ curl \
 [ref-core-data-apis]: /reference/core-data-apis
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-metadata-api]: /reference/core-data-apis/rest-api/reference#metadata-api
-[ref-deployments]: /admin/deployment/index
-[ref-environments]: /admin/workspace/environments
+[ref-deployments]: /admin/deployment
+[ref-environments]: /admin/deployment/environments
 [ref-api-keys]: /admin/account-billing/api-keys
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-audit-log]: /admin/monitoring/audit-log

--- a/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
@@ -88,7 +88,7 @@ and use it.
 [ref-cross-view-filter]: /reference/core-data-apis/dax-api/cross-view-filter
 [link-dax]: https://learn.microsoft.com/en-us/dax/
 [ref-sql-api]: /reference/core-data-apis/sql-api
-[ref-ref-dax-api]: /reference/dax-api/reference
+[ref-ref-dax-api]: /reference/core-data-apis/dax-api/reference
 [ref-views]: /docs/data-modeling/views
 [ref-time-dimensions]: /docs/data-modeling/dimensions#time-dimensions
 [ref-kerberos]: /docs/integrations/power-bi/kerberos

--- a/docs-mintlify/reference/core-data-apis/dax-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/reference.mdx
@@ -382,5 +382,5 @@ No time intelligence functions currently supported.
 | [`SAMPLEAXISWITHLOCALMINMAX`](https://learn.microsoft.com/en-us/dax/sampleaxiswithlocalminmax-function-dax) | — | Acts as the `TOPN` function |
 
 
-[ref-dax-api]: /reference/dax-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
 [link-dax-func-reference]: https://learn.microsoft.com/en-us/dax/dax-function-reference

--- a/docs-mintlify/reference/core-data-apis/graphql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/graphql-api/index.mdx
@@ -233,8 +233,8 @@ to our query as follows:
 [graphql]: https://graphql.org
 [cube-ea]: https://cube.dev/use-cases/embedded-analytics
 [ref-ref-graphql-api]: /reference/core-data-apis/graphql-api/reference
-[ref-websockets]: /reference/core-data-apis/rest-api/real-time-data-fetch#web-sockets
-[ref-subscriptions]: /reference/core-data-apis/rest-api/real-time-data-fetch#client-subscriptions
+[ref-websockets]: /recipes/core-data-api/real-time-data-fetch#web-sockets
+[ref-subscriptions]: /recipes/core-data-api/real-time-data-fetch#client-subscriptions
 [ref-compare-date-range]: /reference/core-data-apis/queries#compare-date-range-query
 [ref-metadata]: /reference/core-data-apis/rest-api/reference#base_path/v1/meta
 [ref-pivot-config]: /reference/javascript-sdk/reference/cubejs-client-core#pivotconfig

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -94,9 +94,9 @@ tools][ref-viz-tools]:
 [ref-auth-ntlm]: /docs/integrations/power-bi/ntlm
 [ref-superset]: /admin/connect-to-data/visualization-tools/superset
 [ref-preset]: /admin/connect-to-data/visualization-tools/superset
-[ref-playground]: /admin/workspace/playground
+[ref-playground]: /docs/explore-analyze/playground
 [ref-custom-time-formats]: /reference/data-modeling/dimensions#format
-[ref-workbooks]: /analytics/workbooks
+[ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-groups]: /admin/users-and-permissions/user-groups
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
 [ref-dap]: /docs/data-modeling/data-access-policies

--- a/docs-mintlify/reference/core-data-apis/queries.mdx
+++ b/docs-mintlify/reference/core-data-apis/queries.mdx
@@ -410,7 +410,7 @@ called `count` to be defined in the cube or view. Please add one to resolve this
 [ref-sql-utils]: /reference/data-modeling/context-variables#sql_utils
 [ref-matching-preaggs-time-dimensions]: /docs/pre-aggregations/matching-pre-aggregations#matching-time-dimensions
 [ref-matching-preaggs-ungrouped]: /docs/pre-aggregations/matching-pre-aggregations#matching-ungrouped-queries
-[ref-pagination-recipe]: /reference/recipes/pagination
+[ref-pagination-recipe]: /recipes/core-data-api/pagination
 [ref-primary-key]: /reference/data-modeling/dimensions#primary_key
 [ref-conf-allow-ungrouped]: /reference/configuration/config#allow_ungrouped_without_primary_key
 [ref-caching]: /docs/pre-aggregations

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -244,8 +244,8 @@ Use the following environment variables to allocate more resources for query pla
 
 
 [link-postgres]: https://www.postgresql.org
-[ref-dax-api]: /reference/dax-api
-[ref-mdx-api]: /reference/mdx-api
+[ref-dax-api]: /reference/core-data-apis/dax-api
+[ref-mdx-api]: /reference/core-data-apis/mdx-api
 [ref-sls]: /docs/integrations/semantic-layer-sync
 [ref-sql-api-auth]: /reference/core-data-apis/sql-api/security
 [ref-config-checksqlauth]: /reference/configuration/config#checksqlauth
@@ -261,7 +261,7 @@ Use the following environment variables to allocate more resources for query pla
 [ref-deepnote]: /admin/connect-to-data/visualization-tools/deepnote
 [ref-sql-query-format]: /reference/core-data-apis/sql-api/query-format
 [ref-ref-sql-api]: /reference/core-data-apis/sql-api/reference
-[ref-data-model-concepts]: /docs/data-modeling/concepts
+[ref-data-model-concepts]: /docs/data-modeling/overview
 [ref-regular-queries]: /reference/core-data-apis/queries#regular-query
 [ref-queries-wpp]: /reference/core-data-apis/queries#query-with-post-processing
 [ref-queries-wpd]: /reference/core-data-apis/queries#query-with-pushdown

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -410,7 +410,7 @@ As you can see, the sorting operation is done after the regular query and the pr
 [ref-regular-queries]: /reference/core-data-apis/queries#regular-query
 [ref-queries-wpp]: /reference/core-data-apis/queries#query-with-post-processing
 [ref-queries-wpd]: /reference/core-data-apis/queries#query-with-pushdown
-[ref-data-model-concepts]: /docs/data-modeling/concepts
+[ref-data-model-concepts]: /docs/data-modeling/overview
 [ref-measure-types]: /reference/data-modeling/measures#type
 [ref-query-default-limit]: /reference/core-data-apis/queries#row-limit
 [ref-ref-sql-api]: /reference/core-data-apis/sql-api/reference

--- a/docs-mintlify/reference/data-modeling/context-variables.mdx
+++ b/docs-mintlify/reference/data-modeling/context-variables.mdx
@@ -812,7 +812,7 @@ cube(`orders`, {
 [ref-config-queryrewrite]: /reference/configuration/config#query_rewrite
 [ref-sec-ctx]: /docs/data-modeling/access-control/context
 [ref-ref-cubes]: /reference/data-modeling/cube
-[ref-syntax-references]: /docs/data-modeling/syntax#references
+[ref-syntax-references]: /docs/data-modeling/concepts/syntax#references
 [ref-dynamic-data-models]: /docs/data-modeling/dynamic/jinja
 [ref-query-filter]: /reference/core-data-apis/rest-api/query-format#query-properties
 [ref-dynamic-jinja]: /docs/data-modeling/dynamic/jinja

--- a/docs-mintlify/reference/data-modeling/cube-package.mdx
+++ b/docs-mintlify/reference/data-modeling/cube-package.mdx
@@ -148,4 +148,4 @@ def wrap_2(data):
 
 [ref-config-options]: /admin/connect-to-data#configuration-options
 [ref-ref-config-options]: /reference/configuration/config
-[ref-model-syntax]: /docs/data-modeling/syntax#model-syntax
+[ref-model-syntax]: /docs/data-modeling/concepts/syntax#model-syntax

--- a/docs-mintlify/reference/data-modeling/cube.mdx
+++ b/docs-mintlify/reference/data-modeling/cube.mdx
@@ -659,7 +659,7 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 [ref-ai-context]: /docs/data-modeling/ai-context
 [ref-config-driverfactory]: /reference/configuration/config#driver_factory
 [ref-recipe-control-access-cubes-views]: /docs/data-modeling/access-control
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-playground]: /docs/explore-analyze/playground
 [ref-apis]: /reference
 [ref-ref-measures]: /reference/data-modeling/measures
@@ -669,7 +669,7 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 [ref-ref-joins]: /reference/data-modeling/joins
 [ref-ref-pre-aggs]: /reference/data-modeling/pre-aggregations
 [ref-ref-dap]: /reference/data-modeling/data-access-policies
-[ref-syntax-cube-sql]: /docs/data-modeling/syntax#cubesql-function
+[ref-syntax-cube-sql]: /docs/data-modeling/concepts/syntax#cubesql-function
 [ref-extension]: /docs/data-modeling/extending-cubes
 [ref-calendar-cubes]: /docs/data-modeling/concepts/calendar-cubes
 [ref-calendar-cubes-time-shifts]: /docs/data-modeling/concepts/calendar-cubes#time-shifts

--- a/docs-mintlify/reference/data-modeling/cube_dbt.mdx
+++ b/docs-mintlify/reference/data-modeling/cube_dbt.mdx
@@ -510,7 +510,7 @@ cubes:
 [link-dbt-materializations]: https://docs.getdbt.com/docs/build/materializations
 
 [ref-cubes]: /reference/data-modeling/cube
-[ref-model-syntax]: /docs/data-modeling/syntax#model-syntax
+[ref-model-syntax]: /docs/data-modeling/concepts/syntax#model-syntax
 [ref-cube-sql-table]: /reference/data-modeling/cube#sql_table
 [ref-dimension-sql]: /reference/data-modeling/dimensions#sql
 [ref-dimension-type]: /reference/data-modeling/dimensions#type

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -1313,7 +1313,7 @@ cube(`fiscal_calendar`, {
 [ref-schema-ref-joins]: /reference/data-modeling/joins
 [ref-subquery]: /docs/data-modeling/dimensions#subquery-dimensions
 [self-subquery]: #sub-query
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-playground]: /docs/explore-analyze/playground
 [ref-apis]: /reference
 [ref-time-dimensions]: #type
@@ -1337,7 +1337,7 @@ cube(`fiscal_calendar`, {
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [link-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target
 [link-tabler]: https://tabler.io/icons
-[ref-references]: /docs/data-modeling/syntax#references
+[ref-references]: /docs/data-modeling/concepts/syntax#references
 [ref-filter-params]: /reference/data-modeling/context-variables#filter_params
 [link-encode-uri-component]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
 [ref-rest-filters]: /reference/core-data-apis/rest-api/query-format#query-properties

--- a/docs-mintlify/reference/data-modeling/hierarchies.mdx
+++ b/docs-mintlify/reference/data-modeling/hierarchies.mdx
@@ -322,7 +322,7 @@ cube(`users`, {
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-ref-dimensions]: /reference/data-modeling/dimensions
 [ref-ref-views]: /reference/data-modeling/view
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-apis-support]: /reference#data-modeling
 [ref-playground]: /docs/explore-analyze/playground#viewing-the-data-model
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools

--- a/docs-mintlify/reference/data-modeling/joins.mdx
+++ b/docs-mintlify/reference/data-modeling/joins.mdx
@@ -666,7 +666,7 @@ Please use views to address join predictability and stability.
 [ref-schema-fundamentals-join-dir]: /docs/data-modeling/joins#direction-of-joins
 [ref-schema-cube-sql]: /reference/data-modeling/cube#sql
 [ref-schema-data-blenging]: /docs/data-modeling/concepts/data-blending#data-blending
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [wiki-djikstra-alg]: https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
 [wiki-left-join]: https://en.wikipedia.org/wiki/Join_(SQL)#Left_outer_join
 [wiki-1-1]: https://en.wikipedia.org/wiki/One-to-one_(data_model)

--- a/docs-mintlify/reference/data-modeling/measures.mdx
+++ b/docs-mintlify/reference/data-modeling/measures.mdx
@@ -1486,8 +1486,8 @@ cube(`orders`, {
 [ref-ai-context]: /docs/data-modeling/ai-context
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-schema-ref-types-formats-measures-formats]: /reference/data-modeling/measures#format
-[ref-drilldowns]: /reference/recipes/drilldowns
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-drilldowns]: /recipes/core-data-api/drilldowns
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-playground]: /docs/explore-analyze/playground
 [ref-apis]: /reference
 [ref-rolling-window]: /docs/data-modeling/measures#rolling-windows

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -1820,7 +1820,7 @@ cube(`orders`, {
 [ref-schema-measures]: /reference/data-modeling/measures
 [ref-schema-segments]: /reference/data-modeling/segments
 [ref-schema-types-dim-time]: /reference/data-modeling/dimensions#type
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [self-granularity]: #granularity
 [self-incremental]: #incremental
 [self-origsql-preaggs]: #use_original_sql_pre_aggregations

--- a/docs-mintlify/reference/data-modeling/segments.mdx
+++ b/docs-mintlify/reference/data-modeling/segments.mdx
@@ -337,6 +337,6 @@ cube(`users`, {
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-backend-query]: /reference/core-data-apis/rest-api/query-format
 [ref-schema-gen]: /recipes/data-modeling/using-dynamic-measures
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-playground]: /docs/explore-analyze/playground
 [ref-apis]: /reference

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -946,7 +946,7 @@ The `access_policy` parameter is used to configure [access policies][ref-ref-dap
 
 [ref-ai-context]: /docs/data-modeling/ai-context
 [ref-recipe-control-access-cubes-views]: /docs/data-modeling/access-control
-[ref-naming]: /docs/data-modeling/syntax#naming
+[ref-naming]: /docs/data-modeling/concepts/syntax#naming
 [ref-apis]: /reference
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-ref-hierarchies]: /reference/data-modeling/hierarchies


### PR DESCRIPTION
## What

Site-wide fix for broken internal links in the Mintlify docs, prompted by [CUB-2899](https://linear.app/cube-d3/issue/CUB-2899/broken-links-on-cube-core-getting-started-page) (broken links on the Cube Core getting-started page).

Rather than fix only the one reported page, I scanned the whole `docs-mintlify` site and found **97 broken internal-link occurrences across 36 targets** — mostly stale paths left over from the Nextra → Mintlify restructure. This PR fixes **92 link targets across 68 files**.

Only link targets changed — **no content edits** (diff is exactly 92 insertions / 92 deletions, all on link lines).

## Highlights

| Broken → Fixed | Count |
|---|---|
| `/docs/data-modeling/syntax` → `/docs/data-modeling/concepts/syntax` | 24 |
| `/reference/dax-api[/reference]` → `/reference/core-data-apis/dax-api[/reference]` | 12 |
| `/admin/deployment/index` → `/admin/deployment` | 5 |
| `/reference/mdx-api` → `/reference/core-data-apis/mdx-api` | 5 |
| `/docs/data-modeling/concepts` → `/docs/data-modeling/overview` | 5 |
| `/analytics/*` → `/docs/explore-analyze/*` (workbooks, explore, dashboards, chat…) | 11 |
| `/docs/deployment/core` → `/admin/deployment/core` | 3 |
| `/reference/core-data-apis/rest-api/real-time-data-fetch` → `/recipes/core-data-api/real-time-data-fetch` | 3 |
| …plus ~20 more single-occurrence renames | |

The specific link from CUB-2899's screenshot was already corrected in git by #11081; the remaining broken link on that page (`learn-more.mdx`) is fixed here.

## Not included (need a content decision)

5 occurrences point at pages that **don't exist anywhere** in the docs, so they were left untouched:

- `/docs/workspace/saved-reports` (3×) — a "Saved Reports" page is linked from playground / Google Sheets / Excel docs but was never created in Mintlify.
- `/admin/workspace` + `/docs/workspace` (2×) — the `[ref-workspace]` "workspace tools" link has no landing page.

Separately, ~15 `/api-reference/*` links were excluded from the scan — those pages are generated by Mintlify from OpenAPI specs and should be validated against the specs, not the filesystem.

## Verification

A repeatable link-scan (excluding fenced/inline code and OpenAPI-generated pages) reports **97 → 5** broken links after this change, and the remaining 5 are the known content gaps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)