### PR TITLE
docs: fill gaps found by a cube-js/cube + cubejs-enterprise feature audit

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/google-bigquery.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/google-bigquery.mdx
@@ -170,7 +170,15 @@ CUBEJS_DB_EXPORT_BUCKET_TYPE=gcp
 Cube does not require any additional configuration to enable SSL as Google
 BigQuery connections are made over HTTPS.
 
+## Query labels
+
+Every query job that Cube submits to BigQuery is automatically tagged with a
+`cube_request_id` [job label][bq-docs-labels]. Use it to find a specific
+Cube-issued query in BigQuery's job history, audit logs, or cost breakdowns by
+`cube_request_id`. No configuration is required.
+
 [bq]: https://cloud.google.com/bigquery
+[bq-docs-labels]: https://cloud.google.com/bigquery/docs/labels-intro
 [bq-docs-getting-started]:
   https://cloud.google.com/docs/authentication/getting-started
 [bq-docs-regional-locations]:

--- a/docs-mintlify/admin/connect-to-data/data-sources/oracle.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/oracle.mdx
@@ -9,6 +9,9 @@ The driver for Oracle is community-supported and is not maintained by Cube or th
 
 </Warning>
 
+The Oracle driver supports the [Tesseract SQL planner][ref-tesseract], including the
+`quarter` [granularity][ref-granularities].
+
 ## Prerequisites
 
 - The hostname for the [Oracle][oracle] database server
@@ -59,6 +62,8 @@ To enable SSL-encrypted connections between Cube and Oracle, set the
 configure custom certificates, please check out [Enable SSL Connections to the
 Database][ref-recipe-enable-ssl].
 
+[ref-tesseract]: /reference/configuration/environment-variables#cubejs_tesseract_sql_planner
+[ref-granularities]: /reference/data-modeling/dimensions#granularities
 [oracle]: https://www.oracle.com/uk/index.html
 [node-oracledb]: https://node-oracledb.readthedocs.io/en/latest/user_guide/introduction.html#architecture
 [node-oracledb-thick]: https://node-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#enabling-node-oracledb-thick-mode

--- a/docs-mintlify/api-reference/api.yaml
+++ b/docs-mintlify/api-reference/api.yaml
@@ -27,6 +27,7 @@ tags:
   - name: App Theme
   - name: Embed
   - name: Embed Tenants
+  - name: GitHub
   - name: Dbt Sync
   - name: Env Variables
   - name: OAuth Integrations
@@ -1697,6 +1698,85 @@ paths:
           If the deployment's plan enforces a workbook limit and it has been reached, the request is
           rejected with `400`. Returns `404` if the workbook does not exist or belongs to a
           different deployment.
+  /v1/deployments/{deploymentId}/workbooks/{workbookId}/embed-access:
+    get:
+      operationId: DashboardEmbedAccessPublicController.getEmbedAccess
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbedAccessResponse'
+          description: ''
+      summary: List a dashboard's embed access
+      tags:
+        - Embed
+      x-mint:
+        content: >-
+          Returns the embed audience of a workbook's published dashboard: the global `allowEmbed`
+          (signed-embedding) flag, whether it is shared with **all embed users**, and the list of
+          individual embed **tenants** it is shared with.
+
+
+          Embed access is a read-only share of the workbook with a system sharing group, so this is
+          scoped to the workbook that owns the dashboard. Requires **read** access to the workbook.
+          Returns `404` if the workbook does not exist or belongs to a different deployment.
+    put:
+      operationId: DashboardEmbedAccessPublicController.updateEmbedAccess
+      parameters:
+        - in: path
+          name: deploymentId
+          required: true
+          schema:
+            type: number
+        - in: path
+          name: workbookId
+          required: true
+          schema:
+            type: number
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateEmbedAccessInput'
+        description: UpdateEmbedAccessInput
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbedAccessResponse'
+          description: ''
+      summary: Update a dashboard's embed access
+      tags:
+        - Embed
+      x-mint:
+        content: >-
+          Adds, updates, or removes one embed audience from a workbook's published dashboard, and/or
+          toggles signed embedding. Returns the updated embed-access view.
+
+
+          Provide exactly one target — `embedTenantName` (a single embed tenant) or `allEmbedUsers:
+          true` (every embed tenant) — together with `action`: `"read"` grants access, `"none"`
+          removes it. Include `allowEmbed` to also flip "Allow signed embedding" in the same request;
+          omit both targets to change only `allowEmbed`.
+
+
+          Requires **manage** access to the workbook. Returns `404` if the workbook or the named
+          embed tenant does not exist, and `400` if the request specifies no change or sets
+          `allowEmbed` on a workbook that has no published dashboard.
   /v1/deployments/{deploymentId}/workbooks/{workbookId}/publish:
     post:
       operationId: publishDashboard
