### PR TITLE
docs: document recent CLI, sheets/excel, and Azure availability changes

### DIFF
--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -49,8 +49,8 @@ You can review its [support terms][ref-free-tier-support] and [limits][ref-cloud
 **Starter product tier targets low-scale production that is not business-critical.**
 
 It offers a [Dedicated deployment][ref-cloud-deployment-prod-cluster], the ability
-to use third-party packages from the npm registry, AWS and GCP support in select
-regions, pre-aggregations of up to 150GB in size, auto-suspend controls, and
+to use third-party packages from the npm registry, AWS, GCP, and Azure support in
+select regions, pre-aggregations of up to 150GB in size, auto-suspend controls, and
 [Semantic Layer Sync][ref-sls] with a single BI tool (such as Preset or Metabase).
 
 You can review its [pricing][cube-pricing], [support
@@ -62,8 +62,8 @@ terms][ref-starter-tier-support], and [limits][ref-cloud-limits].
 
 It offers everything in the [Starter product tier](#starter) as well as enabling
 the use of [Multi-cluster deployments][ref-cloud-deployment-prod-multicluster],
-support for [custom domains][ref-cloud-custom-domains], AWS and GCP support
-in all regions. Cube Cloud provides a 99.95% uptime SLA for this product tier.
+support for [custom domains][ref-cloud-custom-domains], AWS, GCP, and Azure
+support in all regions. Cube Cloud provides a 99.95% uptime SLA for this product tier.
 
 You can review its [pricing][cube-pricing], [support
 terms][ref-premium-tier-support], and [limits][ref-cloud-limits].
@@ -75,7 +75,7 @@ deployments with more significant security and compliance needs.**
 
 It offers everything in the [Premium product tier](#premium) as well as [Semantic Layer
 Sync][ref-sls] with unlimited supported BI tools, SAML
-support for [single sign-on][ref-sso], Azure support for all regions, [dedicated
+support for [single sign-on][ref-sso], [dedicated
 infrastructure][ref-dedicated-infra], [VPC peering][ref-cloud-vpc-peering],
 [monitoring integrations][ref-monitoring-integrations], and [role-based access
 control][ref-cloud-acl]. Cube Cloud provides a 99.99% uptime SLA for this product tier.

--- a/docs-mintlify/admin/deployment/providers/index.mdx
+++ b/docs-mintlify/admin/deployment/providers/index.mdx
@@ -13,9 +13,9 @@ Cube Cloud works with all three major cloud providers:
 
 <Info>
 
-AWS and GCP are available on [all plans](https://cube.dev/pricing).
-Azure is available on [Enterprise plan](https://cube.dev/pricing).
-[Contact us](https://cube.dev/contact) for details.
+AWS, GCP, and Azure are all available on [all plans](https://cube.dev/pricing).
+Region availability may vary by provider and plan; [contact
+us](https://cube.dev/contact) for details.
 
 </Info>
 

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -112,7 +112,7 @@ folder — results are grouped by type and show each item's folder location,
 and selecting one navigates you straight to it.
 
 Click **Refresh** to manually refresh the data in the report's location.
-Click **Edit** to chnage the query or the location.
+Click **Edit** to change the query or the location.
 
 <Frame>
   <img src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/" />

--- a/docs-mintlify/docs/integrations/google-sheets.mdx
+++ b/docs-mintlify/docs/integrations/google-sheets.mdx
@@ -106,7 +106,10 @@ by clicking **Save**.
 ## Work with saved reports
 
 Go to the add-on menu and click **View saved reports** to see a list of
-reports.
+reports. Use the search box above the list to quickly find a folder or
+exploration by name across your whole deployment, not just the current
+folder — results are grouped by type and show each item's folder location,
+and selecting one navigates you straight to it.
 
 Click **Refresh** to manually refresh the data in the report's location.
 Click **Edit** to chnage the query or the location.
@@ -114,6 +117,12 @@ Click **Edit** to chnage the query or the location.
 <Frame>
   <img src="https://ucarecdn.com/c8d490c6-80bf-44fe-9233-45121a7c4088/" />
 </Frame>
+
+If a report has filters applied, an admin can turn on **Show applied filters
+in reports** (Settings → Spreadsheet Add-ins) to make the filter state
+visible on the sheet itself. When enabled, a summary of active filters is
+added above the table, and filtered columns are marked "(filtered)" in
+their header, both when the report is inserted and after **Refresh**.
 
 You can also manage saved reports in the **[Saved Reports][ref-saved-reports]** page
 in Cube Cloud.

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -114,7 +114,10 @@ by clicking **Save**.
 ## Work with saved reports
 
 Go to the add-in menu and click **View saved reports** to see a list of
-reports.
+reports. Use the search box above the list to quickly find a folder or
+exploration by name across your whole deployment, not just the current
+folder — results are grouped by type and show each item's folder location,
+and selecting one navigates you straight to it.
 
 Click **Refresh** to manually refresh the data in the report's location.
 Click **Edit** to chnage the query or the location.
@@ -122,6 +125,12 @@ Click **Edit** to chnage the query or the location.
 <Frame>
   <img src="https://ucarecdn.com/167abe25-635c-4fa6-b4a2-c090aa533f3c/" />
 </Frame>
+
+If a report has filters applied, an admin can turn on **Show applied filters
+in reports** (Settings → Spreadsheet Add-ins) to make the filter state
+visible on the sheet itself. When enabled, a summary of active filters is
+added above the table, and filtered columns are marked "(filtered)" in
+their header, both when the report is inserted and after **Refresh**.
 
 You can also manage saved reports in the **[Saved Reports][ref-saved-reports]** page
 in Cube Cloud.

--- a/docs-mintlify/docs/integrations/microsoft-excel.mdx
+++ b/docs-mintlify/docs/integrations/microsoft-excel.mdx
@@ -120,7 +120,7 @@ folder — results are grouped by type and show each item's folder location,
 and selecting one navigates you straight to it.
 
 Click **Refresh** to manually refresh the data in the report's location.
-Click **Edit** to chnage the query or the location.
+Click **Edit** to change the query or the location.
 
 <Frame>
   <img src="https://ucarecdn.com/167abe25-635c-4fa6-b4a2-c090aa533f3c/" />

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -109,7 +109,8 @@ cube deploy DEPLOYMENT_ID --directory ./my-cube-project -m "initial deploy"
 
 `cube deploy` hashes local files, uploads only what changed, removes remote
 files deleted locally (`--keep-missing` opts out), and triggers a single
-build.
+build. Pass `--branch` to deploy to a specific data model branch instead of
+the active dev-mode branch (or the deploy branch, if none is active).
 
 </Step>
 
@@ -154,7 +155,7 @@ Run `cube <command> --help` for the full options of any command.
 | `deploy` | Upload a local project directory and build it |
 | `logs` | Tail deployment pod logs (`--pod`, `-c/--container`, `--source production\|dev`) |
 | `regions` | List available deployment regions |
-| `github` | GitHub integration: `status`, `installations`, `repos`, `branches`, `connect` |
+| `github` (`gh`) | GitHub integration: `status`, `installations`, `repos`, `branches`, `connect` |
 | `data-model` | Data model files and Git workflow: `list`, `get`, `put`, `delete`, `rename`, `file-hashes`, `branches`, `create-branch`, `dev-mode`, `commit`, `pull`, `merge`, `merge-to-default` |
 | `environments` | Deployment environments and environment tokens |
 | `variables` | Deployment environment variables |
@@ -191,6 +192,7 @@ cube data-model merge-to-default DEPLOYMENT_ID --branch my-branch -m "add orders
 | `CUBE_AUTH_SCHEME` | Force the `Authorization` scheme: `bearer` or `api-key` (auto-detected by default) |
 | `CUBE_NO_UPDATE_CHECK` | Disable the background update check |
 | `CUBE_NO_TELEMETRY` | Disable anonymous usage telemetry (also disabled when `CI` is set) |
+| `CUBEJS_TELEMETRY=false` | Legacy alias for `CUBE_NO_TELEMETRY`, kept for compatibility with the previous `cubejs` CLI |
 | `CUBE_VERSION` | Installer only: release tag to install |
 | `CUBE_INSTALL_DIR` | Installer only: install directory |
 
@@ -199,7 +201,7 @@ cube data-model merge-to-default DEPLOYMENT_ID --branch my-branch -m "add orders
 The CLI sends anonymous usage events (command group, success/failure,
 version, platform). No personal data is collected; the anonymous identifier
 is a hash of the OS machine id. Telemetry is disabled automatically in CI,
-or explicitly with `CUBE_NO_TELEMETRY=1`.
+or explicitly with `CUBE_NO_TELEMETRY=1` (or the legacy `CUBEJS_TELEMETRY=false`).
 
 [ref-api-keys]: /admin/account-billing/api-keys
 [ref-rest-api]: /reference/core-data-apis/rest-api/index


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

Routine audit of recently merged changes against docs-mintlify turned up a few small, already-shipped gaps:

- **Cube CLI reference** (`reference/cli.mdx`): document the `--branch` flag on `cube deploy`, the `gh` alias for `cube github`, and the legacy `CUBEJS_TELEMETRY=false` env var — all shipped in #11289/#11291 but missing from the CLI reference page added in #11333.
- **Google Sheets / Excel add-ins** (`docs/integrations/google-sheets.mdx`, `docs/integrations/microsoft-excel.mdx`): document the workspace quick-find search box in the saved-reports list (companion to the console-ui workspace search already documented in #11324), and the admin-only **Show applied filters in reports** setting (Settings → Spreadsheet Add-ins) shipped in cubejs-enterprise#13181.
- **Cloud providers / pricing** (`admin/deployment/providers/index.mdx`, `admin/account-billing/pricing.mdx`): Azure is now available on all plans (paywall removed in cubejs-enterprise#13158), not just Enterprise — the previous copy was out of date.

No code changes; docs-mintlify only.


---
_Generated by [Claude Code](https://claude.ai/code/session_0193tRNj2LEuVq3G8kDjNsQS)_