### PR TITLE
docs: document all 16 Cube MCP server tools and the dev-branch safety model

### DIFF
--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -7,7 +7,8 @@ Cube MCP (Model Context Protocol) lets MCP-compatible AI clients connect to Cube
 
 <Note>
 
-The MCP server is available on [Premium and Enterprise plans](https://cube.dev/pricing). <br />Users need the [Viewer][ref-roles] role or higher to interact with the MCP server.
+The MCP server is available on [Premium and Enterprise plans](https://cube.dev/pricing). <br />Users need the [Viewer][ref-roles] role or higher to interact with the MCP server. Which tools a
+user sees depends on their role — see [Available actions](#available-actions).
 
 </Note>
 
@@ -210,20 +211,144 @@ neither `listDeployments` nor the `chat` selection can reach an excluded deploym
 
 ## Available actions
 
-- Discover accessible deployments and agents with `listDeployments`
-- Chat with a Cube AI agent over MCP, optionally targeting a specific deployment and agent
-- Query data and request analysis
-- Receive responses directly in your MCP client
+The MCP server exposes 16 tools, grouped below.
+
+Every tool runs as the authenticated user. Queries respect the same
+[permissions][ref-roles] as the rest of Cube, including row-level security — MCP is a new
+way to reach your data, not a new access surface.
+
+### Read and write tools
+
+Each tool is annotated as read-only or destructive. MCP clients that honor these
+annotations — including Claude — run read-only tools automatically and **always ask for
+confirmation** before any of the four destructive ones: `updateDashboard`,
+`publishDashboard`, `writeDataModelFile`, and `deleteDataModelFile`. Nothing that changes
+a dashboard or your data model happens without an explicit approval.
+
+### Deployments and chat
+
+| Tool | Description |
+| --- | --- |
+| `listDeployments` | Lists the deployments and agents you can reach over MCP. |
+| `chat` | Asks a question of a Cube agent, optionally targeting a specific deployment and agent. |
+| `loadQueryResults` | Paginates through the results of a previous query. |
+
+See [Select a deployment and agent](#select-a-deployment-and-agent) for how these three
+work together.
+
+### Query and discovery
+
+| Tool | Description | Access |
+| --- | --- | --- |
+| `searchDataModel` | Searches the semantic model by similarity — views and their measures and dimensions — to discover what is queryable. Returns compact records (name, title, description, type) to reference in `runQuery`. | Read-only |
+| `runQuery` | Runs a Cube SQL query (PostgreSQL dialect) against the [SQL API][ref-sql-api]. Returns a schema, a page of rows, and `hasMore` / `totalRows` for pagination via `offset`. | Read-only |
+
+Call `searchDataModel` before `runQuery` to find exact view and member names rather than
+guessing them.
+
+### Dashboard authoring
+
+These tools build [workbooks][ref-workbooks] and [dashboards][ref-dashboards]
+programmatically. Creating and editing workbooks requires the Explorer role or higher.
+
+| Tool | Description | Access |
+| --- | --- | --- |
+| `readWorkbook` | Reads a workbook — its name and its current dashboard draft and published configs. | Read-only |
+| `createWorkbook` | Creates a new empty workbook, the container that holds reports and a dashboard. | Write |
+| `createReport` | Saves a query plus its visualization as a report inside a workbook, and returns the `reportId` a chart widget references. | Write |
+| `updateDashboard` | Saves the dashboard layout to the workbook **draft**. Replaces the full widget set and does not go live. | Destructive — prompts |
+| `publishDashboard` | Publishes the current draft to make it live. Idempotent — republishing an unchanged draft is a no-op. | Destructive — prompts |
+
+Drafts are the safety net here: `updateDashboard` only ever writes to the draft, so a
+published dashboard keeps serving its previous version until you approve
+`publishDashboard`. See [Build a dashboard](#build-a-dashboard) for the full sequence.
+
+### Data model editing
+
+These tools read and edit the semantic model **source** files. They are registered only
+for users whose role grants permission to edit the semantic model — Admin and Developer by
+default. Users without it never see them.
+
+| Tool | Description | Access |
+| --- | --- | --- |
+| `listDataModelFiles` | Lists the semantic model source files (raw YAML, JavaScript, or Python). | Read-only |
+| `readDataModelFile` | Reads one file's raw source. | Read-only |
+| `startDataModelEdit` | Enters [development mode][ref-dev-mode], starts a dev worker, and returns the dev `branchName` that every write tool requires. | Write |
+| `writeDataModelFile` | Creates or overwrites a model source file on the dev branch (whole-file replacement). Recompiles the model and reports `valid` plus any `validationError`. | Destructive — prompts |
+| `deleteDataModelFile` | Deletes a model source file on the dev branch. | Destructive — prompts |
+| `getDataModelChanges` | Shows the diff of the dev branch against its parent — the pending changes, for review before committing. | Read-only |
+
+#### How model edits stay safe
+
+Letting an AI client edit your semantic model is safe because of four constraints built
+into the MCP server:
+
+- **Edits never touch production.** Every write goes to a personal dev branch named
+  `dev-<user>-<hash>`. The write tools reject any branch that isn't a dev branch, so
+  the deploy branch is never writable over MCP.
+- **`startDataModelEdit` is the only entry point.** It returns the dev `branchName`, and
+  `writeDataModelFile` and `deleteDataModelFile` require it. There is no way to write
+  without going through it first.
+- **Promotion is manual and human.** To publish model changes you commit the dev branch
+  from the Cube UI, as described in [Development mode][ref-dev-mode]. The MCP server
+  deliberately exposes no commit tool — an AI client can prepare changes, but only a
+  person can ship them.
+- **Registration is permission-gated.** The six tools above are only offered to users
+  whose role allows editing the semantic model.
+
+Review pending work with `getDataModelChanges` before you commit.
 
 ## Example workflows
 
-- Ask a data question in natural language
-- Get SQL generated by the agent
-- Request summaries, trends, and insights
+### Ask a data question
+
+Ask a question in natural language and let the agent do the planning: `chat` returns the
+answer along with the SQL it generated, and `loadQueryResults` pages through large result
+sets. Use this for summaries, trends, and ad-hoc analysis.
+
+To drive the query yourself instead, call `searchDataModel` to find the right view and
+members, then run your own SQL with `runQuery`.
 
 <Frame>
   <img src="https://lgo0ecceic.ucarecd.net/102c3c3e-3657-42aa-8d3d-2029ca21115c/" />
 </Frame>
+
+### Build a dashboard
+
+The five dashboard tools are designed to be used in order.
+
+<Steps>
+  <Step title="Create the workbook">
+    Call `createWorkbook` with a name. It returns the `workbookId` every later step needs.
+    If you were given an existing workbook to build into, call `readWorkbook` instead and
+    skip to the next step.
+  </Step>
+  <Step title="Create a report per chart">
+    Call `createReport` once per chart, KPI tile, or table, passing the `workbookId` and
+    the SQL query that powers it. Each call returns a `reportId`.
+  </Step>
+  <Step title="Lay out the dashboard">
+    Call `updateDashboard` with the complete widget set, referencing each `reportId` from
+    the previous step. This replaces the draft layout and saves to the workbook draft —
+    the live dashboard is unchanged. Your client will ask you to confirm.
+  </Step>
+  <Step title="Publish">
+    Review the draft, then call `publishDashboard` to make it live. This also prompts for
+    confirmation. It returns the dashboard URL.
+  </Step>
+</Steps>
+
+To change a dashboard later, call `readWorkbook` first and edit on top of the current
+draft rather than overwriting it.
+
+### Edit the data model
+
+Call `startDataModelEdit` to enter development mode and get a dev `branchName`. Explore
+the current source with `listDataModelFiles` and `readDataModelFile`, then apply changes
+with `writeDataModelFile` or `deleteDataModelFile`, passing that `branchName`. Each write
+recompiles the model and reports validation errors, so you can iterate until it compiles.
+Review the result with `getDataModelChanges`, then commit the branch from the Cube UI to
+publish it.
 
 ## Troubleshooting
 
@@ -233,3 +358,7 @@ neither `listDeployments` nor the `chat` selection can reach an excluded deploym
 - **`Deployment <id> is not available via MCP for this account` (403)**: The requested deployment is excluded by the deployment-access allow-list or by the user's permissions. Call `listDeployments` to see which deployments are reachable, or adjust the allow-list in **Admin → MCP Server → Deployment Access**.
 
 [ref-roles]: /admin/users-and-permissions/roles-and-permissions
+[ref-sql-api]: /reference/core-data-apis/sql-api
+[ref-workbooks]: /docs/explore-analyze/workbooks
+[ref-dashboards]: /docs/explore-analyze/dashboards
+[ref-dev-mode]: /docs/data-modeling/dev-mode


### PR DESCRIPTION
## What

Expands the [MCP server page](https://docs.cube.dev/docs/integrations/mcp-server) to cover the whole tool surface. **Available actions** previously listed 3 of the 16 tools the server exposes; it now documents all 16 in four grouped tables, each with an Access column:

| Group | Tools |
| --- | --- |
| Deployments and chat | `listDeployments`, `chat`, `loadQueryResults` |
| Query and discovery | `searchDataModel`, `runQuery` |
| Dashboard authoring | `readWorkbook`, `createWorkbook`, `createReport`, `updateDashboard`, `publishDashboard` |
| Data model editing | `listDataModelFiles`, `readDataModelFile`, `startDataModelEdit`, `writeDataModelFile`, `deleteDataModelFile`, `getDataModelChanges` |

Two other additions:

- **The dev-branch safety model**, documented publicly for the first time — writes only ever land on a personal dev branch (`dev-<user>-<hash>`), `startDataModelEdit` is the sole entry point, promotion requires committing from the Cube UI (the server deliberately exposes no commit tool), and the six model tools are registered only for roles that may edit the semantic model. Queries reuse the caller's Cube role, including row-level security.
- **The annotation contract**, stated up front — read-only tools auto-run, and the four destructive ones (`updateDashboard`, `publishDashboard`, `writeDataModelFile`, `deleteDataModelFile`) always prompt. This should head off "why does it keep asking me?" tickets.

**Example workflows** replaced three bullets with three worked examples, including the full `createWorkbook → createReport → updateDashboard → publishDashboard` chain as `<Steps>`.

## Why

Public documentation is a hard requirement for the Claude Connectors Directory submission. Reviewers compare the page against the tool list the directory syncs live from the MCP server, so a 3-vs-16 mismatch stalls or fails review. No server-side changes here — that work lives elsewhere and is already merged or in review.

## Reviewer notes

- **`visualize` is deliberately omitted.** It exists on the server but is gated behind a tenant flag and a client capability, and is not part of this submission.
- **A role-precision claim worth a second look.** The prerequisites note said "Viewer role or higher", true as a floor but misleading now that the page covers authoring: per the permissions matrix, workbooks need Explorer+ and model editing needs Developer+. I left the note intact, added a pointer to **Available actions**, and stated the requirement per group. That gating is derived from the permissions matrix rather than from the tool definitions.
- **One existing screenshot moved.** The chat screenshot sat at the end of **Example workflows**; once that section gained subsections it would have landed under *Edit the data model*, which it doesn't illustrate. It's now under *Ask a data question*.
- This did not go on `docs/remove-cli-preview-warning` (whose PR #11352 was squash-merged) — it's branched fresh off `master`.

## Verification

- All 16 descriptions checked against the **live server's own tool definitions**, not just secondhand notes — including the `startDataModelEdit` → `branchName` requirement and `publishDashboard` idempotency.
- Every cited URL curled for a 200 with an empty redirect. `docs.cube.dev` prefixes do not generalize post-migration (`/docs/integrations/mcp-server` vs `/reference/core-data-apis/sql-api`), so no URL was inferred from a sibling page.
- `yarn broken-links --check-anchors` clean for this page. It exits non-zero on 16 pre-existing failures in `embedding/iframe/events.mdx` and `localization.mdx`, both untouched here.
- Rendered on the local Mintlify server: tables, `<Steps>`, and callouts parse, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)