### PR TITLE
feat(cube-cli): show CLI version when run without a command

### DIFF
--- a/packages/cubejs-cli/src/cli.ts
+++ b/packages/cubejs-cli/src/cli.ts
@@ -34,6 +34,7 @@ program
   await configureValidateCommand(program);
 
   if (!process.argv.slice(2).length) {
+    console.log(`Cube.js CLI v${packageJson.version}`);
     program.help();
   }
 

--- a/packages/cubejs-cli/src/cli.ts
+++ b/packages/cubejs-cli/src/cli.ts
@@ -34,7 +34,6 @@ program
   await configureValidateCommand(program);
 
   if (!process.argv.slice(2).length) {
-    console.log(`Cube.js CLI v${packageJson.version}`);
     program.help();
   }
 

--- a/rust/cube-cli/src/main.rs
+++ b/rust/cube-cli/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
     #[command(flatten)]
     global: GlobalArgs,
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(clap::Args, Clone)]
@@ -255,21 +255,29 @@ async fn main() {
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
-    let cli = Cli::parse();
+    let Cli { global, command } = Cli::parse();
     commands::update::cleanup_stale_binary();
+
+    // Bare `cube` with no subcommand: show the version, then the help text.
+    let Some(command) = command else {
+        println!("Cube CLI {}", env!("CUBE_CLI_VERSION"));
+        println!();
+        let _ = cli_command().print_help();
+        return;
+    };
 
     // Check for a newer release concurrently with the command; the notice
     // (if any) prints after the command output. Skipped for `update` itself
     // and `completion` (whose output is eval'd by shells). Completion also
     // skips telemetry — it runs on shell startup.
-    let is_completion = matches!(cli.command, Command::Completion(_));
-    let check = match &cli.command {
+    let is_completion = matches!(command, Command::Completion(_));
+    let check = match &command {
         Command::Update(_) | Command::Completion(_) => None,
         _ => Some(update::spawn_check()),
     };
-    let command_name = cli.command.name();
+    let command_name = command.name();
 
-    let result = run(cli).await;
+    let result = run(global, command).await;
 
     if !is_completion {
         let mut props = serde_json::Map::new();
@@ -293,10 +301,10 @@ async fn main() {
     }
 }
 
-async fn run(cli: Cli) -> Result<()> {
-    let mut ctx = Ctx::new(&cli.global)?;
+async fn run(global: GlobalArgs, command: Command) -> Result<()> {
+    let mut ctx = Ctx::new(&global)?;
     use Command::*;
-    match cli.command {
+    match command {
         Login(args) => commands::login::command(args, &mut ctx).await,
         Logout(args) => commands::logout::command(args, &mut ctx).await,
         Whoami(args) => commands::whoami::command(args, &ctx).await,


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Running bare `cube` (the Rust CLI in `rust/cube-cli`) previously produced clap's missing-subcommand error on stderr with exit code 2. It now prints the CLI version followed by the full help text and exits 0:

```
Cube CLI 1.7.8

Cube Command Line Interface

Usage: cube [OPTIONS] [COMMAND]
...
```

Changes in `rust/cube-cli/src/main.rs`:
- The subcommand is now `Option<Command>` at the parser level.
- `main` handles the no-command case early: it prints `Cube CLI {version}` (same format as `cube update`'s output), then the help text — skipping the update check and telemetry, like `completion`.
- `run()` takes `GlobalArgs` and `Command` separately since the command is destructured in `main`.

Verified with a debug build: bare `cube` shows version + help (exit 0), and `cube --version` still prints `Cube CLI 1.7.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McCxp9LtvvZ5cMhStkHfS1

---
_Generated by [Claude Code](https://claude.ai/code/session_01McCxp9LtvvZ5cMhStkHfS1)_