### PR TITLE
docs: add Claude Opus 5, Opus 4.8, and Sonnet 5 to agent LLM models

### DIFF
--- a/docs-mintlify/admin/ai/index.mdx
+++ b/docs-mintlify/admin/ai/index.mdx
@@ -78,6 +78,9 @@ To pin a specific model, set the `llm` property to one of the predefined models:
 - `claude_4_6_sonnet`
 - `claude_4_6_opus`
 - `claude_4_7_opus`
+- `claude_4_8_opus`
+- `claude_5_sonnet`
+- `claude_5_opus`
 
 **OpenAI GPT:**
 - `gpt_4o`


### PR DESCRIPTION
The list of predefined agent models on the AI configuration page stopped at `claude_4_7_opus` and had fallen behind the models the product actually accepts.

Adds the three missing entries:

- `claude_4_8_opus`
- `claude_5_sonnet`
- `claude_5_opus`

Ordering follows the existing convention on the page (ascending by version, Opus before Sonnet within a generation).

These are the exact config strings accepted by the `llm` property, verified against the model enum rather than the UI display names. The Bring Your Own Model page needs no change — it documents providers generically and does not enumerate model versions.
