### PR TITLE
feat(cubestore): add SYSTEM CACHESTORE WIPE command

### DIFF
--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -489,9 +489,12 @@ impl RocksCacheStore {
         RocksStore::check_all_indexes(&self.store).await
     }
 
-    /// Schedules a no-op on both RW loops (default + queue) and awaits them, guaranteeing that
-    /// any previously enqueued operation has finished and released its transient Arc<DB> clone.
-    /// Used by LazyRocksCacheStore::wipe before dropping/reopening the RocksDB.
+    /// Schedules a no-op on both RW loops (default + queue) and awaits them, so that any
+    /// operation previously enqueued on those loops has finished and released its transient
+    /// Arc<DB> clone. NOTE: this only flushes the two RW loops; it does NOT wait for out-of-queue
+    /// readers (read_operation_out_of_queue), which run on detached spawn_blocking tasks with
+    /// their own Arc<DB> clone. LazyRocksCacheStore::wipe additionally waits on db_strong_count()
+    /// to cover those before closing the DB.
     pub async fn drain_rw_loops(&self) -> Result<(), CubeError> {
         self.store
             .read_operation("wipe_barrier", |_| Ok(()))
@@ -500,6 +503,13 @@ impl RocksCacheStore {
             .await?;
 
         Ok(())
+    }
+
+    /// Number of strong references to the underlying RocksDB handle. LazyRocksCacheStore::wipe
+    /// uses this to confirm the DB is uniquely held (so dropping the store closes it and
+    /// releases the directory LOCK) before removing and reopening the folder.
+    pub fn db_strong_count(&self) -> usize {
+        Arc::strong_count(&self.store.db)
     }
 }
 

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -505,9 +505,7 @@ impl RocksCacheStore {
         Ok(())
     }
 
-    /// Number of strong references to the underlying RocksDB handle. LazyRocksCacheStore::wipe
-    /// uses this to confirm the DB is uniquely held (so dropping the store closes it and
-    /// releases the directory LOCK) before removing and reopening the folder.
+    /// Number of strong references to the underlying RocksDB handle.
     pub fn db_strong_count(&self) -> usize {
         Arc::strong_count(&self.store.db)
     }

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -928,6 +928,9 @@ pub trait CacheStore: DIService + Send + Sync {
     async fn persist(&self) -> Result<(), CubeError>;
     async fn healthcheck(&self) -> Result<(), CubeError>;
     async fn rocksdb_properties(&self) -> Result<Vec<RocksPropertyRow>, CubeError>;
+    // Wipe all cachestore state (cache + queue) and persist a fresh snapshot, updating the
+    // remote cachestore-current pointer so a poisoned snapshot is not re-hydrated on reload
+    async fn wipe(&self) -> Result<(), CubeError>;
 }
 
 #[async_trait]
@@ -1683,6 +1686,20 @@ impl CacheStore for RocksCacheStore {
     async fn rocksdb_properties(&self) -> Result<Vec<RocksPropertyRow>, CubeError> {
         self.store.rocksdb_properties()
     }
+
+    async fn wipe(&self) -> Result<(), CubeError> {
+        // Truncate all cachestore tables (cache_item, queue_item, queue_item_payload,
+        // queue_result) via the serialized RW loops.
+        self.cache_truncate().await?;
+        self.queue_truncate().await?;
+
+        // Persist a fresh full snapshot and move the remote cachestore-current pointer to it
+        // (also prunes old snapshots), so the poisoned lineage is superseded and future boots
+        // load the clean state instead of re-hydrating the bad one.
+        self.store.upload_check_point().await?;
+
+        Ok(())
+    }
 }
 
 crate::di_service!(RocksCacheStore, [CacheStore]);
@@ -1835,6 +1852,10 @@ impl CacheStore for ClusterCacheStoreClient {
     async fn rocksdb_properties(&self) -> Result<Vec<RocksPropertyRow>, CubeError> {
         panic!("CacheStore cannot be used on the worker node! rocksdb_properties was used.")
     }
+
+    async fn wipe(&self) -> Result<(), CubeError> {
+        panic!("CacheStore cannot be used on the worker node! wipe was used.")
+    }
 }
 
 crate::di_service!(ClusterCacheStoreClient, [CacheStore]);
@@ -1921,6 +1942,102 @@ mod tests {
         assert_eq!(row.expire.is_some(), true);
 
         RocksCacheStore::cleanup_test_cachestore("cache_set");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_wipe_clears_state() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (_, cachestore) =
+            RocksCacheStore::prepare_test_cachestore("wipe_clears_state", Config::test("wipe"));
+
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:key1".to_string(), Some(60), "v1".to_string()),
+                false,
+            )
+            .await?;
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:key2".to_string(), Some(60), "v2".to_string()),
+                false,
+            )
+            .await?;
+        cachestore
+            .queue_add(QueueAddPayload {
+                path: "queue:job1".to_string(),
+                value: "payload".to_string(),
+                priority: 0,
+                orphaned: None,
+                process_id: None,
+                exclusive: false,
+                external_id: None,
+            })
+            .await?;
+
+        assert_eq!(cachestore.cache_all(None).await?.len(), 2);
+        assert_eq!(cachestore.queue_all(None).await?.len(), 1);
+
+        cachestore.wipe().await?;
+
+        assert_eq!(cachestore.cache_all(None).await?.len(), 0);
+        assert_eq!(cachestore.queue_all(None).await?.len(), 0);
+
+        RocksCacheStore::cleanup_test_cachestore("wipe_clears_state");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_wipe_persists_fresh_snapshot() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
+            "wipe_persists_fresh_snapshot",
+            Config::test("wipe_snapshot"),
+        );
+
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:key1".to_string(), Some(60), "v1".to_string()),
+                false,
+            )
+            .await?;
+
+        cachestore.wipe().await?;
+
+        // wipe() must persist a fresh checkpoint and move cachestore-current onto it.
+        let snapshots = cachestore.store.get_snapshots_list().await?;
+        assert_eq!(
+            snapshots.iter().filter(|s| s.current).count(),
+            1,
+            "exactly one snapshot must be marked as current after wipe"
+        );
+
+        RocksCacheStore::cleanup_test_cachestore("wipe_persists_fresh_snapshot");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_wipe_on_empty_store() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
+            "wipe_on_empty_store",
+            Config::test("wipe_empty"),
+        );
+
+        // Wiping a fresh empty store must succeed and still produce a current snapshot.
+        cachestore.wipe().await?;
+
+        assert_eq!(cachestore.cache_all(None).await?.len(), 0);
+        let snapshots = cachestore.store.get_snapshots_list().await?;
+        assert_eq!(snapshots.iter().filter(|s| s.current).count(), 1);
+
+        RocksCacheStore::cleanup_test_cachestore("wipe_on_empty_store");
 
         Ok(())
     }

