### PR TITLE
fix(schema-compiler): do not stamp default target on links meta

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.ts
@@ -112,7 +112,7 @@ export type LinkConfig = {
   label: string;
   dashboard?: string;
   icon?: string;
-  target: 'blank' | 'self';
+  target?: 'blank' | 'self';
   primary?: boolean;
   params?: string[];
 };
@@ -341,7 +341,7 @@ export class CubeToMetaTransformer implements CompilerInterface {
               label: link.label,
               ...(link.dashboard ? { dashboard: typeof link.dashboard === 'function' ? link.dashboard() : link.dashboard } : {}),
               icon: link.icon,
-              target: link.target || 'blank',
+              ...(link.target ? { target: link.target } : {}),
               ...(link.primary ? { primary: true } : {}),
               ...(link.params && Array.isArray(link.params) && link.params.length > 0
                 ? { params: link.params.map((p: any) => (typeof p.key === 'function' ? p.key() : p.key)) }

--- a/packages/cubejs-schema-compiler/test/unit/links.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/links.test.ts
@@ -91,6 +91,12 @@ cubes:
     expect(fullNameDim!.links![0].icon).toBe('brand-google');
     expect(fullNameDim!.links![0].target).toBe('blank');
 
+    // The send_email link does not set a target in the model, so target
+    // must not be stamped into the meta (no implicit 'blank' default).
+    expect(fullNameDim!.links![1].label).toBe('Write an email');
+    expect(fullNameDim!.links![1].target).toBeUndefined();
+    expect('target' in fullNameDim!.links![1]).toBe(false);
+
     const syntheticDim = usersCube!.config.dimensions.find(
       (d: any) => d.name === 'users.full_name___link_google_search_url'
     );
@@ -264,6 +270,25 @@ cubes:
       );
       expect(fullNameDim).toBeDefined();
       expect(fullNameDim!.links![0].dashboard).toBe('abc123');
+    });
+
+    it('should not stamp a default target on dashboard links', async () => {
+      const compilers = prepareYamlCompiler(schemaWithDashboardLink);
+      await compilers.compiler.compile();
+
+      const { metaTransformer } = compilers;
+      const { cubes } = metaTransformer;
+      const usersCube = cubes.find((c: any) => c.config.name === 'users');
+      expect(usersCube).toBeDefined();
+
+      const fullNameDim = usersCube!.config.dimensions.find(
+        (d: any) => d.name === 'users.full_name'
+      );
+      expect(fullNameDim).toBeDefined();
+      // The dashboard link does not specify a target, so meta must not
+      // force target: 'blank' onto it.
+      expect(fullNameDim!.links![0].target).toBeUndefined();
+      expect('target' in fullNameDim!.links![0]).toBe(false);
     });
 
     it('should not allow both url and dashboard on same link', async () => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made**

Resolves CORE-566.

The links meta builder in `CubeToMetaTransformer.ts` unconditionally added `target: 'blank'` to every link, even when the data model author never set a `target`:

```ts
target: link.target || 'blank',
```

As a result any link that omitted `target` — including dashboard links — got `target: 'blank'` baked into the meta. This forced an "open in a new tab" default and prevented consuming tools (e.g. Workbooks) from applying their own per-link-type default for dashboard links.

Changes:
- Only emit `target` in the meta when the model explicitly sets it: `...(link.target ? { target: link.target } : {})`.
- Make the `target` field optional on the `LinkConfig` type (`target?: 'blank' | 'self'`), consistent with the already-optional link type in `CubeEvaluator`.

Tests (`packages/cubejs-schema-compiler/test/unit/links.test.ts`):
- Assert a URL link without a `target` no longer has `target` stamped.
- New test that a dashboard link with no `target` does not get a default `target` in its meta.

All 19 tests in `links.test.ts` pass. The existing test for a link that explicitly sets `target: blank` still verifies it is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011sFTeoyUk7NX6nXxTNWbwc)_