### PR TITLE
docs: document branch deep-link copy button in Data Model IDE

### DIFF
--- a/docs-mintlify/docs/data-modeling/data-model-ide.mdx
+++ b/docs-mintlify/docs/data-modeling/data-model-ide.mdx
@@ -86,6 +86,11 @@ want to delete, then open the switcher and click **Remove Branch**:
   <img src="https://ucarecdn.com/f1d37fe6-a6ae-4d78-a801-133639daf1ec/" alt="Delete a branch" />
 </Frame>
 
+To share a link to the branch you're currently viewing, click the copy-link
+button next to the branch switcher. It copies the current URL with
+`?branch=<branch-name>` appended; opening that link switches the recipient to
+the same branch.
+
 ## Generating data model files
 
 You can generate data model files when [creating a new


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (docs-only change)
- [ ] Linter has been run for changed code (docs-only change)
- [ ] Tests for the changes have been added if not covered yet (docs-only change)

**Description of Changes Made**

Documents a small, previously-undocumented Data Model IDE feature: a copy-link button next to the branch switcher that copies the current IDE URL with `?branch=<branch-name>` appended. Opening that link switches the recipient to the same branch.

Found while cross-checking recent `cubedevinc/cubejs-enterprise` changes against the docs. The button shipped in cubedevinc/cubejs-enterprise#13236 (CUB-3358); the underlying `?branch=` deep-link support (CUB-3318) had also shipped without a docs mention.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oDPYVCuEQjxm6Uqe3E4pb)_