### PR TITLE
docs: document ?branch= deep link for the Data Model IDE

### DIFF
--- a/docs-mintlify/docs/data-modeling/data-model-ide.mdx
+++ b/docs-mintlify/docs/data-modeling/data-model-ide.mdx
@@ -86,6 +86,21 @@ want to delete, then open the switcher and click **Remove Branch**:
   <img src="https://ucarecdn.com/f1d37fe6-a6ae-4d78-a801-133639daf1ec/" alt="Delete a branch" />
 </Frame>
 
+### Sharing a link to a specific branch
+
+Add a `?branch=<name>` query parameter to a Data Model IDE URL to share a link
+that opens directly on that branch, for example:
+
+```
+https://<deployment-url>/d/<deployment-id>/model/files?branch=my-branch
+```
+
+Opening the link switches the viewer to `my-branch` once the branch list
+loads, then removes the parameter from the URL. It keeps the viewer's current
+mode — a read-only viewer stays read-only, and dev mode stays on if it was
+already on — but never turns on dev mode or creates a branch on its own. If
+the branch doesn't exist, you'll see an error toast instead.
+
 ## Generating data model files
 
 You can generate data model files when [creating a new


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

`cubedevinc/cubejs-enterprise` PR #13126 (`feat(console-ui): switch branch via ?branch= deep link on the model page`) added a `?branch=<name>` query parameter to the Data Model IDE page so a shared URL can open directly on a specific branch, but this wasn't documented anywhere.

Adds a short "Sharing a link to a specific branch" subsection to `docs-mintlify/docs/data-modeling/data-model-ide.mdx`, in the Git integration section right after the branch switcher, covering the param, its one-shot/self-stripping behavior, and that it preserves the viewer's current mode without force-entering dev mode or creating branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxTwgqCp92arbPTsakmQnw


---
_Generated by [Claude Code](https://claude.ai/code/session_01CxTwgqCp92arbPTsakmQnw)_