### PR TITLE
fix(shared): honor absolute schema paths

### DIFF
--- a/packages/cubejs-backend-shared/src/FileRepository.ts
+++ b/packages/cubejs-backend-shared/src/FileRepository.ts
@@ -20,7 +20,7 @@ export class FileRepository implements SchemaFileRepository {
   }
 
   public localPath(): string {
-    return path.join(process.cwd(), this.repositoryPath);
+    return path.resolve(process.cwd(), this.repositoryPath);
   }
 
   protected async getFiles(dir: string, fileList: string[] = []): Promise<string[]> {

--- a/packages/cubejs-backend-shared/test/FileRepository.test.ts
+++ b/packages/cubejs-backend-shared/test/FileRepository.test.ts
@@ -1,0 +1,31 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+import { FileRepository } from '../src/FileRepository';
+
+describe('FileRepository', () => {
+  let repositoryPath: string;
+
+  beforeEach(() => {
+    repositoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'cube-models-'));
+  });
+
+  afterEach(() => {
+    fs.removeSync(repositoryPath);
+  });
+
+  test('reads data models from an absolute repository path', async () => {
+    fs.writeFileSync(path.join(repositoryPath, 'orders.yml'), 'cubes: []');
+
+    const repository = new FileRepository(repositoryPath);
+
+    expect(repository.localPath()).toBe(repositoryPath);
+    await expect(repository.dataSchemaFiles()).resolves.toEqual([
+      {
+        fileName: 'orders.yml',
+        content: 'cubes: []',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve configured schema paths against the working directory while preserving absolute paths
- add a regression test that loads a model from an absolute repository path

## Verification
- `yarn workspace @cubejs-backend/shared unit --runTestsByPath test/FileRepository.test.ts --runInBand`
- `yarn workspace @cubejs-backend/shared tsc`
- ESLint passed for both changed files (with `linebreak-style` disabled locally because Git for Windows checked the sparse worktree out as CRLF)

Fixes #10746