@@ -1876,6 +1956,40 @@ paths:
           Moving a folder into one of its own descendants, or exceeding the maximum folder depth, is
           rejected with `400`. Returns `404` if the item does not exist or belongs to a different
           deployment.
+  /v1/embed-tenants/:
+    get:
+      operationId: EmbedTenantAdminPublicController.listEmbedTenants
+      parameters:
+        - in: query
+          name: search
+          schema:
+            oneOf:
+              - type: string
+              - type: 'null'
+        - in: query
+          name: after
+          schema:
+            type: string
+        - in: query
+          name: first
+          schema:
+            minimum: 1
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbedTenantsPublicResponse'
+          description: ''
+      summary: List embed tenants
+      tags:
+        - Embed Tenants
+      x-mint:
+        content: >-
+          Lists the account's embed tenants, cursor-paginated. Supports `first`/`after` pagination
+          and a case-insensitive `search` substring match on the tenant name. Requires an admin API
+          key.
   /v1/embed-tenants/{embedTenantName}:
     delete:
       operationId: deleteEmbedTenant
@@ -2075,6 +2189,85 @@ paths:
           This endpoint is unauthenticated — it is called from the embedding client and the session
           id itself is the credential. Returns `401` if the session id is unknown or has already
           been redeemed.
+  /v1/github/installations:
+    get:
+      operationId: GitHubPublicController.installations
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitHubInstallationsListResponse'
+          description: ''
+      summary: List the user's GitHub App installations (orgs/accounts)
+      tags:
+        - GitHub
+  /v1/github/installations/{installationId}/repositories:
+    get:
+      operationId: GitHubPublicController.repositories
+      parameters:
+        - in: path
+          name: installationId
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitHubReposListResponse'
+          description: ''
+      summary: List repositories accessible to a GitHub App installation
+      tags:
+        - GitHub
+  /v1/github/repositories/{owner}/{repo}/branches:
+    get:
+      operationId: GitHubPublicController.branches
+      parameters:
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: repo
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: installationId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitHubBranchesListResponse'
+          description: ''
+      summary: List branches of a repository
+      tags:
+        - GitHub
+  /v1/github/status:
+    get:
+      operationId: GitHubPublicController.status
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GitHubConnectStatusResponse'
+          description: ''
+      summary: Whether GitHub is linked, plus the link/install URLs
+      tags:
+        - GitHub
+      x-mint:
+        content: >-
+          Requires the `github.read` scope. Use `linkUrl`/`settingsUrl` from an unlinked response to
+          send the caller through the GitHub account-linking / App-installation browser flow, then
+          read `installationId` from `GET /api/v1/github/installations` once connected.
   /v1/oauth-integrations:
     get:
       operationId: listOAuthIntegrations
@@ -3867,6 +4060,58 @@ components:
             - type: boolean
             - type: 'null'
       type: object
+    EmbedAccessAllEmbedUsers:
+      properties:
+        action:
+          $ref: '#/components/schemas/EmbedAccessAllEmbedUsersAction'
+        enabled:
+          type: boolean
+        groupId:
+          oneOf:
+            - type: integer
+            - type: 'null'
+      required:
+        - enabled
+        - action
+      type: object
+    EmbedAccessAllEmbedUsersAction:
+      enum:
+        - read
+        - none
+      type: string
+    EmbedAccessResponse:
+      properties:
+        allEmbedUsers:
+          $ref: '#/components/schemas/EmbedAccessAllEmbedUsers'
+        allowEmbed:
+          type: boolean
+        tenants:
+          items:
+            $ref: '#/components/schemas/EmbedAccessTenantEntry'
+          type: array
+      required:
+        - allowEmbed
+        - allEmbedUsers
+        - tenants
+      type: object
+    EmbedAccessTenantEntry:
+      properties:
+        action:
+          $ref: '#/components/schemas/EmbedAccessTenantEntryAction'
+        embedTenantName:
+          type: string
+        groupId:
+          type: integer
+      required:
+        - embedTenantName
+        - groupId
+        - action
+      type: object
+    EmbedAccessTenantEntryAction:
+      enum:
+        - read
+        - none
+      type: string
     EmbedSessionSettings:
       properties:
         showDashboardChat:
