### PR TITLE
fix(cubesql): Keep PostgreSQL integer division semantics in pushdown SQL

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksQuery.ts
@@ -195,6 +195,9 @@ export class DatabricksQuery extends BaseQuery {
       "'DDD', '@DOY@'), 'Day', 'EEEE'), 'Dy', 'EEE'), 'DD', 'dd'), '@DOY@', 'DDD'), " +
       "'AM', 'a'), 'PM', 'a'))";
     templates.expressions.timestamp_literal = 'from_utc_timestamp(\'{{ value }}\', \'UTC\')';
+    // Spark `/` returns DOUBLE for integer operands; `div` returns the integral
+    // part of the division as BIGINT (truncation toward zero), matching PostgreSQL
+    templates.expressions.int_division = '({{ left }} div {{ right }})';
     templates.expressions.extract = '{% if date_part|lower == "epoch" %}unix_timestamp({{ expr }}){% else %}EXTRACT({{ date_part }} FROM {{ expr }}){% endif %}';
     templates.expressions.interval_single_date_part = 'INTERVAL \'{{ num }}\' {{ date_part }}';
     templates.quotes.identifiers = '`';

--- a/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
+++ b/packages/cubejs-duckdb-driver/src/DuckDBQuery.ts
@@ -69,6 +69,10 @@ export class DuckDBQuery extends BaseQuery {
     templates.functions.STRING_AGG = 'STRING_AGG({% if distinct %}DISTINCT {% endif %}{{ args[0] }}, COALESCE({{ args[1] }}, \'\'))';
     templates.expressions.like = '{{ expr }} {% if negated %}NOT {% endif %}LIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
     templates.expressions.ilike = '{{ expr }} {% if negated %}NOT {% endif %}ILIKE {{ pattern }}{% if default_escape %} ESCAPE \'\\\'{% endif %}';
+    // DuckDB `/` performs float division even for integer operands (since v0.8);
+    // `//` is integer division truncating toward zero (-7 // 2 = -3), matching
+    // PostgreSQL
+    templates.expressions.int_division = '({{ left }} // {{ right }})';
     return templates;
   }
 

--- a/packages/cubejs-pinot-driver/src/PinotQuery.ts
+++ b/packages/cubejs-pinot-driver/src/PinotQuery.ts
@@ -235,6 +235,12 @@ export class PinotQuery extends BaseQuery {
       '{% if limit is not none %}\nLIMIT {{ limit }}{% endif %}' +
       '{% if offset is not none %}\nOFFSET {{ offset }}{% endif %}';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
+    // Pinot `/` returns DOUBLE for integer operands, and intDiv() is floor
+    // division (intDiv(-7, 2) = -4). CAST to LONG truncates toward zero
+    // (CAST(-7 / 2 AS LONG) = -3), matching PostgreSQL integer division.
+    // Note: the division itself happens in DOUBLE, so results are exact only
+    // up to 2^53
+    templates.expressions.int_division = 'CAST({{ left }} / {{ right }} AS LONG)';
     templates.expressions.timestamp_literal = 'fromDateTime(\'{{ value }}\', \'yyyy-MM-dd\'\'T\'\'HH:mm:ss.SSS\'\'Z\'\'\')';
     // NOTE: this template contains a comma; two order expressions are being generated
     templates.expressions.sort = '{{ expr }} IS NULL {% if nulls_first %}DESC{% else %}ASC{% endif %}, {{ expr }} {% if asc %}ASC{% else %}DESC{% endif %}';

--- a/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/BaseQuery.js
@@ -4609,6 +4609,10 @@ export class BaseQuery {
         case: 'CASE{% if expr %} {{ expr }}{% endif %}{% for when, then in when_then %} WHEN {{ when }} THEN {{ then }}{% endfor %}{% if else_expr %} ELSE {{ else_expr }}{% endif %} END',
         is_null: '({{ expr }} IS {% if negate %}NOT {% endif %}NULL)',
         binary: '({{ left }} {{ op }} {{ right }})',
+        // Integer division with PostgreSQL semantics: truncation toward zero.
+        // Plain `/` is correct for dialects where int / int is integer division;
+        // dialects with decimal or float `/` must override this template
+        int_division: '({{ left }} / {{ right }})',
         sort: '{{ expr }} {% if asc %}ASC{% else %}DESC{% endif %} NULLS {% if nulls_first %}FIRST{% else %}LAST{% endif %}',
         order_by: '{% if index %} {{ index }} {% else %} {{ expr }} {% endif %} {% if asc %}ASC{% else %}DESC{% endif %}{% if nulls_first %} NULLS FIRST{% endif %}',
         cast: 'CAST({{ expr }} AS {{ data_type }})',

--- a/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/BigqueryQuery.ts
@@ -337,6 +337,9 @@ export class BigqueryQuery extends BaseQuery {
     delete templates.functions.PERCENTILECONT;
     templates.expressions.binary = '{% if op == \'%\' %}MOD({{ left }}, {{ right }}){% else %}({{ left }} {{ op }} {{ right }}){% endif %}';
     templates.expressions.interval = 'INTERVAL {{ interval }}';
+    // BigQuery `/` on INT64 operands returns FLOAT64; DIV() is integer division
+    // truncating toward zero, matching PostgreSQL (DIV(12, -7) = -1)
+    templates.expressions.int_division = 'DIV({{ left }}, {{ right }})';
     templates.expressions.extract = 'EXTRACT({% if date_part == \'DOW\' %}DAYOFWEEK{% elif date_part == \'DOY\' %}DAYOFYEAR{% else %}{{ date_part }}{% endif %} FROM {{ expr }})';
     templates.expressions.timestamp_literal = 'TIMESTAMP(\'{{ value }}\')';
     templates.expressions.rolling_window_expr_timestamp_cast = 'TIMESTAMP({{ value }})';

--- a/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/ClickHouseQuery.ts
@@ -279,6 +279,10 @@ export class ClickHouseQuery extends BaseQuery {
     delete templates.types.interval;
     delete templates.types.binary;
     templates.expressions.is_not_distinct_from = 'isNotDistinctFrom({{ left }}, {{ right }})';
+    // ClickHouse `/` always returns Float64; intDiv is integer division truncating
+    // toward zero, matching PostgreSQL (intDiv(-7, 2) = -3 despite docs saying
+    // "rounded down")
+    templates.expressions.int_division = 'intDiv({{ left }}, {{ right }})';
 
     templates.statements.time_series_select = 'SELECT parseDateTimeBestEffort(dates.f) date_from, parseDateTimeBestEffort(dates.t) date_to \n' +
     'FROM (\n' +

--- a/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/MysqlQuery.ts
@@ -193,6 +193,9 @@ export class MysqlQuery extends BaseQuery {
     templates.quotes.escape = '\\`';
     // NOTE: this template contains a comma; two order expressions are being generated
     templates.expressions.sort = '{{ expr }} IS NULL {% if nulls_first %}DESC{% else %}ASC{% endif %}, {{ expr }} {% if asc %}ASC{% else %}DESC{% endif %}';
+    // MySQL `/` returns DECIMAL even for integer operands; DIV discards the
+    // fractional part (truncation toward zero), matching PostgreSQL (-5 DIV 2 = -2)
+    templates.expressions.int_division = '({{ left }} DIV {{ right }})';
     delete templates.expressions.ilike;
     templates.types.string = 'CHAR';
     templates.types.boolean = 'TINYINT';

--- a/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/OracleQuery.ts
@@ -218,6 +218,9 @@ export class OracleQuery extends BaseQuery {
     templates.functions.UTCTIMESTAMP = 'SYS_EXTRACT_UTC(SYSTIMESTAMP)';
     // Oracle forbids `AS` before a table/subquery alias.
     templates.expressions.query_aliased = '{{ query }} {{ quoted_alias }}';
+    // Oracle `/` on NUMBER keeps the fractional part; TRUNC drops decimal digits
+    // (truncation toward zero), matching PostgreSQL integer division
+    templates.expressions.int_division = 'TRUNC({{ left }} / {{ right }})';
     // Oracle does not support positional GROUP BY — group by expressions.
     templates.statements.group_by_exprs = '{{ group_by | map(attribute=\'expr\') | join(\', \') }}';
     // No `AS` before the FROM subquery alias, and Oracle row-limiting syntax.

--- a/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/SnowflakeQuery.ts
@@ -115,6 +115,10 @@ export class SnowflakeQuery extends BaseQuery {
     templates.functions.BTRIM = 'TRIM({{ args_concat }})';
     templates.functions.STRING_AGG = 'LISTAGG({% if distinct %}DISTINCT {% endif %}{{ args_concat }})';
     templates.expressions.extract = 'EXTRACT({{ date_part }} FROM {{ expr }})';
+    // Snowflake `/` is decimal division even for integer operands (output scale
+    // is dividend scale + 6), while this template must keep PostgreSQL integer
+    // division semantics. TRUNC rounds toward zero, matching PostgreSQL.
+    templates.expressions.int_division = 'CAST(TRUNC({{ left }} / {{ right }}) AS BIGINT)';
     // Snowflake can't EXTRACT(EPOCH FROM <interval>), so the epoch of a timestamp
     // difference (left - right) is rendered as fractional seconds between them.
     // TIMESTAMPDIFF is measured once at microsecond granularity (no per-second

--- a/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/wrapper.rs
@@ -26,11 +26,17 @@ use cubeclient::models::{V1LoadRequestQuery, V1LoadRequestQueryJoinSubquery};
 use datafusion::logical_plan::{ExprVisitable, ExpressionVisitor, Recursion};
 use datafusion::{
     error::{DataFusionError, Result},
+    logical_expr::{ReturnTypeFunction, ScalarFunctionImplementation},
     logical_plan::{
-        plan::Extension, replace_col, Column, DFSchema, DFSchemaRef, Expr, GroupingSet, JoinType,
-        LogicalPlan, Operator, UserDefinedLogicalNode,
+        plan::Extension, replace_col, Column, DFSchema, DFSchemaRef, Expr, ExprRewritable,
+        ExprRewriter, ExprSchemable, GroupingSet, JoinType, LogicalPlan, Operator,
+        UserDefinedLogicalNode,
     },
-    physical_plan::{aggregates::AggregateFunction, functions::BuiltinScalarFunction},
+    physical_plan::{
+        aggregates::AggregateFunction,
+        functions::{BuiltinScalarFunction, Signature, Volatility},
+        udf::ScalarUDF,
+    },
     scalar::ScalarValue,
 };
 use futures::FutureExt;
@@ -672,6 +678,82 @@ pub struct SqlGenerationResult {
 }
 
 static DATE_PART_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[A-Za-z_ ]+$").unwrap());
+
+/// Marker function for integer division. DataFusion types `int / int` as integer
+/// division (PostgreSQL semantics: truncation toward zero), but `/` in some dialects
+/// (Snowflake, BigQuery, MySQL, ...) performs decimal or float division. Integer
+/// divisions are rewritten to this marker during SQL generation, and the marker is
+/// rendered with the `expressions/int_division` template, so each dialect can map it
+/// to a construct that keeps PostgreSQL semantics. The marker never reaches execution.
+const INT_DIVISION_MARKER: &str = "__int_division";
+
+static INT_DIVISION_UDF: LazyLock<Arc<ScalarUDF>> = LazyLock::new(|| {
+    let fun: ScalarFunctionImplementation = Arc::new(|_| {
+        Err(DataFusionError::Internal(format!(
+            "{INT_DIVISION_MARKER} marker is only used for SQL generation and can't be evaluated"
+        )))
+    });
+    let return_type: ReturnTypeFunction = Arc::new(|types| Ok(Arc::new(types[0].clone())));
+    Arc::new(ScalarUDF::new(
+        INT_DIVISION_MARKER,
+        &Signature::any(2, Volatility::Immutable),
+        &return_type,
+        &fun,
+    ))
+});
+
+fn is_integer_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+    )
+}
+
+/// Replaces `left / right` with the `__int_division` marker when both operands are
+/// integers per `schema`. Subtrees whose types can't be resolved are left unchanged.
+struct IntDivisionRewriter<'a> {
+    schema: &'a DFSchema,
+}
+
+impl ExprRewriter for IntDivisionRewriter<'_> {
+    fn mutate(&mut self, expr: Expr) -> Result<Expr> {
+        match expr {
+            Expr::BinaryExpr {
+                left,
+                op: Operator::Divide,
+                right,
+            } => {
+                let operand_is_integer = |operand: &Expr| {
+                    operand
+                        .get_type(self.schema)
+                        .map(|t| is_integer_type(&t))
+                        .unwrap_or(false)
+                };
+                let is_int_division = operand_is_integer(&left) && operand_is_integer(&right);
+                if is_int_division {
+                    Ok(Expr::ScalarUDF {
+                        fun: INT_DIVISION_UDF.clone(),
+                        args: vec![*left, *right],
+                    })
+                } else {
+                    Ok(Expr::BinaryExpr {
+                        left,
+                        op: Operator::Divide,
+                        right,
+                    })
+                }
+            }
+            _ => Ok(expr),
+        }
+    }
+}
 
 macro_rules! generate_sql_for_timestamp {
     (@generic $literal:ident, $value:ident, $value_block:expr, $sql_generator:expr, $sql_query:expr) => {
@@ -1515,6 +1597,34 @@ impl WrappedSelectNode {
         Ok((patches, other, sql_query))
     }
 
+    /// Rewrites integer divisions in `exprs` to the `__int_division` marker (see
+    /// [`INT_DIVISION_UDF`]). When a rewrite changes an expression, it is wrapped in an
+    /// alias with the original expression name, so generated column aliases stay stable.
+    fn rewrite_int_divisions(exprs: Vec<Expr>, input_schema: &DFSchema) -> Vec<Expr> {
+        exprs
+            .into_iter()
+            .map(|expr| {
+                let Ok(rewritten) = expr.clone().rewrite(&mut IntDivisionRewriter {
+                    schema: input_schema,
+                }) else {
+                    return expr;
+                };
+                if rewritten == expr {
+                    return expr;
+                }
+                match &rewritten {
+                    // Sort and alias expressions can't be wrapped in an alias, and
+                    // their names are not used for generated column aliases
+                    Expr::Sort { .. } | Expr::Alias(_, _) => rewritten,
+                    _ => match expr.name(input_schema) {
+                        Ok(name) => Expr::Alias(Box::new(rewritten), name),
+                        Err(_) => rewritten,
+                    },
+                }
+            })
+            .collect()
+    }
+
     async fn generate_columns(
         &self,
         meta: &MetaContext,
@@ -1556,9 +1666,22 @@ impl WrappedSelectNode {
                 ))
             })?
             .clone();
+
+        // Integer division type detection needs a schema that resolves input columns
+        // of this select: `from` combined with any join inputs
+        let mut input_schema = self.from.schema().as_ref().clone();
+        for (join_plan, _, _) in &self.joins {
+            input_schema = input_schema.join(join_plan.schema()).map_err(|e| {
+                CubeError::internal(format!(
+                    "Can't join schemas for wrapped select input: {}",
+                    e
+                ))
+            })?;
+        }
+
         let (projection, sql) = Self::generate_column_expr(
             schema.clone(),
-            self.projection_expr.iter().cloned(),
+            Self::rewrite_int_divisions(self.projection_expr.clone(), &input_schema),
             sql,
             generator.clone(),
             column_remapping,
@@ -1571,7 +1694,7 @@ impl WrappedSelectNode {
         let flat_group_expr = extract_exprlist_from_groupping_set(&self.group_expr);
         let (group_by, sql) = Self::generate_column_expr(
             schema.clone(),
-            flat_group_expr.clone(),
+            Self::rewrite_int_divisions(flat_group_expr.clone(), &input_schema),
             sql,
             generator.clone(),
             column_remapping,
@@ -1598,7 +1721,7 @@ impl WrappedSelectNode {
 
         let (aggregate, sql) = Self::generate_column_expr(
             schema.clone(),
-            aggr_expr.clone(),
+            Self::rewrite_int_divisions(aggr_expr.clone(), &input_schema),
             sql,
             generator.clone(),
             column_remapping,
@@ -1611,7 +1734,7 @@ impl WrappedSelectNode {
 
         let (filter, sql) = Self::generate_column_expr(
             schema.clone(),
-            self.filter_expr.iter().cloned(),
+            Self::rewrite_int_divisions(self.filter_expr.clone(), &input_schema),
             sql,
             generator.clone(),
             column_remapping,
@@ -1624,7 +1747,7 @@ impl WrappedSelectNode {
 
         let (window, sql) = Self::generate_column_expr(
             schema.clone(),
-            self.window_expr.iter().cloned(),
+            Self::rewrite_int_divisions(self.window_expr.clone(), &input_schema),
             sql,
             generator.clone(),
             column_remapping,
@@ -1661,7 +1784,7 @@ impl WrappedSelectNode {
 
         let (order, sql) = Self::generate_column_expr(
             schema.clone(),
-            order_expr,
+            Self::rewrite_int_divisions(order_expr, &input_schema),
             sql,
             generator.clone(),
             column_remapping,
@@ -2969,6 +3092,37 @@ impl WrappedSelectNode {
                 "generate_sql_for_scalar_udf called with non-ScalarUDF expr".to_string(),
             ));
         };
+        if fun.name == INT_DIVISION_MARKER {
+            let [left, right]: [Expr; 2] = args.try_into().map_err(|args| {
+                DataFusionError::Internal(format!(
+                    "{INT_DIVISION_MARKER} marker expects exactly 2 arguments, got {args:?}"
+                ))
+            })?;
+            let (left, sql_query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                left,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            let (right, sql_query) = Self::generate_sql_for_expr(
+                sql_query,
+                sql_generator.clone(),
+                right,
+                push_to_cube_context,
+                subqueries,
+            )?;
+            let resulting_sql = sql_generator
+                .get_sql_templates()
+                .int_division_expr(left, right)
+                .map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "Can't generate SQL for integer division: {}",
+                        e
+                    ))
+                })?;
+            return Ok((resulting_sql, sql_query));
+        }
         let date_part_err = |dp| {
             DataFusionError::Internal(format!(
                 "Can't generate SQL for scalar function: date part '{}' is not supported",

--- a/rust/cubesql/cubesql/src/compile/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/mod.rs
@@ -15431,6 +15431,66 @@ ORDER BY "source"."str0" ASC
     }
 
     #[tokio::test]
+    async fn test_int_division_template() {
+        init_testing_logger();
+
+        let int_division_templates = vec![(
+            "expressions/int_division".to_string(),
+            "CAST(TRUNC({{ left }} / {{ right }}) AS BIGINT)".to_string(),
+        )];
+
+        // Integer / integer division must be rendered through the
+        // expressions/int_division template to keep PostgreSQL integer division
+        // semantics on dialects where `/` is decimal or float division
+        let query_plan = convert_select_to_query_plan_customized(
+            "
+            SELECT customer_gender, COUNT(*) / NULLIF(COUNT(DISTINCT notes), 0) AS ratio
+            FROM KibanaSampleDataEcommerce
+            WHERE LOWER(customer_gender) = 'test'
+            GROUP BY 1
+            ORDER BY 2 DESC
+            LIMIT 100
+            "
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+            int_division_templates.clone(),
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        assert!(
+            sql.contains("CAST(TRUNC("),
+            "{}",
+            "int/int division must use expressions/int_division template, got: {sql}"
+        );
+
+        // Float division must stay on the plain binary expression template
+        let query_plan = convert_select_to_query_plan_customized(
+            "
+            SELECT customer_gender, SUM(taxful_total_price) / NULLIF(COUNT(DISTINCT notes), 0) AS ratio
+            FROM KibanaSampleDataEcommerce
+            WHERE LOWER(customer_gender) = 'test'
+            GROUP BY 1
+            ORDER BY 2 DESC
+            LIMIT 100
+            "
+            .to_string(),
+            DatabaseProtocol::PostgreSQL,
+            int_division_templates,
+        )
+        .await;
+
+        let logical_plan = query_plan.as_logical_plan();
+        let sql = logical_plan.find_cube_scan_wrapped_sql().wrapped_sql.sql;
+        assert!(
+            !sql.contains("CAST(TRUNC("),
+            "{}",
+            "float division must not use expressions/int_division template, got: {sql}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_string_multiply_interval() -> Result<(), CubeError> {
         init_testing_logger();
 

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -672,6 +672,7 @@ pub fn sql_generator(
             SqlTemplates::new(
                 vec![
                     ("functions/COALESCE".to_string(), "COALESCE({{ args_concat }})".to_string()),
+                    ("functions/NULLIF".to_string(), "NULLIF({{ args_concat }})".to_string()),
                     ("functions/SUM".to_string(), "SUM({{ args_concat }})".to_string()),
                     ("functions/MIN".to_string(), "MIN({{ args_concat }})".to_string()),
                     ("functions/MAX".to_string(), "MAX({{ args_concat }})".to_string()),
@@ -733,6 +734,7 @@ OFFSET {{ offset }}{% endif %}"#.to_string(),
                         "{{expr}} {{quoted_alias}}".to_string(),
                     ),
                     ("expressions/binary".to_string(), "({{ left }} {{ op }} {{ right }})".to_string()),
+                    ("expressions/int_division".to_string(), "({{ left }} / {{ right }})".to_string()),
                     ("expressions/is_null".to_string(), "({{ expr }} IS {% if negate %}NOT {% endif %}NULL)".to_string()),
                     ("expressions/case".to_string(), "CASE{% if expr %} {{ expr }}{% endif %}{% for when, then in when_then %} WHEN {{ when }} THEN {{ then }}{% endfor %}{% if else_expr %} ELSE {{ else_expr }}{% endif %} END".to_string()),
                     ("expressions/sort".to_string(), "{{ expr }} {% if asc %}ASC{% else %}DESC{% endif %}{% if nulls_first %} NULLS FIRST {% endif %}".to_string()),

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -765,6 +765,13 @@ impl SqlTemplates {
         )
     }
 
+    pub fn int_division_expr(&self, left: String, right: String) -> Result<String, CubeError> {
+        self.render_template(
+            "expressions/int_division",
+            context! { left => left, right => right },
+        )
+    }
+
     pub fn is_null_expr(&self, expr: String, negate: bool) -> Result<String, CubeError> {
         self.render_template(
             "expressions/is_null",


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR renders integer division in pushdown SQL through a new `expressions/int_division` template so that dialects where `/` is decimal or float division (Snowflake, BigQuery, etc.) keep PostgreSQL integer division semantics (truncation toward zero) instead of returning fractional values that fail Int64 decoding as silent `NULL`s. Related test is included.