--- a/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
+++ b/rust/cubestore/cubestore/src/cachestore/cache_rocksstore.rs
@@ -488,6 +488,19 @@ impl RocksCacheStore {
     pub async fn check_all_indexes(&self) -> Result<(), CubeError> {
         RocksStore::check_all_indexes(&self.store).await
     }
+
+    /// Schedules a no-op on both RW loops (default + queue) and awaits them, guaranteeing that
+    /// any previously enqueued operation has finished and released its transient Arc<DB> clone.
+    /// Used by LazyRocksCacheStore::wipe before dropping/reopening the RocksDB.
+    pub async fn drain_rw_loops(&self) -> Result<(), CubeError> {
+        self.store
+            .read_operation("wipe_barrier", |_| Ok(()))
+            .await?;
+        self.read_operation_queue("wipe_barrier", |_| Ok(()))
+            .await?;
+
+        Ok(())
+    }
 }
 
 impl RocksCacheStore {
@@ -1688,17 +1701,12 @@ impl CacheStore for RocksCacheStore {
     }
 
     async fn wipe(&self) -> Result<(), CubeError> {
-        // Truncate all cachestore tables (cache_item, queue_item, queue_item_payload,
-        // queue_result) via the serialized RW loops.
-        self.cache_truncate().await?;
-        self.queue_truncate().await?;
-
-        // Persist a fresh full snapshot and move the remote cachestore-current pointer to it
-        // (also prunes old snapshots), so the poisoned lineage is superseded and future boots
-        // load the clean state instead of re-hydrating the bad one.
-        self.store.upload_check_point().await?;
-
-        Ok(())
+        // Wiping requires dropping and reopening the RocksDB from scratch, which a bare inner
+        // store cannot do to itself (it cannot rebuild its own Arc / swap the state). The
+        // registered production impl is always LazyRocksCacheStore, which owns the teardown.
+        Err(CubeError::internal(
+            "cachestore wipe is only supported through LazyRocksCacheStore".to_string(),
+        ))
     }
 }
 
