### PR TITLE
docs: document undocumented recent features

### DIFF
--- a/docs-mintlify/docs/data-modeling/configuration.mdx
+++ b/docs-mintlify/docs/data-modeling/configuration.mdx
@@ -85,6 +85,18 @@ run against the data source.
 Backed by
 [`CUBEJS_DB_QUERY_TIMEOUT`](/reference/configuration/environment-variables#cubejs_db_query_timeout).
 
+## Auto-run
+
+The deployment-wide default for whether [Explore][ref-explore] and
+[Workbooks][ref-workbooks] tabs run their query automatically as you build it,
+or wait for you to click **Run query**. Defaults to on.
+
+A semantic view's [`meta.auto_run`][ref-view-auto-run] setting and a user's
+own per-tab toggle both take precedence over this deployment default.
+
+Backed by
+[`CUBEJS_AUTO_RUN_MODE`](/reference/configuration/environment-variables#cubejs_auto_run_mode).
+
 ## Applying changes
 
 Saving Model Configuration restarts the deployment's development-mode
@@ -98,3 +110,6 @@ pick up the changes on the next build or deploy.
 [ref-row-limit]: /reference/core-data-apis/queries#row-limit
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-environments-dev]: /admin/deployment/environments#development-environments
+[ref-explore]: /docs/explore-analyze/explore
+[ref-workbooks]: /docs/explore-analyze/workbooks/querying-data
+[ref-view-auto-run]: /reference/data-modeling/view#auto_run

--- a/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx
@@ -24,6 +24,11 @@ A data model author can change the default for a semantic view with the
 views that are expensive to query. You can still toggle auto-run back on at
 any time.
 
+An admin can also turn auto-run off by default for every tab in the
+deployment, from **Model Configuration**. Per-view and per-tab settings still
+take precedence over this deployment-wide default. See
+[Auto-run][ref-configuration-auto-run] in the Model Configuration reference.
+
 When a cell's value is too long for its column, it is truncated with an
 ellipsis. Hover over a truncated cell to see its full value in a tooltip.
 
@@ -322,4 +327,5 @@ behaves as intended.
 [ref-table-chart]: /docs/explore-analyze/charts/chart-types/table
 [ref-calculated-fields]: /docs/explore-analyze/workbooks/calculated-fields
 [ref-auto-run]: /reference/data-modeling/view#auto_run
+[ref-configuration-auto-run]: /docs/data-modeling/configuration#auto-run
 

--- a/docs-mintlify/embedding/iframe/analytics-chat.mdx
+++ b/docs-mintlify/embedding/iframe/analytics-chat.mdx
@@ -47,3 +47,24 @@ See [Signed embedding](/embedding/iframe/auth/signed) for the full session gener
 ## Personalize chat with user attributes
 
 When using signed embedding, you can pass [user attributes](/embedding/iframe/auth/signed#user-attributes) during session generation to personalize chat responses for each user — for example, scoping answers to a specific region, department, or tenant.
+
+## Customize the chat
+
+Add these query parameters to the embed URL to hide parts of the chat UI:
+
+| Parameter        | Effect                                             |
+| ----------------- | --------------------------------------------------- |
+| `hideNewChat=1`   | Hides the **New chat** button.                     |
+| `hideChatInput=1` | Hides the message input, for a read-only transcript. |
+| `hideHistory=1`   | Hides the **Chat History** button.                 |
+
+By default, the chat header shows a **Chat History** button that lists the
+user's past conversations (matched by `externalId` under signed embedding) so
+they can resume one instead of always starting fresh.
+
+To deep-link directly into a specific past conversation, pass its ID as
+`chatId` alongside `sessionId` on the short embed URL:
+
+```text
+https://your-tenant.cubecloud.dev/embed/chat?sessionId=YOUR_SESSION_ID&chatId=YOUR_CHAT_ID
+```

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -31,6 +31,20 @@ different for multitenant setups.
 | --------------- | ---------------------- | --------------------- |
 | A valid string  | `cubejs`               | `cubejs`              |
 
+## `CUBEJS_AUTO_RUN_MODE`
+
+The deployment-wide default for whether [Explore](/docs/explore-analyze/explore)
+and [Workbooks](/docs/explore-analyze/workbooks/querying-data) tabs run their
+query automatically as it's built, or wait for an explicit **Run query**. Set
+via the **Auto-run** switch in [Model Configuration](/docs/data-modeling/configuration#auto-run).
+A view's `meta.auto_run` setting and a user's per-tab toggle both take
+precedence over this default. Only the literal string `false` turns it off —
+any other value (including unset) is treated as on.
+
+| Possible Values | Default in Development | Default in Production |
+| ---------------- | ----------------------- | ----------------------- |
+| `true`, `false`  | `true`                   | `true`                   |
+
 ## `CUBEJS_AWS_KEY`
 
 The AWS Access Key ID to use for database connections.

--- a/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/reference.mdx
@@ -49,6 +49,19 @@ HAVING status = 'shipped'
 LIMIT 1 OFFSET 1;
 ```
 
+`SELECT DISTINCT ON (expression [, ...])` is also supported, with the same
+semantics as PostgreSQL: for each set of rows with matching values in the
+given expressions, only the first row is kept, using the order specified by
+`ORDER BY` (which must start with the `DISTINCT ON` expressions).
+
+Example:
+
+```sql
+SELECT DISTINCT ON (status) status, city
+FROM orders
+ORDER BY status, id DESC;
+```
+
 ### `EXPLAIN`
 
 Synopsis:


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required

**Description of Changes Made**

Found via a docs-audit pass cross-checking recent `cube-js/cube` and `cubejs-enterprise` commits against `docs-mintlify`. These three shipped features had no documentation:

- **`CUBEJS_AUTO_RUN_MODE`** — deployment-wide default for whether Explore/Workbooks tabs auto-run their query, configurable from Model Configuration. Documented in the [environment variables reference](docs-mintlify/reference/configuration/environment-variables.mdx) and the [Model Configuration page](docs-mintlify/docs/data-modeling/configuration.mdx), cross-linked from [Querying data](docs-mintlify/docs/explore-analyze/workbooks/querying-data.mdx).
- **`SELECT DISTINCT ON`** — now supported by the SQL API (Postgres semantics). Documented in the [SQL API reference](docs-mintlify/reference/core-data-apis/sql-api/reference.mdx).
- **Embedded Analytics Chat history** — `hideNewChat`/`hideChatInput`/`hideHistory` query params and `chatId` deep-linking for the embedded chat. Documented in [Analytics Chat](docs-mintlify/embedding/iframe/analytics-chat.mdx) (this page previously had no query-param documentation at all).

Two other candidates were checked and found to be **already documented** (no action needed): hiding the AI chat on embedded dashboards (`showDashboardChat`), and the STRING_AGG SQL function.

Two larger undocumented surfaces — the new native Rust Cube Cloud CLI, and the console's multi-language/i18n support — are broad enough to warrant dedicated pages rather than a quick edit; filed as separate tickets rather than included here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NBsyzxcTZJYcJMEGMiQty7)_