@@ -3891,12 +4136,49 @@ components:
             - type: boolean
             - type: 'null'
       type: object
+    EmbedTenant:
+      properties:
+        createdAt:
+          oneOf:
+            - oneOf:
+                - format: date
+                  type: string
+                - format: date-time
+                  type: string
+            - type: 'null'
+        displayName:
+          oneOf:
+            - type: string
+            - type: 'null'
+        id:
+          type: integer
+        name:
+          type: string
+        userCount:
+          type: integer
+      required:
+        - id
+        - name
+        - userCount
+      type: object
     EmbedTenantProfile:
       properties:
         displayName:
           oneOf:
             - type: string
             - type: 'null'
+      type: object
+    EmbedTenantsPublicResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/EmbedTenant'
+          type: array
+        pageInfo:
+          $ref: '#/components/schemas/PageInfo'
+      required:
+        - items
+        - pageInfo
       type: object
     EmbedTheme:
       properties:
@@ -4264,6 +4546,85 @@ components:
         - name
         - viewer_last_viewed_at
       type: string
+    GitHubBranchDto:
+      properties:
+        isDefault:
+          type: boolean
+        name:
+          type: string
+      required:
+        - name
+        - isDefault
+      type: object
+    GitHubBranchesListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/GitHubBranchDto'
+          type: array
+      required:
+        - data
+      type: object
+    GitHubConnectStatusResponse:
+      properties:
+        connected:
+          type: boolean
+        linkUrl:
+          type: string
+        settingsUrl:
+          type: string
+      required:
+        - connected
+        - linkUrl
+        - settingsUrl
+      type: object
+    GitHubInstallationDto:
+      properties:
+        avatarUrl:
+          type: string
+        id:
+          type: string
+        installationId:
+          type: string
+        login:
+          type: string
+      required:
+        - installationId
+        - id
+        - login
+        - avatarUrl
+      type: object
+    GitHubInstallationsListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/GitHubInstallationDto'
+          type: array
+      required:
+        - data
+      type: object
+    GitHubRepoDto:
+      properties:
+        htmlUrl:
+          type: string
+        id:
+          type: integer
+        name:
+          type: string
+      required:
+        - id
+        - name
+        - htmlUrl
+      type: object
+    GitHubReposListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/GitHubRepoDto'
+          type: array
+      required:
+        - data
+      type: object
     GroupDefinition:
       properties:
         description:
@@ -4689,6 +5050,10 @@ components:
       type: object
     PublishDashboardInput:
       properties:
+        allowEmbed:
+          oneOf:
+            - type: boolean
+            - type: 'null'
         config:
           oneOf:
             - $ref: '#/components/schemas/DashboardConfigInput'
@@ -5285,6 +5650,30 @@ components:
       enum:
         - git
         - cli
+      type: string
+    UpdateEmbedAccessInput:
+      properties:
+        action:
+          oneOf:
+            - $ref: '#/components/schemas/UpdateEmbedAccessInputAction'
+            - type: 'null'
+        allEmbedUsers:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        allowEmbed:
+          oneOf:
+            - type: boolean
+            - type: 'null'
+        embedTenantName:
+          oneOf:
+            - type: string
+            - type: 'null'
+      type: object
+    UpdateEmbedAccessInputAction:
+      enum:
+        - read
+        - none
       type: string
     UpdateFolderInput:
       properties:

