### PR TITLE
fix(cubejs-client-core): avoid stack overflow on large cubeSql results

### DIFF
--- a/packages/cubejs-client-core/src/index.ts
+++ b/packages/cubejs-client-core/src/index.ts
@@ -817,7 +817,13 @@ class CubeApi {
             }
 
             if (parsed.data) {
-              rows.push(...parsed.data);
+              // Append rows one at a time instead of spreading the whole chunk as
+              // call arguments (`rows.push(...parsed.data)`). A large single-chunk
+              // result (e.g. 130k+ rows) otherwise exceeds V8's argument-count
+              // limit and throws "RangeError: Maximum call stack size exceeded".
+              for (let i = 0; i < parsed.data.length; i++) {
+                rows.push(parsed.data[i]);
+              }
             }
           }
         }

--- a/packages/cubejs-client-core/test/CubeApi.test.ts
+++ b/packages/cubejs-client-core/test/CubeApi.test.ts
@@ -504,6 +504,34 @@ describe('CubeApi cubeSql', () => {
       cubeApi.cubeSql('SELECT created_date FROM deals')
     ).rejects.toThrow('Post-Processing Error: Cast error: Error parsing \'2026-05-01\' as timestamp');
   });
+
+  // Regression: a large result returned in a single data chunk must not be spread
+  // into `rows.push(...)` — beyond ~123k elements that overflows V8's argument-count
+  // limit with "RangeError: Maximum call stack size exceeded".
+  test('should handle a large single-chunk result without a call-stack overflow', async () => {
+    const rowCount = 130000;
+    const largeResponseBody = [
+      JSON.stringify({ schema: [{ name: 'id', column_type: 'Int64' }] }),
+      JSON.stringify({ data: Array.from({ length: rowCount }, (_, i) => [String(i)]) }),
+    ].join('\n');
+
+    vi.spyOn(HttpTransport.prototype, 'request').mockImplementation(() => ({
+      subscribe: (cb) => Promise.resolve(cb({
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ error: largeResponseBody })),
+      } as any,
+      async () => undefined as any))
+    }));
+
+    const cubeApi = new CubeApi('token', {
+      apiUrl: 'http://localhost:4000/cubejs-api/v1',
+    });
+
+    const res = await cubeApi.cubeSql('SELECT id FROM big_table');
+    expect(res.data).toHaveLength(rowCount);
+    expect(res.data[0]).toEqual(['0']);
+    expect(res.data[rowCount - 1]).toEqual([String(rowCount - 1)]);
+  });
 });
 
 describe('CubeApi with baseRequestId', () => {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required (no user-facing API change — none required)

**Description of Changes Made**

`CubeApi.cubeSql()` assembled its result by spreading each JSONL data chunk into the accumulator:

```js
if (parsed.data) {
  rows.push(...parsed.data);
}
```

A spread in a call position passes every element as a separate function argument. When the SQL API returns a large result inside a **single** data chunk, that exceeds V8's argument-count limit (empirically ~123k) and throws:

```
RangeError: Maximum call stack size exceeded
```

The failure is size-dependent, so it stays invisible until a deployment's row limit is raised: a ~50k-row result parses fine, while a ~130k-row result reliably throws. Because the query itself executes and returns successfully, server-side query history shows no error at all — only the client fails, while parsing an otherwise valid response. Every consumer that loads results through `cubeSql` is affected.

**Fix:** append the rows with an element-wise loop, which has no argument-count limit and produces an identical `rows` array.

```js
if (parsed.data) {
  for (let i = 0; i < parsed.data.length; i++) {
    rows.push(parsed.data[i]);
  }
}
```

`cubeSqlStream` is unaffected — it yields each chunk to the caller and never spreads rows.

**Testing**

Added a regression test to `test/CubeApi.test.ts` that parses a 130k-row single-chunk response and asserts the row count plus first/last rows.

- With the fix: the full `CubeApi` suite passes (28/28).
- Reverting only the `src/index.ts` change makes the new test fail with exactly `RangeError: Maximum call stack size exceeded`, confirming it covers the reported defect.
- `eslint src/index.ts test/CubeApi.test.ts` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)