### PR TITLE
fix(api-gateway): pass job data source when checking pre-agg queue status

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -1210,7 +1210,7 @@ class ApiGateway {
   ): Promise<false | string> {
     let inQueue = false;
     let status: string = 'n/a';
-    const queuedList = await orchestrator.getPreAggregationQueueStates();
+    const queuedList = await orchestrator.getPreAggregationQueueStates(job.dataSource);
     queuedList.forEach((item) => {
       if (
         item.queryHandler &&

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -18,6 +18,7 @@ import {
   AdapterApiMock
 } from './mocks';
 import { ApiScopesTuple } from '../src/types/auth';
+import { PreAggJob } from '../src/types/request';
 
 const logger = (type, message) => console.log({ type, ...message });
 
@@ -1183,6 +1184,57 @@ describe('API Gateway', () => {
       res = await req;
       expect(res.status).toEqual(400);
       expect(res.body.error.includes('Cannot parse selector date range')).toBeTruthy();
+    });
+
+    // https://github.com/cube-js/cube/issues/11313
+    test('job queue status is reported per job data source, not only for the default one', async () => {
+      // Constructed off the prototype (bypassing the constructor, which requires a full
+      // native SQL server) since getPreAggJobQueueStatus doesn't use instance state.
+      const apiGateway = Object.create(ApiGateway.prototype);
+
+      const job: PreAggJob = {
+        request: 'request-id',
+        context: { securityContext: {} },
+        preagg: 'orders_test.main',
+        table: 'orders_test_main',
+        target: 'orders_test_main_20200101',
+        structure: 'structure-version',
+        content: 'content-version',
+        updated: 1,
+        key: [],
+        status: 'scheduled',
+        timezone: 'UTC',
+        dataSource: 'test_ds',
+      };
+
+      // Mimics QueryOrchestrator#getPreAggregationQueueStates, which defaults
+      // its dataSource argument to 'default' and only returns queue entries
+      // that were scheduled on the requested data source's queue.
+      const orchestrator = {
+        getPreAggregationQueueStates: jest.fn((dataSource = 'default') => {
+          if (dataSource !== job.dataSource) {
+            return [];
+          }
+          return [{
+            queryHandler: 'query',
+            query: {
+              requestId: job.request,
+              newVersionEntry: {
+                table_name: job.table,
+                structure_version: job.structure,
+                content_version: job.content,
+                last_updated_at: job.updated,
+              },
+            },
+            status: ['active'],
+          }];
+        }),
+      };
+
+      const status = await (apiGateway as any).getPreAggJobQueueStatus(orchestrator, job);
+
+      expect(orchestrator.getPreAggregationQueueStates).toHaveBeenCalledWith(job.dataSource);
+      expect(status).toEqual('processing');
     });
   });
 

--- a/packages/cubejs-server-core/src/core/OrchestratorApi.ts
+++ b/packages/cubejs-server-core/src/core/OrchestratorApi.ts
@@ -289,8 +289,8 @@ export class OrchestratorApi {
     return this.orchestrator.checkPartitionsBuildRangeCache(queryBody);
   }
 
-  public async getPreAggregationQueueStates() {
-    return this.orchestrator.getPreAggregationQueueStates();
+  public async getPreAggregationQueueStates(dataSource?: string) {
+    return this.orchestrator.getPreAggregationQueueStates(dataSource);
   }
 
   public async cancelPreAggregationQueriesFromQueue(queryKeys: string[], dataSource: string) {

--- a/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
+++ b/packages/cubejs-server-core/test/unit/OrchestratorApi.test.ts
@@ -1,0 +1,18 @@
+import { OrchestratorApi } from '../../src/core/OrchestratorApi';
+
+describe('OrchestratorApi', () => {
+  // https://github.com/cube-js/cube/issues/11313
+  test('getPreAggregationQueueStates forwards dataSource to the orchestrator', async () => {
+    const api = Object.create(OrchestratorApi.prototype);
+    const getPreAggregationQueueStates = jest.fn(async () => []);
+    api.orchestrator = { getPreAggregationQueueStates };
+
+    await api.getPreAggregationQueueStates('test_ds');
+    expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith('test_ds');
+
+    // QueryOrchestrator#getPreAggregationQueueStates defaults an undefined
+    // dataSource to 'default', so calls without one keep working.
+    await api.getPreAggregationQueueStates();
+    expect(getPreAggregationQueueStates).toHaveBeenLastCalledWith(undefined);
+  });
+});


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #11313

**Description of Changes Made**

When polling pre-aggregation build jobs via the Orchestration API (`POST /cubejs-api/v1/pre-aggregations/jobs`, `action: get`), builds on named (non-default) data sources reported `missing_partition` for the entire duration of a healthy build, while builds on the default data source correctly reported `processing`.

Root cause: `ApiGateway#getPreAggJobQueueStatus` called `orchestrator.getPreAggregationQueueStates()` without arguments, so `QueryOrchestrator#getPreAggregationQueueStates(dataSource = 'default')` only ever inspected the default data source's queue. Jobs on named data sources were never matched in the queue and fell through to the table-existence check, which returns `missing_partition` while the target table does not exist yet.

Fix: pass `job.dataSource` (already present on the job object) to `getPreAggregationQueueStates`.

Also adds a unit test in `packages/cubejs-api-gateway/test/index.test.ts` that reproduces the bug: it fails on the previous behavior (queue states requested with no data source argument) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTFSSej9SP4JTbWBxZKgBq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTFSSej9SP4JTbWBxZKgBq)_