### PR TITLE
docs: pre-aggregation data source activation, variable families and driver_factory precedence

### DIFF
--- a/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
@@ -87,7 +87,7 @@ the dedicated connection always uses the same driver as the data source it belon
 [`CUBEJS_PRE_AGGREGATIONS_BACKOFF_MAX_TIME`](/reference/configuration/environment-variables#cubejs_pre_aggregations_backoff_max_time),
 and [`CUBEJS_PRE_AGGREGATIONS_ALLOW_NON_STRICT_DATE_RANGE_MATCH`](/reference/configuration/environment-variables#cubejs_pre_aggregations_allow_non_strict_date_range_match)
 share the prefix but configure pre-aggregation behavior rather than a connection, so they
-do not switch the data source onto a dedicated connection.
+do not switch the data source's pre-aggregations onto a dedicated connection.
 
 </Info>
 

--- a/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
@@ -54,6 +54,29 @@ The `PRE_AGGREGATIONS` variant supports the same connection variables as the reg
 `CUBEJS_DB_*` / `CUBEJS_DS_<NAME>_DB_*` data source variables (for example `_DB_TYPE`,
 `_DB_HOST`, `_DB_PORT`, `_DB_USER`, `_DB_PASS`, and `_DB_SSL`).
 
+Driver-specific variables take the same segment, so the dedicated connection is not
+limited to the `_DB_*` family — for example `CUBEJS_PRE_AGGREGATIONS_JDBC_URL` or
+`CUBEJS_PRE_AGGREGATIONS_AWS_REGION`. In the decorated form for a named data source, the
+`DB_`, `JDBC_`, `AWS_`, `DATABASE`, and `FIREBOLT_` families are supported.
+
+Setting any one of these variables switches the data source onto the dedicated
+connection; there is no separate flag to enable it.
+
+<Info>
+
+[`CUBEJS_PRE_AGGREGATIONS_SCHEMA`](/reference/configuration/environment-variables#cubejs_pre_aggregations_schema),
+[`CUBEJS_PRE_AGGREGATIONS_BUILDER`](/reference/configuration/environment-variables#cubejs_pre_aggregations_builder),
+[`CUBEJS_PRE_AGGREGATIONS_BACKOFF_MAX_TIME`](/reference/configuration/environment-variables#cubejs_pre_aggregations_backoff_max_time),
+and [`CUBEJS_PRE_AGGREGATIONS_ALLOW_NON_STRICT_DATE_RANGE_MATCH`](/reference/configuration/environment-variables#cubejs_pre_aggregations_allow_non_strict_date_range_match)
+share the prefix but configure pre-aggregation behavior rather than a connection, so they
+do not switch the data source onto a dedicated connection.
+
+</Info>
+
+A custom [`driver_factory`][ref-config-driver-factory] takes precedence over these
+variables: if both are configured, the `driver_factory` connection is used for
+pre-aggregations as well and a `Pre-aggregation driver conflict` warning is logged.
+
 ## Troubleshooting
 
 ### `Refresh scheduler interval error`
@@ -83,3 +106,4 @@ that would automatically do this for you.
 [ref-preaggs]: /docs/pre-aggregations/using-pre-aggregations
 [ref-production-multi-cluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-multiple-data-sources]: /admin/connect-to-data/multiple-data-sources
+[ref-config-driver-factory]: /reference/configuration/config#driver_factory

--- a/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
@@ -39,20 +39,22 @@ CUBEJS_DB_TYPE=postgres
 CUBEJS_DB_HOST=localhost
 
 # Dedicated pre-aggregation data source for the default data source
-CUBEJS_PRE_AGGREGATIONS_DB_TYPE=postgres
 CUBEJS_PRE_AGGREGATIONS_DB_HOST=preagg-host
+CUBEJS_PRE_AGGREGATIONS_DB_USER=preagg-user
+CUBEJS_PRE_AGGREGATIONS_DB_PASS=preagg-pass
 
 # A named data source and its dedicated pre-aggregation data source
 CUBEJS_DATASOURCES=default,analytics
 CUBEJS_DS_ANALYTICS_DB_TYPE=postgres
 CUBEJS_DS_ANALYTICS_DB_HOST=remotehost
-CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_TYPE=postgres
 CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_HOST=analytics-preagg-host
+CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_USER=analytics-preagg-user
+CUBEJS_DS_ANALYTICS_PRE_AGGREGATIONS_DB_PASS=analytics-preagg-pass
 ```
 
 The `PRE_AGGREGATIONS` variant supports the same connection variables as the regular
-`CUBEJS_DB_*` / `CUBEJS_DS_<NAME>_DB_*` data source variables (for example `_DB_TYPE`,
-`_DB_HOST`, `_DB_PORT`, `_DB_USER`, `_DB_PASS`, and `_DB_SSL`).
+`CUBEJS_DB_*` / `CUBEJS_DS_<NAME>_DB_*` data source variables (for example `_DB_HOST`,
+`_DB_PORT`, `_DB_USER`, `_DB_PASS`, and `_DB_SSL`).
 
 Driver-specific variables take the same segment, so the dedicated connection is not
 limited to the `_DB_*` family — for example `CUBEJS_PRE_AGGREGATIONS_JDBC_URL` or
@@ -61,6 +63,19 @@ limited to the `_DB_*` family — for example `CUBEJS_PRE_AGGREGATIONS_JDBC_URL`
 
 Setting any one of these variables switches the data source onto the dedicated
 connection; there is no separate flag to enable it.
+
+<Warning>
+
+Each variable is read independently, and an unset one does **not** fall back to its
+`CUBEJS_DB_*` counterpart — it falls back to the driver's own default. Configure the
+dedicated connection in full: if you set only `CUBEJS_PRE_AGGREGATIONS_DB_HOST`, the build
+connects to that host with the driver's default user and password rather than the ones
+from `CUBEJS_DB_USER` and `CUBEJS_DB_PASS`.
+
+The one exception is the driver type: `CUBEJS_PRE_AGGREGATIONS_DB_TYPE` is ignored, since
+the dedicated connection always uses the same driver as the data source it belongs to.
+
+</Warning>
 
 <Info>
 

--- a/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/refreshing-pre-aggregations.mdx
@@ -61,8 +61,11 @@ limited to the `_DB_*` family — for example `CUBEJS_PRE_AGGREGATIONS_JDBC_URL`
 `CUBEJS_PRE_AGGREGATIONS_AWS_REGION`. In the decorated form for a named data source, the
 `DB_`, `JDBC_`, `AWS_`, `DATABASE`, and `FIREBOLT_` families are supported.
 
-Setting any one of these variables switches the data source onto the dedicated
-connection; there is no separate flag to enable it.
+Setting any one of these variables switches the data source's pre-aggregations onto the
+dedicated connection; there is no separate flag to enable it. Activation is prefix-based
+rather than name-based, so a misspelled variable such as
+`CUBEJS_PRE_AGGREGATIONS_DB_HSOT` still switches it on — combined with the rule below,
+that leaves every setting at its driver default.
 
 <Warning>
 

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -425,13 +425,15 @@ in the drivers' [source code][link-github-cube-drivers].
 <Info>
 
 A custom `driver_factory` takes precedence over the [`CUBEJS_PRE_AGGREGATIONS_*`
-environment variables][ref-preagg-data-source]. If both are configured, the
-`driver_factory` is used for pre-aggregations as well and a `Pre-aggregation driver
-conflict` warning is logged.
+environment variables][ref-preagg-data-source], for every data source rather than only the
+ones it handles. If both are configured, the `driver_factory` connection is used for
+pre-aggregations as well and a `Pre-aggregation driver conflict` warning is logged.
 
-To use a dedicated connection for pre-aggregation builds, either define it entirely
-through the `CUBEJS_PRE_AGGREGATIONS_*` environment variables without a custom
-`driver_factory`, or return the appropriate connection from the `driver_factory` itself.
+The factory can't return a different connection for pre-aggregations either, since it
+receives no signal distinguishing a pre-aggregation connection request from a regular one.
+To use a dedicated connection for pre-aggregation builds, define it entirely through the
+`CUBEJS_PRE_AGGREGATIONS_*` environment variables and don't configure a custom
+`driver_factory`.
 
 </Info>
 

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -422,6 +422,19 @@ It should contain the `type` element corresponding to data source type and other
 options that will be passed to a data source driver. You can lookup supported options
 in the drivers' [source code][link-github-cube-drivers]. 
 
+<Info>
+
+A custom `driver_factory` takes precedence over the [`CUBEJS_PRE_AGGREGATIONS_*`
+environment variables][ref-preagg-data-source]. If both are configured, the
+`driver_factory` is used for pre-aggregations as well and a `Pre-aggregation driver
+conflict` warning is logged.
+
+To use a dedicated connection for pre-aggregation builds, either define it entirely
+through the `CUBEJS_PRE_AGGREGATIONS_*` environment variables without a custom
+`driver_factory`, or return the appropriate connection from the `driver_factory` itself.
+
+</Info>
+
 <CodeGroup>
 
 ```python title="Python"
@@ -1496,6 +1509,7 @@ module.exports = {
 [link-wiki-tz]: https://en.wikipedia.org/wiki/Tz_database
 [ref-development-mode]: /docs/data-modeling/dev-mode
 [ref-multitenancy]: /embedding/multitenancy
+[ref-preagg-data-source]: /docs/pre-aggregations/refreshing-pre-aggregations#pre-aggregation-data-source
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-pre-aggregations-refresh-key]: /reference/data-modeling/pre-aggregations#refresh_key

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1348,7 +1348,8 @@ and `FIREBOLT_` variable families are supported.
 Setting any one of these variables switches the data source's pre-aggregations onto the
 dedicated connection. Configure it in full: an unset variable falls back to the driver's
 default rather than to its `CUBEJS_DB_*` counterpart. `CUBEJS_PRE_AGGREGATIONS_DB_TYPE` is
-ignored — the dedicated connection always uses the data source's driver.
+ignored — the dedicated connection always uses the data source's driver. A custom
+[`driver_factory`][ref-config-driver-factory] takes precedence over these variables.
 
 See [pre-aggregation data source][ref-preagg-data-source] for details and examples.
 
@@ -2184,6 +2185,7 @@ The port for a Cube deployment to listen to API connections on.
 [motherduck-docs-svc-token]:
   https://motherduck.com/docs/authenticating-to-motherduck/#authentication-using-a-service-token
 [ref-config-db]: /admin/connect-to-data/data-sources
+[ref-config-driver-factory]: /reference/configuration/config#driver_factory
 [ref-config-multiple-ds-cloud]: /admin/connect-to-data/multiple-data-sources
 [ref-config-multiple-ds-decorating-env]: /admin/connect-to-data/multiple-data-sources#under-the-hood
 [ref-preagg-data-source]: /docs/pre-aggregations/refreshing-pre-aggregations#pre-aggregation-data-source

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1336,9 +1336,18 @@ data source's pre-aggregations, instead of its own connection. They mirror the r
 `CUBEJS_PRE_AGGREGATIONS_DB_SSL`. For a [named data source][ref-config-multiple-ds-decorating-env],
 use the decorated form `CUBEJS_DS_<NAME>_PRE_AGGREGATIONS_DB_*`.
 
-| Possible Values                              | Default in Development | Default in Production |
-| -------------------------------------------- | ---------------------- | --------------------- |
-| Same as the corresponding `CUBEJS_DB_*` variable | N/A                | N/A                   |
+Driver-specific connection variables take the same segment, so the dedicated connection
+is not limited to the `_DB_*` family — for example `CUBEJS_PRE_AGGREGATIONS_JDBC_URL`,
+`CUBEJS_PRE_AGGREGATIONS_AWS_REGION`, and `CUBEJS_PRE_AGGREGATIONS_FIREBOLT_ENGINE_NAME`.
+In the decorated form for a named data source, the `DB_`, `JDBC_`, `AWS_`, `DATABASE`,
+and `FIREBOLT_` variable families are supported.
+
+| Possible Values                                  | Default in Development | Default in Production |
+| ------------------------------------------------ | ---------------------- | --------------------- |
+| Same as the corresponding `CUBEJS_DB_*` variable | Not set                | Not set               |
+
+Setting any one of these variables switches the data source's pre-aggregations onto the
+dedicated connection.
 
 See [pre-aggregation data source][ref-preagg-data-source] for details and examples.
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1330,10 +1330,9 @@ This allows reusing pre-aggregations across environments, saving both time and c
 
 Connection variables for a dedicated data source used to build and store the default
 data source's pre-aggregations, instead of its own connection. They mirror the regular
-`CUBEJS_DB_*` connection variables — for example `CUBEJS_PRE_AGGREGATIONS_DB_TYPE`,
-`CUBEJS_PRE_AGGREGATIONS_DB_HOST`, `CUBEJS_PRE_AGGREGATIONS_DB_PORT`,
-`CUBEJS_PRE_AGGREGATIONS_DB_USER`, `CUBEJS_PRE_AGGREGATIONS_DB_PASS`, and
-`CUBEJS_PRE_AGGREGATIONS_DB_SSL`. For a [named data source][ref-config-multiple-ds-decorating-env],
+`CUBEJS_DB_*` connection variables — for example `CUBEJS_PRE_AGGREGATIONS_DB_HOST`,
+`CUBEJS_PRE_AGGREGATIONS_DB_PORT`, `CUBEJS_PRE_AGGREGATIONS_DB_USER`,
+`CUBEJS_PRE_AGGREGATIONS_DB_PASS`, and `CUBEJS_PRE_AGGREGATIONS_DB_SSL`. For a [named data source][ref-config-multiple-ds-decorating-env],
 use the decorated form `CUBEJS_DS_<NAME>_PRE_AGGREGATIONS_DB_*`.
 
 Driver-specific connection variables take the same segment, so the dedicated connection
@@ -1347,7 +1346,9 @@ and `FIREBOLT_` variable families are supported.
 | Same as the corresponding `CUBEJS_DB_*` variable | Not set                | Not set               |
 
 Setting any one of these variables switches the data source's pre-aggregations onto the
-dedicated connection.
+dedicated connection. Configure it in full: an unset variable falls back to the driver's
+default rather than to its `CUBEJS_DB_*` counterpart. `CUBEJS_PRE_AGGREGATIONS_DB_TYPE` is
+ignored — the dedicated connection always uses the data source's driver.
 
 See [pre-aggregation data source][ref-preagg-data-source] for details and examples.
 


### PR DESCRIPTION
Follow-up to #10587. The main documentation for pre-aggregation-specific data source credentials landed in 3a84d1a, but a few points that trip readers up were missing.

- **Activation rule.** Setting any one credential variable with the `PRE_AGGREGATIONS` segment switches the data source onto the dedicated connection — there is no separate flag. Called out explicitly, along with the four `CUBEJS_PRE_AGGREGATIONS_*` variables that share the prefix but configure behavior rather than a connection (`SCHEMA`, `BUILDER`, `BACKOFF_MAX_TIME`, `ALLOW_NON_STRICT_DATE_RANGE_MATCH`) and so deliberately do *not* trigger it. These look like they would, which was the most confusing part.
- **Variable families.** The segment isn't limited to `_DB_*` — `JDBC_`, `AWS_`, `DATABASE` and `FIREBOLT_` take it too. Previously an Athena or Firebolt user would conclude the feature didn't apply to them.
- **`driver_factory` precedence.** A custom `driver_factory` wins over the env vars and logs a `Pre-aggregation driver conflict` warning. This was undocumented on both the pre-aggregations page and the `driver_factory` reference.

Also replaced the `N/A` placeholders in the `CUBEJS_PRE_AGGREGATIONS_DB_*` reference table with `Not set`.

`yarn broken-links --check-anchors` reports no issues in the changed files (the 16 pre-existing failures are all in `embedding/iframe/`, untouched here).