### PR TITLE
fix(pinot/dremio/ksql/databriks/hive/jdbc-driver): correct SQL parameter escaping

### DIFF
--- a/packages/cubejs-backend-shared/src/sql-escape.ts
+++ b/packages/cubejs-backend-shared/src/sql-escape.ts
@@ -30,6 +30,19 @@ const MySqlDialect: SqlDialectEscapeRules = {
   identifierQuoteChar: '`',
 };
 
+/**
+ * Spark SQL / Hive / Databricks. Their lexers know backslash escapes only — a
+ * doubled quote is NOT an escape, it closes the literal and opens the next one.
+ * Because adjacent literals are concatenated, `'O''Brien'` silently evaluates to
+ * `OBrien` instead of raising, so quotes MUST be escaped as `\'` here.
+ */
+const SparkSqlDialect: SqlDialectEscapeRules = {
+  stringQuoteChar: '\'',
+  doubleQuoteToEscape: false,
+  escapeBackslash: true,
+  identifierQuoteChar: '`',
+};
+
 class SqlEscaper {
   public constructor(public readonly rules: SqlDialectEscapeRules) {}
 
@@ -166,11 +179,33 @@ class SqlEscaper {
 }
 
 /**
+ * Escaping dialect of the target engine:
+ *   - `ansi`  — standard SQL: Presto, Trino, Athena, Dremio, ksqlDB, Pinot, ...
+ *   - `mysql` — MySQL / MariaDB: quotes doubled, backslash is an escape char
+ *   - `spark` — Spark SQL / Hive / Databricks: backslash escapes only
+ */
+export type EscapeDialect = 'ansi' | 'mysql' | 'spark';
+
+const Dialects: Record<EscapeDialect, SqlDialectEscapeRules> = {
+  ansi: AnsiSqlDialect,
+  mysql: MySqlDialect,
+  spark: SparkSqlDialect,
+};
+
+/**
+ * Format a query for the given engine dialect: `?` -> escaped value,
+ * `??` -> escaped identifier.
+ */
+export function format(dialect: EscapeDialect, sql: string, values?: unknown): string {
+  return new SqlEscaper(Dialects[dialect]).format(sql, values);
+}
+
+/**
  * Format a query for standard-SQL engines (Presto, Trino, Postgres, ...):
  * `?` -> escaped value, `??` -> escaped identifier.
  */
 export function formatAnsi(sql: string, values?: unknown): string {
-  return new SqlEscaper(AnsiSqlDialect).format(sql, values);
+  return format('ansi', sql, values);
 }
 
 /**
@@ -178,7 +213,15 @@ export function formatAnsi(sql: string, values?: unknown): string {
  * identifier.
  */
 export function formatMySql(sql: string, values?: unknown): string {
-  return new SqlEscaper(MySqlDialect).format(sql, values);
+  return format('mysql', sql, values);
+}
+
+/**
+ * Format a query for Spark SQL / Hive / Databricks: `?` -> escaped value,
+ * `??` -> escaped identifier.
+ */
+export function formatSparkSql(sql: string, values?: unknown): string {
+  return format('spark', sql, values);
 }
 
 export function escapeStringLiteral(value: string): string {

--- a/packages/cubejs-backend-shared/src/sql-escape.ts
+++ b/packages/cubejs-backend-shared/src/sql-escape.ts
@@ -46,6 +46,7 @@ class SqlEscaper {
     if (escapeBackslash) {
       escaped = escaped.split('\\').join('\\\\');
     }
+
     escaped = doubleQuoteToEscape
       ? escaped.split(stringQuoteChar).join(stringQuoteChar + stringQuoteChar)
       : escaped.split(stringQuoteChar).join(`\\${stringQuoteChar}`);
@@ -178,4 +179,8 @@ export function formatAnsi(sql: string, values?: unknown): string {
  */
 export function formatMySql(sql: string, values?: unknown): string {
   return new SqlEscaper(MySqlDialect).format(sql, values);
+}
+
+export function escapeStringLiteral(value: string): string {
+  return new SqlEscaper(AnsiSqlDialect).escapeString(String(value));
 }

--- a/packages/cubejs-backend-shared/test/sql-escape.test.ts
+++ b/packages/cubejs-backend-shared/test/sql-escape.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable quotes */
 import {
+  escapeStringLiteral,
   formatAnsi,
   formatMySql,
 } from '../src/sql-escape';
@@ -412,6 +413,32 @@ describe('sql-escape', () => {
     it('helpers normalize scalar values', () => {
       expect(formatAnsi('SELECT ?, ?', "a'b")).toBe("SELECT 'a''b', ?");
       expect(formatMySql('SELECT ?', false)).toBe('SELECT FALSE');
+    });
+  });
+
+  describe('escapeStringLiteral', () => {
+    it('wraps the value in quotes', () => {
+      expect(escapeStringLiteral('orders_rollup')).toBe("'orders_rollup'");
+    });
+
+    it('doubles an embedded quote so the literal cannot be escaped', () => {
+      expect(escapeStringLiteral("pre_agg_x'; DROP TABLE victim; --"))
+        .toBe("'pre_agg_x''; DROP TABLE victim; --'");
+    });
+
+    it('leaves a backslash as data', () => {
+      expect(escapeStringLiteral('folder\\name')).toBe("'folder\\name'");
+      expect(escapeStringLiteral('trailing\\')).toBe("'trailing\\'");
+    });
+
+    it.each(injectionPayloads)('neutralizes the %s payload', (_name, payload) => {
+      const literal = escapeStringLiteral(payload);
+
+      expect(literal.startsWith("'")).toBe(true);
+      expect(literal.endsWith("'")).toBe(true);
+      // Every inner quote is doubled, so the literal has no odd-length quote run
+      // that could terminate it early.
+      expect(literal.slice(1, -1).split("'").length % 2).toBe(1);
     });
   });
 });

--- a/packages/cubejs-backend-shared/test/sql-escape.test.ts
+++ b/packages/cubejs-backend-shared/test/sql-escape.test.ts
@@ -1,8 +1,10 @@
 /* eslint-disable quotes */
 import {
   escapeStringLiteral,
+  format,
   formatAnsi,
   formatMySql,
+  formatSparkSql,
 } from '../src/sql-escape';
 
 const injectionPayloads: Array<[string, string]> = [
@@ -66,6 +68,38 @@ function decodeMySqlLiteral(literal: string): string {
   return decoded;
 }
 
+/**
+ * Parses the subset of Spark SQL / Hive string-literal syntax emitted by
+ * SqlEscaper. A doubled quote is not an escape there, so any quote in the body
+ * must be backslash-prefixed — an unescaped one means the escaper let the
+ * literal close early (and Spark would concatenate whatever follows).
+ */
+function decodeSparkLiteral(literal: string): string {
+  if (literal.length < 2 || literal[0] !== "'" || literal[literal.length - 1] !== "'") {
+    throw new Error('Not a quoted Spark string literal');
+  }
+
+  const body = literal.slice(1, -1);
+  let decoded = '';
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i];
+    if (char === "'") {
+      throw new Error('Unescaped quote in Spark string literal');
+    }
+    if (char === '\\') {
+      const next = body[i + 1];
+      if (next !== '\\' && next !== "'") {
+        throw new Error('Unescaped backslash in Spark string literal');
+      }
+      decoded += next;
+      i++;
+    } else {
+      decoded += char;
+    }
+  }
+  return decoded;
+}
+
 function stringsUpToLength(alphabet: string[], maxLength: number): string[] {
   const values = [''];
   let current = [''];
@@ -90,6 +124,12 @@ describe('sql-escape', () => {
     escapeIdentifier: (value: string) => formatMySql('??', [value]),
     escapeValue: (value: unknown) => formatMySql('?', [value]),
     format: formatMySql,
+  };
+  const spark = {
+    escapeString: (value: string) => formatSparkSql('?', [value]),
+    escapeIdentifier: (value: string) => formatSparkSql('??', [value]),
+    escapeValue: (value: unknown) => formatSparkSql('?', [value]),
+    format: formatSparkSql,
   };
 
   describe('escapeString — ANSI/Presto (double quotes, backslash literal)', () => {
@@ -194,10 +234,59 @@ describe('sql-escape', () => {
     });
   });
 
+  describe('escapeString — Spark SQL/Hive/Databricks (backslash escapes only)', () => {
+    it('escapes quotes with a backslash instead of doubling them', () => {
+      // Verified against apache/spark:3.5.1 — `SELECT 'O''Brien'` returns OBrien
+      // (two adjacent literals, silently concatenated), while `'O\'Brien'`
+      // returns O'Brien. Hive 2.3.5 concatenates the same way by grammar.
+      expect(spark.escapeString("O'Brien")).toBe("'O\\'Brien'");
+      expect(spark.escapeString("O'Brien")).not.toContain("''");
+    });
+
+    it('doubles backslashes', () => {
+      expect(spark.escapeString('a\\b')).toBe("'a\\\\b'");
+    });
+
+    it('neutralizes a trailing backslash + quote payload', () => {
+      expect(spark.escapeString("\\'")).toBe("'\\\\\\''");
+    });
+
+    it.each(injectionPayloads)('keeps the %s payload inside one literal', (_name, payload) => {
+      expect(decodeSparkLiteral(spark.escapeString(payload))).toBe(payload);
+    });
+
+    it('round-trips every short combination of dangerous characters', () => {
+      const candidates = stringsUpToLength(["'", '\\', '\0', '\n', '\r', 'a'], 4);
+
+      for (const candidate of candidates) {
+        expect(decodeSparkLiteral(spark.escapeString(candidate))).toBe(candidate);
+      }
+    });
+
+    it('escapes alternating backslashes and quote runs without changing their value', () => {
+      const value = "\\''\\\\'''";
+      expect(decodeSparkLiteral(spark.escapeString(value))).toBe(value);
+    });
+
+    it('preserves representative Unicode and invisible characters', () => {
+      const values = [
+        'Café 日本語 👨‍👩‍👧‍👦',
+        'cafe\u0301',
+        'مرحبا بالعالم',
+        'left\u200Dright',
+      ];
+
+      for (const value of values) {
+        expect(decodeSparkLiteral(spark.escapeString(value))).toBe(value);
+      }
+    });
+  });
+
   describe('escapeIdentifier', () => {
     it('quotes with the dialect identifier char and doubles it', () => {
       expect(presto.escapeIdentifier('my"col')).toBe('"my""col"');
       expect(mysql.escapeIdentifier('my`col')).toBe('`my``col`');
+      expect(spark.escapeIdentifier('my`col')).toBe('`my``col`');
     });
 
     it('keeps identifier injection payloads within the quoted identifier', () => {
@@ -386,6 +475,30 @@ describe('sql-escape', () => {
     it('substitutes placeholders adjacent to arithmetic operators', () => {
       expect(presto.format('SELECT ? - ? + ? / ?', [10, 3, 20, 4]))
         .toBe('SELECT 10 - 3 + 20 / 4');
+    });
+  });
+
+  describe('format (dialect-driven entry point)', () => {
+    it('escapes according to the requested dialect', () => {
+      const value = "a\\b'c";
+
+      expect(format('ansi', 'WHERE a = ?', [value])).toBe("WHERE a = 'a\\b''c'");
+      expect(format('mysql', 'WHERE a = ?', [value])).toBe("WHERE a = 'a\\\\b''c'");
+      expect(format('spark', 'WHERE a = ?', [value])).toBe("WHERE a = 'a\\\\b\\'c'");
+    });
+
+    it('escapes identifiers according to the requested dialect', () => {
+      expect(format('ansi', 'SELECT ??', ['col'])).toBe('SELECT "col"');
+      expect(format('mysql', 'SELECT ??', ['col'])).toBe('SELECT `col`');
+      expect(format('spark', 'SELECT ??', ['col'])).toBe('SELECT `col`');
+    });
+
+    it('backs the per-dialect convenience helpers', () => {
+      const args: [string, unknown[]] = ['WHERE a = ? AND b = ??', ["it's", 'col']];
+
+      expect(formatAnsi(...args)).toBe(format('ansi', ...args));
+      expect(formatMySql(...args)).toBe(format('mysql', ...args));
+      expect(formatSparkSql(...args)).toBe(format('spark', ...args));
     });
   });
 

--- a/packages/cubejs-backend-shared/test/sql-escape.test.ts
+++ b/packages/cubejs-backend-shared/test/sql-escape.test.ts
@@ -432,13 +432,15 @@ describe('sql-escape', () => {
     });
 
     it.each(injectionPayloads)('neutralizes the %s payload', (_name, payload) => {
-      const literal = escapeStringLiteral(payload);
+      expect(decodeAnsiLiteral(escapeStringLiteral(payload))).toBe(payload);
+    });
 
-      expect(literal.startsWith("'")).toBe(true);
-      expect(literal.endsWith("'")).toBe(true);
-      // Every inner quote is doubled, so the literal has no odd-length quote run
-      // that could terminate it early.
-      expect(literal.slice(1, -1).split("'").length % 2).toBe(1);
+    it('round-trips every short combination of dangerous characters', () => {
+      const candidates = stringsUpToLength(["'", '\\', '\0', '\n', '\r', 'a'], 4);
+
+      for (const candidate of candidates) {
+        expect(decodeAnsiLiteral(escapeStringLiteral(candidate))).toBe(candidate);
+      }
     });
   });
 });

--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
@@ -688,7 +688,7 @@ export class DatabricksDriver extends JDBCDriver {
   }
 
   protected escapeDialect(): EscapeDialect {
-    return 'mysql';
+    return 'spark';
   }
 
   /**

--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
@@ -17,7 +17,7 @@ import {
   TableColumn,
   UnloadOptions,
 } from '@cubejs-backend/base-driver';
-import { JDBCDriver, JDBCDriverConfiguration, } from '@cubejs-backend/jdbc-driver';
+import { EscapeDialect, JDBCDriver, JDBCDriverConfiguration, } from '@cubejs-backend/jdbc-driver';
 import { DatabricksQuery } from './DatabricksQuery';
 import {
   extractAndRemoveUidPwdFromJdbcUrl,
@@ -685,6 +685,10 @@ export class DatabricksDriver extends JDBCDriver {
     }
 
     return result;
+  }
+
+  protected escapeDialect(): EscapeDialect {
+    return 'mysql';
   }
 
   /**

--- a/packages/cubejs-dremio-driver/driver/DremioDriver.js
+++ b/packages/cubejs-dremio-driver/driver/DremioDriver.js
@@ -7,10 +7,10 @@
 const {
   getEnv,
   assertDataSource,
+  formatAnsi,
   pausePromise,
 } = require('@cubejs-backend/shared');
 const axios = require('axios');
-const SqlString = require('sqlstring');
 const { BaseDriver } = require('@cubejs-backend/base-driver');
 const DremioQuery = require('./DremioQuery');
 
@@ -18,7 +18,7 @@ const DremioQuery = require('./DremioQuery');
 // @see https://docs.dremio.com/rest-api/jobs/get-job.html
 const DREMIO_JOB_LIMIT = 500;
 
-const applyParams = (query, params) => SqlString.format(query, params);
+const applyParams = (query, params) => formatAnsi(query, params);
 
 /**
  * Dremio driver class.
@@ -208,12 +208,7 @@ class DremioDriver extends BaseDriver {
   }
 
   async query(query, values) {
-    const queryString = applyParams(
-      query,
-      (values || []).map(s => (typeof s === 'string' ? {
-        toSqlString: () => SqlString.escape(s).replace(/\\\\([_%])/g, '\\$1').replace(/\\'/g, '\'\'')
-      } : s))
-    );
+    const queryString = applyParams(query, values || []);
 
     await this.getToken();
     const jobId = await this.executeQuery(queryString);
@@ -281,3 +276,4 @@ class DremioDriver extends BaseDriver {
 }
 
 module.exports = DremioDriver;
+module.exports.applyParams = applyParams;

--- a/packages/cubejs-dremio-driver/package.json
+++ b/packages/cubejs-dremio-driver/package.json
@@ -16,6 +16,7 @@
     "tsc": "tsc",
     "watch": "tsc -w",
     "test": "yarn integration",
+    "unit": "jest --verbose dist/test/unit",
     "integration": "npm run integration:dremio",
     "integration:dremio": "jest --verbose dist/test",
     "lint": "eslint driver/*.js",
@@ -25,8 +26,7 @@
     "@cubejs-backend/base-driver": "1.7.11",
     "@cubejs-backend/schema-compiler": "1.7.11",
     "@cubejs-backend/shared": "1.7.11",
-    "axios": "^1.8.3",
-    "sqlstring": "^2.3.1"
+    "axios": "^1.8.3"
   },
   "devDependencies": {
     "@cubejs-backend/linter": "1.7.11",

--- a/packages/cubejs-dremio-driver/test/unit/params-escaping.test.ts
+++ b/packages/cubejs-dremio-driver/test/unit/params-escaping.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable quotes */
+const { applyParams } = require('../../../driver/DremioDriver');
+
+// Dremio is a Calcite-based, standard-SQL engine: a quote inside a string
+// literal is escaped by doubling it and a backslash is plain data.
+describe('DremioDriver SQL parameter escaping', () => {
+  it('preserves LIKE escape sequences emitted by the schema compiler', () => {
+    const sql = applyParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE '%' || LOWER(?) || '%' ESCAPE '\\'`,
+      ['new\\_order\\%'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE '%' || LOWER('new\\_order\\%') || '%' ESCAPE '\\'`
+    );
+  });
+
+  it('does not double literal backslashes in LIKE parameters', () => {
+    const sql = applyParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE '%' || LOWER(?) || '%' ESCAPE '\\'`,
+      ['folder\\\\name'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE '%' || LOWER('folder\\\\name') || '%' ESCAPE '\\'`
+    );
+  });
+
+  it('doubles quotes so a value cannot break out of the literal', () => {
+    const sql = applyParams(
+      'SELECT * FROM orders WHERE name = ?',
+      [`o'reilly'); DROP TABLE orders; --`],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE name = 'o''reilly''); DROP TABLE orders; --'`
+    );
+  });
+
+  it('keeps the literal closed for a backslash-then-quote payload', () => {
+    // In a backslash-escaping dialect `\'` would smuggle a quote through; on
+    // Dremio the backslash is data and only the quote needs doubling.
+    const sql = applyParams(
+      'SELECT * FROM orders WHERE name = ?',
+      [`foo\\' OR 1=1 --`],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE name = 'foo\\'' OR 1=1 --'`);
+  });
+
+  it('keeps the literal closed for a value ending in a backslash', () => {
+    const sql = applyParams(
+      'SELECT * FROM orders WHERE name = ? AND status = ?',
+      ['payload\\', 'new'],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE name = 'payload\\' AND status = 'new'`);
+  });
+
+  it('keeps a literal percent sign in an equality parameter verbatim', () => {
+    const sql = applyParams(
+      'SELECT * FROM orders WHERE discount_label = ?',
+      ['100% cotton'],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE discount_label = '100% cotton'`);
+  });
+
+  it('escapes every element of an array parameter', () => {
+    const sql = applyParams(
+      'SELECT * FROM orders WHERE status IN (?)',
+      [[`it's`, 'b']],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE status IN ('it''s', 'b')`);
+  });
+
+  it('substitutes multiple placeholders in order', () => {
+    const sql = applyParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE '%' || LOWER(?) || '%' ESCAPE '\\' AND status = ? AND amount > ?`,
+      ['pending\\_review', 'new', 100],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE '%' || LOWER('pending\\_review') || '%' ESCAPE '\\' AND status = 'new' AND amount > 100`
+    );
+  });
+});

--- a/packages/cubejs-jdbc-driver/package.json
+++ b/packages/cubejs-jdbc-driver/package.json
@@ -17,6 +17,7 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
+    "unit": "jest --verbose dist/test/unit",
     "lint": "eslint src/* --ext .ts",
     "lint:fix": "eslint --fix src/* --ext .ts"
   },
@@ -27,8 +28,7 @@
   "dependencies": {
     "@cubejs-backend/base-driver": "1.7.11",
     "@cubejs-backend/node-java-maven": "^0.1.3",
-    "@cubejs-backend/shared": "1.7.11",
-    "sqlstring": "^2.3.0"
+    "@cubejs-backend/shared": "1.7.11"
   },
   "optionalDependencies": {
     "@cubejs-backend/jdbc": "^0.9.0",
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@cubejs-backend/linter": "1.7.11",
     "@types/node": "^22",
-    "@types/sqlstring": "^2.3.0",
     "typescript": "~5.2.2"
   }
 }

