### PR TITLE
docs: clarify conditional formatting behavior under column pivots

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -273,6 +273,8 @@ The **Conditional formatting** tab applies cell or row styling based on conditio
 
 To make a background transparent, open the color picker and clear the hex value.
 
+A rule can apply to just its source column, to selected columns, or to the entire row. Under a column pivot, a row spans several values of the same measure (one per pivot combination), so a row-spanning rule (**Entire row** or **Selected columns**) styles each measure cell by its own combination's value. Cells with no single value to test — row headers, row dimensions, and any rule whose source dimension has been pivoted into columns — are left unstyled.
+
 {/* TODO screenshot: conditional formatting panel with a condition configured (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ### Color scale


### PR DESCRIPTION
## Summary

Documents how conditional-formatting rules behave under a column pivot in the table visualization: a row-spanning rule (**Entire row** / **Selected columns**) styles each measure cell by its own pivot combination's value, and leaves cells with no single value to test — row headers, row dimensions, and rules sourced on a dimension pivoted into columns — unstyled.

Adds one short paragraph to the Conditional formatting section of the table chart page.

## Test plan

- [x] Prose only; renders in the Conditional formatting section of `explore-analyze/charts/chart-types/table.mdx`