### PR TITLE
docs: remove preview warning from Cube CLI page

### DIFF
--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -3,14 +3,6 @@ title: Cube CLI
 description: Command-line interface for managing Cube deployments, data models, and workspace resources.
 ---
 
-<Warning>
-
-The Cube CLI is currently in preview, and commands and flags may still
-change. Reach out to the [Cube support team](/admin/account-billing/support)
-to activate this feature for your account.
-
-</Warning>
-
 The Cube CLI (`cube`) is a single-binary command-line interface for the Cube
 platform. Use it to create and manage deployments, deploy data model code,
 work with the data model Git workflow, connect GitHub repositories, tail


### PR DESCRIPTION
Removes the preview `<Warning>` callout from the Cube CLI reference page. The page now opens directly with the description of what the CLI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)