### PR TITLE
docs: full value on hover for truncated table cells

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -51,6 +51,8 @@ Configure individual columns in the **Columns** section of the **Style** tab (or
 | **Width** | **Flexible** (a weight) or **Fixed** (pixels) — see [Column width](#column-width) |
 | **Hide** | Show or hide the column |
 
+When a cell's value is too long for its column and word wrap is off, the value is truncated with an ellipsis. Hover over a truncated cell to see its full value in a tooltip.
+
 ## Column width
 
 Each column's width is set independently in the **Columns** section of the **Style** tab. A column is in one of two modes:

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -24,6 +24,9 @@ A data model author can change the default for a semantic view with the
 views that are expensive to query. You can still toggle auto-run back on at
 any time.
 
+When a cell's value is too long for its column, it is truncated with an
+ellipsis. Hover over a truncated cell to see its full value in a tooltip.
+
 ## Filtering
 
 Dimensions and measures can be added as filters to focus on specific rows of data.
@@ -212,6 +215,13 @@ The **Semantic SQL** tab also has a dropdown for viewing the same query in the f
 - **Semantic GraphQL** — the [GraphQL API][ref-graphql-api] query format
 
 These views are convenient when you want to take a query you've built interactively in a workbook and reuse it directly through one of the Core Data APIs from your own application.
+
+## Result freshness and provenance
+
+Two indicators next to each result describe the data behind it.
+
+- **Freshness** — a leaf icon shows how recently the underlying data was refreshed. Hover over it to see the last refresh time (for example, "Refreshed 5 minutes ago"); its color shifts as the data ages, so you can tell fresh from stale results at a glance. If the refresh time can't be determined, the leaf turns gray with a "Data age unknown" label. When you have access to [Query History](/admin/monitoring/query-history), clicking the leaf opens the underlying request for that result.
+- **Pre-aggregation** — for those same users, a lightning-bolt icon appears next to the leaf with a "Served from a pre-aggregation" label whenever the result was served from a [pre-aggregation](/docs/pre-aggregations). If no icon is shown, the query ran directly against your data source.
 
 ## Editing Semantic SQL by hand
 


### PR DESCRIPTION
## Summary

Documents that a truncated cell reveals its full value on hover:

- **Table chart** (`charts/chart-types/table.mdx`) — one line next to the **Word wrap** column option, so the truncate/wrap behavior and its hover affordance are described together.
- **Results table** (`workbooks/querying-data.mdx`) — one line in **Running queries**.

## Test plan

- [x] Wording matches the shipped behavior (tooltip shows only when a cell is actually truncated and word wrap is off).
- [ ] Mintlify build passes.
