### PR TITLE
feat(cube-cli): add embed enable-dashboard / disable-dashboard commands

### DIFF
--- a/rust/cube-cli/README.md
+++ b/rust/cube-cli/README.md
@@ -145,7 +145,7 @@ Every endpoint of the Console Server public API is covered:
 | `attributes` | list, create, update, delete, values get/set |
 | `policies` | get, set-user, set-group |
 | `tenant` | settings, update |
-| `embed` | generate-session, token, dashboard, tenant delete/groups/delete-group |
+| `embed` | generate-session, token, dashboard, enable-dashboard, disable-dashboard, tenant delete/groups/delete-group |
 | `integrations` | list, get, create, update, delete, tokens list/get/revoke/initiate |
 | `oidc` | list, get, create, update, delete |
 | `agents` | list, skills |

--- a/rust/cube-cli/src/commands/embed.rs
+++ b/rust/cube-cli/src/commands/embed.rs
@@ -29,6 +29,16 @@ enum Cmd {
         /// Public id
         public_id: String,
     },
+    /// Enable signed embedding for a dashboard (admin only)
+    EnableDashboard {
+        /// Public id
+        public_id: String,
+    },
+    /// Disable signed embedding for a dashboard (admin only)
+    DisableDashboard {
+        /// Public id
+        public_id: String,
+    },
     /// Manage embed tenants
     Tenant {
         #[command(subcommand)]
@@ -96,6 +106,36 @@ pub async fn command(args: Args, ctx: &Ctx) -> Result<()> {
                 .get(&format!("/api/v1/embed/dashboard/{public_id}"), &Vec::new())
                 .await?;
             output::print_json(&res);
+        }
+        Cmd::EnableDashboard { public_id } => {
+            let res = api
+                .patch(
+                    &format!("/api/v1/embed/dashboard/{public_id}"),
+                    Some(&json!({ "allowEmbed": true })),
+                )
+                .await?;
+            if ctx.json {
+                output::print_json(&res);
+            } else {
+                output::success(&format!(
+                    "Enabled signed embedding for dashboard `{public_id}`"
+                ));
+            }
+        }
+        Cmd::DisableDashboard { public_id } => {
+            let res = api
+                .patch(
+                    &format!("/api/v1/embed/dashboard/{public_id}"),
+                    Some(&json!({ "allowEmbed": false })),
+                )
+                .await?;
+            if ctx.json {
+                output::print_json(&res);
+            } else {
+                output::success(&format!(
+                    "Disabled signed embedding for dashboard `{public_id}`"
+                ));
+            }
         }
         Cmd::Tenant { cmd } => match cmd {
             TenantCmd::Delete { name } => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made (if issue reference is not provided)**

Adds two `cube embed` subcommands that wire up the new admin-only Cube Cloud endpoint `PATCH /api/v1/embed/dashboard/{publicId}` (cubedevinc/cubejs-enterprise#13274), so a dashboard's "Allow signed embedding" flag can be toggled from the CLI instead of the console UI:

```
cube embed enable-dashboard <publicId>     # PATCH { "allowEmbed": true }
cube embed disable-dashboard <publicId>    # PATCH { "allowEmbed": false }
```

Plain mode prints a success line; `--json` echoes the endpoint's `{ publicId, allowEmbed }` response. This unblocks the flow where `cube embed dashboard <publicId>` returns `403 "Embedding is not allowed for this dashboard"` with no programmatic way to enable it.

Notes:
- Both commands reuse the client's existing `patch` helper and mirror the existing `embed dashboard` GET command's structure.
- README command table updated.
- Verified with `cargo build`, `cargo fmt --check`, `cargo clippy` (clean), and `cube embed --help` / `cube embed enable-dashboard --help` output. `rust/cube-cli` has no test suite ("tests added" left unchecked); the endpoint behavior itself is covered by console-server integration tests and a public-API playwright test in the enterprise repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErSCcNzYLYkCgKEuCe5bVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErSCcNzYLYkCgKEuCe5bVh)_