### PR TITLE
docs: document sending email notifications to user groups

### DIFF
--- a/docs-mintlify/docs/explore-analyze/notifications.mdx
+++ b/docs-mintlify/docs/explore-analyze/notifications.mdx
@@ -33,8 +33,10 @@ scratch — the copy carries over the source schedule's notification settings.
 
 Toggle between two delivery channels:
 
-- **Email** — select multiple recipients from workspace users using a searchable
-  picker with checkboxes.
+- **Email** — select recipients using a searchable picker with checkboxes. The
+  picker is grouped into **Users** and **User groups** sections, so you can add
+  individual workspace users, entire [user groups][ref-user-groups], or a mix of
+  both.
 - **Slack** — select a Slack channel to post to. Requires connecting your Slack
   workspace first (one-time OAuth flow via **Connect to Slack**). Once
   connected, select a channel from a searchable picker.
@@ -59,9 +61,22 @@ notification card header before saving.
 
 ## Email notifications
 
-Email notifications are sent to selected workspace users after a scheduled
+Email notifications are sent to the selected recipients after a scheduled
 refresh completes. Each recipient receives a message with a link to the
 dashboard and the attached screenshot.
+
+### Recipients
+
+The recipient picker is split into two sections:
+
+- **Users** — individual workspace users.
+- **User groups** — [user groups][ref-user-groups]. A group is expanded to its
+  current members each time the notification is sent, so adding or removing
+  members takes effect on the next run without editing the schedule. The **User
+  groups** section only appears when your workspace has at least one user group.
+
+A recipient who is selected individually and also belongs to a selected group is
+emailed only once.
 
 ## Slack notifications
 
@@ -83,4 +98,4 @@ workspace has access to.
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
 [ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes
 [ref-duplicate]: /docs/explore-analyze/scheduled-refreshes#duplicating-a-schedule
-[ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes
+[ref-user-groups]: /admin/users-and-permissions/user-groups


### PR DESCRIPTION
## Description

Documents that dashboard scheduled-refresh **email** notifications can now be sent to **user groups** alongside individual users.

Changes to `docs-mintlify/docs/explore-analyze/notifications.mdx`:

- **Delivery channel** — the Email bullet now notes that the recipient picker is grouped into **Users** and **User groups** sections, so you can add individual workspace users, entire user groups, or a mix of both.
- **Email notifications** — new **Recipients** subsection describing the two picker sections and the behaviour that matters at send time:
  - A group is expanded to its **current** members each time the notification is sent, so membership changes take effect on the next run without editing the schedule.
  - The **User groups** section only appears when the workspace has at least one user group.
  - A recipient selected individually who is also a member of a selected group is emailed only once.
- Added a `[ref-user-groups]` cross-link to the [user groups](/admin/users-and-permissions/user-groups) page.
- Removed a stray duplicate `[ref-scheduled-refreshes]` link-reference definition that was left in this file's footer by the merge in #11246.

## Notes

Docs-only change. The link targets were verified against the existing pages (`user-groups.mdx`, matching the `[ref-roles]` link style already used on this page).

Recreated from the upstream repo (supersedes the fork-based #11285, which couldn't run the `review-with-tracking` check). Rebased onto current `master`.
