### PR TITLE
docs: document subscribing to scheduled-refresh notifications

### DIFF
--- a/docs-mintlify/docs/explore-analyze/notifications.mdx
+++ b/docs-mintlify/docs/explore-analyze/notifications.mdx
@@ -65,6 +65,14 @@ Email notifications are sent to the selected recipients after a scheduled
 refresh completes. Each recipient receives a message with a link to the
 dashboard and the attached screenshot.
 
+<Tip>
+
+Recipients don't have to be added by an editor. Anyone who can view the dashboard
+can [subscribe themselves][ref-subscribe] to a schedule's email notifications
+from the published dashboard.
+
+</Tip>
+
 ### Recipients
 
 The recipient picker is split into two sections:
@@ -99,3 +107,4 @@ workspace has access to.
 [ref-scheduled-refreshes]: /docs/explore-analyze/scheduled-refreshes
 [ref-duplicate]: /docs/explore-analyze/scheduled-refreshes#duplicating-a-schedule
 [ref-user-groups]: /admin/users-and-permissions/user-groups
+[ref-subscribe]: /docs/explore-analyze/scheduled-refreshes#subscribing-to-notifications

--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -7,7 +7,9 @@ description: Scheduled refreshes are available on Premium and Enterprise plans.
 
 Scheduled refreshes are available on [Premium and Enterprise plans](https://cube.dev/pricing).
 <br/ >Users need at least the [Explorer][ref-roles] role and Edit or Manage permission
-on the workbook to set up scheduled refreshes.
+on the workbook to set up scheduled refreshes. Anyone who can view the dashboard
+can open the sidebar to see its schedules and [subscribe to
+notifications](#subscribing-to-notifications).
 
 </Info>
 
@@ -24,6 +26,16 @@ send email or Slack messages with a dashboard screenshot after each refresh.
 From the Dashboard Builder, click the calendar icon in the toolbar to open the
 scheduled refreshes sidebar. From this sidebar, you can create new schedules,
 modify existing ones, or remove schedules you no longer need.
+
+The same calendar icon is also available on a published dashboard, so you can
+reach the sidebar without opening the builder. What you can do there depends on
+your permission on the workbook:
+
+- **Edit** or **Manage** — the full sidebar: create, edit, run, and delete
+  schedules.
+- **View only** — a read-only list of the configured schedules, where you can
+  [subscribe or unsubscribe](#subscribing-to-notifications) yourself from each
+  schedule's email notifications.
 
 <Warning>
 
@@ -103,6 +115,22 @@ duplicate it. There are two ways:
 
 Duplicates are independent schedules: the original is left unchanged, and the
 copy keeps the source schedule's enabled or disabled state.
+
+## Subscribing to notifications
+
+If a schedule sends [email notifications][ref-notifications], anyone who can view
+the dashboard can subscribe to it themselves — an editor does not have to add
+them as a recipient. Open the scheduled refreshes sidebar from the published
+dashboard and use the toggle on a schedule to subscribe or unsubscribe.
+Subscribing adds you to the schedule's email recipients; unsubscribing removes
+you. The change takes effect on the next run.
+
+The toggle appears only for schedules that email individual recipients — those
+with notifications enabled and the email delivery channel. Schedules that post to
+Slack deliver to a channel rather than to individuals, and schedules with
+notifications turned off send nothing, so there is nothing to subscribe to. If
+you are already subscribed, the toggle always remains available so that you can
+unsubscribe.
 
 ## Run phases
 

--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -126,11 +126,11 @@ Subscribing adds you to the schedule's email recipients; unsubscribing removes
 you. The change takes effect on the next run.
 
 The toggle appears only for schedules that email individual recipients — those
-with notifications enabled and the email delivery channel. Schedules that post to
-Slack deliver to a channel rather than to individuals, and schedules with
-notifications turned off send nothing, so there is nothing to subscribe to. If
-you are already subscribed, the toggle always remains available so that you can
-unsubscribe.
+with notifications enabled and the email delivery channel. A schedule delivers to
+either individual inboxes or a Slack channel, not both, so a schedule that posts
+to Slack (or that has notifications turned off) has nothing to subscribe to. If an
+editor switches a schedule to Slack, its existing subscriptions are cancelled;
+you can subscribe again if it is later switched back to email.
 
 ## Run phases
 


### PR DESCRIPTION
## Description

Documents that the **scheduled refreshes sidebar is now available on published dashboards**, and that anyone who can view a dashboard can **subscribe or unsubscribe themselves** to a schedule's email notifications — without an editor adding them as a recipient.

Changes to `docs-mintlify/docs/explore-analyze/`:

- **`scheduled-refreshes.mdx`**
  - Noted in the intro `<Info>` box that viewing schedules and subscribing to notifications only needs view access (setting schedules up still needs Edit/Manage).
  - Expanded **"Accessing scheduled refreshes"** to cover opening the sidebar from a published dashboard, and what each permission level can do there (Edit/Manage → full sidebar; View only → read-only list with a subscribe toggle).
  - New **"Subscribing to notifications"** section: how the per-schedule subscribe/unsubscribe toggle works, that it adds/removes you from the schedule's email recipients and takes effect on the next run, and when the toggle appears (email-channel schedules with notifications on — Slack/disabled schedules have nothing to subscribe to). Also notes that if an editor switches a schedule to Slack its existing subscriptions are cancelled, and you can subscribe again if it is later switched back to email.
- **`notifications.mdx`**
  - Added a `<Tip>` in the **Email notifications** section cross-linking the self-subscribe flow.

## Notes

Docs-only change. The `<Tip>`/`<Info>`/`<Warning>` components and all anchor/link targets were verified against existing usage on these pages.

Recreated from the upstream repo (supersedes the fork-based #11286, which couldn't run the `review-with-tracking` check). Rebased onto current `master`, on top of the merged #11246 (duplicating schedules) — the **Duplicating** and **Subscribing** sections coexist on `scheduled-refreshes.mdx`.
