### PR TITLE
docs: add concise-authoring guidance for docs contributions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ yarn dev    # Start the Mintlify dev server
   relevant `group` to appear in the sidebar).
 - Use Mintlify components: `<Note>`, `<Warning>`, `<Info>`, `<Tip>`, `<Steps>`/`<Step>`,
   `<CardGroup>`/`<Card>`. Internal links are root-relative (e.g. `/admin/ai/rules`).
+- Keep docs concise — most changes are small, surgical edits to existing pages, not new
+  pages or walls of text. Prefer editing an existing page over creating a new one.
 - See `docs-mintlify/CLAUDE.md` for full conventions.
 
 ## Architecture Overview

--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -245,6 +245,24 @@ Benchmarking the agent's answers against a known-correct ground truth.
   inline backticks for identifiers (`accessible_views`, `agents/rules/`).
 - **Paragraphs**: keep them short; use `-` bullet lists for multiple items.
 
+### Be concise; prefer surgical edits over new content
+
+**Be explicit with yourself about length: most doc changes are small.** Do not
+produce walls of text. Be less verbose. Write the shortest version that fully
+answers "how do I use this?" and stop.
+
+- **Default to editing existing pages, not creating new ones.** A new feature
+  usually extends a page that already exists — add a row to a table, a config
+  option to a reference page, a sentence to the relevant section. Search the
+  docs first and integrate there. Only create a new page when the topic
+  genuinely has no home.
+- **Do not pad.** No "Overview" / "Use cases" / "Best practices" scaffolding
+  for a small feature. A single config option is usually a paragraph plus a
+  code block — not a multi-section page.
+- **Say it once.** Don't restate the same point in prose and again in a
+  callout, and don't explain what the code sample already shows.
+- **One good example beats three near-identical ones.**
+
 ## File and frontmatter conventions
 
 - Content is `.mdx`, organized by topic directory (e.g. `admin/ai/`, `docs/explore-analyze/`).


### PR DESCRIPTION
## Summary

Adds guidance for contributors (and agents) that most documentation changes should be **small, surgical edits to existing pages** rather than new pages or walls of text — addressing a recurring flaw where small features get sprawling, over-scaffolded coverage.

## Changes

- **`docs-mintlify/CLAUDE.md`** — new `### Be concise; prefer surgical edits over new content` subsection under **Writing style**:
  - Be explicit about length; no walls of text; be less verbose.
  - Default to editing existing pages, not creating new ones.
  - Don't pad with boilerplate sections; say it once; one good example over three.
- **`CLAUDE.md`** (root) — one-line pointer in the docs section so the guidance is surfaced on every task, not just docs-specific work.

Docs-only change; no code or navigation impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)