--- a/docs-mintlify/embedding/iframe/creator-mode.mdx
+++ b/docs-mintlify/embedding/iframe/creator-mode.mdx
@@ -59,6 +59,17 @@ Embed users in Creator Mode can share the workbooks and dashboards they build wi
   Sharing is scoped to the [embed tenant](#embed-tenant-scoping): users can only share with others in the same tenant, never across tenants.
 </Note>
 
+## SQL visibility
+
+By default, embed users in Creator Mode can view both the Semantic SQL and the Generated SQL for a query — in Analytics Chat, in a workbook's SQL panel, and in the Error/SQL switcher. Generated SQL is the query sent to your underlying data source, so it can expose physical table and schema names.
+
+Control this from **Admin → Embed → Settings**:
+
+- **Show Semantic SQL** — on by default.
+- **Show Generated SQL** — off by default, since it exposes your data source's schema.
+
+Turning a toggle off removes the corresponding tab and entry points (including the chat **Show SQL** button) from every Creator Mode embed for your account. A workbook's own SQL-based reports keep their SQL editor regardless of these settings, since that SQL is the report definition, not a derived schema view. These settings don't affect the authenticated Cube app, where both are always visible.
+
 ## Example
 
 ```javascript

--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -154,7 +154,7 @@ Run `cube <command> --help` for the full options of any command.
 | `folders`, `workbooks`, `reports`, `workspace` | Workspace content management |
 | `users`, `groups`, `attributes`, `policies` | Users, groups, and access control |
 | `tenant`, `notifications`, `integrations`, `oidc`, `api-keys` | Account administration |
-| `embed` | Embed sessions, tokens, and embed tenants |
+| `embed` | Embed sessions, tokens, `enable-dashboard`/`disable-dashboard`, and embed tenants |
 | `agents`, `app`, `meta`, `scim` | Agents, app config, model metadata, SCIM v2 |
 | `api` | Raw authenticated API request (escape hatch): `cube api GET /api/v1/... -q key=value -d '{...}'` |
 | `update` | Update the CLI to the latest release |

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -2022,6 +2022,18 @@ If `true`, then sends telemetry to Cube.
 | --------------- | ---------------------- | --------------------- |
 | `true`, `false` | `true`                 | `true`                |
 
+## `CUBESTORE_TOPK_STRATEGY`
+
+The merge strategy Cube Store's router uses for distributed top-k queries
+(`SELECT ... GROUP BY ... ORDER BY ... LIMIT k`). `vectorized` keeps the same
+early-termination behavior as the default `streaming` strategy but processes
+rows in batches; `full_merge` re-aggregates every distinct group on the router
+before sorting, trading router memory for a ClickHouse-style merge. Optional.
+
+| Possible Values                       | Default in Development | Default in Production |
+| -------------------------------------- | ---------------------- | --------------------- |
+| `streaming`, `vectorized`, `full_merge` | `streaming`             | `streaming`            |
+
 ## `CUBESTORE_WAL_SPLIT_THRESHOLD`
 
 The maximum number of rows to keep in a single chunk of data right after


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (n/a — docs only)
- [ ] Linter has been run for changed code (n/a — docs only)
- [ ] Tests for the changes have been added if not covered yet (n/a — docs only)

**Description of Changes Made**

Surgical edits to close documentation gaps identified by an automated audit of recently merged, customer-facing PRs in `cube-js/cube` and `cubedevinc/cubejs-enterprise` cross-checked against docs-mintlify.

- `reference/cli.mdx` — document the `embed enable-dashboard` / `disable-dashboard` CLI commands (cube-js/cube#11356).
- `admin/connect-to-data/data-sources/google-bigquery.mdx` — document the automatic `cube_request_id` BigQuery job label (cube-js/cube#11299).
- `reference/configuration/environment-variables.mdx` — document `CUBESTORE_TOPK_STRATEGY` (cube-js/cube#11152).
- `admin/connect-to-data/data-sources/oracle.mdx` — document Tesseract SQL planner support and the `quarter` granularity (cube-js/cube#11174).
- `embedding/iframe/creator-mode.mdx` — document the account-wide **Show Semantic SQL** / **Show Generated SQL** Creator Mode toggles (cubedevinc/cubejs-enterprise#13014).
- `api-reference/api.yaml` — add the GitHub integration read endpoints (`/v1/github/*`) and the dashboard embed-access API (`GET`/`PUT .../embed-access`, `allowEmbed` on publish, `GET /v1/embed-tenants/`) (cubedevinc/cubejs-enterprise#13102, #13351).

A few larger undocumented features surfaced by the same audit (CubeStore admin SQL commands, pre-aggregation matching for switch/calc-group dimensions, period-over-period comparison, Python analysis persistence on reports, and the broader public REST API surface for deployment lifecycle/data-model/device-auth) need new pages rather than surgical edits, so those were filed as Linear tickets instead of included here.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019dEUMp3bGfRphALcSBY65X)_