### PR TITLE
feat(cubesql): Support parsing date-only timestamp strings

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "arrow"
 version = "13.0.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=de57e9799dcfde7bdd02885e63b65e3499f192e5#de57e9799dcfde7bdd02885e63b65e3499f192e5"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=837ddde06037034056b9faced3d8ea7073529cfc#837ddde06037034056b9faced3d8ea7073529cfc"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "13.0.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=de57e9799dcfde7bdd02885e63b65e3499f192e5#de57e9799dcfde7bdd02885e63b65e3499f192e5"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=837ddde06037034056b9faced3d8ea7073529cfc#837ddde06037034056b9faced3d8ea7073529cfc"
 dependencies = [
  "arrow 13.0.0",
  "base64 0.13.1",

--- a/packages/cubejs-druid-driver/src/DruidQuery.ts
+++ b/packages/cubejs-druid-driver/src/DruidQuery.ts
@@ -57,6 +57,11 @@ export class DruidQuery extends BaseQuery {
 
     // Druid doesn't support ILIKE, so case-insensitive matching is emulated with LOWER(...) LIKE CONCAT(...)
     templates.expressions.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE LOWER({{ pattern }})';
+    // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z');
+    // TIME_PARSE without a pattern parses ISO-8601, which is also Druid's native
+    // timestamp format. The base template renders the value bare, which is invalid
+    // syntax
+    templates.expressions.timestamp_literal = 'TIME_PARSE(\'{{ value }}\')';
     delete templates.expressions.like_escape;
     templates.filters.like_pattern = 'CONCAT({% if start_wild %}\'%\'{% else %}\'\'{% endif %}, LOWER({{ value }}), {% if end_wild %}\'%\'{% else %}\'\'{% endif %})';
     templates.tesseract.ilike = 'LOWER({{ expr }}) {% if negated %}NOT {% endif %}LIKE {{ pattern }}';

--- a/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
+++ b/packages/cubejs-firebolt-driver/src/FireboltQuery.ts
@@ -51,6 +51,11 @@ export class FireboltQuery extends BaseQuery {
 
   public sqlTemplates() {
     const templates = super.sqlTemplates();
+    // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z');
+    // the TIMESTAMPTZ literal accepts a 'T' separator and the 'Z' UTC designator per
+    // Firebolt's documented ISO-8601/RFC-3339 grammar. The base template renders the
+    // value bare, which is invalid syntax
+    templates.expressions.timestamp_literal = 'TIMESTAMPTZ \'{{ value }}\'';
     templates.tesseract.bool_param_cast = 'CAST({{ expr }} AS BOOLEAN)';
     return templates;
   }

--- a/packages/cubejs-ksql-driver/src/KsqlQuery.ts
+++ b/packages/cubejs-ksql-driver/src/KsqlQuery.ts
@@ -65,6 +65,12 @@ export class KsqlQuery extends BaseQuery {
     // ksqlDB has no `||` string operator — concatenation and LIKE-pattern
     // wildcards must use CONCAT (mirrors concatStringsSql / KsqlFilter).
     templates.expressions.concat_strings = 'CONCAT({{ strings | join(\', \') }})';
+    // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z').
+    // ksqlDB silently returns NULL when casting strings with a trailing 'Z'
+    // (confluentinc/ksql#9094), so the markers are stripped and the UTC zone is passed
+    // to PARSE_TIMESTAMP explicitly. The base template renders the value bare, which
+    // is invalid syntax
+    templates.expressions.timestamp_literal = 'PARSE_TIMESTAMP(\'{{ value | replace("T", " ") | replace("Z", "") }}\', \'yyyy-MM-dd HH:mm:ss.SSS\', \'UTC\')';
     templates.filters.like_pattern =
       '{% if start_wild or end_wild %}CONCAT(' +
       '{% if start_wild %}\'%\', {% endif %}{{ value }}{% if end_wild %}, \'%\'{% endif %})' +

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4637,7 +4637,10 @@ export class BaseQuery {
         wrap_segment_select: '{{ expr }}',
         wrap_segment_filter: '{{ expr }}',
         rolling_window_expr_timestamp_cast: '{{ value }}',
-        timestamp_literal: '{{ value }}',
+        // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z').
+        // ANSI CAST of the quoted value is the most portable default; dialects override
+        // with their exact parsing construct. A bare unquoted value is never valid SQL
+        timestamp_literal: 'CAST(\'{{ value }}\' AS TIMESTAMP)',
         between: '{{ expr }} {% if negated %}NOT {% endif %}BETWEEN {{ low }} AND {{ high }}',
       },
       tesseract: {

--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.ts
@@ -281,6 +281,11 @@ export class MssqlQuery extends BaseQuery {
     templates.expressions.concat_strings = '{{ strings | join(\' + \' ) }}';
     // NOTE: this template contains a comma; two order expressions are being generated
     templates.expressions.sort = '{{ expr }} IS NULL {% if nulls_first %}DESC{% else %}ASC{% endif %}, {{ expr }} {% if asc %}ASC{% else %}DESC{% endif %}';
+    // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z');
+    // CONVERT style 127 is defined as exactly this format (yyyy-mm-ddThh:mi:ss.mmmZ,
+    // "ISO8601 with time zone Z"). The base template renders the value bare, which is
+    // invalid T-SQL syntax
+    templates.expressions.timestamp_literal = 'CONVERT(DATETIME2, \'{{ value }}\', 127)';
     templates.types.string = 'VARCHAR';
     templates.types.boolean = 'BIT';
     templates.types.integer = 'INT';

--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -196,6 +196,12 @@ export class MysqlQuery extends BaseQuery {
     // MySQL `/` returns DECIMAL even for integer operands; DIV discards the
     // fractional part (truncation toward zero), matching PostgreSQL (-5 DIV 2 = -2)
     templates.expressions.int_division = '({{ left }} DIV {{ right }})';
+    // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z').
+    // MySQL parses the 'T'/'Z' markers only with a "Truncated incorrect datetime value"
+    // warning and ignores the zone, so both markers are stripped instead. The driver
+    // pins the session time zone to UTC, which keeps the naive literal on the same
+    // instant. The base template renders the value bare, which is invalid MySQL syntax
+    templates.expressions.timestamp_literal = 'TIMESTAMP(\'{{ value | replace("T", " ") | replace("Z", "") }}\')';
     delete templates.expressions.ilike;
     templates.types.string = 'CHAR';
     templates.types.boolean = 'TINYINT';

--- a/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
@@ -221,6 +221,10 @@ export class OracleQuery extends BaseQuery {
     // Oracle `/` on NUMBER keeps the fractional part; TRUNC drops decimal digits
     // (truncation toward zero), matching PostgreSQL integer division
     templates.expressions.int_division = 'TRUNC({{ left }} / {{ right }})';
+    // Timestamp constants arrive as ISO-8601 UTC strings ('2021-01-01T00:00:00.000Z');
+    // the 'T'/'Z' markers are consumed as literal chunks in the format mask. The base
+    // template renders the value bare, which is invalid Oracle syntax
+    templates.expressions.timestamp_literal = 'TO_TIMESTAMP(\'{{ value }}\', \'YYYY-MM-DD"T"HH24:MI:SS.FF3"Z"\')';
     // Oracle does not support positional GROUP BY — group by expressions.
     templates.statements.group_by_exprs = '{{ group_by | map(attribute=\'expr\') | join(\', \') }}';
     // No `AS` before the FROM subquery alias, and Oracle row-limiting syntax.

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "13.0.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=de57e9799dcfde7bdd02885e63b65e3499f192e5#de57e9799dcfde7bdd02885e63b65e3499f192e5"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=837ddde06037034056b9faced3d8ea7073529cfc#837ddde06037034056b9faced3d8ea7073529cfc"
 dependencies = [
  "bitflags 1.3.2",
  "chrono",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=b01223b6454b0d72154d15a88aec76efc9da726d#b01223b6454b0d72154d15a88aec76efc9da726d"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "13.0.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=de57e9799dcfde7bdd02885e63b65e3499f192e5#de57e9799dcfde7bdd02885e63b65e3499f192e5"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=837ddde06037034056b9faced3d8ea7073529cfc#837ddde06037034056b9faced3d8ea7073529cfc"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "b01223b6454b0d72154d15a88aec76efc9da726d", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "d203d8771a9673fb676b44dce1f99e91634b4080", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -2928,6 +2928,19 @@ limit
                     ])),
                 }])
             ),
+            // DATE_ADD with a date-only string argument
+            (
+                "COUNT(*), DATE(order_date) AS __timestamp".to_string(),
+                "order_date >= DATE_ADD('2021-09-30', INTERVAL '-30' DAY) AND order_date < '2021-09-07'".to_string(),
+                Some(vec![V1LoadRequestQueryTimeDimension {
+                    dimension: "KibanaSampleDataEcommerce.order_date".to_string(),
+                    granularity: Some("day".to_string()),
+                    date_range: Some(json!(vec![
+                        "2021-08-31T00:00:00.000Z".to_string(),
+                        "2021-09-06T23:59:59.999Z".to_string()
+                    ])),
+                }])
+            ),
             // Column precedence vs projection alias
             (
                 "COUNT(*), DATE(order_date) AS order_date".to_string(),
@@ -15487,6 +15500,46 @@ ORDER BY "source"."str0" ASC
             !sql.contains("CAST(TRUNC("),
             "{}",
             "float division must not use expressions/int_division template, got: {sql}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_literal_from_date_only_string() {
+        if !Rewriter::sql_push_down_enabled() {
+            return;
+        }
+        init_testing_logger();
+
+        // MySQL-style timestamp_literal template: ISO-8601 'T'/'Z' markers are
+        // stripped with the replace filter. A date-only string cast to timestamp
+        // constant-folds, so the resulting constant must be rendered through the
+        // timestamp_literal template instead of being emitted bare
+        let templates = vec![(
+            "expressions/timestamp_literal".to_string(),
+            "TIMESTAMP('{{ value | replace(\"T\", \" \") | replace(\"Z\", \"\") }}')".to_string(),
+        )];
+
+        let query_plan = convert_select_to_query_plan_customized(
+            r#"
+            SELECT customer_gender
+            FROM KibanaSampleDataEcommerce
+            WHERE DATE_ADD(order_date, INTERVAL '2 DAY') < CAST('2021-01-01' AS TIMESTAMP)
+            GROUP BY 1
+            "#
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+            templates,
+        )
+        .await;
+
+        let request = query_plan
+            .as_logical_plan()
+            .find_cube_scan_wrapped_sql()
+            .request;
+        let request_json = serde_json::to_string(&request).unwrap();
+        assert!(
+            request_json.contains("TIMESTAMP('2021-01-01 00:00:00.000')"),
+            "{}", "timestamp literal must render through the timestamp_literal template, got: {request_json}"
         );
     }
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@d203d87, accepting date-only strings (e.g. `2026-06-24`) as timestamps, interpreted as midnight local time; consistent with the other timezone-less formats and with PostgreSQL, which accepts date-only input wherever a timestamp is expected. Related test is included.

In addition, `timestamp_literal` template has been fixed for several dialects; incorrect SQL generation wasn't detected by tests because date-only formats weren't transformed to Arrow primitive types, producing a `CAST` in the plan instead.