### PR TITLE
docs: DAX single-perspective env var and measure names

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1578,6 +1578,15 @@ If `true`, the DAX API will expose time dimensions as calendar hierarchies.
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `true` | `true` |
 
+## `CUBEJS_DAX_SINGLE_PERSPECTIVE`
+
+If `true`, the [DAX API][ref-dax-api] exposes all views as part of a single
+perspective, enabling [cross-view filtering][ref-dax-cross-view-filter].
+
+| Possible Values | Default in Development | Default in Production |
+| --------------- | ---------------------- | --------------------- |
+| `true`, `false` | `false` | `false` |
+
 ## `CUBE_XMLA_LANGUAGE`
 
 This variable is used to [configure the locale][ref-mdx-api-locale] for the [MDX API][ref-mdx-api].
@@ -2140,6 +2149,8 @@ The port for a Cube deployment to listen to API connections on.
 [wiki-tz-database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-sql-api-streaming]: /reference/core-data-apis/sql-api#streaming
+[ref-dax-api]: /reference/core-data-apis/dax-api
+[ref-dax-cross-view-filter]: /reference/core-data-apis/dax-api/cross-view-filter
 [ref-row-limit]: /reference/core-data-apis/queries#row-limit
 [mysql-server-tz-support]: https://dev.mysql.com/doc/refman/8.4/en/time-zone-support.html
 [ref-schema-ref-preagg-allownonstrict]: /reference/data-modeling/pre-aggregations#allow_non_strict_date_range_match

--- a/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
@@ -50,6 +50,29 @@ Likewise, if `orders_view` exposes an `address_country` column pointing to
 `country.country`, cross-filtering will not be applied, because the column
 names differ between the views.
 
+## Measure names
+
+Because all views share a single perspective, measures are identified by their
+view name and measure name, joined with a dot: `<view>.<measure>`. This keeps
+measures with the same name in different views from colliding.
+
+Field names shown in Power BI are unaffected, so a `count` measure still appears
+as `Count` in the field list. However, when writing DAX explicitly, reference
+measures by their qualified name:
+
+```text
+CALCULATE('orders_view'[orders_view.count])
+```
+
+The view name can also be omitted from the table qualifier, in which case the
+prefix identifies the view:
+
+```text
+[orders_view.count]
+```
+
+Dimensions are not prefixed and are referenced by their column name.
+
 
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-views]: /docs/data-modeling/views

--- a/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
@@ -13,7 +13,8 @@ that span multiple views and apply filters consistently across visualizations.
 
 To use cross-view filters such as slicers, you must enable single-perspective mode
 in the DAX API. To enable single-perspective mode in the DAX API,
-set the `CUBEJS_DAX_SINGLE_PERSPECTIVE` environment variable to `true`.
+set the [`CUBEJS_DAX_SINGLE_PERSPECTIVE`](/reference/configuration/environment-variables#cubejs_dax_single_perspective)
+environment variable to `true`.
 
 In single-perspective mode, all views are exposed as part of a single perspective.
 This allows you to use a single connection and show visualizations from different
@@ -61,18 +62,17 @@ as `Count` in the field list. However, when writing DAX explicitly, reference
 measures by their qualified name:
 
 ```text
-CALCULATE('orders_view'[orders_view.count])
+CALCULATE('orders_view'[orders_view.count], 'orders_view'[status] = "completed")
 ```
 
-The view name can also be omitted from the table qualifier, in which case the
-prefix identifies the view:
+The table qualifier can also be omitted, since the prefix already identifies the
+view:
 
 ```text
 [orders_view.count]
 ```
 
 Dimensions are not prefixed and are referenced by their column name.
-
 
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-views]: /docs/data-modeling/views


### PR DESCRIPTION
## Summary

Follow-up to the DAX single-perspective mode docs (#10891, #10901), covering two gaps:

- `CUBEJS_DAX_SINGLE_PERSPECTIVE` was missing from the environment variables reference, even though its sibling `CUBEJS_DAX_CREATE_DATE_HIERARCHIES` is documented there. Added with its `false` default and a link to the cross-view filtering page.
- The `<view>.<measure>` measure naming used in single-perspective mode was not documented anywhere. Added a short "Measure names" section to the cross-view filtering page: field names in Power BI are unaffected, but explicit DAX must reference measures by their qualified name.

Both pages already existed, so there are no new pages and no `docs.json` changes.

## Test plan

- Behavior verified against the implementation rather than assumed: the env var name and its `false` default, the `<view>.<measure>` separator, that Power BI captions stay unprefixed, and that both the qualified and unqualified reference forms resolve.
- `mint dev` — both changed pages plus the DAX API index render (HTTP 200), no MDX errors.
- `mint broken-links` — no broken links, including the two new link references.