### PR TITLE
docs: dashboard link drill-ins honor explicit target (v1.7.5+)

### DIFF
--- a/docs-mintlify/docs/data-modeling/dimensions.mdx
+++ b/docs-mintlify/docs/data-modeling/dimensions.mdx
@@ -408,7 +408,7 @@ Dimension `links` require Cube **v1.6.53** or newer.
 | `url` | **Either `url` or `dashboard`** | SQL expression that builds an **external** URL per row. May [reference][ref-references] columns and other dimensions. |
 | `dashboard` | **Either `url` or `dashboard`** | The target Cube Cloud dashboard's **slug** (a **drill-in**). Each link sets exactly one of `url` or `dashboard` — never both — but different links on the same dimension can mix the two. |
 | `icon` | Optional | A [Tabler icon][link-tabler] name (see [Icons](#icons)). Defaults to a generic link icon. |
-| `target` | Optional | Where to open the link: `blank` (default — new tab) or `self` (same tab). Applies to **external** links only — drill-ins always navigate in-app (see [Behavior](#behavior)). |
+| `target` | Optional | Where to open the link: `blank` (new tab) or `self` (same tab). The default depends on the link kind — `url:` links default to `blank`, `dashboard:` drill-ins default to `self` (in-app). An explicit `target` is honored for both (on `dashboard:` drill-ins this requires Cube **v1.7.5** or newer; see [Behavior](#behavior)). |
 | `params` | Optional | Extra per-row parameters. For `url:` they are appended as query parameters. For `dashboard:` they become **equality filters** on the target dashboard — each `key` is a member of the target dashboard's view (a cube path such as `orders.status` is auto-resolved to the matching view member), and `value` is the per-row value. |
 
 ### Example
@@ -513,8 +513,11 @@ working as soon as both sides use the same slug.
   and Explore / SQL results). A left-click on a cell opens the menu listing the
   dimension's links, alongside **Copy value** and, on measures, **Drill down**.
 - **Drill-in vs external** — a `dashboard:` link navigates **in-app, in the same
-  tab** (Cmd/Ctrl-click opens a new tab), ignoring `target`; a `url:` link opens
-  per its `target` (`blank` by default).
+  tab** by default; an explicit `target` is honored (`blank` opens a new tab,
+  `self` stays in-app), and a Cmd/Ctrl-click always opens a new tab. A `url:`
+  link opens per its `target` (`blank` by default). Honoring an explicit `target`
+  on a drill-in requires Cube **v1.7.5** or newer — older runtimes always navigate
+  drill-ins in-app regardless of `target`.
 - **Filters** — for `dashboard:` links, each `params` entry becomes an
   **equality filter** on the target (the `key` is a view member, the `value` is
   the per-row value). An unknown or inaccessible target slug is skipped

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -454,7 +454,10 @@ browse the available names at [tabler.io/icons][link-tabler]. When omitted, a de
 icon is shown.
 
 Optionally, a link might use the `target` parameter to specify [where to open it][link-target]:
-`blank` (default) to open in a new tab/window or `self` to open in the same tab/window.
+`blank` to open in a new tab/window or `self` to open in the same tab/window. The default
+depends on the link kind: `url:` links default to `blank` (new tab), while `dashboard:`
+drill-ins default to `self` (in-app). An explicit `target` on a `dashboard:` drill-in is
+honored on Cube **v1.7.5** or newer.
 
 ```yaml
 cubes:


### PR DESCRIPTION
## Summary

Follow-up to the frontend change that lets `dashboard:` drill-in links honor an explicit `target` (CUB-3339), now that the runtime only emits `target` when the model sets it (CORE-566 fix, #11294, shipped in v1.7.5).

The dimension `links` docs still described the old workaround behavior — that drill-ins *always* navigate in-app and *ignore* `target`. Updated to the current contract:

- `url:` links → default `blank` (new tab); explicit `target` honored (unchanged)
- `dashboard:` drill-ins → default `self` (in-app); **explicit `target` now honored** (`blank` = new tab, `self` = same tab); Cmd/Ctrl-click still forces a new tab
- Honoring an explicit `target` on a drill-in requires **v1.7.5+** — older runtimes always navigate drill-ins in-app

## Changes

- `docs-mintlify/docs/data-modeling/dimensions.mdx` — `target` parameter row + Behavior → "Drill-in vs external" bullet
- `docs-mintlify/reference/data-modeling/dimensions.mdx` — `target` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)