### PR TITLE
feat(cube-cli): expose the dev-mode branch name and document dev-mode-only data-model writes

### DIFF
--- a/rust/cube-cli/README.md
+++ b/rust/cube-cli/README.md
@@ -132,7 +132,7 @@ Every endpoint of the Console Server public API is covered:
 | `regions` | list available deployment regions |
 | `logs` | tail deployment pod logs (`--pod`, `-c/--container`; defaults to the Cube API container) |
 | `github` (`gh`) | status, installations, repos, branches, connect (import a repo into a deployment + first build) |
-| `data-model` (`dm`) | list, get, put, delete, rename files; branches, create-branch, dev-mode, exit-dev-mode, commit, pull |
+| `data-model` (`dm`) | list, get, put, delete, rename files; branches, create-branch, dev-mode, exit-dev-mode, commit, pull. File writes only land on a **dev-mode branch**: `dev-mode <branch>` forks a personal `dev-…` branch and prints its name — pass that via `--branch` (or omit `--branch` to use your active dev-mode branch); puts to any other branch are rejected by the API |
 | `environments` | list, tokens, create-token (incl. `--meta-sync`) |
 | `variables` | list, set (`KEY=VALUE` upserts) |
 | `folders` | list, create, update, delete, ancestors |

--- a/rust/cube-cli/src/commands/data_model.rs
+++ b/rust/cube-cli/src/commands/data_model.rs
@@ -185,6 +185,15 @@ fn flatten(nodes: &[serde_json::Value], out: &mut Vec<serde_json::Value>) {
     }
 }
 
+/// Printed after entering dev mode, so the user knows which branch the write
+/// commands accept.
+fn dev_branch_hint(dev_branch: &str) -> String {
+    format!(
+        "Data-model writes target it: pass --branch {dev_branch} \
+         (or omit --branch to use your active dev-mode branch)."
+    )
+}
+
 /// The source tree reports absolute paths (`/model/cubes/orders.yml`) while the
 /// write endpoints accept them with or without the leading slash, so compare
 /// paths without it.
@@ -369,7 +378,7 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
                     output::success(&format!(
                         "Created branch {name}; entered dev mode on {dev_branch}"
                     ));
-                    println!("Data-model writes target it: pass --branch {dev_branch} (or omit --branch to use your active dev-mode branch).");
+                    println!("{}", dev_branch_hint(&dev_branch));
                 } else {
                     output::success(&format!("Created branch {name}"));
                 }
@@ -395,7 +404,7 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
                     output::success(&format!(
                         "Entered dev mode on {dev_branch} (forked from {branch})"
                     ));
-                    println!("Data-model writes target it: pass --branch {dev_branch} (or omit --branch to use your active dev-mode branch).");
+                    println!("{}", dev_branch_hint(&dev_branch));
                 }
             }
         }

--- a/rust/cube-cli/src/commands/data_model.rs
+++ b/rust/cube-cli/src/commands/data_model.rs
@@ -38,7 +38,7 @@ enum Cmd {
         #[arg(long)]
         branch: Option<String>,
     },
