### PR TITLE
docs: document workspace search and Chats History source filter

### DIFF
--- a/docs-mintlify/admin/monitoring/chats-history.mdx
+++ b/docs-mintlify/admin/monitoring/chats-history.mdx
@@ -4,6 +4,8 @@ description: Admins can access users chat history through Admin → Chats Histor
 ---
 
 It's possible to search specific chats by the first message content or chat UUID.
+You can also filter the list by user type, creation date, and source
+(**Web**, **MCP**, **Slack**, **Scheduled**, or **API**).
 
 <video
   autoPlay

--- a/docs-mintlify/docs/organize-content/folders.mdx
+++ b/docs-mintlify/docs/organize-content/folders.mdx
@@ -63,6 +63,14 @@ workspace.
 types — at least one workbook, one dashboard, and one exploration visible
 in the list. */}
 
+## Searching your workspace
+
+Use the search box in the Workspace page toolbar to quickly find a workbook,
+dashboard, or exploration by name, no matter how deeply it's nested. Results
+are grouped by content type and show each item's folder location, so you can
+jump straight to it without browsing the folder tree. Selecting a result
+navigates you directly to that item.
+
 ## Moving content into folders
 
 To move a workbook, dashboard, or exploration into a folder, open the


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Two small, surgical docs additions for shipped-but-undocumented features found while auditing recent product changes against docs-mintlify:

- `docs/organize-content/folders.mdx`: documents the Workspace page's search box (finds workbooks/dashboards/explorations by name across the whole folder tree, groups results by type, shows each result's folder location, navigates on select).
- `admin/monitoring/chats-history.mdx`: documents the filters available on the Chats History admin page — user type, creation date range, and the new source filter (Web, MCP, Slack, Scheduled, API).

Both are additive UI capabilities with no prior mention anywhere in the docs; no existing content was inaccurate, so these are pure additions rather than corrections.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BajmBG2PUEsNB45xNjZWFU)_