### PR TITLE
fix(schema-compiler): resolve view extends order dependency

### DIFF
--- a/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeSymbols.ts
@@ -513,6 +513,27 @@ export class CubeSymbols implements TranspilerSymbolResolver, CompilerInterface 
     },
     cubeDefinition);
 
+    if (cubeDefinition.isView) {
+      // Without this accessor, `Object.assign(cubeObject, cubeDefinition)` above would shadow
+      // `cubes` with the view's own un-merged, un-camelized `cubeDefinition.cubes`, bypassing
+      // `rawCubes()`. That breaks callers (e.g. `camelizeCube`) that read `cube.cubes` directly:
+      // for a view that `extends` another, the parent's cube-include entries would only get
+      // camelized (join_path -> joinPath) once the parent itself is transformed, making
+      // compilation depend on schema file processing order. `cubes` is only defined for views
+      // (see `viewSchema` in CubeValidator.ts), so this is scoped to `isView` to avoid adding
+      // an unexpected `cubes` key to plain cubes.
+      Object.defineProperty(cubeObject, 'cubes', {
+        enumerable: true,
+        configurable: true,
+        get(this: CubeDefinitionExtended) {
+          return this.rawCubes();
+        },
+        set(_v) {
+          // Dont allow to modify
+        },
+      });
+    }
+
     if (cubeDefinition.extends) {
       const superCube = this.resolveSymbolsCall(cubeDefinition.extends, (name: string) => this.cubeReferenceProxy(name));
       // eslint-disable-next-line no-underscore-dangle

--- a/packages/cubejs-schema-compiler/test/unit/repro-11260.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/repro-11260.test.ts
@@ -42,23 +42,35 @@ view(\`b_view\`, {
 });
 `;
 
+  const expectBViewInheritsDimensions = (metaTransformer: any) => {
+    const bViewMeta = metaTransformer.cubes.map((def: any) => def.config).find((def: any) => def.name === 'b_view');
+    const dimensionNames = (bViewMeta.dimensions || []).map((d: any) => d.name).sort();
+    expect(dimensionNames).toEqual(['b_view.id', 'b_view.name']);
+  };
+
   it('compiles when base view (a_view) file comes before subview (b_view) file', async () => {
-    const { compiler } = prepareCompiler([
+    const { compiler, metaTransformer } = prepareCompiler([
       { content: testCubeContent, fileName: 'test.js' },
       { content: viewAContent, fileName: 'view_a.js' },
       { content: viewBContent, fileName: 'view_b.js' },
     ]);
 
     await compiler.compile();
+    compiler.throwIfAnyErrors();
+
+    expectBViewInheritsDimensions(metaTransformer);
   });
 
   it('compiles when subview (b_view) file comes before base view (a_view) file', async () => {
-    const { compiler } = prepareCompiler([
+    const { compiler, metaTransformer } = prepareCompiler([
       { content: testCubeContent, fileName: 'test.js' },
       { content: viewBContent, fileName: 'view_b.js' },
       { content: viewAContent, fileName: 'view_a.js' },
     ]);
 
     await compiler.compile();
+    compiler.throwIfAnyErrors();
+
+    expectBViewInheritsDimensions(metaTransformer);
   });
 });

--- a/packages/cubejs-schema-compiler/test/unit/repro-11260.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/repro-11260.test.ts
@@ -1,0 +1,64 @@
+import { prepareCompiler } from './PrepareCompiler';
+
+describe('Repro #11260 - view extends order dependency', () => {
+  const testCubeContent = `
+cube(\`test\`, {
+    public: false,
+    sql: \`select 1 as id, 'test' as name\`,
+
+    dimensions: {
+        id: {
+            sql: \`id\`,
+            type: \`number\`
+        },
+        name: {
+            sql: \`name\`,
+            type: \`string\`
+        }
+    }
+});
+`;
+
+  const viewAContent = `
+view(\`a_view\`, {
+    public: true,
+    cubes: [
+        {
+            join_path: \`test\`,
+            includes: [
+                "id",
+                "name"
+            ]
+        }
+    ]
+});
+`;
+
+  const viewBContent = `
+view(\`b_view\`, {
+    public: true,
+    extends: a_view,
+    cubes: []
+});
+`;
+
+  it('compiles when base view (a_view) file comes before subview (b_view) file', async () => {
+    const { compiler } = prepareCompiler([
+      { content: testCubeContent, fileName: 'test.js' },
+      { content: viewAContent, fileName: 'view_a.js' },
+      { content: viewBContent, fileName: 'view_b.js' },
+    ]);
+
+    await compiler.compile();
+  });
+
+  it('compiles when subview (b_view) file comes before base view (a_view) file', async () => {
+    const { compiler } = prepareCompiler([
+      { content: testCubeContent, fileName: 'test.js' },
+      { content: viewBContent, fileName: 'view_b.js' },
+      { content: viewAContent, fileName: 'view_a.js' },
+    ]);
+
+    await compiler.compile();
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

#11260

**Description of Changes Made**

Views composed via `cubes: [...] includes` that use `extends` (e.g. a view extending another view) could fail to compile with:

```
Cannot read properties of undefined (reading 'apply')
```

...depending purely on the order schema files were processed in. Renaming a file so a subview sorted before the view it extended was enough to trigger it.

**Root cause**: `CubeSymbols.createCube()` builds each cube/view object via `Object.assign({ ...methods/getters... }, cubeDefinition)`. Inheritable fields like `measures`, `dimensions`, `preAggregations`, `accessPolicy`, and `joins` are protected with a `get`/`set` accessor pair (the setter is a no-op), so `Object.assign` can never shadow them with the raw, un-merged `cubeDefinition` value — reads always go through the lazy, `extends`-aware computation regardless of processing order.

`cubes` (the view `includes` composition list) was missing this protection — it only had a `rawCubes()` *method*, not a `cubes` accessor. `Object.assign` therefore shadowed `cube.cubes` with the view's own un-merged, raw `cubeDefinition.cubes`.

`camelizeCube()` reads `cube.cubes` directly to camelize `join_path` → `joinPath`. For a subview extending a base view with its own `cubes: []`, `cube.cubes` was this shadowed empty array, so camelization was a no-op on the subview itself — the *real* (inherited) entries only got camelized as a side effect of the base view's own transform running first. If the subview was transformed first (an artifact of raw file/array order — see the `// TODO support actual dependency sorting` comment already in `CubeSymbols.compile()`), `prepareIncludes()` picked up the inherited `join_path` entry still in raw form, `joinPath` was `undefined`, and `resolveSymbolsCall` crashed calling `.apply` on it.

**Fix**: add a `cubes` accessor, scoped to `isView` (since `cubes` is view-only per `viewSchema` in `CubeValidator.ts` — an unconditional accessor broke validation for plain cubes with "cubes is not allowed"), that always resolves through the existing `rawCubes()` method. This mirrors the exact pattern already used for every other inheritable field.

**Verification**

- Added `packages/cubejs-schema-compiler/test/unit/repro-11260.test.ts`, using the exact schema from the issue report. It compiles a base view + subview (`extends`) in both file orders and asserts the subview actually inherits the base view's dimensions (not just "doesn't throw").
- Full `cubejs-schema-compiler` unit suite (669 tests): all green except 2 pre-existing, unrelated snapshot failures in `error-reporter.test.ts` (ANSI color formatting in this sandbox) — confirmed identical on a clean checkout without this change.
- Ran `cube-validator.test.ts` and `views.test.ts` specifically to confirm the `isView`-scoped accessor doesn't affect plain-cube or existing view validation/behavior.

Fixes #11260

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH2aXmuwotLzYpCtJ2bLPT)_