-    /// Create or overwrite a file
+    /// Create or overwrite a file (writes require a dev-mode branch)
     Put {
         /// Deployment id
         deployment: i64,
@@ -50,11 +50,12 @@ enum Cmd {
         /// Inline content (use `-` to read stdin)
         #[arg(long)]
         content: Option<String>,
-        /// Branch name (defaults to the deployment default branch)
+        /// Dev-mode branch to write to, as returned by `dev-mode` (defaults to
+        /// your active dev-mode branch)
         #[arg(long)]
         branch: Option<String>,
     },
-    /// Delete files
+    /// Delete files (writes require a dev-mode branch)
     #[command(alias = "rm")]
     Delete {
         /// Deployment id
@@ -62,11 +63,12 @@ enum Cmd {
         /// One or more file paths to delete
         #[arg(required = true)]
         paths: Vec<String>,
-        /// Branch name (defaults to the deployment default branch)
+        /// Dev-mode branch to write to, as returned by `dev-mode` (defaults to
+        /// your active dev-mode branch)
         #[arg(long)]
         branch: Option<String>,
     },
-    /// Rename (move) a file
+    /// Rename (move) a file (writes require a dev-mode branch)
     Rename {
         /// Deployment id
         deployment: i64,
@@ -74,7 +76,8 @@ enum Cmd {
         from: String,
         /// Destination path
         to: String,
-        /// Branch name (defaults to the deployment default branch)
+        /// Dev-mode branch to write to, as returned by `dev-mode` (defaults to
+        /// your active dev-mode branch)
         #[arg(long)]
         branch: Option<String>,
     },
@@ -93,11 +96,12 @@ enum Cmd {
         #[arg(long)]
         dev_mode: bool,
     },
-    /// Enter dev mode / switch to a branch
+    /// Enter dev mode on a branch (prints the personal dev-mode branch that
+    /// file writes must target)
     DevMode {
         /// Deployment id
         deployment: i64,
-        /// Branch to switch to (required by the API)
+        /// Branch to base dev mode on (required by the API)
         branch: String,
     },
     /// Exit dev mode
@@ -350,7 +354,17 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             if ctx.json {
                 output::print_json(&res);
             } else {
-                output::success(&format!("Created branch {name}"));
+                // With --dev-mode the server forks a personal dev-mode branch off
+                // the new branch; that's the branch file writes must target.
+                let dev_branch = output::field(&res, "branchName");
+                if dev_mode && !dev_branch.is_empty() && dev_branch != name {
+                    output::success(&format!(
+                        "Created branch {name}; entered dev mode on {dev_branch}"
+                    ));
+                    println!("Data-model writes target it: pass --branch {dev_branch} (or omit --branch to use your active dev-mode branch).");
+                } else {
+                    output::success(&format!("Created branch {name}"));
+                }
             }
         }
         Cmd::DevMode { deployment, branch } => {
@@ -364,7 +378,17 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             if ctx.json {
                 output::print_json(&res);
             } else {
-                output::success(&format!("Entered dev mode on {branch}"));
+                // Dev mode runs on a personal `dev-…` branch forked from the
+                // requested one — expose it, since file writes only accept it.
+                let dev_branch = output::field(&res, "branchName");
+                if dev_branch.is_empty() || dev_branch == branch {
+                    output::success(&format!("Entered dev mode on {branch}"));
+                } else {
+                    output::success(&format!(
+                        "Entered dev mode on {dev_branch} (forked from {branch})"
+                    ));
+                    println!("Data-model writes target it: pass --branch {dev_branch} (or omit --branch to use your active dev-mode branch).");
+                }
             }
         }
         Cmd::ExitDevMode { deployment } => {

--- a/rust/cube-cli/src/commands/data_model.rs
+++ b/rust/cube-cli/src/commands/data_model.rs
@@ -185,6 +185,13 @@ fn flatten(nodes: &[serde_json::Value], out: &mut Vec<serde_json::Value>) {
     }
 }
 
+/// The source tree reports absolute paths (`/model/cubes/orders.yml`) while the
+/// write endpoints accept them with or without the leading slash, so compare
+/// paths without it.
+fn same_path(a: &str, b: &str) -> bool {
+    a.trim_start_matches('/') == b.trim_start_matches('/')
+}
+
 fn tree_nodes(res: &serde_json::Value) -> Vec<serde_json::Value> {
     let mut out = Vec::new();
     if let Some(arr) = res.get("data").and_then(|d| d.as_array()) {
@@ -256,9 +263,9 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             let mut query: Query = vec![("withContent".into(), "true".into())];
             util::push(&mut query, "branchName", &branch);
             let res = api.get(&base(deployment), &query).await?;
-            let file = tree_nodes(&res)
-                .into_iter()
-                .find(|f| output::field(f, "path") == path && output::field(f, "type") == "file");
+            let file = tree_nodes(&res).into_iter().find(|f| {
+                same_path(&output::field(f, "path"), &path) && output::field(f, "type") == "file"
+            });
             match file {
                 Some(f) => print!("{}", output::field(&f, "content")),
                 None => anyhow::bail!("file not found: {path}"),
@@ -307,9 +314,10 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
             to,
             branch,
         } => {
+            // Like put/delete, the rename endpoint expects `files` as an array
+            // of objects — here `{ path, newPath }`.
             let mut map = serde_json::Map::new();
-            map.insert("from".into(), json!(from));
-            map.insert("to".into(), json!(to));
+            map.insert("files".into(), json!([{ "path": from, "newPath": to }]));
             let res = api
                 .post(
                     &format!("{}/rename", base(deployment)),


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Entering dev mode on Cube Cloud forks a personal `dev-…` branch off the branch you name, and data-model file writes only land on that branch — but the CLI never showed it, so `data-model put --branch <feature-branch>` targeted branches where writes are ignored. Pairs with the Cube Cloud API change that returns the real dev branch from `POST .../dev-mode` / `POST .../branches` and rejects file writes to non-dev-mode branches.

- `cube data-model dev-mode <branch>` and `cube data-model create-branch --dev-mode` now print the actual dev-mode branch from the response, e.g. `✓ Entered dev mode on dev-pavel-ab12cd34 (forked from feature-x)`, with a hint to pass it via `--branch` (omitting `--branch` still uses your active dev-mode session). `--json` exposes the raw response.
- `put` / `delete` / `rename` help text now states writes require a dev-mode branch (from `dev-mode`; defaults to your active dev-mode branch).
- README: documented the dev-mode-only write workflow in the `data-model` command group.

Verified with `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (all green). Output falls back to the old message when the server doesn't return a branch name, so the CLI stays compatible with older APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fUkRZ53YkiVnr4iYrMgQa

---
_Generated by [Claude Code](https://claude.ai/code/session_019fUkRZ53YkiVnr4iYrMgQa)_