### PR TITLE
fix(cube-cli): default to https:// for scheme-less Cube Cloud URLs

### DIFF
--- a/rust/cube-cli/src/commands/login.rs
+++ b/rust/cube-cli/src/commands/login.rs
@@ -25,7 +25,7 @@ pub async fn command(args: Args, ctx: &mut Ctx) -> Result<()> {
             .with_placeholder("https://<tenant>.cubecloud.dev")
             .prompt()?,
     };
-    let url = url.trim().trim_end_matches('/').to_string();
+    let url = crate::util::normalize_url(&url);
 
     let (token, refresh_token) = match args.api_key {
         Some(key) => (key, None),

--- a/rust/cube-cli/src/main.rs
+++ b/rust/cube-cli/src/main.rs
@@ -71,7 +71,8 @@ impl Ctx {
         let url = self
             .api_url
             .clone()
-            .or_else(|| ctx.map(|(_, c)| c.url.clone()));
+            .or_else(|| ctx.map(|(_, c)| c.url.clone()))
+            .map(|u| util::normalize_url(&u));
         // An explicit --token / CUBE_API_KEY wins and disables auto-refresh
         // (it isn't tied to a stored refresh token).
         let token = self

--- a/rust/cube-cli/src/util.rs
+++ b/rust/cube-cli/src/util.rs
@@ -43,6 +43,18 @@ pub fn push<T: ToString>(query: &mut Query, key: &str, value: &Option<T>) {
     }
 }
 
+/// Normalize a user-supplied Cube Cloud URL: trim whitespace and trailing
+/// slashes, and default to `https://` when no scheme is given (reqwest
+/// otherwise fails with "relative URL without a base").
+pub fn normalize_url(url: &str) -> String {
+    let url = url.trim().trim_end_matches('/');
+    if url.is_empty() || url.contains("://") {
+        url.to_string()
+    } else {
+        format!("https://{url}")
+    }
+}
+
 /// Parse a `KEY=VALUE` pair (for `cube variables set`).
 pub fn parse_kv(s: &str) -> Result<(String, String), String> {
     match s.split_once('=') {
@@ -79,6 +91,27 @@ mod tests {
         assert!(parse_data(Some("[1, 2]")).is_err());
         assert!(parse_data(Some("not json")).is_err());
         assert!(parse_data(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn normalize_url_defaults_to_https() {
+        assert_eq!(
+            normalize_url("cloud.cubecloud.dev"),
+            "https://cloud.cubecloud.dev"
+        );
+        assert_eq!(
+            normalize_url(" cloud.cubecloud.dev/ "),
+            "https://cloud.cubecloud.dev"
+        );
+        assert_eq!(
+            normalize_url("https://cloud.cubecloud.dev/"),
+            "https://cloud.cubecloud.dev"
+        );
+        assert_eq!(
+            normalize_url("http://localhost:4000"),
+            "http://localhost:4000"
+        );
+        assert_eq!(normalize_url(""), "");
     }
 
     #[test]


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Entering a Cube Cloud URL without a scheme (e.g. `cloud.cubecloud.dev`) at the `cube login` prompt — or via `--api-url` / `CUBE_API_URL` / a saved context — failed with reqwest's `error: builder error: relative URL without a base`.

- Added a `normalize_url` helper in `src/util.rs` that trims whitespace and trailing slashes and prepends `https://` when no scheme is present (explicit schemes like `http://localhost:4000` are left untouched).
- Applied it to the URL from the `cube login` prompt / `--url` flag, and in `Ctx::api()` so `--api-url`, `CUBE_API_URL`, and contexts saved with a scheme-less URL are normalized too.
- Added unit tests covering scheme-less, trailing-slash, explicit-scheme, and empty inputs.

`cargo test`, `cargo clippy`, and `cargo fmt --check` pass in `rust/cube-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLCPy9xaxFgSdH7fPMMLwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLCPy9xaxFgSdH7fPMMLwX)_