@@ -1942,102 +1950,6 @@ mod tests {
         assert_eq!(row.expire.is_some(), true);
 
         RocksCacheStore::cleanup_test_cachestore("cache_set");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_wipe_clears_state() -> Result<(), CubeError> {
-        init_test_logger().await;
-
-        let (_, cachestore) =
-            RocksCacheStore::prepare_test_cachestore("wipe_clears_state", Config::test("wipe"));
-
-        cachestore
-            .cache_set(
-                CacheItem::new("prefix:key1".to_string(), Some(60), "v1".to_string()),
-                false,
-            )
-            .await?;
-        cachestore
-            .cache_set(
-                CacheItem::new("prefix:key2".to_string(), Some(60), "v2".to_string()),
-                false,
-            )
-            .await?;
-        cachestore
-            .queue_add(QueueAddPayload {
-                path: "queue:job1".to_string(),
-                value: "payload".to_string(),
-                priority: 0,
-                orphaned: None,
-                process_id: None,
-                exclusive: false,
-                external_id: None,
-            })
-            .await?;
-
-        assert_eq!(cachestore.cache_all(None).await?.len(), 2);
-        assert_eq!(cachestore.queue_all(None).await?.len(), 1);
-
-        cachestore.wipe().await?;
-
-        assert_eq!(cachestore.cache_all(None).await?.len(), 0);
-        assert_eq!(cachestore.queue_all(None).await?.len(), 0);
-
-        RocksCacheStore::cleanup_test_cachestore("wipe_clears_state");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_wipe_persists_fresh_snapshot() -> Result<(), CubeError> {
-        init_test_logger().await;
-
-        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
-            "wipe_persists_fresh_snapshot",
-            Config::test("wipe_snapshot"),
-        );
-
-        cachestore
-            .cache_set(
-                CacheItem::new("prefix:key1".to_string(), Some(60), "v1".to_string()),
-                false,
-            )
-            .await?;
-
-        cachestore.wipe().await?;
-
-        // wipe() must persist a fresh checkpoint and move cachestore-current onto it.
-        let snapshots = cachestore.store.get_snapshots_list().await?;
-        assert_eq!(
-            snapshots.iter().filter(|s| s.current).count(),
-            1,
-            "exactly one snapshot must be marked as current after wipe"
-        );
-
-        RocksCacheStore::cleanup_test_cachestore("wipe_persists_fresh_snapshot");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_wipe_on_empty_store() -> Result<(), CubeError> {
-        init_test_logger().await;
-
-        let (_, cachestore) = RocksCacheStore::prepare_test_cachestore(
-            "wipe_on_empty_store",
-            Config::test("wipe_empty"),
-        );
-
-        // Wiping a fresh empty store must succeed and still produce a current snapshot.
-        cachestore.wipe().await?;
-
-        assert_eq!(cachestore.cache_all(None).await?.len(), 0);
-        let snapshots = cachestore.store.get_snapshots_list().await?;
-        assert_eq!(snapshots.iter().filter(|s| s.current).count(), 1);
-
-        RocksCacheStore::cleanup_test_cachestore("wipe_on_empty_store");
 
         Ok(())
     }

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -12,19 +12,17 @@ use crate::config::ConfigObj;
 use crate::metastore::{IdRow, MetaStoreEvent, MetaStoreFs, RocksPropertyRow};
 use crate::CubeError;
 use async_trait::async_trait;
-use log::trace;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::watch::{Receiver, Sender};
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 pub enum LazyRocksCacheStoreState {
     FromRemote {
-        path: String,
-        metastore_fs: Arc<dyn MetaStoreFs>,
-        config: Arc<dyn ConfigObj>,
-        listeners: Vec<tokio::sync::broadcast::Sender<MetaStoreEvent>>,
-        #[allow(dead_code)] // Receiver closed on drop
+        #[allow(dead_code)] // Receiver notified when this sender is dropped on transition
         init_flag: Sender<bool>,
     },
     Closed {},
@@ -36,6 +34,16 @@ pub enum LazyRocksCacheStoreState {
 pub struct LazyRocksCacheStore {
     init_signal: Option<Receiver<bool>>,
     state: tokio::sync::RwLock<LazyRocksCacheStoreState>,
+    // Kept on the wrapper (not only inside the state enum) so that `wipe` can rebuild the store
+    // from scratch regardless of the current state.
+    path: String,
+    metastore_fs: Arc<dyn MetaStoreFs>,
+    config: Arc<dyn ConfigObj>,
+    listeners: Vec<tokio::sync::broadcast::Sender<MetaStoreEvent>>,
+    // Handles of the currently running processing loops. Owned here (rather than by CubeServices)
+    // so that `wipe` can stop and join them before dropping/reopening the RocksDB.
+    running_loops: Mutex<Vec<JoinHandle<Result<(), CubeError>>>>,
+    shutdown_token: CancellationToken,
 }
 
 impl LazyRocksCacheStore {
@@ -46,15 +54,23 @@ impl LazyRocksCacheStore {
         config: Arc<dyn ConfigObj>,
         listeners: Vec<tokio::sync::broadcast::Sender<MetaStoreEvent>>,
     ) -> Result<Arc<Self>, CubeError> {
-        let store = RocksCacheStore::load_from_dump(path, dump_path, metastore_fs, config).await?;
+        let store =
+            RocksCacheStore::load_from_dump(path, dump_path, metastore_fs.clone(), config.clone())
+                .await?;
 
-        for listener in listeners {
-            store.add_listener(listener).await;
+        for listener in &listeners {
+            store.add_listener(listener.clone()).await;
         }
 
         Ok(Arc::new(Self {
             init_signal: None,
             state: tokio::sync::RwLock::new(LazyRocksCacheStoreState::Initialized { store }),
+            path: path.to_string_lossy().to_string(),
+            metastore_fs,
+            config,
+            listeners,
+            running_loops: Mutex::new(vec![]),
+            shutdown_token: CancellationToken::new(),
         }))
     }
 
@@ -68,13 +84,13 @@ impl LazyRocksCacheStore {
 
         Ok(Arc::new(Self {
             init_signal: Some(init_signal),
-            state: tokio::sync::RwLock::new(LazyRocksCacheStoreState::FromRemote {
-                path: path.to_string(),
-                metastore_fs,
-                config,
-                listeners,
-                init_flag,
-            }),
+            state: tokio::sync::RwLock::new(LazyRocksCacheStoreState::FromRemote { init_flag }),
+            path: path.to_string(),
+            metastore_fs,
+            config,
+            listeners,
+            running_loops: Mutex::new(vec![]),
+            shutdown_token: CancellationToken::new(),
         }))
     }
 
@@ -96,78 +112,96 @@ impl LazyRocksCacheStore {
 
         let mut guard = self.state.write().await;
         match &*guard {
-            LazyRocksCacheStoreState::FromRemote {
-                path,
-                metastore_fs,
-                config,
-                listeners,
-                // receiver will be closed on drop
-                init_flag: _,
-            } => {
-                let store =
-                    RocksCacheStore::load_from_remote(&path, metastore_fs.clone(), config.clone())
-                        .await?;
+            LazyRocksCacheStoreState::FromRemote { .. } => {
+                let store = RocksCacheStore::load_from_remote(
+                    &self.path,
+                    self.metastore_fs.clone(),
+                    self.config.clone(),
+                )
+                .await?;
 
-                for listener in listeners {
+                for listener in &self.listeners {
                     store.add_listener(listener.clone()).await;
                 }
 
+                // Dropping the previous FromRemote (via replace) drops init_flag, which
+                // notifies run_processing_loops to spawn the processing loops.
                 *guard = LazyRocksCacheStoreState::Initialized {
                     store: store.clone(),
                 };
 
                 Ok(store)
             }
-            _ => Err(CubeError::internal(
-                "Unable to initialize Cache Store on lazy call, unexpected state".to_string(),
+            // Another caller initialized it between our read and write lock.
+            LazyRocksCacheStoreState::Initialized { store } => Ok(store.clone()),
+            LazyRocksCacheStoreState::Closed { .. } => Err(CubeError::internal(
+                "Unable to initialize Cache Store on lazy call, it was closed".to_string(),
             )),
         }
     }
 
-    pub async fn spawn_processing_loops(self: Arc<Self>) -> Vec<JoinHandle<Result<(), CubeError>>> {
+    /// Owns the processing-loop lifecycle for the cachestore. Called once by CubeServices; it
+    /// waits until the store is initialized, spawns the processing loops (stored in
+    /// `running_loops` so `wipe` can manage them), then blocks until shutdown.
+    pub async fn run_processing_loops(self: Arc<Self>) -> Result<(), CubeError> {
         if let Some(init_signal) = &self.init_signal {
             let _ = init_signal.clone().changed().await;
         }
 
-        let store = {
-            let guard = self.state.read().await;
-            if let LazyRocksCacheStoreState::Initialized { store } = &*guard {
-                store.clone()
-            } else {
-                return vec![];
+        {
+            let store = {
+                let guard = self.state.read().await;
+                if let LazyRocksCacheStoreState::Initialized { store } = &*guard {
+                    Some(store.clone())
+                } else {
+                    None
+                }
+            };
+
+            if let Some(store) = store {
+                let mut loops = self.running_loops.lock().await;
+                if loops.is_empty() {
+                    *loops = store.spawn_processing_loops();
+                }
+                // `store` clone is dropped at the end of this block so it does not keep the
+                // RocksDB alive while we are parked on the shutdown token.
             }
-        };
+        }
 
-        trace!("start_processing_loops unblocked, Cache Store was initialized");
+        self.shutdown_token.cancelled().await;
 
-        store.spawn_processing_loops()
+        Ok(())
     }
 
     pub async fn stop_processing_loops(&self) {
         let store = {
             let mut guard = self.state.write().await;
             match &*guard {
-                LazyRocksCacheStoreState::Closed { .. } => {
-                    return ();
-                }
+                LazyRocksCacheStoreState::Closed { .. } => None,
                 LazyRocksCacheStoreState::FromRemote { .. } => {
                     *guard = LazyRocksCacheStoreState::Closed {};
-
-                    return ();
+                    None
                 }
                 LazyRocksCacheStoreState::Initialized { store } => {
                     let store_to_move = store.clone();
-
                     *guard = LazyRocksCacheStoreState::Closed {};
-
-                    store_to_move
+                    Some(store_to_move)
                 }
             }
         };
 
-        trace!("stop_processing_loops unblocked, Cache Store was initialized");
+        if let Some(store) = store {
+            store.stop_processing_loops().await;
+        }
 
-        store.stop_processing_loops().await
+        {
+            let mut loops = self.running_loops.lock().await;
+            for handle in loops.drain(..) {
+                let _ = handle.await;
+            }
+        }
+
+        self.shutdown_token.cancel();
     }
 }
 
@@ -336,8 +370,237 @@ impl CacheStore for LazyRocksCacheStore {
     }
 
     async fn wipe(&self) -> Result<(), CubeError> {
-        self.init().await?.wipe().await
+        // Make sure the store is initialized. init() fires init_signal so run_processing_loops
+        // spawns the initial loops; the returned Arc is dropped immediately so it does not
+        // inflate the strong count we rely on below.
+        self.init().await?;
+
+        // Hold the state write lock for the whole teardown: new operations block on
+        // state.read() in init() until we install the fresh store.
+        let mut guard = self.state.write().await;
+        let store = match std::mem::replace(&mut *guard, LazyRocksCacheStoreState::Closed {}) {
+            LazyRocksCacheStoreState::Initialized { store } => store,
+            LazyRocksCacheStoreState::Closed {} => {
+                return Err(CubeError::internal(
+                    "Unable to wipe Cache Store, it was closed".to_string(),
+                ));
+            }
+            LazyRocksCacheStoreState::FromRemote { init_flag } => {
+                // init() above guarantees Initialized; restore defensively.
+                *guard = LazyRocksCacheStoreState::FromRemote { init_flag };
+                return Err(CubeError::internal(
+                    "Unable to wipe Cache Store, unexpected state".to_string(),
+                ));
+            }
+        };
+
+        // Stop the worker loops and JOIN them so their Arc<RocksCacheStore> clones are released.
+        store.stop_processing_loops().await;
+        {
+            let mut loops = self.running_loops.lock().await;
+            for handle in loops.drain(..) {
+                let _ = handle.await;
+            }
+        }
+
+        // Flush both RW loops so no in-flight operation still holds an Arc<DB> clone.
+        store.drain_rw_loops().await?;
+
+        // Wait until we are the sole owner of the store before closing it, so RocksDB releases
+        // the directory LOCK and the reopen below succeeds.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Arc::strong_count(&store) > 1 {
+            if Instant::now() >= deadline {
+                // Restore the store so the cachestore stays usable instead of corrupting it.
+                let mut loops = self.running_loops.lock().await;
+                *loops = store.clone().spawn_processing_loops();
+                *guard = LazyRocksCacheStoreState::Initialized { store };
+                return Err(CubeError::internal(
+                    "Unable to wipe Cache Store: store is still in use after draining loops"
+                        .to_string(),
+                ));
+            }
+
+            tokio::task::yield_now().await;
+        }
+
+        // Close the DB (drops the last Arc<DB>) and drop the folder.
+        drop(store);
+
+        if let Err(err) = std::fs::remove_dir_all(&self.path) {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                return Err(CubeError::internal(format!(
+                    "Unable to wipe Cache Store: failed to remove {}: {}",
+                    self.path, err
+                )));
+            }
+        }
+
+        // Reopen from scratch (create_if_missing, no remote download), run migrations and
+        // re-attach listeners.
+        let fresh = RocksCacheStore::new(
+            Path::new(&self.path),
+            self.metastore_fs.clone(),
+            self.config.clone(),
+        )?;
+        fresh.check_all_indexes().await?;
+        for listener in &self.listeners {
+            fresh.add_listener(listener.clone()).await;
+        }
+
+        // Persist a fresh full snapshot and move the remote cachestore-current pointer onto it,
+        // superseding the poisoned lineage.
+        fresh.upload_check_point().await?;
+
+        // Respawn the worker loops against the fresh store.
+        {
+            let mut loops = self.running_loops.lock().await;
+            *loops = fresh.clone().spawn_processing_loops();
+        }
+
+        *guard = LazyRocksCacheStoreState::Initialized { store: fresh };
+
+        Ok(())
     }
 }
 
 crate::di_service!(LazyRocksCacheStore, [CacheStore]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{init_test_logger, Config};
+    use crate::metastore::BaseRocksStoreFs;
+    use crate::remotefs::LocalDirRemoteFs;
+    use std::env;
+    use std::path::PathBuf;
+
+    fn test_dirs(test_name: &str) -> (PathBuf, PathBuf) {
+        let base = env::current_dir().unwrap().join("db-tmp").join("tests");
+        (
+            base.join(format!("{}-local", test_name)),
+            base.join(format!("{}-remote", test_name)),
+        )
+    }
+
+    async fn build_lazy(
+        config: Config,
+        local_path: PathBuf,
+        remote_path: PathBuf,
+    ) -> Arc<LazyRocksCacheStore> {
+        let config_obj = config.config_obj();
+        let remote_fs = LocalDirRemoteFs::new(Some(remote_path), local_path.clone());
+        let cachestore_path = local_path.join("cachestore");
+        let metastore_fs = BaseRocksStoreFs::new_for_cachestore(remote_fs, config_obj.clone());
+
+        LazyRocksCacheStore::load_from_remote(
+            cachestore_path.to_str().unwrap(),
+            metastore_fs,
+            config_obj,
+            vec![],
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_lazy_wipe_clears_state_and_stays_usable() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (local, remote) = test_dirs("lazy_wipe_clears");
+        let _ = std::fs::remove_dir_all(&local);
+        let _ = std::fs::remove_dir_all(&remote);
+
+        let cachestore = build_lazy(Config::test("lazy_wipe_clears"), local.clone(), remote).await;
+
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:key1".to_string(), Some(60), "v1".to_string()),
+                false,
+            )
+            .await?;
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:key2".to_string(), Some(60), "v2".to_string()),
+                false,
+            )
+            .await?;
+        cachestore
+            .queue_add(QueueAddPayload {
+                path: "queue:job1".to_string(),
+                value: "payload".to_string(),
+                priority: 0,
+                orphaned: None,
+                process_id: None,
+                exclusive: false,
+                external_id: None,
+            })
+            .await?;
+
+        assert_eq!(cachestore.cache_all(None).await?.len(), 2);
+        assert_eq!(cachestore.queue_all(None).await?.len(), 1);
+
+        cachestore.wipe().await?;
+
+        assert_eq!(cachestore.cache_all(None).await?.len(), 0);
+        assert_eq!(cachestore.queue_all(None).await?.len(), 0);
+
+        // The reopened store must still be usable.
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:after".to_string(), Some(60), "fresh".to_string()),
+                false,
+            )
+            .await?;
+        let row = cachestore
+            .cache_get("prefix:after".to_string())
+            .await?
+            .expect("must return row after wipe");
+        assert_eq!(row.into_row().value, "fresh".to_string());
+
+        // The local cachestore folder must exist again after the reopen.
+        assert!(local.join("cachestore").exists());
+
+        let _ = std::fs::remove_dir_all(&local);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_wipe_publishes_clean_remote_snapshot() -> Result<(), CubeError> {
+        init_test_logger().await;
+
+        let (local, remote) = test_dirs("lazy_wipe_remote");
+        let _ = std::fs::remove_dir_all(&local);
+        let _ = std::fs::remove_dir_all(&remote);
+
+        let cachestore = build_lazy(
+            Config::test("lazy_wipe_remote"),
+            local.clone(),
+            remote.clone(),
+        )
+        .await;
+
+        cachestore
+            .cache_set(
+                CacheItem::new("prefix:key1".to_string(), Some(60), "v1".to_string()),
+                false,
+            )
+            .await?;
+
+        cachestore.wipe().await?;
+
+        // A fresh instance pointing at the same remote (with an empty local dir) must download
+        // the post-wipe snapshot via cachestore-current and come back empty.
+        let local2 = local.parent().unwrap().join("lazy_wipe_remote-local2");
+        let _ = std::fs::remove_dir_all(&local2);
+
+        let reloaded = build_lazy(Config::test("lazy_wipe_remote"), local2.clone(), remote).await;
+        assert_eq!(reloaded.cache_all(None).await?.len(), 0);
+
+        let _ = std::fs::remove_dir_all(&local);
+        let _ = std::fs::remove_dir_all(&local2);
+
+        Ok(())
+    }
+}

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -554,6 +554,12 @@ impl LazyRocksCacheStore {
         {
             let mut guard = self.state.write().await;
 
+            if matches!(&*guard, LazyRocksCacheStoreState::Closed { .. }) {
+                return Err(CubeError::internal(
+                    "WIPE aborted: shutdown requested during teardown".to_string(),
+                ));
+            }
+
             // Respawn the worker loops against the fresh store, then install it and release the
             // state lock BEFORE the (remote, slow, fallible) snapshot upload.
             {

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -21,8 +21,6 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-// Bounds for the `wipe` teardown so it can never hang the whole cachestore (every op funnels
-// through init() -> state.read(), which is blocked while wipe holds state.write()).
 const WIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 const WIPE_CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
 const WIPE_CLOSE_POLL_INTERVAL: Duration = Duration::from_millis(20);
@@ -41,6 +39,7 @@ pub enum LazyRocksCacheStoreState {
         init_flag: Sender<bool>,
     },
     Closed {},
+    Wiping {},
     Initialized {
         store: Arc<RocksCacheStore>,
     },
@@ -119,6 +118,12 @@ impl LazyRocksCacheStore {
                         "Unable to initialize Cache Store on lazy call, it was closed".to_string(),
                     ));
                 }
+                LazyRocksCacheStoreState::Wiping { .. } => {
+                    return Err(CubeError::internal(
+                        "Unable to initialize Cache Store on lazy call, a wipe is in progress"
+                            .to_string(),
+                    ));
+                }
                 LazyRocksCacheStoreState::Initialized { store } => {
                     return Ok(store.clone());
                 }
@@ -151,6 +156,9 @@ impl LazyRocksCacheStore {
             LazyRocksCacheStoreState::Initialized { store } => Ok(store.clone()),
             LazyRocksCacheStoreState::Closed { .. } => Err(CubeError::internal(
                 "Unable to initialize Cache Store on lazy call, it was closed".to_string(),
+            )),
+            LazyRocksCacheStoreState::Wiping { .. } => Err(CubeError::internal(
+                "Unable to initialize Cache Store on lazy call, a wipe is in progress".to_string(),
             )),
         }
     }
@@ -194,6 +202,12 @@ impl LazyRocksCacheStore {
             match &*guard {
                 LazyRocksCacheStoreState::Closed { .. } => None,
                 LazyRocksCacheStoreState::FromRemote { .. } => {
+                    *guard = LazyRocksCacheStoreState::Closed {};
+                    None
+                }
+                LazyRocksCacheStoreState::Wiping { .. } => {
+                    // A wipe owns the store; marking Closed makes the wipe abort its re-install
+                    // (see wipe) instead of resurrecting the store after shutdown was requested.
                     *guard = LazyRocksCacheStoreState::Closed {};
                     None
                 }
@@ -387,32 +401,72 @@ impl CacheStore for LazyRocksCacheStore {
     async fn wipe(&self) -> Result<(), CubeError> {
         // Make sure the store is initialized. init() fires init_signal so run_processing_loops
         // spawns the initial loops; the returned Arc is dropped immediately so it does not
-        // inflate the strong count we rely on below.
+        // inflate the strong count the teardown relies on below.
         self.init().await?;
 
-        // Hold the state write lock for the destructive part of the teardown: new operations
-        // block on state.read() in init() until we install the fresh store. We deliberately
-        // release it before the remote snapshot upload (see the end of this method).
-        let mut guard = self.state.write().await;
-        let store = match std::mem::replace(&mut *guard, LazyRocksCacheStoreState::Closed {}) {
-            LazyRocksCacheStoreState::Initialized { store } => store,
-            LazyRocksCacheStoreState::Closed {} => {
-                return Err(CubeError::internal(
-                    "Unable to wipe Cache Store, it was closed".to_string(),
-                ));
-            }
-            LazyRocksCacheStoreState::FromRemote { init_flag } => {
-                // init() above guarantees Initialized; restore defensively.
-                *guard = LazyRocksCacheStoreState::FromRemote { init_flag };
-                return Err(CubeError::internal(
-                    "Unable to wipe Cache Store, unexpected state".to_string(),
-                ));
-            }
-        };
+        {
+            let mut guard = self.state.write().await;
+            match std::mem::replace(&mut *guard, LazyRocksCacheStoreState::Wiping {}) {
+                LazyRocksCacheStoreState::Initialized { store } => {
+                    // Drop the guard before the teardown so the lock is not held across it.
+                    drop(guard);
 
+                    // Everything from here is the point of no return: the loops are stopped and
+                    // the store is destroyed, so it cannot be restored.
+                    if let Err(err) = self.wipe_teardown(store).await {
+                        let mut guard = self.state.write().await;
+                        *guard = LazyRocksCacheStoreState::Closed {};
+                        drop(guard);
+
+                        if self.shutdown_token.is_cancelled() {
+                            log::error!(
+                                "SYSTEM CACHESTORE WIPE aborted during shutdown; cachestore left \
+                                 closed: {}",
+                                err
+                            );
+                        } else {
+                            log::error!(
+                                "SYSTEM CACHESTORE WIPE failed after the teardown point of no \
+                                 return; cachestore is now CLOSED and will reject every operation \
+                                 until the node is restarted: {}",
+                                err
+                            );
+                        }
+
+                        return Err(err);
+                    }
+
+                    Ok(())
+                }
+                LazyRocksCacheStoreState::Wiping {} => {
+                    *guard = LazyRocksCacheStoreState::Wiping {};
+                    Err(CubeError::internal(
+                        "Unable to wipe Cache Store: a wipe is already in progress".to_string(),
+                    ))
+                }
+                LazyRocksCacheStoreState::Closed {} => {
+                    *guard = LazyRocksCacheStoreState::Closed {};
+                    Err(CubeError::internal(
+                        "Unable to wipe Cache Store, it was closed".to_string(),
+                    ))
+                }
+                LazyRocksCacheStoreState::FromRemote { init_flag } => {
+                    // init() above guarantees Initialized; restore defensively.
+                    *guard = LazyRocksCacheStoreState::FromRemote { init_flag };
+                    Err(CubeError::internal(
+                        "Unable to wipe Cache Store, unexpected state".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+}
+
+impl LazyRocksCacheStore {
+    async fn wipe_teardown(&self, store: Arc<RocksCacheStore>) -> Result<(), CubeError> {
         // Stop the worker loops and JOIN them so their Arc<RocksCacheStore> clones are released.
-        // This is the point of no return: WorkerLoop/IntervalLoop tokens are permanently
-        // cancelled, so the old `store` can no longer run loops and there is no restore path.
+        // WorkerLoop/IntervalLoop tokens are permanently cancelled, so the old `store` can no
+        // longer run loops and there is no restore path.
         store.stop_processing_loops().await;
         {
             let mut loops = self.running_loops.lock().await;
@@ -422,7 +476,7 @@ impl CacheStore for LazyRocksCacheStore {
         }
 
         // Flush both RW loops so in-flight serialized ops release their transient Arc<DB> clones.
-        // Bounded so a wedged RW loop cannot hang wipe forever while holding state.write().
+        // Bounded so a wedged RW loop cannot hang wipe forever.
         if let Err(err) = tokio::time::timeout(WIPE_DRAIN_TIMEOUT, store.drain_rw_loops()).await {
             log::warn!(
                 "Wiping cachestore: draining RW loops timed out ({:?}), continuing: {}",
@@ -436,11 +490,12 @@ impl CacheStore for LazyRocksCacheStore {
         // the real Arc<DB> via db_strong_count() to catch detached out-of-queue spawn_blocking
         // readers that the RW-loop drain above does not cover. Sleep-backoff, not a busy spin.
         let deadline = Instant::now() + WIPE_CLOSE_TIMEOUT;
+
         while Arc::strong_count(&store) > 1 || store.db_strong_count() > 1 {
             if Instant::now() >= deadline {
                 // We already committed (loops stopped); the store cannot be restored cleanly.
-                // Leave it Closed and require a restart rather than risk removing/reopening the
-                // directory while the old DB is still open (which could corrupt the new DB).
+                // Bail rather than risk removing/reopening the directory while the old DB is still
+                // open (which could corrupt the new DB); the caller marks the state Closed.
                 return Err(CubeError::internal(
                     "Unable to wipe Cache Store: still in use after draining; restart the node"
                         .to_string(),
@@ -496,17 +551,20 @@ impl CacheStore for LazyRocksCacheStore {
             fresh.add_listener(listener.clone()).await;
         }
 
-        // Respawn the worker loops against the fresh store, then install it and release the
-        // state lock BEFORE the (remote, slow, fallible) snapshot upload.
         {
-            let mut loops = self.running_loops.lock().await;
-            *loops = fresh.clone().spawn_processing_loops();
-        }
+            let mut guard = self.state.write().await;
 
-        *guard = LazyRocksCacheStoreState::Initialized {
-            store: fresh.clone(),
-        };
-        drop(guard);
+            // Respawn the worker loops against the fresh store, then install it and release the
+            // state lock BEFORE the (remote, slow, fallible) snapshot upload.
+            {
+                let mut loops = self.running_loops.lock().await;
+                *loops = fresh.clone().spawn_processing_loops();
+            }
+
+            *guard = LazyRocksCacheStoreState::Initialized {
+                store: fresh.clone(),
+            };
+        }
 
         // Persist a fresh full snapshot and move the remote cachestore-current pointer onto it.
         // Best-effort: the store is already installed and usable, and the upload loop retries;

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -12,6 +12,7 @@ use crate::config::ConfigObj;
 use crate::metastore::{IdRow, MetaStoreEvent, MetaStoreFs, RocksPropertyRow};
 use crate::CubeError;
 use async_trait::async_trait;
+use datafusion::cube_ext;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -19,6 +20,19 @@ use tokio::sync::watch::{Receiver, Sender};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+
+// Bounds for the `wipe` teardown so it can never hang the whole cachestore (every op funnels
+// through init() -> state.read(), which is blocked while wipe holds state.write()).
+const WIPE_DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
+const WIPE_CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
+const WIPE_CLOSE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const WIPE_REOPEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Best-effort detection of a RocksDB "directory lock is held" open error, used to retry the
+/// reopen while a detached out-of-queue operation still holds an `Arc<DB>` clone.
+fn is_rocksdb_lock_error(err: &CubeError) -> bool {
+    err.to_string().to_lowercase().contains("lock")
+}
 
 pub enum LazyRocksCacheStoreState {
     FromRemote {
@@ -375,8 +389,9 @@ impl CacheStore for LazyRocksCacheStore {
         // inflate the strong count we rely on below.
         self.init().await?;
 
-        // Hold the state write lock for the whole teardown: new operations block on
-        // state.read() in init() until we install the fresh store.
+        // Hold the state write lock for the destructive part of the teardown: new operations
+        // block on state.read() in init() until we install the fresh store. We deliberately
+        // release it before the remote snapshot upload (see the end of this method).
         let mut guard = self.state.write().await;
         let store = match std::mem::replace(&mut *guard, LazyRocksCacheStoreState::Closed {}) {
             LazyRocksCacheStoreState::Initialized { store } => store,
@@ -395,6 +410,8 @@ impl CacheStore for LazyRocksCacheStore {
         };
 
         // Stop the worker loops and JOIN them so their Arc<RocksCacheStore> clones are released.
+        // This is the point of no return: WorkerLoop/IntervalLoop tokens are permanently
+        // cancelled, so the old `store` can no longer run loops and there is no restore path.
         store.stop_processing_loops().await;
         {
             let mut loops = self.running_loops.lock().await;
@@ -403,62 +420,93 @@ impl CacheStore for LazyRocksCacheStore {
             }
         }
 
-        // Flush both RW loops so no in-flight operation still holds an Arc<DB> clone.
-        store.drain_rw_loops().await?;
+        // Flush both RW loops so in-flight serialized ops release their transient Arc<DB> clones.
+        // Bounded so a wedged RW loop cannot hang wipe forever while holding state.write().
+        if let Err(err) = tokio::time::timeout(WIPE_DRAIN_TIMEOUT, store.drain_rw_loops()).await {
+            log::warn!(
+                "Wiping cachestore: draining RW loops timed out ({:?}), continuing: {}",
+                WIPE_DRAIN_TIMEOUT,
+                err
+            );
+        }
 
-        // Wait until we are the sole owner of the store before closing it, so RocksDB releases
-        // the directory LOCK and the reopen below succeeds.
-        let deadline = Instant::now() + Duration::from_secs(30);
-        while Arc::strong_count(&store) > 1 {
+        // Wait until nothing else references the store or the underlying RocksDB, so that
+        // drop(store) closes the DB (releasing the directory LOCK) before we reopen. We watch
+        // the real Arc<DB> via db_strong_count() to catch detached out-of-queue spawn_blocking
+        // readers that the RW-loop drain above does not cover. Sleep-backoff, not a busy spin.
+        let deadline = Instant::now() + WIPE_CLOSE_TIMEOUT;
+        while Arc::strong_count(&store) > 1 || store.db_strong_count() > 1 {
             if Instant::now() >= deadline {
-                // Restore the store so the cachestore stays usable instead of corrupting it.
-                let mut loops = self.running_loops.lock().await;
-                *loops = store.clone().spawn_processing_loops();
-                *guard = LazyRocksCacheStoreState::Initialized { store };
+                // We already committed (loops stopped); the store cannot be restored cleanly.
+                // Leave it Closed and require a restart rather than risk removing/reopening the
+                // directory while the old DB is still open (which could corrupt the new DB).
                 return Err(CubeError::internal(
-                    "Unable to wipe Cache Store: store is still in use after draining loops"
+                    "Unable to wipe Cache Store: still in use after draining; restart the node"
                         .to_string(),
                 ));
             }
 
-            tokio::task::yield_now().await;
+            tokio::time::sleep(WIPE_CLOSE_POLL_INTERVAL).await;
         }
 
-        // Close the DB (drops the last Arc<DB>) and drop the folder.
+        // Close the DB (drops the last Arc<DB>) synchronously.
         drop(store);
 
-        if let Err(err) = std::fs::remove_dir_all(&self.path) {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                return Err(CubeError::internal(format!(
-                    "Unable to wipe Cache Store: failed to remove {}: {}",
-                    self.path, err
-                )));
+        // Remove the folder and reopen from scratch off the async executor (blocking syscalls +
+        // RocksDB open). Retry the open on a held directory LOCK to cover any residual detached
+        // Arc<DB> that outlived the wait above.
+        let path = self.path.clone();
+        let metastore_fs = self.metastore_fs.clone();
+        let config = self.config.clone();
+        let fresh = cube_ext::spawn_blocking(move || -> Result<Arc<RocksCacheStore>, CubeError> {
+            if let Err(err) = std::fs::remove_dir_all(&path) {
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    return Err(CubeError::internal(format!(
+                        "Unable to wipe Cache Store: failed to remove {}: {}",
+                        path, err
+                    )));
+                }
             }
-        }
 
-        // Reopen from scratch (create_if_missing, no remote download), run migrations and
-        // re-attach listeners.
-        let fresh = RocksCacheStore::new(
-            Path::new(&self.path),
-            self.metastore_fs.clone(),
-            self.config.clone(),
-        )?;
+            let reopen_deadline = Instant::now() + WIPE_REOPEN_TIMEOUT;
+            loop {
+                match RocksCacheStore::new(Path::new(&path), metastore_fs.clone(), config.clone()) {
+                    Ok(store) => return Ok(store),
+                    Err(err) if is_rocksdb_lock_error(&err) && Instant::now() < reopen_deadline => {
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        })
+        .await??;
+
+        // Run migrations / re-enable auto-compaction and re-attach listeners.
         fresh.check_all_indexes().await?;
         for listener in &self.listeners {
             fresh.add_listener(listener.clone()).await;
         }
 
-        // Persist a fresh full snapshot and move the remote cachestore-current pointer onto it,
-        // superseding the poisoned lineage.
-        fresh.upload_check_point().await?;
-
-        // Respawn the worker loops against the fresh store.
+        // Respawn the worker loops against the fresh store, then install it and release the
+        // state lock BEFORE the (remote, slow, fallible) snapshot upload.
         {
             let mut loops = self.running_loops.lock().await;
             *loops = fresh.clone().spawn_processing_loops();
         }
+        *guard = LazyRocksCacheStoreState::Initialized {
+            store: fresh.clone(),
+        };
+        drop(guard);
 
-        *guard = LazyRocksCacheStoreState::Initialized { store: fresh };
+        // Persist a fresh full snapshot and move the remote cachestore-current pointer onto it.
+        // Best-effort: the store is already installed and usable, and the upload loop retries;
+        // a transient remote error must not brick the cachestore.
+        if let Err(err) = fresh.upload_check_point().await {
+            log::warn!(
+                "Wiped cachestore reopened, but persisting the fresh snapshot failed (upload loop will retry): {}",
+                err
+            );
+        }
 
         Ok(())
     }
@@ -511,7 +559,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&local);
         let _ = std::fs::remove_dir_all(&remote);
 
-        let cachestore = build_lazy(Config::test("lazy_wipe_clears"), local.clone(), remote).await;
+        let cachestore = build_lazy(
+            Config::test("lazy_wipe_clears"),
+            local.clone(),
+            remote.clone(),
+        )
+        .await;
 
         cachestore
             .cache_set(
@@ -561,7 +614,11 @@ mod tests {
         // The local cachestore folder must exist again after the reopen.
         assert!(local.join("cachestore").exists());
 
+        // Stop the loops respawned by wipe so the test does not leak background tasks.
+        cachestore.stop_processing_loops().await;
+
         let _ = std::fs::remove_dir_all(&local);
+        let _ = std::fs::remove_dir_all(&remote);
 
         Ok(())
     }
@@ -571,8 +628,11 @@ mod tests {
         init_test_logger().await;
 
         let (local, remote) = test_dirs("lazy_wipe_remote");
-        let _ = std::fs::remove_dir_all(&local);
-        let _ = std::fs::remove_dir_all(&remote);
+        let local_pre = local.parent().unwrap().join("lazy_wipe_remote-local-pre");
+        let local2 = local.parent().unwrap().join("lazy_wipe_remote-local2");
+        for dir in [&local, &remote, &local_pre, &local2] {
+            let _ = std::fs::remove_dir_all(dir);
+        }
 
         let cachestore = build_lazy(
             Config::test("lazy_wipe_remote"),
@@ -588,18 +648,45 @@ mod tests {
             )
             .await?;
 
+        // Upload the seed to the remote so the test actually proves that wipe RESETS the remote
+        // (rather than that an empty remote yields an empty store). init() returns the inner
+        // store; the returned Arc is scoped so it is dropped before wipe (else it would inflate
+        // the strong count wipe waits on).
+        {
+            let store = cachestore.init().await?;
+            store.upload_check_point().await?;
+        }
+
+        // A fresh instance over the same remote must now see the seeded row (pre-wipe state).
+        {
+            let reloaded = build_lazy(
+                Config::test("lazy_wipe_remote"),
+                local_pre.clone(),
+                remote.clone(),
+            )
+            .await;
+            assert_eq!(reloaded.cache_all(None).await?.len(), 1);
+            reloaded.stop_processing_loops().await;
+        }
+
         cachestore.wipe().await?;
 
-        // A fresh instance pointing at the same remote (with an empty local dir) must download
-        // the post-wipe snapshot via cachestore-current and come back empty.
-        let local2 = local.parent().unwrap().join("lazy_wipe_remote-local2");
-        let _ = std::fs::remove_dir_all(&local2);
-
-        let reloaded = build_lazy(Config::test("lazy_wipe_remote"), local2.clone(), remote).await;
+        // After wipe, a fresh instance over the same remote must download the post-wipe snapshot
+        // via cachestore-current and come back empty.
+        let reloaded = build_lazy(
+            Config::test("lazy_wipe_remote"),
+            local2.clone(),
+            remote.clone(),
+        )
+        .await;
         assert_eq!(reloaded.cache_all(None).await?.len(), 0);
+        reloaded.stop_processing_loops().await;
 
-        let _ = std::fs::remove_dir_all(&local);
-        let _ = std::fs::remove_dir_all(&local2);
+        cachestore.stop_processing_loops().await;
+
+        for dir in [&local, &remote, &local_pre, &local2] {
+            let _ = std::fs::remove_dir_all(dir);
+        }
 
         Ok(())
     }

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -334,6 +334,10 @@ impl CacheStore for LazyRocksCacheStore {
     async fn rocksdb_properties(&self) -> Result<Vec<RocksPropertyRow>, CubeError> {
         self.init().await?.rocksdb_properties().await
     }
+
+    async fn wipe(&self) -> Result<(), CubeError> {
+        self.init().await?.wipe().await
+    }
 }
 
 crate::di_service!(LazyRocksCacheStore, [CacheStore]);

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -28,10 +28,11 @@ const WIPE_CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
 const WIPE_CLOSE_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const WIPE_REOPEN_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Best-effort detection of a RocksDB "directory lock is held" open error, used to retry the
-/// reopen while a detached out-of-queue operation still holds an `Arc<DB>` clone.
 fn is_rocksdb_lock_error(err: &CubeError) -> bool {
-    err.to_string().to_lowercase().contains("lock")
+    let msg = err.to_string();
+    msg.contains("lock hold by current process")
+        || msg.contains("While lock file")
+        || msg.contains("Resource temporarily unavailable")
 }
 
 pub enum LazyRocksCacheStoreState {
@@ -446,6 +447,12 @@ impl CacheStore for LazyRocksCacheStore {
                 ));
             }
 
+            log::warn!(
+                "Wiping cachestore: waiting for outstanding Cache Store references to be released before closing the DB (store strong count: {}, DB strong count: {})",
+                Arc::strong_count(&store),
+                store.db_strong_count()
+            );
+
             tokio::time::sleep(WIPE_CLOSE_POLL_INTERVAL).await;
         }
 
@@ -458,6 +465,7 @@ impl CacheStore for LazyRocksCacheStore {
         let path = self.path.clone();
         let metastore_fs = self.metastore_fs.clone();
         let config = self.config.clone();
+
         let fresh = cube_ext::spawn_blocking(move || -> Result<Arc<RocksCacheStore>, CubeError> {
             if let Err(err) = std::fs::remove_dir_all(&path) {
                 if err.kind() != std::io::ErrorKind::NotFound {
@@ -469,11 +477,12 @@ impl CacheStore for LazyRocksCacheStore {
             }
 
             let reopen_deadline = Instant::now() + WIPE_REOPEN_TIMEOUT;
+
             loop {
                 match RocksCacheStore::new(Path::new(&path), metastore_fs.clone(), config.clone()) {
                     Ok(store) => return Ok(store),
                     Err(err) if is_rocksdb_lock_error(&err) && Instant::now() < reopen_deadline => {
-                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        std::thread::sleep(Duration::from_millis(50));
                     }
                     Err(err) => return Err(err),
                 }
@@ -481,8 +490,8 @@ impl CacheStore for LazyRocksCacheStore {
         })
         .await??;
 
-        // Run migrations / re-enable auto-compaction and re-attach listeners.
         fresh.check_all_indexes().await?;
+
         for listener in &self.listeners {
             fresh.add_listener(listener.clone()).await;
         }
@@ -493,6 +502,7 @@ impl CacheStore for LazyRocksCacheStore {
             let mut loops = self.running_loops.lock().await;
             *loops = fresh.clone().spawn_processing_loops();
         }
+
         *guard = LazyRocksCacheStoreState::Initialized {
             store: fresh.clone(),
         };

--- a/rust/cubestore/cubestore/src/cachestore/lazy.rs
+++ b/rust/cubestore/cubestore/src/cachestore/lazy.rs
@@ -34,7 +34,7 @@ fn is_rocksdb_lock_error(err: &CubeError) -> bool {
 }
 
 pub enum LazyRocksCacheStoreState {
-    FromRemote {
+    Initializing {
         #[allow(dead_code)] // Receiver notified when this sender is dropped on transition
         init_flag: Sender<bool>,
     },
@@ -98,7 +98,7 @@ impl LazyRocksCacheStore {
 
         Ok(Arc::new(Self {
             init_signal: Some(init_signal),
-            state: tokio::sync::RwLock::new(LazyRocksCacheStoreState::FromRemote { init_flag }),
+            state: tokio::sync::RwLock::new(LazyRocksCacheStoreState::Initializing { init_flag }),
             path: path.to_string(),
             metastore_fs,
             config,
@@ -112,7 +112,7 @@ impl LazyRocksCacheStore {
         {
             let guard = self.state.read().await;
             match &*guard {
-                LazyRocksCacheStoreState::FromRemote { .. } => {}
+                LazyRocksCacheStoreState::Initializing { .. } => {}
                 LazyRocksCacheStoreState::Closed { .. } => {
                     return Err(CubeError::internal(
                         "Unable to initialize Cache Store on lazy call, it was closed".to_string(),
@@ -132,7 +132,7 @@ impl LazyRocksCacheStore {
 
         let mut guard = self.state.write().await;
         match &*guard {
-            LazyRocksCacheStoreState::FromRemote { .. } => {
+            LazyRocksCacheStoreState::Initializing { .. } => {
                 let store = RocksCacheStore::load_from_remote(
                     &self.path,
                     self.metastore_fs.clone(),
@@ -144,7 +144,7 @@ impl LazyRocksCacheStore {
                     store.add_listener(listener.clone()).await;
                 }
 
-                // Dropping the previous FromRemote (via replace) drops init_flag, which
+                // Dropping the previous Initializing (via replace) drops init_flag, which
                 // notifies run_processing_loops to spawn the processing loops.
                 *guard = LazyRocksCacheStoreState::Initialized {
                     store: store.clone(),
@@ -201,7 +201,7 @@ impl LazyRocksCacheStore {
             let mut guard = self.state.write().await;
             match &*guard {
                 LazyRocksCacheStoreState::Closed { .. } => None,
-                LazyRocksCacheStoreState::FromRemote { .. } => {
+                LazyRocksCacheStoreState::Initializing { .. } => {
                     *guard = LazyRocksCacheStoreState::Closed {};
                     None
                 }
@@ -450,9 +450,9 @@ impl CacheStore for LazyRocksCacheStore {
                         "Unable to wipe Cache Store, it was closed".to_string(),
                     ))
                 }
-                LazyRocksCacheStoreState::FromRemote { init_flag } => {
+                LazyRocksCacheStoreState::Initializing { init_flag } => {
                     // init() above guarantees Initialized; restore defensively.
-                    *guard = LazyRocksCacheStoreState::FromRemote { init_flag };
+                    *guard = LazyRocksCacheStoreState::Initializing { init_flag };
                     Err(CubeError::internal(
                         "Unable to wipe Cache Store, unexpected state".to_string(),
                     ))

--- a/rust/cubestore/cubestore/src/config/mod.rs
+++ b/rust/cubestore/cubestore/src/config/mod.rs
@@ -135,11 +135,7 @@ impl CubeServices {
 
             let rocks_cache_store = self.rocks_cache_store.clone().unwrap();
             futures.push(cube_ext::spawn(async move {
-                let loops = rocks_cache_store.spawn_processing_loops().await;
-
-                Self::wait_loops(loops).await?;
-
-                Ok(())
+                rocks_cache_store.run_processing_loops().await
             }));
 
             let cluster = self.cluster.clone();

--- a/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/test_utils.rs
@@ -923,6 +923,10 @@ impl CacheStore for CacheStoreMock {
     async fn rocksdb_properties(&self) -> Result<Vec<RocksPropertyRow>, CubeError> {
         panic!("CacheStore mock!")
     }
+
+    async fn wipe(&self) -> Result<(), CubeError> {
+        panic!("CacheStore mock!")
+    }
 }
 
 crate::di_service!(CacheStoreMock, [CacheStore]);

--- a/rust/cubestore/cubestore/src/sql/cachestore.rs
+++ b/rust/cubestore/cubestore/src/sql/cachestore.rs
@@ -175,6 +175,13 @@ impl CacheStoreSqlService {
                 self.cachestore.healthcheck().await?;
                 Ok(Arc::new(DataFrame::new(vec![], vec![])))
             }
+            CacheStoreCommand::Wipe => {
+                log::warn!(
+                    "Wiping cachestore state (SYSTEM CACHESTORE WIPE): truncating all tables and persisting a fresh snapshot"
+                );
+                self.cachestore.wipe().await?;
+                Ok(Arc::new(DataFrame::new(vec![], vec![])))
+            }
         }
     }
 

--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -218,6 +218,7 @@ pub enum CacheStoreCommand {
     Eviction,
     Info,
     Persist,
+    Wipe,
 }
 
 type QueryParameterHolder = Option<QueryParameter>;
@@ -605,6 +606,8 @@ impl<'a> CubeStoreParser<'a> {
             CacheStoreCommand::Info
         } else if self.parse_custom_token("healthcheck") {
             CacheStoreCommand::Healthcheck
+        } else if self.parse_custom_token("wipe") {
+            CacheStoreCommand::Wipe
         } else {
             return Err(ParserError::ParserError(
                 "Unknown cachestore command".to_string(),


### PR DESCRIPTION
Adds a SQL command to wipe unrecoverable cachestore state (CUB-3308). The cachestore can get stuck in a non-recoverable logical state, and there was previously no command to clear it and force a clean snapshot.

WIPE truncates all cachestore tables (cache_item, queue_item, queue_item_payload, queue_result) and then persists a fresh full checkpoint, moving the remote cachestore-current pointer to it (and pruning old snapshots) so the poisoned lineage is superseded and future boots load the clean state instead of re-hydrating the bad one.