### PR TITLE
fix(native): Jinja - forward kwargs on sync Python function/method calls

### DIFF
--- a/packages/cubejs-backend-native/src/python/runtime.rs
+++ b/packages/cubejs-backend-native/src/python/runtime.rs
@@ -1,6 +1,6 @@
 use crate::cross::CLRepr;
 use crate::python::neon_py::*;
-use crate::python::utils::PyAnyHelpers;
+use crate::python::utils::{split_positional_and_kwargs, PyAnyHelpers};
 use crate::tokio_runtime_node;
 use cubesql::CubeError;
 use futures::FutureExt;
@@ -133,16 +133,7 @@ impl PyRuntime {
 
         let task_block = panic::AssertUnwindSafe(|| {
             Python::with_gil(move |py| -> PyResult<PyScheduledFunResult> {
-                let mut prep_tuple = Vec::with_capacity(args.len());
-                let mut kwargs_dict_opt = None;
-
-                for arg in args {
-                    if arg.is_kwarg() {
-                        kwargs_dict_opt = Some(arg.into_py_dict(py)?);
-                    } else {
-                        prep_tuple.push(arg.into_py(py)?);
-                    }
-                }
+                let (prep_tuple, kwargs_dict_opt) = split_positional_and_kwargs(py, args)?;
 
                 let py_args = PyTuple::new_bound(py, prep_tuple);
                 let py_kwargs = kwargs_dict_opt.as_ref();

--- a/packages/cubejs-backend-native/src/python/utils.rs
+++ b/packages/cubejs-backend-native/src/python/utils.rs
@@ -5,10 +5,7 @@ use pyo3::types::{PyDict, PyFunction, PyString, PyTuple};
 use pyo3::{ffi, AsPyPointer};
 use std::ffi::c_int;
 
-/// Splits minijinja call arguments into a positional tuple and an optional
-/// kwargs dict, so `fn(key=value)` reaches Python as a keyword argument rather
-/// than a positional kwargs dict. Mirrors the async path in runtime.rs.
-fn split_positional_and_kwargs(
+pub(crate) fn split_positional_and_kwargs(
     py: Python<'_>,
     arguments: Vec<CLRepr>,
 ) -> PyResult<(Vec<PyObject>, Option<Bound<'_, PyDict>>)> {

--- a/packages/cubejs-backend-native/src/python/utils.rs
+++ b/packages/cubejs-backend-native/src/python/utils.rs
@@ -5,11 +5,9 @@ use pyo3::types::{PyDict, PyFunction, PyString, PyTuple};
 use pyo3::{ffi, AsPyPointer};
 use std::ffi::c_int;
 
-/// Splits synchronously-collected minijinja arguments into a positional tuple
-/// and an optional kwargs dict. Keyword arguments (`fn(key=value)`) arrive as a
-/// dedicated kwargs CLRepr and must be forwarded as Python kwargs, not appended
-/// to the positional tuple — otherwise the callee receives the kwargs dict as a
-/// positional value. Mirrors the function-call path in runtime.rs.
+/// Splits minijinja call arguments into a positional tuple and an optional
+/// kwargs dict, so `fn(key=value)` reaches Python as a keyword argument rather
+/// than a positional kwargs dict. Mirrors the async path in runtime.rs.
 fn split_positional_and_kwargs(
     py: Python<'_>,
     arguments: Vec<CLRepr>,

--- a/packages/cubejs-backend-native/src/python/utils.rs
+++ b/packages/cubejs-backend-native/src/python/utils.rs
@@ -1,21 +1,40 @@
 use crate::cross::*;
 use pyo3::exceptions::{PyNotImplementedError, PySystemError};
 use pyo3::prelude::*;
-use pyo3::types::{PyFunction, PyString, PyTuple};
+use pyo3::types::{PyDict, PyFunction, PyString, PyTuple};
 use pyo3::{ffi, AsPyPointer};
 use std::ffi::c_int;
 
-pub fn python_fn_call_sync(py_fun: &Py<PyFunction>, arguments: Vec<CLRepr>) -> PyResult<CLRepr> {
-    Python::with_gil(|py| {
-        let mut args_tuple = Vec::with_capacity(arguments.len());
+/// Splits synchronously-collected minijinja arguments into a positional tuple
+/// and an optional kwargs dict. Keyword arguments (`fn(key=value)`) arrive as a
+/// dedicated kwargs CLRepr and must be forwarded as Python kwargs, not appended
+/// to the positional tuple — otherwise the callee receives the kwargs dict as a
+/// positional value. Mirrors the function-call path in runtime.rs.
+fn split_positional_and_kwargs(
+    py: Python<'_>,
+    arguments: Vec<CLRepr>,
+) -> PyResult<(Vec<PyObject>, Option<Bound<'_, PyDict>>)> {
+    let mut args_tuple = Vec::with_capacity(arguments.len());
+    let mut kwargs_dict_opt: Option<Bound<PyDict>> = None;
 
-        for arg in arguments {
+    for arg in arguments {
+        if arg.is_kwarg() {
+            kwargs_dict_opt = Some(arg.into_py_dict(py)?);
+        } else {
             args_tuple.push(arg.into_py(py)?);
         }
+    }
+
+    Ok((args_tuple, kwargs_dict_opt))
+}
+
+pub fn python_fn_call_sync(py_fun: &Py<PyFunction>, arguments: Vec<CLRepr>) -> PyResult<CLRepr> {
+    Python::with_gil(|py| {
+        let (args_tuple, kwargs_dict_opt) = split_positional_and_kwargs(py, arguments)?;
 
         let tuple = PyTuple::new_bound(py, args_tuple);
 
-        let call_res = py_fun.call1(py, tuple)?;
+        let call_res = py_fun.call_bound(py, tuple, kwargs_dict_opt.as_ref())?;
 
         if call_res.is_coroutine()? {
             Err(PyErr::new::<PyNotImplementedError, _>(
@@ -29,15 +48,11 @@ pub fn python_fn_call_sync(py_fun: &Py<PyFunction>, arguments: Vec<CLRepr>) -> P
 
 pub fn python_obj_call_sync(py_fun: &PyObject, arguments: Vec<CLRepr>) -> PyResult<CLRepr> {
     Python::with_gil(|py| {
-        let mut args_tuple = Vec::with_capacity(arguments.len());
-
-        for arg in arguments {
-            args_tuple.push(arg.into_py(py)?);
-        }
+        let (args_tuple, kwargs_dict_opt) = split_positional_and_kwargs(py, arguments)?;
 
         let tuple = PyTuple::new_bound(py, args_tuple);
 
-        let call_res = py_fun.call1(py, tuple)?;
+        let call_res = py_fun.call_bound(py, tuple, kwargs_dict_opt.as_ref())?;
 
         if call_res.is_coroutine()? {
             Err(PyErr::new::<PyNotImplementedError, _>(
@@ -58,15 +73,11 @@ where
     N: IntoPy<Py<PyString>>,
 {
     Python::with_gil(|py| {
-        let mut args_tuple = Vec::with_capacity(arguments.len());
-
-        for arg in arguments {
-            args_tuple.push(arg.into_py(py)?);
-        }
+        let (args_tuple, kwargs_dict_opt) = split_positional_and_kwargs(py, arguments)?;
 
         let tuple = PyTuple::new_bound(py, args_tuple);
 
-        let call_res = py_fun.call_method1(py, name, tuple)?;
+        let call_res = py_fun.call_method_bound(py, name, tuple, kwargs_dict_opt.as_ref())?;
 
         if call_res.is_coroutine()? {
             Err(PyErr::new::<PyNotImplementedError, _>(

--- a/packages/cubejs-backend-native/test/__snapshots__/jinja.test.ts.snap
+++ b/packages/cubejs-backend-native/test/__snapshots__/jinja.test.ts.snap
@@ -194,7 +194,8 @@ exports[`Jinja (new api) render arguments-test.yml.jinja: arguments-test.yml.jin
   method_kwargs1: \\"arg1: first value, arg2: second value, kwarg:(three=3 arg)\\"
   method_kwargs2: \\"arg1: first value, arg2: second value, kwarg:(four=4 arg,three=3 arg)\\"
   method_named_arguments1: \\"arg1: 1 arg, arg2: 2 arg\\"
-  method_named_arguments2: \\"arg1: 1 arg, arg2: 2 arg\\""
+  method_named_arguments2: \\"arg1: 1 arg, arg2: 2 arg\\"
+  callable_kwargs: \\"arg1: first value, arg2: second value, kwarg:(three=3 arg)\\""
 `;
 
 exports[`Jinja (new api) render data-model.yml.jinja: data-model.yml.jinja 1`] = `
@@ -258,7 +259,7 @@ dump:
 exports[`Jinja (new api) render template_error_python.jinja: template_error_python.jinja 1`] = `
 [Error: could not render block: Call error: Internal Error: Python error: Exception: Random Exception
 Traceback (most recent call last):
-  File "jinja-instance.py", line 131, in throw_exception
+  File "jinja-instance.py", line 142, in throw_exception
 
 ------------------------- template_error_python.jinja -------------------------
    3 | 3

--- a/packages/cubejs-backend-native/test/__snapshots__/jinja.test.ts.snap
+++ b/packages/cubejs-backend-native/test/__snapshots__/jinja.test.ts.snap
@@ -190,7 +190,11 @@ exports[`Jinja (new api) render arguments-test.yml.jinja: arguments-test.yml.jin
   arg_kwargs2: \\"arg1: first value, arg2: second value, kwarg:(four=4 arg,three=3 arg)\\"
   arg_kwargs3: \\"arg1: first value, arg2: second value, kwarg:(five=5 arg,four=4 arg,three=3 arg)\\"
   arg_named_arguments1: \\"arg1: 1 arg, arg2: 2 arg\\"
-  arg_named_arguments2: \\"arg1: 1 arg, arg2: 2 arg\\""
+  arg_named_arguments2: \\"arg1: 1 arg, arg2: 2 arg\\"
+  method_kwargs1: \\"arg1: first value, arg2: second value, kwarg:(three=3 arg)\\"
+  method_kwargs2: \\"arg1: first value, arg2: second value, kwarg:(four=4 arg,three=3 arg)\\"
+  method_named_arguments1: \\"arg1: 1 arg, arg2: 2 arg\\"
+  method_named_arguments2: \\"arg1: 1 arg, arg2: 2 arg\\""
 `;
 
 exports[`Jinja (new api) render data-model.yml.jinja: data-model.yml.jinja 1`] = `
@@ -254,7 +258,7 @@ dump:
 exports[`Jinja (new api) render template_error_python.jinja: template_error_python.jinja 1`] = `
 [Error: could not render block: Call error: Internal Error: Python error: Exception: Random Exception
 Traceback (most recent call last):
-  File "jinja-instance.py", line 120, in throw_exception
+  File "jinja-instance.py", line 131, in throw_exception
 
 ------------------------- template_error_python.jinja -------------------------
    3 | 3

--- a/packages/cubejs-backend-native/test/jinja.test.ts
+++ b/packages/cubejs-backend-native/test/jinja.test.ts
@@ -102,6 +102,7 @@ suite('Python model', () => {
       new_safe_string: expect.any(Object),
       new_object_from_dict: expect.any(Object),
       load_class_model: expect.any(Object),
+      load_callable: expect.any(Object),
       throw_exception: expect.any(Object),
     });
 

--- a/packages/cubejs-backend-native/test/templates/arguments-test.yml.jinja
+++ b/packages/cubejs-backend-native/test/templates/arguments-test.yml.jinja
@@ -3,6 +3,7 @@
 {%- set my_map = {'field_a' : 5, 'field_b' : 15} -%}
 {%- set my_int_tuple = new_int_tuple() -%}
 {%- set my_str_tuple = new_str_tuple() -%}
+{%- set my_model = load_class_model() -%}
 
 test:
   arg_sum_integers_int_int: {{ arg_sum_integers(1, 1) }}
@@ -20,3 +21,7 @@ test:
   arg_kwargs3: {{ arg_kwargs("first value", "second value", three="3 arg", four="4 arg", five="5 arg") }}
   arg_named_arguments1: {{ arg_named_arguments(arg2="2 arg", arg1="1 arg") }}
   arg_named_arguments2: {{ arg_named_arguments(arg1="1 arg", arg2="2 arg") }}
+  method_kwargs1: {{ my_model.method_kwargs("first value", "second value", three="3 arg") }}
+  method_kwargs2: {{ my_model.method_kwargs("first value", "second value", three="3 arg", four="4 arg") }}
+  method_named_arguments1: {{ my_model.method_named_arguments(arg2="2 arg", arg1="1 arg") }}
+  method_named_arguments2: {{ my_model.method_named_arguments(arg1="1 arg", arg2="2 arg") }}

--- a/packages/cubejs-backend-native/test/templates/arguments-test.yml.jinja
+++ b/packages/cubejs-backend-native/test/templates/arguments-test.yml.jinja
@@ -4,6 +4,7 @@
 {%- set my_int_tuple = new_int_tuple() -%}
 {%- set my_str_tuple = new_str_tuple() -%}
 {%- set my_model = load_class_model() -%}
+{%- set my_callable = load_callable() -%}
 
 test:
   arg_sum_integers_int_int: {{ arg_sum_integers(1, 1) }}
@@ -25,3 +26,4 @@ test:
   method_kwargs2: {{ my_model.method_kwargs("first value", "second value", three="3 arg", four="4 arg") }}
   method_named_arguments1: {{ my_model.method_named_arguments(arg2="2 arg", arg1="1 arg") }}
   method_named_arguments2: {{ my_model.method_named_arguments(arg1="1 arg", arg2="2 arg") }}
+  callable_kwargs: {{ my_callable("first value", "second value", three="3 arg") }}

--- a/packages/cubejs-backend-native/test/templates/jinja-instance.py
+++ b/packages/cubejs-backend-native/test/templates/jinja-instance.py
@@ -103,6 +103,17 @@ class ExampleClassModelA:
   def get_name_method(self):
     return "example"
 
+  # Mirrors cube_dbt's model.as_dimensions(skip=[...]) — a method invoked with
+  # keyword arguments. Regression coverage for CUB-2659: kwargs on object-method
+  # calls must reach Python as kwargs, not as a positional dict.
+  def method_kwargs(self, arg1, arg2, **kwargs):
+    kwargs_str = ",".join(f"{key}={value}" for key, value in sorted(kwargs.items()))
+
+    return "arg1: " + arg1 + ", arg2: " + arg2 + ", kwarg:(" + kwargs_str + ")"
+
+  def method_named_arguments(self, arg1, arg2):
+    return "arg1: " + arg1 + ", arg2: " + arg2
+
 @template.function
 def load_class_model():
   return ExampleClassModelA()

--- a/packages/cubejs-backend-native/test/templates/jinja-instance.py
+++ b/packages/cubejs-backend-native/test/templates/jinja-instance.py
@@ -99,6 +99,17 @@ async def load_data():
   }
   return api_response
 
+class ExampleCallable:
+  # Invoked as `obj(...)` in a template — exercises python_obj_call_sync.
+  def __call__(self, arg1, arg2, **kwargs):
+    kwargs_str = ",".join(f"{key}={value}" for key, value in sorted(kwargs.items()))
+
+    return "arg1: " + arg1 + ", arg2: " + arg2 + ", kwarg:(" + kwargs_str + ")"
+
+@template.function
+def load_callable():
+  return ExampleCallable()
+
 class ExampleClassModelA:
   def get_name_method(self):
     return "example"


### PR DESCRIPTION
## Summary

- Keyword arguments passed to Python functions/methods from Jinja templates on the **synchronous** call path were flattened into the positional tuple instead of being forwarded as kwargs. The callee received the kwargs dict as a positional value, so e.g. `model.as_dimensions(skip=['id'])` reached Python as `as_dimensions({'skip': ['id']})` — the `skip` list never applied, producing surprising results (e.g. a column that should have been skipped still rendered).
- The async function-call path (`process_task` in `runtime.rs`) already split kwargs correctly (#9276); the three sync helpers in `python/utils.rs` (`python_fn_call_sync`, `python_obj_call_sync`, `python_obj_method_call_sync`) did not. This brings them to parity: a shared `split_positional_and_kwargs` partitions args by `is_kwarg()` into a positional tuple + optional `PyDict`, and the calls switch from `call1`/`call_method1` (positional-only) to `call_bound`/`call_method_bound` (kwargs-aware).
- No behavior change for positional-only calls (empty kwargs → `None`, identical to before).

## Test plan

- [x] Added method-call-with-kwargs coverage to `arguments-test.yml.jinja` (a new `ExampleClassModelA.method_kwargs` / `method_named_arguments` invoked with keyword args, including out-of-order named args) — snapshot confirms kwargs now resolve by name.
- [x] `yarn native:build-debug-python`, `yarn tsc`, `cargo fmt --check`, `cargo clippy --features python`, `yarn lint` all clean.
- [x] Jinja test suite green (17/17).
- [ ] CI must pass.
