### PR TITLE
docs: document one-click email unsubscribe and dbt review dev-mode link

### DIFF
--- a/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
+++ b/docs-mintlify/docs/explore-analyze/scheduled-refreshes.mdx
@@ -132,6 +132,11 @@ to Slack (or that has notifications turned off) has nothing to subscribe to. If 
 editor switches a schedule to Slack, its existing subscriptions are cancelled;
 you can subscribe again if it is later switched back to email.
 
+Every notification email also includes a one-click **Unsubscribe** link in its
+footer, so a recipient can stop receiving a schedule's emails without signing in
+to Cube. This works for any recipient, including those added directly by an
+editor and embed users who have no Cube account of their own.
+
 ## Run phases
 
 When a scheduled refresh runs, it progresses through these phases:

--- a/docs-mintlify/docs/integrations/dbt.mdx
+++ b/docs-mintlify/docs/integrations/dbt.mdx
@@ -284,7 +284,10 @@ to the branch you're syncing.
 
 When an automated sync produces a branch that's ready to review, Cube emails the
 recipients you configure — a comma-separated list in the settings card — with a link
-straight to the review. No one has to poll the UI to notice that dbt changed.
+straight to the review. No one has to poll the UI to notice that dbt changed. Recipients
+who can edit the data model land on the branch in [development
+mode](/docs/data-modeling/dev-mode), ready to make changes; recipients without edit access
+see a read-only diff instead.
 
 ## What gets generated
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Found while sweeping recent `cubejs-enterprise` changes for undocumented
customer-facing behavior:

- **Scheduled refreshes** (`docs/explore-analyze/scheduled-refreshes.mdx`):
  dashboard-refresh notification emails now include a one-click
  **Unsubscribe** link (RFC 8058, no sign-in required) — added a note next to
  the existing in-app subscribe/unsubscribe toggle, since this also covers
  recipients with no Cube account (e.g. embed users).
- **dbt integration** (`docs/integrations/dbt.mdx`): the "ready to review"
  email link now drops edit-capable recipients directly into development mode
  on the synced branch instead of a read-only diff — noted alongside the
  existing review-notifications description.

Both are small, surgical additions to existing pages, per
`docs-mintlify/CLAUDE.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JxGbgQ77E8CoFqAiFcQxHQ)_