### PR TITLE
fix(tesseract): Emit GROUP BY for non-windowed Aggregate stages in ungrouped queries

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_measure_calculation.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/physical_plan_builder/processors/multi_stage_measure_calculation.rs
@@ -1,6 +1,8 @@
 use super::super::context::PushDownBuilderContext;
 use super::super::{LogicalNodeProcessor, ProcessableNode};
-use crate::logical_plan::{MultiStageCalculationWindowFunction, MultiStageMeasureCalculation};
+use crate::logical_plan::{
+    MultiStageCalculationType, MultiStageCalculationWindowFunction, MultiStageMeasureCalculation,
+};
 use crate::physical_plan::ReferencesBuilder;
 use crate::physical_plan::{Expr, MemberExpression, QueryPlan, SelectBuilder};
 use crate::physical_plan_builder::PhysicalPlanBuilder;
@@ -58,7 +60,18 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageMeasureCalculation>
             select_builder.add_projection_member(measure, alias);
         }
 
-        if !measure_calculation.is_ungrouped() {
+        // A non-windowed Aggregate stage projects plain aggregate functions
+        // (e.g. `sum(...)`) next to its dimensions, so the select must be
+        // grouped by those dimensions regardless of the query-level ungrouped
+        // flag — the enclosing FullKeyAggregate join broadcasts the stage
+        // output back to detail rows, keeping ungrouped semantics intact.
+        // Rank / Calculate / windowed stages render window functions or plain
+        // expressions and stay valid without GROUP BY.
+        let renders_plain_aggregates = measure_calculation.calculation_type()
+            == &MultiStageCalculationType::Aggregate
+            && measure_calculation.window_function_to_use()
+                == &MultiStageCalculationWindowFunction::None;
+        if !measure_calculation.is_ungrouped() || renders_plain_aggregates {
             let group_by = all_dimensions
                 .iter()
                 .map(|dim| -> Result<_, CubeError> {
@@ -66,6 +79,8 @@ impl<'a> LogicalNodeProcessor<'a, MultiStageMeasureCalculation>
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             select_builder.set_group_by(group_by);
+        }
+        if !measure_calculation.is_ungrouped() {
             select_builder.set_order_by(
                 self.builder
                     .make_order_by(measure_calculation.schema(), measure_calculation.order_by())?,

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -249,6 +249,16 @@ cubes:
                 - orders.status
                 - orders.created_at.month
 
+          # group_by-locked sum over a non-sum-rollable input
+          # (count_distinct): not window-path eligible, so the Aggregate
+          # stage renders a plain sum() over the FullKeyAggregate join.
+          - name: unique_customers_group_by_status
+            type: sum
+            sql: "{CUBE.unique_customers}"
+            multi_stage: true
+            group_by:
+                - orders.status
+
           - name: amount_grain_keep_only_status
             type: sum
             sql: "{CUBE.total_amount}"

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__ungrouped__ungrouped_group_by_locked_aggregate_with_dimension.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__ungrouped__ungrouped_group_by_locked_aggregate_with_dimension.snap
@@ -1,0 +1,9 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/ungrouped.rs
+expression: result
+---
+orders__category | orders__unique_customers_group_by_status
+-----------------+-----------------------------------------
+books            | 30                                      
+clothing         | 30                                      
+electronics      | 30

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/ungrouped.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/ungrouped.rs
@@ -57,6 +57,37 @@ async fn test_ungrouped_with_dimension() {
     }
 }
 
+// An ungrouped query selecting a group_by-locked Aggregate measure whose
+// input is not sum-rollable (count_distinct) goes through the
+// FullKeyAggregate JOIN model: the measure stage projects the query
+// dimensions next to a plain sum(). That stage must be grouped even though
+// the query itself is ungrouped — otherwise databases enforcing SQL
+// grouping rules (e.g. Postgres) reject the statement. This is exactly the
+// shape BI tools emit when browsing a table through the SQL API.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ungrouped_group_by_locked_aggregate_with_dimension() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.unique_customers_group_by_status
+        dimensions:
+          - orders.category
+        ungrouped: true
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert!(
+        sql.contains("GROUP BY"),
+        "the Aggregate stage projects sum() next to bare dimension columns \
+         and must be grouped even in an ungrouped query, got: {sql}"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
 // Cross-product issue: ungrouped mode prevents aggregation in both
 // current and shifted CTEs. The JOIN between them produces a cartesian
 // product — Feb has 5 current rows × 5 shifted Jan rows = 25 rows,


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Issue Reference this PR resolves**

Fixes #11327

**Description of Changes Made**

An ungrouped SQL API query (bare `SELECT` without `GROUP BY`, the shape BI tools emit when browsing a table) selecting a `group_by`/`reduce_by`-locked multi-stage measure plus any dimension produced invalid SQL: the measure's Aggregate stage projected plain `sum(...)` next to bare dimension columns with no `GROUP BY`, so databases enforcing SQL grouping rules (e.g. Postgres) rejected the statement. Full trace in #11327.

The fix follows from what the stage renders: a **non-windowed Aggregate stage projects plain aggregate functions by construction**, so its select must be grouped by its projected dimensions regardless of the query-level `ungrouped` flag. Ungrouped semantics are unaffected — the enclosing `FullKeyAggregate` join broadcasts the stage output back to detail rows. Rank / Calculate / windowed stages are untouched: they render window functions or plain expressions and are valid without `GROUP BY`. `ORDER BY` behavior is unchanged.

Changes:
- `physical_plan_builder/processors/multi_stage_measure_calculation.rs`: emit `GROUP BY` when the stage is grouped **or** renders plain aggregates (`calculation_type == Aggregate && window_function_to_use == None`).
- `test_fixtures/.../integration_multi_stage.yaml`: add `unique_customers_group_by_status` — a `group_by`-locked `sum` over `count_distinct`, i.e. a non-sum-rollable input that is not window-path eligible and therefore hits the plain-aggregate JOIN model (existing ungrouped tests only covered Calculate-type / window-path measures, which are valid without `GROUP BY`).
- `tests/integration/multi_stage/ungrouped.rs`: regression test — fails on master (`assert sql.contains("GROUP BY")`; the whole statement previously had none), passes with the fix; also executes against Postgres under the `integration-postgres` feature.

Verification: `cargo test -p cubesqlplanner` — 1076 passed, 0 failed (new test red on master, green with the fix).
