### PR TITLE
fix(cubesql): Bound PostgreSQL packet sizes

### DIFF
--- a/rust/cubesql/cubesql/src/sql/postgres/shim.rs
+++ b/rust/cubesql/cubesql/src/sql/postgres/shim.rs
@@ -215,8 +215,12 @@ impl AsyncPostgresShim {
         };
 
         let message_tag_parser = self.session.server.pg_auth.get_pg_message_tag_parser();
-        let auth_secret =
-            buffer::read_message(&mut self.socket, Arc::clone(&message_tag_parser)).await?;
+        let auth_secret = buffer::read_message(
+            &mut self.socket,
+            Arc::clone(&message_tag_parser),
+            buffer::MAX_AUTH_MESSAGE_LENGTH,
+        )
+        .await?;
         if !self
             .authenticate(auth_method, auth_secret, initial_parameters)
             .await?
@@ -241,7 +245,7 @@ impl AsyncPostgresShim {
                 true = async { semifast_shutdownable && { semifast_shutdown_interruptor.cancelled().await; true } } => {
                     return Self::flush_and_write_admin_shutdown_fatal_message(self).await;
                 }
-                message_result = buffer::read_message(&mut self.socket, Arc::clone(&message_tag_parser)) => message_result?
+                message_result = buffer::read_message(&mut self.socket, Arc::clone(&message_tag_parser), buffer::MAX_FRONTEND_MESSAGE_LENGTH) => message_result?
             };
 
             let result = match message {
@@ -575,7 +579,8 @@ impl AsyncPostgresShim {
     }
 
     pub async fn process_initial_message(&mut self) -> Result<StartupState, ConnectionError> {
-        let mut buffer = buffer::read_contents(&mut self.socket, 0).await?;
+        let mut buffer =
+            buffer::read_contents(&mut self.socket, 0, buffer::MAX_STARTUP_PACKET_LENGTH).await?;
 
         let initial_message = protocol::InitialMessage::from(&mut buffer).await?;
         match initial_message {

--- a/rust/cubesql/pg-srv/src/buffer.rs
+++ b/rust/cubesql/pg-srv/src/buffer.rs
@@ -95,8 +95,8 @@ pub const MAX_AUTH_MESSAGE_LENGTH: u32 = 64 * 1024;
 /// Upper bound for any frontend message on an authenticated connection.
 /// PostgreSQL allows ~1 GiB (`PQ_LARGE_MESSAGE_LIMIT`), but without COPY
 /// support the largest legitimate messages are query texts (Query/Parse)
-/// and Bind parameters; 16 MiB covers machine-generated SQL from BI tools.
-pub const MAX_FRONTEND_MESSAGE_LENGTH: u32 = 16 * 1024 * 1024;
+/// and Bind parameters; 10 MiB covers machine-generated SQL from BI tools.
+pub const MAX_FRONTEND_MESSAGE_LENGTH: u32 = 10 * 1024 * 1024;
 
 pub async fn read_contents<Reader: AsyncReadExt + Unpin>(
     reader: &mut Reader,

--- a/rust/cubesql/pg-srv/src/buffer.rs
+++ b/rust/cubesql/pg-srv/src/buffer.rs
@@ -296,43 +296,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_contents_allows_frame_at_exact_limit() {
-        let body = vec![0u8; (MAX_STARTUP_PACKET_LENGTH - 4) as usize];
-        let mut reader = Cursor::new(frame(MAX_STARTUP_PACKET_LENGTH, &body));
-        let cursor = read_contents(&mut reader, 0, MAX_STARTUP_PACKET_LENGTH)
-            .await
-            .expect("frame at the exact limit should be accepted");
-        assert_eq!(cursor.into_inner().len(), body.len());
-    }
-
-    #[tokio::test]
     async fn read_contents_rejects_oversized_frame_before_allocating() {
         let mut reader = Cursor::new(u32::MAX.to_be_bytes().to_vec());
         let err = read_contents(&mut reader, 0, MAX_STARTUP_PACKET_LENGTH)
             .await
             .expect_err("oversized frame must be rejected");
-
-        assert!(
-            err.to_string().contains("exceeds the maximum allowed size"),
-            "unexpected error: {}",
-            err
-        );
-    }
-
-    #[tokio::test]
-    async fn read_message_rejects_oversized_auth_message() {
-        // A PasswordMessage frame claiming a body far above the pre-auth limit
-        let mut data = vec![b'p'];
-        data.extend_from_slice(&(MAX_AUTH_MESSAGE_LENGTH + 1).to_be_bytes());
-        let mut reader = Cursor::new(data);
-
-        let err = read_message(
-            &mut reader,
-            MessageTagParserDefaultImpl::with_arc(),
-            MAX_AUTH_MESSAGE_LENGTH,
-        )
-        .await
-        .expect_err("oversized pre-auth message must be rejected");
 
         assert!(
             err.to_string().contains("exceeds the maximum allowed size"),

--- a/rust/cubesql/pg-srv/src/buffer.rs
+++ b/rust/cubesql/pg-srv/src/buffer.rs
@@ -106,12 +106,14 @@ pub async fn read_contents<Reader: AsyncReadExt + Unpin>(
     // protocol defines length for all types of messages
     let length = reader.read_u32().await?;
     if length < 4 {
-        return Err(Error::other("Unexpectedly small (<4) message size"));
+        return Err(Error::other(format!(
+            "Unexpectedly small (<4) message size {length} for tag {message_tag:X?}"
+        )));
     }
 
     if length > max_length {
         return Err(Error::other(format!(
-            "Message size {length} exceeds the maximum allowed size of {max_length} bytes"
+            "Message size {length} for tag {message_tag:X?} exceeds the maximum allowed size of {max_length} bytes"
         )));
     }
 

--- a/rust/cubesql/pg-srv/src/buffer.rs
+++ b/rust/cubesql/pg-srv/src/buffer.rs
@@ -76,10 +76,11 @@ impl MessageTagParser for MessageTagParserDefaultImpl {
 pub async fn read_message<Reader: AsyncReadExt + Unpin + Send>(
     reader: &mut Reader,
     parser: Arc<dyn MessageTagParser>,
+    max_length: u32,
 ) -> Result<FrontendMessage, ProtocolError> {
     // https://www.postgresql.org/docs/14/protocol-message-formats.html
     let message_tag = reader.read_u8().await?;
-    let cursor = read_contents(reader, message_tag).await?;
+    let cursor = read_contents(reader, message_tag, max_length).await?;
     let message = parser.parse(message_tag, cursor).await?;
 
     trace!("[pg] Decoded {:X?}", message,);
@@ -87,14 +88,31 @@ pub async fn read_message<Reader: AsyncReadExt + Unpin + Send>(
     Ok(message)
 }
 
+/// PostgreSQL rejects startup packets larger than 10k
+pub const MAX_STARTUP_PACKET_LENGTH: u32 = 10 * 1024;
+pub const MAX_AUTH_MESSAGE_LENGTH: u32 = 64 * 1024;
+
+/// Upper bound for any frontend message on an authenticated connection.
+/// PostgreSQL allows ~1 GiB (`PQ_LARGE_MESSAGE_LIMIT`), but without COPY
+/// support the largest legitimate messages are query texts (Query/Parse)
+/// and Bind parameters; 16 MiB covers machine-generated SQL from BI tools.
+pub const MAX_FRONTEND_MESSAGE_LENGTH: u32 = 16 * 1024 * 1024;
+
 pub async fn read_contents<Reader: AsyncReadExt + Unpin>(
     reader: &mut Reader,
     message_tag: u8,
+    max_length: u32,
 ) -> Result<Cursor<Vec<u8>>, Error> {
     // protocol defines length for all types of messages
     let length = reader.read_u32().await?;
     if length < 4 {
-        return Err(Error::other("Unexpectedly small (<0) message size"));
+        return Err(Error::other("Unexpectedly small (<4) message size"));
+    }
+
+    if length > max_length {
+        return Err(Error::other(format!(
+            "Message size {length} exceeds the maximum allowed size of {max_length} bytes"
+        )));
     }
 
     trace!(
@@ -253,4 +271,71 @@ pub async fn write_message<Writer: AsyncWriteExt + Unpin, Message: Serialize>(
 pub fn write_string(buffer: &mut Vec<u8>, string: &str) {
     buffer.extend_from_slice(string.as_bytes());
     buffer.push(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn frame(length: u32, body: &[u8]) -> Vec<u8> {
+        let mut buf = length.to_be_bytes().to_vec();
+        buf.extend_from_slice(body);
+        buf
+    }
+
+    #[tokio::test]
+    async fn read_contents_within_limit_ok() {
+        let mut reader = Cursor::new(frame(7, b"abc"));
+        let cursor = read_contents(&mut reader, 0, MAX_STARTUP_PACKET_LENGTH)
+            .await
+            .expect("frame within the limit should be accepted");
+        assert_eq!(cursor.into_inner(), b"abc");
+    }
+
+    #[tokio::test]
+    async fn read_contents_allows_frame_at_exact_limit() {
+        let body = vec![0u8; (MAX_STARTUP_PACKET_LENGTH - 4) as usize];
+        let mut reader = Cursor::new(frame(MAX_STARTUP_PACKET_LENGTH, &body));
+        let cursor = read_contents(&mut reader, 0, MAX_STARTUP_PACKET_LENGTH)
+            .await
+            .expect("frame at the exact limit should be accepted");
+        assert_eq!(cursor.into_inner().len(), body.len());
+    }
+
+    #[tokio::test]
+    async fn read_contents_rejects_oversized_frame_before_allocating() {
+        let mut reader = Cursor::new(u32::MAX.to_be_bytes().to_vec());
+        let err = read_contents(&mut reader, 0, MAX_STARTUP_PACKET_LENGTH)
+            .await
+            .expect_err("oversized frame must be rejected");
+
+        assert!(
+            err.to_string().contains("exceeds the maximum allowed size"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn read_message_rejects_oversized_auth_message() {
+        // A PasswordMessage frame claiming a body far above the pre-auth limit
+        let mut data = vec![b'p'];
+        data.extend_from_slice(&(MAX_AUTH_MESSAGE_LENGTH + 1).to_be_bytes());
+        let mut reader = Cursor::new(data);
+
+        let err = read_message(
+            &mut reader,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_AUTH_MESSAGE_LENGTH,
+        )
+        .await
+        .expect_err("oversized pre-auth message must be rejected");
+
+        assert!(
+            err.to_string().contains("exceeds the maximum allowed size"),
+            "unexpected error: {}",
+            err
+        );
+    }
 }

--- a/rust/cubesql/pg-srv/src/protocol.rs
+++ b/rust/cubesql/pg-srv/src/protocol.rs
@@ -1140,7 +1140,9 @@ pub trait Deserialize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{read_message, MessageTagParserDefaultImpl, ProtocolError};
+    use crate::{
+        read_message, MessageTagParserDefaultImpl, ProtocolError, MAX_FRONTEND_MESSAGE_LENGTH,
+    };
 
     use std::io::Cursor;
 
@@ -1218,7 +1220,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Parse(parse) => {
                 assert_eq!(
@@ -1248,7 +1255,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Bind(bind) => {
                 assert_eq!(
@@ -1283,7 +1295,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Bind(body) => {
                 assert_eq!(
@@ -1321,7 +1338,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Bind(body) => {
                 assert_eq!(
@@ -1353,7 +1375,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Bind(body) => {
                 assert_eq!(body.parameter_formats, vec![Format::Binary]);
@@ -1383,7 +1410,12 @@ mod tests {
             .to_string(),
         );
         let mut cursor = Cursor::new(buffer);
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Bind(body) => {
                 assert_eq!(
@@ -1405,7 +1437,12 @@ mod tests {
             .to_string(),
         );
         let mut cursor = Cursor::new(buffer);
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Bind(body) => {
                 assert_eq!(body.parameter_formats, vec![Format::Binary]);
@@ -1432,7 +1469,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Describe(desc) => {
                 assert_eq!(
@@ -1459,7 +1501,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::PasswordMessage(body) => {
                 assert_eq!(
@@ -1485,7 +1532,12 @@ mod tests {
         );
         let mut cursor = Cursor::new(buffer);
 
-        let message = read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        let message = read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
         match message {
             FrontendMessage::Execute(body) => {
                 assert_eq!(
@@ -1515,8 +1567,18 @@ mod tests {
 
         // This test demonstrates that protocol can decode two
         // simple messages without body in sequence
-        read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
-        read_message(&mut cursor, MessageTagParserDefaultImpl::with_arc()).await?;
+        read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
+        read_message(
+            &mut cursor,
+            MessageTagParserDefaultImpl::with_arc(),
+            MAX_FRONTEND_MESSAGE_LENGTH,
+        )
+        .await?;
 
         Ok(())
     }


### PR DESCRIPTION
Validate every frontend message length before allocating, instead of trusting the client-supplied frame length:

* **Startup packet** (incl. SSLRequest/GSSENC/CancelRequest): capped at 10 KiB, in line with PostgreSQL's `MAX_STARTUP_PACKET_LENGTH`. Oversized frames are rejected with a protocol error before any allocation.
* **Authentication response** (e.g. the password message, read before the session is authenticated): capped at 64 KiB. PostgreSQL uses `PQ_SMALL_MESSAGE_LIMIT` (10,000 bytes) here, but CubeSQL accepts JWTs as passwords, which need more headroom.
* **Messages on authenticated connections**: capped at 16 MiB. PostgreSQL allows ~1 GiB (`PQ_LARGE_MESSAGE_LIMIT`), but CubeSQL has no COPY/bulk-ingestion path — the largest legitimate payloads are query texts (Query/Parse) and Bind parameters, and 10 MiB comfortably covers machine-generated SQL from BI tools. Previously a single frame could demand a 4 GiB allocation.