### PR TITLE
fix(cubesql): Support `GROUP BY ()` empty grouping set

### DIFF
--- a/packages/cubejs-backend-native/Cargo.lock
+++ b/packages/cubejs-backend-native/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "arrow 13.0.0",
  "chrono",
@@ -1073,7 +1073,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "arrow 13.0.0",
  "ordered-float 2.10.1",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "ahash 0.7.8",
  "arrow 13.0.0",

--- a/rust/cubesql/Cargo.lock
+++ b/rust/cubesql/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "cube-ext"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "arrow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "arrow",
  "ordered-float 2.10.0",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-data-access"
 version = "1.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "ahash 0.7.8",
  "arrow",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "7.0.0"
-source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=d203d8771a9673fb676b44dce1f99e91634b4080#d203d8771a9673fb676b44dce1f99e91634b4080"
+source = "git+https://github.com/cube-js/arrow-datafusion.git?rev=ee20ad38796f4a9966ff58b9ace425c7488459e9#ee20ad38796f4a9966ff58b9ace425c7488459e9"
 dependencies = [
  "ahash 0.7.8",
  "arrow",

--- a/rust/cubesql/cubesql/Cargo.toml
+++ b/rust/cubesql/cubesql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cube.dev"
 
 [dependencies]
 arc-swap = "1"
-datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "d203d8771a9673fb676b44dce1f99e91634b4080", default-features = false, features = [
+datafusion = { git = 'https://github.com/cube-js/arrow-datafusion.git', rev = "ee20ad38796f4a9966ff58b9ace425c7488459e9", default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }

--- a/rust/cubesql/cubesql/src/compile/test/test_cube_scan.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_cube_scan.rs
@@ -1,4 +1,4 @@
-use cubeclient::models::V1LoadRequestQuery;
+use cubeclient::models::{V1LoadRequestQuery, V1LoadRequestQueryFilterItem};
 use pretty_assertions::assert_eq;
 
 use crate::compile::{
@@ -223,4 +223,50 @@ async fn cubescan_limit_offset_limit_offset() {
             }
         );
     }
+}
+
+/// GROUP BY () is an empty grouping set, equivalent to aggregation without GROUP BY
+#[tokio::test]
+async fn cubescan_empty_group_by_tuple() {
+    init_testing_logger();
+
+    let query_plan = convert_select_to_query_plan(
+        // language=PostgreSQL
+        r#"
+        SELECT
+            MEASURE(count),
+            MEASURE(maxPrice)
+        FROM
+            KibanaSampleDataEcommerce
+        WHERE customer_gender = 'female'
+        GROUP BY ()
+        LIMIT 100
+        "#
+        .to_string(),
+        DatabaseProtocol::PostgreSQL,
+    )
+    .await;
+
+    let logical_plan = query_plan.as_logical_plan();
+    assert_eq!(
+        logical_plan.find_cube_scan().request,
+        V1LoadRequestQuery {
+            measures: Some(vec![
+                "KibanaSampleDataEcommerce.count".to_string(),
+                "KibanaSampleDataEcommerce.maxPrice".to_string(),
+            ]),
+            dimensions: Some(vec![]),
+            segments: Some(vec![]),
+            order: Some(vec![]),
+            limit: Some(100),
+            filters: Some(vec![V1LoadRequestQueryFilterItem {
+                member: Some("KibanaSampleDataEcommerce.customer_gender".to_string()),
+                operator: Some("equals".to_string()),
+                values: Some(vec!["female".to_string()]),
+                or: None,
+                and: None,
+            }]),
+            ..Default::default()
+        }
+    );
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR bumps cube-js/arrow-datafusion@ee20ad3, fixing `GROUP BY ()` queries failing with `Planning Error: Initial planning error: This feature is not implemented: Unsupported ast node Tuple([]) in sqltorel`: `GROUP BY ()` is a valid PostgreSQL empty grouping set equivalent to aggregation without `GROUP BY`. Related test is included.