### PR TITLE
docs: document embed dashboard CLI toggle, CLI version banner, and devmode deep link

### DIFF
--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -59,6 +59,23 @@ You'll then be able to either resolve them manually or discard the changes.
   <img src="https://ucarecdn.com/4834bbf0-7b9c-41ae-b562-4362c25ec3fe/" alt="Conflict Resolution UI" />
 </Frame>
 
+## Deep-link into development mode
+
+You can link directly into development mode on the Semantic Model IDE by
+adding query parameters to the page URL:
+
+- `?branch=<name>` switches to the given branch, entering development mode
+  if you're already in it (or staying read-only otherwise).
+- `?devmode=true` enters development mode on the current branch. Combine it
+  with `?branch=` to enter development mode on a specific branch in one step:
+
+```text
+https://your-tenant.cubecloud.dev/d/DEPLOYMENT_ID/schema?branch=my-branch&devmode=true
+```
+
+Both parameters are stripped from the URL once applied. They're a no-op for
+users without permission to use development mode.
+
 ## Finding endpoints
 
 In Development Mode, you'll have dedicated endpoints that will track the branch you're on.

--- a/docs-mintlify/embedding/iframe/dashboards.mdx
+++ b/docs-mintlify/embedding/iframe/dashboards.mdx
@@ -37,6 +37,15 @@ Users will be prompted to sign in with their Cube credentials when accessing the
 
 ## Embed with signed embedding
 
+Signed embedding must be allowed on the dashboard first: open the dashboard,
+click **Share** → **Embed**, and turn on **Allow signed embedding**. You can
+also toggle it without opening the UI using the [Cube CLI](/reference/cli):
+
+```bash
+cube embed enable-dashboard YOUR_DASHBOARD_PUBLIC_ID
+cube embed disable-dashboard YOUR_DASHBOARD_PUBLIC_ID
+```
+
 To embed a dashboard for external/customer-facing applications, generate a session on your backend and pass the session ID into the iframe:
 
 ```html

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -41,6 +41,9 @@ cube update          # install the latest release
 cube update --check  # only report what's available
 ```
 
+Running `cube` with no arguments prints the installed version above the help
+text.
+
 ## Authentication
 
 Sign in with the browser device flow — the CLI prints a URL and a short
@@ -154,7 +157,7 @@ Run `cube <command> --help` for the full options of any command.
 | `folders`, `workbooks`, `reports`, `workspace` | Workspace content management |
 | `users`, `groups`, `attributes`, `policies` | Users, groups, and access control |
 | `tenant`, `notifications`, `integrations`, `oidc`, `api-keys` | Account administration |
-| `embed` | Embed sessions, tokens, and embed tenants |
+| `embed` | Embed sessions, tokens, embed tenants; `enable-dashboard`/`disable-dashboard` toggle signed embedding for a dashboard |
 | `agents`, `app`, `meta`, `scim` | Agents, app config, model metadata, SCIM v2 |
 | `api` | Raw authenticated API request (escape hatch): `cube api GET /api/v1/... -q key=value -d '{...}'` |
 | `update` | Update the CLI to the latest release |


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (docs-only change)
- [ ] Linter has been run for changed code (docs-only change)
- [ ] Tests for the changes have been added if not covered yet (docs-only change)

**Description of Changes Made**

Found while cross-checking recent `cube-js/cube` and `cubejs-enterprise` changes against docs-mintlify for undocumented customer-facing features:

- **`reference/cli.mdx`**: note the new `cube embed enable-dashboard` / `disable-dashboard` subcommands (#11356), and that running bare `cube` with no arguments now prints the installed version (#11344).
- **`embedding/iframe/dashboards.mdx`**: document that signed embedding must be allowed on a dashboard via the **Allow signed embedding** toggle (Share → Embed), and that it can now also be toggled via the CLI commands above — backed by the new public admin endpoint `PATCH /api/v1/embed/dashboard/:publicId` added in cubejs-enterprise#13274.
- **`docs/data-modeling/dev-mode.mdx`**: document the `?branch=`/`?devmode=true` deep-link query params into the Semantic Model IDE, added in cubejs-enterprise#13237.

All are small, surgical additions to existing pages per `docs-mintlify/CLAUDE.md` conventions — no new pages.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XXfGH6ruPWCo4zCTJNc1RC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXfGH6ruPWCo4zCTJNc1RC)_