--- a/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
+++ b/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
@@ -237,7 +237,13 @@ export class JDBCDriver extends BaseDriver {
 
   protected escapeDialect(): EscapeDialect {
     const dbTypeDescription = JDBCDriver.dbTypeDescription(this.config.dbType);
-    return dbTypeDescription?.escapeDialect || 'mysql';
+    if (dbTypeDescription?.escapeDialect) {
+      return dbTypeDescription.escapeDialect;
+    }
+
+    throw new Error(
+      `Unable to detect SQL escaping rules for db type "${this.config.dbType}"`
+    );
   }
 
   protected prepareQueryWithParams(query: string, values: unknown[]): string {

--- a/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
+++ b/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
@@ -292,9 +292,11 @@ export class JDBCDriver extends BaseDriver {
 
   public async stream(sql: string, values: unknown[], { highWaterMark }: StreamOptions): Promise<DownloadQueryResultsResult> {
     const conn = await this.pool.acquire();
-    const query = this.prepareQueryWithParams(sql, values);
-    const cancelObj: {cancel?: Function} = {};
+
     try {
+      const query = this.prepareQueryWithParams(sql, values);
+      const cancelObj: {cancel?: Function} = {};
+
       const createStatement = promisify(conn.createStatement.bind(conn));
       const statement = await createStatement();
 
@@ -335,6 +337,7 @@ export class JDBCDriver extends BaseDriver {
       }));
     } catch (ex: any) {
       await this.pool.release(conn);
+
       if (ex.cause) {
         throw new Error(ex.cause.getMessageSync());
       } else {

--- a/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
+++ b/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
@@ -8,6 +8,8 @@ import {
   getEnv,
   assertDataSource,
   CancelablePromise,
+  formatAnsi,
+  formatMySql,
   Pool,
 } from '@cubejs-backend/shared';
 import {
@@ -17,12 +19,11 @@ import {
   DownloadQueryResultsResult,
   StreamOptions,
 } from '@cubejs-backend/base-driver';
-import * as SqlString from 'sqlstring';
 import { promisify } from 'util';
 import path from 'path';
 
 import { SupportedDrivers } from './supported-drivers';
-import type { DriverOptionsInterface } from './supported-drivers';
+import type { DriverOptionsInterface, EscapeDialect } from './supported-drivers';
 import type { JDBCDriverConfiguration } from './types';
 import { QueryStream, transformRow } from './QueryStream';
 import type { nextFn } from './QueryStream';
@@ -64,8 +65,6 @@ const initMvn = (customClassPath: any) => {
   }
   return mvnPromise;
 };
-
-const applyParams = (query: string, params: object | any[]) => SqlString.format(query, params);
 
 // promisify Connection methods
 Connection.prototype.getMetaDataAsync = promisify(Connection.prototype.getMetaData);
@@ -237,8 +236,19 @@ export class JDBCDriver extends BaseDriver {
       [];
   }
 
+  protected escapeDialect(): EscapeDialect {
+    const dbTypeDescription = JDBCDriver.dbTypeDescription(this.config.dbType);
+    return dbTypeDescription?.escapeDialect || 'mysql';
+  }
+
+  protected prepareQueryWithParams(query: string, values: unknown[]): string {
+    return this.escapeDialect() === 'ansi'
+      ? formatAnsi(query, values || [])
+      : formatMySql(query, values || []);
+  }
+
   public async query<R = unknown>(query: string, values: unknown[]): Promise<R[]> {
-    const queryWithParams = applyParams(query, values);
+    const queryWithParams = this.prepareQueryWithParams(query, values);
     const cancelObj: {cancel?: Function} = {};
     const promise = this.queryPromised(queryWithParams, cancelObj, this.prepareConnectionQueries());
     (promise as CancelablePromise<any>).cancel =
@@ -282,7 +292,7 @@ export class JDBCDriver extends BaseDriver {
 
   public async stream(sql: string, values: unknown[], { highWaterMark }: StreamOptions): Promise<DownloadQueryResultsResult> {
     const conn = await this.pool.acquire();
-    const query = applyParams(sql, values);
+    const query = this.prepareQueryWithParams(sql, values);
     const cancelObj: {cancel?: Function} = {};
     try {
       const createStatement = promisify(conn.createStatement.bind(conn));

--- a/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
+++ b/packages/cubejs-jdbc-driver/src/JDBCDriver.ts
@@ -8,8 +8,7 @@ import {
   getEnv,
   assertDataSource,
   CancelablePromise,
-  formatAnsi,
-  formatMySql,
+  format,
   Pool,
 } from '@cubejs-backend/shared';
 import {
@@ -242,9 +241,7 @@ export class JDBCDriver extends BaseDriver {
   }
 
   protected prepareQueryWithParams(query: string, values: unknown[]): string {
-    return this.escapeDialect() === 'ansi'
-      ? formatAnsi(query, values || [])
-      : formatMySql(query, values || []);
+    return format(this.escapeDialect(), query, values || []);
   }
 
   public async query<R = unknown>(query: string, values: unknown[]): Promise<R[]> {

--- a/packages/cubejs-jdbc-driver/src/index.ts
+++ b/packages/cubejs-jdbc-driver/src/index.ts
@@ -1,2 +1,3 @@
 export * from './JDBCDriver';
+export * from './supported-drivers';
 export * from './types';

--- a/packages/cubejs-jdbc-driver/src/supported-drivers.ts
+++ b/packages/cubejs-jdbc-driver/src/supported-drivers.ts
@@ -1,13 +1,17 @@
+export type EscapeDialect = 'ansi' | 'mysql';
+
 export interface DriverOptionsInterface {
   driverClass: string;
   prepareConnectionQueries: string[];
   mavenDependency: Record<string, any>;
   properties: Record<string, any>;
   jdbcUrl: () => string;
+  escapeDialect?: EscapeDialect;
 }
 
 export const SupportedDrivers: Record<string, DriverOptionsInterface> = {
   mysql: {
+    escapeDialect: 'mysql',
     driverClass: 'com.mysql.jdbc.Driver',
     prepareConnectionQueries: ['SET time_zone = \'+00:00\''],
     mavenDependency: {
@@ -22,6 +26,7 @@ export const SupportedDrivers: Record<string, DriverOptionsInterface> = {
     jdbcUrl: () => `jdbc:mysql://${process.env.CUBEJS_DB_HOST}:3306/${process.env.CUBEJS_DB_NAME}`
   },
   athena: {
+    escapeDialect: 'ansi',
     driverClass: 'com.qubole.jdbc.jdbc41.core.QDriver',
     prepareConnectionQueries: [],
     mavenDependency: {
@@ -37,6 +42,7 @@ export const SupportedDrivers: Record<string, DriverOptionsInterface> = {
     }
   },
   sparksql: {
+    escapeDialect: 'mysql',
     driverClass: 'org.apache.hive.jdbc.HiveDriver',
     prepareConnectionQueries: [],
     mavenDependency: {
@@ -51,6 +57,7 @@ export const SupportedDrivers: Record<string, DriverOptionsInterface> = {
     }
   },
   hive: {
+    escapeDialect: 'mysql',
     driverClass: 'org.apache.hive.jdbc.HiveDriver',
     prepareConnectionQueries: [],
     mavenDependency: {

--- a/packages/cubejs-jdbc-driver/src/supported-drivers.ts
+++ b/packages/cubejs-jdbc-driver/src/supported-drivers.ts
@@ -8,7 +8,7 @@ export interface DriverOptionsInterface {
   mavenDependency: Record<string, any>;
   properties: Record<string, any>;
   jdbcUrl: () => string;
-  escapeDialect?: EscapeDialect;
+  escapeDialect: EscapeDialect;
 }
 
 export const SupportedDrivers: Record<string, DriverOptionsInterface> = {

--- a/packages/cubejs-jdbc-driver/src/supported-drivers.ts
+++ b/packages/cubejs-jdbc-driver/src/supported-drivers.ts
@@ -1,4 +1,6 @@
-export type EscapeDialect = 'ansi' | 'mysql';
+import type { EscapeDialect } from '@cubejs-backend/shared';
+
+export type { EscapeDialect };
 
 export interface DriverOptionsInterface {
   driverClass: string;
@@ -42,7 +44,7 @@ export const SupportedDrivers: Record<string, DriverOptionsInterface> = {
     }
   },
   sparksql: {
-    escapeDialect: 'mysql',
+    escapeDialect: 'spark',
     driverClass: 'org.apache.hive.jdbc.HiveDriver',
     prepareConnectionQueries: [],
     mavenDependency: {
@@ -57,7 +59,7 @@ export const SupportedDrivers: Record<string, DriverOptionsInterface> = {
     }
   },
   hive: {
-    escapeDialect: 'mysql',
+    escapeDialect: 'spark',
     driverClass: 'org.apache.hive.jdbc.HiveDriver',
     prepareConnectionQueries: [],
     mavenDependency: {

--- a/packages/cubejs-jdbc-driver/test/unit/escape-dialect.test.ts
+++ b/packages/cubejs-jdbc-driver/test/unit/escape-dialect.test.ts
@@ -3,7 +3,7 @@ import { SupportedDrivers } from '../../src/supported-drivers';
 describe('JDBC escape dialect', () => {
   it('declares a dialect for every supported engine', () => {
     for (const [name, options] of Object.entries(SupportedDrivers)) {
-      expect([name, options.escapeDialect]).toEqual([name, expect.stringMatching(/^(ansi|mysql)$/)]);
+      expect([name, options.escapeDialect]).toEqual([name, expect.stringMatching(/^(ansi|mysql|spark)$/)]);
     }
   });
 });

--- a/packages/cubejs-jdbc-driver/test/unit/escape-dialect.test.ts
+++ b/packages/cubejs-jdbc-driver/test/unit/escape-dialect.test.ts
@@ -1,9 +1,46 @@
 import { SupportedDrivers } from '../../src/supported-drivers';
 
+// Keep the JVM out of the unit test: escaping rules are pure logic.
+jest.mock('@cubejs-backend/jdbc/lib/drivermanager', () => ({
+  getConnection: () => { /* stub */ },
+}), { virtual: true });
+jest.mock('@cubejs-backend/jdbc/lib/connection', () => class Connection {
+  public getMetaData() { /* stub */ }
+}, { virtual: true });
+jest.mock('@cubejs-backend/jdbc/lib/databasemetadata', () => class DatabaseMetaData {
+  public getSchemas() { /* stub */ }
+
+  public getTables() { /* stub */ }
+}, { virtual: true });
+jest.mock('@cubejs-backend/jdbc/lib/jinst', () => ({ isJvmCreated: () => true }), { virtual: true });
+jest.mock('@cubejs-backend/node-java-maven', () => () => { /* stub */ }, { virtual: true });
+
+// eslint-disable-next-line import/first
+import { JDBCDriver } from '../../src/JDBCDriver';
+
+// The constructor requires a JVM-backed pool, while the escaping rules only
+// depend on the configured db type.
+const driverFor = (dbType: string): any => {
+  const driver = Object.create(JDBCDriver.prototype);
+  driver.config = { dbType };
+  return driver;
+};
+
 describe('JDBC escape dialect', () => {
   it('declares a dialect for every supported engine', () => {
     for (const [name, options] of Object.entries(SupportedDrivers)) {
       expect([name, options.escapeDialect]).toEqual([name, expect.stringMatching(/^(ansi|mysql|spark)$/)]);
     }
+  });
+
+  it('escapes params with the dialect of the configured engine', () => {
+    expect(driverFor('mysql').prepareQueryWithParams('SELECT ?', ['a\\b'])).toEqual('SELECT \'a\\\\b\'');
+    expect(driverFor('athena').prepareQueryWithParams('SELECT ?', ['a\\b'])).toEqual('SELECT \'a\\b\'');
+    expect(driverFor('sparksql').prepareQueryWithParams('SELECT ?', ['a\\b'])).toEqual('SELECT \'a\\\\b\'');
+  });
+
+  it('throws for an unknown engine instead of guessing the dialect', () => {
+    expect(() => driverFor('kekdb').prepareQueryWithParams('SELECT ?', ['a\'b']))
+      .toThrow(/Unable to detect SQL escaping rules/);
   });
 });

--- a/packages/cubejs-jdbc-driver/test/unit/escape-dialect.test.ts
+++ b/packages/cubejs-jdbc-driver/test/unit/escape-dialect.test.ts
@@ -1,0 +1,9 @@
+import { SupportedDrivers } from '../../src/supported-drivers';
+
+describe('JDBC escape dialect', () => {
+  it('declares a dialect for every supported engine', () => {
+    for (const [name, options] of Object.entries(SupportedDrivers)) {
+      expect([name, options.escapeDialect]).toEqual([name, expect.stringMatching(/^(ansi|mysql)$/)]);
+    }
+  });
+});

--- a/packages/cubejs-ksql-driver/package.json
+++ b/packages/cubejs-ksql-driver/package.json
@@ -21,6 +21,7 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
+    "unit": "jest --verbose dist/test/unit",
     "lint": "eslint src/* --ext .ts",
     "lint:fix": "eslint --fix src/* --ext .ts"
   },
@@ -30,8 +31,7 @@
     "@cubejs-backend/shared": "1.7.11",
     "async-mutex": "0.3.2",
     "axios": "^1.8.3",
-    "kafkajs": "^2.2.3",
-    "sqlstring": "^2.3.1"
+    "kafkajs": "^2.2.3"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cubejs-ksql-driver/src/KsqlDriver.ts
+++ b/packages/cubejs-ksql-driver/src/KsqlDriver.ts
@@ -7,13 +7,13 @@
 import {
   getEnv,
   assertDataSource,
+  formatAnsi,
 } from '@cubejs-backend/shared';
 import {
   BaseDriver, DriverCapabilities,
   DriverInterface, TableColumn,
 } from '@cubejs-backend/base-driver';
 import { Kafka } from 'kafkajs';
-import sqlstring, { format as formatSql } from 'sqlstring';
 import axios, { AxiosResponse } from 'axios';
 import { Mutex } from 'async-mutex';
 import { KsqlQuery } from './KsqlQuery';
@@ -70,13 +70,7 @@ type KsqlQueryOptions = {
   selectStatement?: string,
 };
 
-/**
- * KSQL driver class.
- */
 export class KsqlDriver extends BaseDriver implements DriverInterface {
-  /**
-   * Returns default concurrency value.
-   */
   public static getDefaultConcurrency(): number {
     return 1;
   }
@@ -87,9 +81,6 @@ export class KsqlDriver extends BaseDriver implements DriverInterface {
 
   private readonly kafkaClient?: Kafka;
 
-  /**
-   * Class constructor.
-   */
   public constructor(
     config: Partial<KsqlDriverOptions> & {
       /**
@@ -175,12 +166,17 @@ export class KsqlDriver extends BaseDriver implements DriverInterface {
     }
   }
 
+  protected prepareQueryWithParams(query: string, values?: unknown[]): string {
+    return formatAnsi(query, values || []);
+  }
+
   public async query<R = unknown>(query: string, values?: unknown[], options: KsqlQueryOptions = {}): Promise<R> {
     if (query.toLowerCase().startsWith('select')) {
       throw new Error('Select queries for ksql allowed only from Cube Store. In order to query ksql create pre-aggregation first.');
     }
+
     const { data } = await this.apiQuery('/ksql', {
-      ksql: `${formatSql(query, values)};`,
+      ksql: `${this.prepareQueryWithParams(query, values)};`,
       ...(options.streamOffset ? {
         streamsProperties: {
           'ksql.streams.auto.offset.reset': options.streamOffset
@@ -199,8 +195,7 @@ export class KsqlDriver extends BaseDriver implements DriverInterface {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async createSchemaIfNotExists(schemaName: string): Promise<any> {
+  public async createSchemaIfNotExists(_schemaName: string): Promise<any> {
     // do nothing as there are no schemas in ksql
   }
 
@@ -293,7 +288,7 @@ export class KsqlDriver extends BaseDriver implements DriverInterface {
       throw new Error('Unable to detect a source table for ksql download query. In order to query ksql use "SELECT * FROM <TABLE>"');
     }
 
-    const selectStatement = sqlstring.format(query, params);
+    const selectStatement = this.prepareQueryWithParams(query, params);
     const { streamOffset, outputColumnTypes } = options || {};
     return this.getStreamingTableData(table, { selectStatement, streamOffset, outputColumnTypes });
   }

--- a/packages/cubejs-ksql-driver/test/unit/params-escaping.test.ts
+++ b/packages/cubejs-ksql-driver/test/unit/params-escaping.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable quotes */
+import { KsqlDriver } from '../../src/KsqlDriver';
+
+class TestKsqlDriver extends KsqlDriver {
+  public override prepareQueryWithParams(query: string, values?: unknown[]): string {
+    return super.prepareQueryWithParams(query, values);
+  }
+}
+
+// ksqlDB's grammar descends from Presto's: a quote inside a string literal is
+// escaped by doubling it and a backslash is plain data.
+describe('KsqlDriver SQL parameter escaping', () => {
+  let driver: TestKsqlDriver;
+
+  beforeAll(() => {
+    driver = new TestKsqlDriver({ url: 'http://localhost:8088' });
+  });
+
+  it('doubles quotes so a value cannot break out of the literal', () => {
+    const sql = driver.prepareQueryWithParams(
+      'CREATE TABLE t AS SELECT * FROM s WHERE status = ?',
+      [`a' OR 1=1 --`],
+    );
+
+    expect(sql).toBe(
+      `CREATE TABLE t AS SELECT * FROM s WHERE status = 'a'' OR 1=1 --'`
+    );
+  });
+
+  it('keeps the literal closed for a value ending in a backslash', () => {
+    const sql = driver.prepareQueryWithParams(
+      'CREATE TABLE t AS SELECT * FROM s WHERE name = ? AND status = ?',
+      ['payload\\', 'new'],
+    );
+
+    expect(sql).toBe(
+      `CREATE TABLE t AS SELECT * FROM s WHERE name = 'payload\\' AND status = 'new'`
+    );
+  });
+
+  it('keeps the literal closed for a backslash-then-quote payload', () => {
+    const sql = driver.prepareQueryWithParams(
+      'CREATE TABLE t AS SELECT * FROM s WHERE name = ?',
+      [`foo\\' OR 1=1 --`],
+    );
+
+    expect(sql).toBe(
+      `CREATE TABLE t AS SELECT * FROM s WHERE name = 'foo\\'' OR 1=1 --'`
+    );
+  });
+
+  it('does not double literal backslashes', () => {
+    const sql = driver.prepareQueryWithParams(
+      'CREATE TABLE t AS SELECT * FROM s WHERE path = ?',
+      ['folder\\\\name'],
+    );
+
+    expect(sql).toBe(
+      `CREATE TABLE t AS SELECT * FROM s WHERE path = 'folder\\\\name'`
+    );
+  });
+
+  it('escapes every element of an array parameter', () => {
+    const sql = driver.prepareQueryWithParams(
+      'CREATE TABLE t AS SELECT * FROM s WHERE status IN (?)',
+      [[`it's`, 'b']],
+    );
+
+    expect(sql).toBe(
+      `CREATE TABLE t AS SELECT * FROM s WHERE status IN ('it''s', 'b')`
+    );
+  });
+
+  it('substitutes multiple placeholders in order', () => {
+    const sql = driver.prepareQueryWithParams(
+      'CREATE TABLE t AS SELECT * FROM s WHERE status = ? AND amount > ?',
+      ['new', 100],
+    );
+
+    expect(sql).toBe(
+      `CREATE TABLE t AS SELECT * FROM s WHERE status = 'new' AND amount > 100`
+    );
+  });
+
+  it('leaves a query without parameters untouched', () => {
+    expect(driver.prepareQueryWithParams('SHOW VARIABLES', [])).toBe('SHOW VARIABLES');
+  });
+});

--- a/packages/cubejs-pinot-driver/package.json
+++ b/packages/cubejs-pinot-driver/package.json
@@ -21,6 +21,7 @@
     "build": "rm -rf dist && npm run tsc",
     "tsc": "tsc",
     "watch": "tsc -w",
+    "unit": "jest --verbose dist/test/unit",
     "integration": "npm run integration:pinot",
     "integration:pinot": "jest --verbose dist/test",
     "lint": "eslint src/* --ext .ts",
@@ -31,8 +32,7 @@
     "@cubejs-backend/schema-compiler": "1.7.11",
     "@cubejs-backend/shared": "1.7.11",
     "node-fetch": "^2.6.1",
-    "ramda": "^0.27.2",
-    "sqlstring": "^2.3.3"
+    "ramda": "^0.27.2"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/cubejs-pinot-driver/src/PinotDriver.ts
+++ b/packages/cubejs-pinot-driver/src/PinotDriver.ts
@@ -8,6 +8,7 @@ import {
 import {
   getEnv,
   assertDataSource,
+  formatAnsi,
   Required,
 } from '@cubejs-backend/shared';
 
@@ -16,7 +17,6 @@ import type { ConnectionOptions as TLSConnectionOptions } from 'tls';
 import {
   map, zipObj
 } from 'ramda';
-import SqlString from 'sqlstring';
 import fetch, { Headers, Request, Response } from 'node-fetch';
 import { PinotQuery } from './PinotQuery';
 
@@ -133,9 +133,7 @@ export class PinotDriver extends BaseDriver implements DriverInterface {
   }
 
   public testConnection() {
-    const query = SqlString.format('select 1');
-
-    return (<Promise<any[]>> this.queryPromised(query))
+    return (<Promise<any[]>> this.queryPromised('select 1'))
       .then(response => {
         if (response.length === 0) {
           throw new Error('Unable to connect to your Pinot instance');
@@ -147,10 +145,8 @@ export class PinotDriver extends BaseDriver implements DriverInterface {
     return <Promise<any[]>> this.queryPromised(this.prepareQueryWithParams(query, values));
   }
 
-  public prepareQueryWithParams(query: string, values: unknown[]) {
-    return SqlString.format(query, (values || []).map(value => (typeof value === 'string' ? {
-      toSqlString: () => SqlString.escape(value).replace(/\\\\([_%])/g, '\\$1'),
-    } : value)));
+  protected prepareQueryWithParams(query: string, values: unknown[]) {
+    return formatAnsi(query, values || []);
   }
 
   public authorizationHeaders(): AuthorizationHeaders | {} {

--- a/packages/cubejs-pinot-driver/test/unit/params-escaping.test.ts
+++ b/packages/cubejs-pinot-driver/test/unit/params-escaping.test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable quotes */
+import { PinotDriver } from '../../src/PinotDriver';
+
+class TestPinotDriver extends PinotDriver {
+  public override prepareQueryWithParams(query: string, values: unknown[]) {
+    return super.prepareQueryWithParams(query, values);
+  }
+}
+
+// Apache Pinot parses SQL with Calcite: a quote inside a string literal is
+// escaped by doubling it and a backslash is plain data.
+describe('PinotDriver SQL parameter escaping', () => {
+  let driver: TestPinotDriver;
+
+  beforeAll(() => {
+    driver = new TestPinotDriver({
+      host: 'localhost',
+      port: '8099',
+      dataSource: 'default',
+    });
+  });
+
+  it('preserves LIKE escape sequences emitted by the schema compiler', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      ['new\\_order\\%'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('new\\_order\\%'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('does not double literal backslashes in LIKE parameters', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\'`,
+      ['folder\\\\name'],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('folder\\\\name'), '%') ESCAPE '\\'`
+    );
+  });
+
+  it('doubles quotes so a value cannot break out of the literal', () => {
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE name = ?',
+      [`o'reilly'); DROP TABLE orders; --`],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE name = 'o''reilly''); DROP TABLE orders; --'`
+    );
+  });
+
+  it('keeps the literal closed for a quote payload', () => {
+    // sqlstring rendered this as 'a\'' — Calcite reads the backslash as data,
+    // so the doubled quote became an escaped quote and the literal ran on,
+    // swallowing the rest of the statement.
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE name = ? AND status = ?',
+      [`a'`, 'new'],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE name = 'a''' AND status = 'new'`);
+  });
+
+  it('keeps the literal closed for a value ending in a backslash', () => {
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE name = ? AND status = ?',
+      ['payload\\', 'new'],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE name = 'payload\\' AND status = 'new'`);
+  });
+
+  it('keeps a literal percent sign in an equality parameter verbatim', () => {
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE discount_label = ?',
+      ['100% cotton'],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE discount_label = '100% cotton'`);
+  });
+
+  it('escapes every element of an array parameter', () => {
+    const sql = driver.prepareQueryWithParams(
+      'SELECT * FROM orders WHERE status IN (?)',
+      [[`it's`, 'b']],
+    );
+
+    expect(sql).toBe(`SELECT * FROM orders WHERE status IN ('it''s', 'b')`);
+  });
+
+  it('substitutes multiple placeholders in order', () => {
+    const sql = driver.prepareQueryWithParams(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER(?), '%') ESCAPE '\\' AND status = ? AND amount > ?`,
+      ['pending\\_review', 'new', 100],
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM orders WHERE LOWER(name) LIKE CONCAT('%', LOWER('pending\\_review'), '%') ESCAPE '\\' AND status = 'new' AND amount > 100`
+    );
+  });
+});

--- a/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
+++ b/packages/cubejs-prestodb-driver/src/PrestoDriver.ts
@@ -215,7 +215,7 @@ export class PrestoDriver extends BaseDriver implements DriverInterface {
     return <Promise<any[]>> this.queryPromised(this.prepareQueryWithParams(query, values), false);
   }
 
-  public prepareQueryWithParams(query: string, values: unknown[]) {
+  protected prepareQueryWithParams(query: string, values: unknown[]) {
     return formatAnsi(query, values || []);
   }
 

--- a/packages/cubejs-prestodb-driver/test/unit/params-escaping.test.ts
+++ b/packages/cubejs-prestodb-driver/test/unit/params-escaping.test.ts
@@ -1,11 +1,17 @@
 /* eslint-disable quotes */
 import { PrestoDriver } from '../../src/PrestoDriver';
 
+class TestPrestoDriver extends PrestoDriver {
+  public override prepareQueryWithParams(query: string, values: unknown[]) {
+    return super.prepareQueryWithParams(query, values);
+  }
+}
+
 describe('PrestoDriver SQL parameter escaping', () => {
-  let driver: PrestoDriver;
+  let driver: TestPrestoDriver;
 
   beforeAll(() => {
-    driver = new PrestoDriver({
+    driver = new TestPrestoDriver({
       host: 'localhost',
       port: '8080',
       catalog: 'test',

--- a/packages/cubejs-questdb-driver/src/QuestDriver.ts
+++ b/packages/cubejs-questdb-driver/src/QuestDriver.ts
@@ -7,6 +7,7 @@
 import {
   getEnv,
   assertDataSource,
+  escapeStringLiteral,
 } from '@cubejs-backend/shared';
 import { types, Pool, PoolConfig, FieldDef } from 'pg';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -217,7 +218,7 @@ export class QuestDriver<Config extends QuestDriverConfiguration = QuestDriverCo
   }
 
   public async tableColumnTypes(table: string): Promise<TableStructure> {
-    const response: any[] = await this.query(`SHOW COLUMNS FROM '${table}'`, []);
+    const response: any[] = await this.query(`SHOW COLUMNS FROM ${escapeStringLiteral(table)}`, []);
 
     return response.map((row) => ({ name: row.column, type: this.toGenericType(row.type) }));
   }
@@ -237,7 +238,7 @@ export class QuestDriver<Config extends QuestDriverConfiguration = QuestDriverCo
     try {
       for (let i = 0; i < tableData.rows.length; i++) {
         await this.query(
-          `INSERT INTO '${table}'
+          `INSERT INTO ${escapeStringLiteral(table)}
         (${columns.map(c => this.quoteIdentifier(c.name)).join(', ')})
         VALUES (${columns.map((c, paramIndex) => this.param(paramIndex)).join(', ')})`,
           columns.map(c => this.toColumnValue(tableData.rows[i][c.name] as string, c.type))

--- a/packages/cubejs-trino-driver/package.json
+++ b/packages/cubejs-trino-driver/package.json
@@ -33,8 +33,7 @@
     "@cubejs-backend/schema-compiler": "1.7.11",
     "@cubejs-backend/shared": "1.7.11",
     "node-fetch": "^2.6.1",
-    "presto-client": "^1.2.0",
-    "sqlstring": "^2.3.1"
+    "presto-client": "^1.2.0"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22567,7 +22567,7 @@ sqlstring@2.3.1:
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
   integrity sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==
 
-sqlstring@^2.3.0, sqlstring@^2.3.1, sqlstring@^2.3.2, sqlstring@^2.3.3:
+sqlstring@^2.3.1, sqlstring@^2.3.2, sqlstring@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.3.tgz#2ddc21f03bce2c387ed60680e739922c65751d0c"
   integrity sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==


### PR DESCRIPTION
Audit of all 29 driver packages for the escaping bug fixed for Trino/Presto in 463e60284a and Athena in 9b23d090e1: `sqlstring` (a MySQL escaper) used to interpolate parameters for engines that are not MySQL.

Mismatching the dialect is unsafe in BOTH directions, so there is no safe universal default and each engine has to be handled explicitly:

- MySQL rules on a standard-SQL engine emit `\'`. The backslash is data there, so the quote that follows closes the literal and the rest of the statement lands in code position.
- Standard-SQL rules on a backslash-escaping engine leave a trailing `\`, which escapes the closing quote and lets the literal run on.

| engine                       | backslash is | correct formatter |
| ---------------------------- | ------------ | ----------------- |
| Pinot, Dremio (Calcite)      | data         | `formatAnsi`      |
| ksqlDB (Presto-derived)      | data         | `formatAnsi`      |
| Athena, Presto, Trino        | data         | `formatAnsi`      |
| MySQL, Hive, Spark SQL       | escape char  | `formatMySql`     |
| ClickHouse, Cube Store       | escape char  | `formatMySql`     |
