### PR TITLE
fix(cubesql): Preserve `lastRefreshTime` with post-processing and SQL pushdown

### DIFF
--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -2225,7 +2225,17 @@ class ApiGateway {
              * TODO(ovr): You must finish it, move to ResultWrapper after optimizing it.
              */
             data: rowsToColumnar(response.data),
-            annotation
+            annotation,
+            // Freshness metadata has to travel with the pushed-down result too,
+            // otherwise the SQL API reports "unknown" for every query cubesql
+            // hands over as pre-generated SQL.
+            lastRefreshTime: response.lastRefreshTime?.toISOString(),
+            // Always false: this branch builds its sqlQuery with
+            // `disableExternalPreAggregations` set (above), which makes
+            // `externalPreAggregationQuery()` return false, and the
+            // orchestrator only echoes that flag back. Mirrored anyway for
+            // shape parity with `prepareResultTransformData`.
+            external: response.external,
           }];
         }
 

--- a/packages/cubejs-api-gateway/test/sql-api-load.test.ts
+++ b/packages/cubejs-api-gateway/test/sql-api-load.test.ts
@@ -1,0 +1,91 @@
+import { ApiGateway } from '../src';
+import { compilerApi, AdapterApiMock, DataSourceStorageMock } from './mocks';
+
+const logger = (type: any, message: any) => console.log({ type, ...message });
+
+const LAST_REFRESH_TIME = new Date('2024-01-01T00:00:00.000Z');
+
+class FreshnessAdapterApiMock extends AdapterApiMock {
+  public lastRefreshTime: Date | undefined;
+
+  public constructor(lastRefreshTime?: Date) {
+    super();
+    this.lastRefreshTime = lastRefreshTime;
+  }
+
+  public async executeQuery(_query: any) {
+    return {
+      data: [{ foo__bar: 42 }],
+      lastRefreshTime: this.lastRefreshTime,
+      // Always falsy for a pushdown query — see the note in
+      // `sqlApiLoad`. Mirrors what the orchestrator actually echoes back.
+      external: false,
+    };
+  }
+}
+
+function createGateway(adapterApi: any) {
+  return new ApiGateway('secret', compilerApi, async () => adapterApi, logger, {
+    standalone: true,
+    dataSourceStorage: new DataSourceStorageMock(),
+    basePath: '/cubejs-api',
+    refreshScheduler: {},
+  });
+}
+
+async function sqlApiLoad(adapterApi: any, sqlQuery?: [string, any[]]) {
+  const apiGateway = createGateway(adapterApi);
+
+  let response: any;
+
+  await apiGateway.sqlApiLoad({
+    query: { measures: ['Foo.bar'] },
+    sqlQuery,
+    streaming: false,
+    memberExpressions: true,
+    context: {
+      requestId: 'sql-api-load-test',
+      securityContext: {},
+      signedWithPlaygroundAuthSecret: false,
+    } as any,
+    res: (r: any) => {
+      response = r;
+    },
+    apiType: 'sql',
+  } as any);
+
+  return response;
+}
+
+describe('sqlApiLoad freshness metadata', () => {
+  // cubesql hands pre-generated SQL back to the gateway for any query it pushes
+  // down (`sqlQuery` set). That branch used to build its result object without
+  // `lastRefreshTime`, so the SQL API reported the result's age as unknown even
+  // though the underlying query-cache entry had the timestamp.
+  test('pushed-down sqlQuery result carries lastRefreshTime', async () => {
+    const response = await sqlApiLoad(
+      new FreshnessAdapterApiMock(LAST_REFRESH_TIME),
+      ['SELECT * FROM test', []]
+    );
+
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].lastRefreshTime).toBe(
+      LAST_REFRESH_TIME.toISOString()
+    );
+    expect(response.results[0].external).toBe(false);
+  });
+
+  // No cache entry and no pre-aggregation: the orchestrator returns no
+  // timestamp at all, so the gateway must not invent one. `JSON.stringify`
+  // then drops the `undefined` and the Rust side decodes the missing key into
+  // `None` (`V1LoadResult.last_refresh_time: Option<String>`).
+  test('pushed-down sqlQuery result omits lastRefreshTime when absent', async () => {
+    const response = await sqlApiLoad(
+      new FreshnessAdapterApiMock(undefined),
+      ['SELECT * FROM test', []]
+    );
+
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].lastRefreshTime).toBeUndefined();
+  });
+});

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -303,6 +303,7 @@ async fn handle_sql_query(
 
         let session_clone = Arc::clone(&session);
         let span_id_clone = span_id.clone();
+        let span_id_for_schema = span_id.clone();
 
         let (close_tx, close_rx) = oneshot::channel::<()>();
         let close_handler =
@@ -373,20 +374,57 @@ async fn handle_sql_query(
             let mut schema_response = Map::new();
             schema_response.insert("schema".into(), serde_json::to_value(&columns)?);
 
-            if let Some(last_refresh_time) = stream.schema().metadata().get("lastRefreshTime") {
+            // Result freshness metadata is recorded on the span by `load_data`,
+            // so it survives post-processing nodes (a calculated projection over
+            // MEASURE(), a sort, a filter) that rebuild the schema and drop its
+            // metadata. The stream schema is only a fallback for plans with no
+            // span.
+            //
+            // Reading it here, before the first `stream.next()`, relies on
+            // `ExecutionPlan::execute` being async in this DataFusion fork with
+            // every parent awaiting its children's `execute()` before returning
+            // a stream — that is what has already run `load_data` by now. A node
+            // that deferred child execution to first poll would silently empty
+            // this header again, and the tests would not catch it.
+            //
+            // Not covered: stream mode, where `execute` takes the `load_stream`
+            // branch and never calls `load_data`, so neither the span nor the
+            // stream schema carries the metadata and the header omits it.
+            //
+            // Both values take the same precedence: whatever the span reported
+            // wins outright, and the schema is consulted only when the span was
+            // silent. `external` must not be OR-ed with the schema — a span that
+            // folded to `false` because only some of its loads were external
+            // would then be overridden back to `true`, undoing the conservative
+            // fold in `SpanId::set_external`.
+            let (span_last_refresh_time, span_external) = match span_id_for_schema.as_ref() {
+                Some(span_id) => (span_id.last_refresh_time().await, span_id.external().await),
+                None => (None, None),
+            };
+
+            let last_refresh_time = span_last_refresh_time.or_else(|| {
+                stream
+                    .schema()
+                    .metadata()
+                    .get("lastRefreshTime")
+                    .map(|t| t.to_string())
+            });
+            if let Some(last_refresh_time) = last_refresh_time {
                 schema_response.insert(
                     "lastRefreshTime".into(),
-                    serde_json::Value::String(last_refresh_time.clone()),
+                    serde_json::Value::String(last_refresh_time),
                 );
             }
 
-            if stream
-                .schema()
-                .metadata()
-                .get("external")
-                .map(|v| v == "true")
-                .unwrap_or(false)
-            {
+            let external = span_external.unwrap_or_else(|| {
+                stream
+                    .schema()
+                    .metadata()
+                    .get("external")
+                    .map(|v| v == "true")
+                    .unwrap_or(false)
+            });
+            if external {
                 schema_response.insert("external".into(), serde_json::Value::Bool(true));
             }
 

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -568,4 +568,91 @@ describe('SQLInterface', () => {
       await native.shutdownInterface(instance, 'fast');
     }
   });
+
+  // A calculated projection over MEASURE() (a query-level member expression,
+  // e.g. an "average order value" field) leaves the cube scan wrapped in
+  // DataFusion Projection/Sort nodes. Those build their own output schema and
+  // drop the scan's `lastRefreshTime` / `external` metadata, so the JSONL
+  // header used to come back without them while the same base measures queried
+  // plainly did carry them.
+  //
+  // Both queries carry an explicit LIMIT to pin them to the buffered path.
+  // `CubeScanExecutionPlan::execute` switches to `load_stream` when stream mode
+  // is on and the request has no limit, and that branch never runs `load_data`,
+  // so no freshness metadata is recorded at all — a known gap, and this suite
+  // runs under CUBESQL_STREAM_MODE=true in CI.
+  test.each([
+    [
+      'plain measure projection',
+      'SELECT customer_gender, MEASURE(count) AS cnt FROM KibanaSampleDataEcommerce GROUP BY 1 LIMIT 10;',
+    ],
+    [
+      'calculated projection over MEASURE()',
+      'SELECT customer_gender, ROUND(MEASURE(maxPrice) / MEASURE(count), 2) AS avg_value, MEASURE(count) AS cnt FROM KibanaSampleDataEcommerce GROUP BY 1 ORDER BY 3 DESC LIMIT 10;',
+    ],
+  ])(
+    'lastRefreshTime and external survive in /cubesql JSONL header for a %s',
+    async (_name, sql) => {
+      const methods = {
+        ...interfaceMethods(),
+        sqlApiLoad: jest.fn(async ({ streaming, query }: any) => {
+          if (streaming) {
+            return { stream: new FakeRowStream(query) };
+          }
+          return {
+            results: [
+              {
+                annotation: {
+                  measures: {},
+                  dimensions: {},
+                  segments: {},
+                  timeDimensions: {},
+                },
+                data: {
+                  members: [
+                    'KibanaSampleDataEcommerce.customer_gender',
+                    'KibanaSampleDataEcommerce.maxPrice',
+                    'KibanaSampleDataEcommerce.count',
+                  ],
+                  columns: [['female'], [10], [4]],
+                },
+                lastRefreshTime: '2024-01-01T00:00:00.000Z',
+                external: true,
+              },
+            ],
+          };
+        }),
+      };
+
+      const instance = await native.registerInterface({
+        ...methods,
+        canSwitchUserForSession: (_payload: any) => true,
+      });
+
+      let buf = '';
+      const lines: any[] = [];
+      const write = jest.fn((chunk, _enc, callback) => {
+        const raw = (buf + chunk.toString('utf-8')).split('\n');
+        buf = raw.pop() || '';
+        for (const l of raw) {
+          if (l.trim().length) {
+            lines.push(JSON.parse(l));
+          }
+        }
+        callback();
+      });
+      const cubeSqlStream = new Writable({ write });
+
+      try {
+        await native.execSql(instance, sql, cubeSqlStream);
+
+        const schemaLine = lines.find((o) => o.schema);
+        expect(schemaLine).toBeDefined();
+        expect(schemaLine.lastRefreshTime).toBe('2024-01-01T00:00:00.000Z');
+        expect(schemaLine.external).toBe(true);
+      } finally {
+        await native.shutdownInterface(instance, 'fast');
+      }
+    }
+  );
 });

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -905,14 +905,32 @@ async fn load_data(
             })?;
 
         if let Some(data) = result.into_iter().next() {
+            // Mirror the result freshness metadata onto the span. The schema
+            // metadata only survives while this scan's batch is the root of the
+            // plan — any post-processing DataFusion node on top (a calculated
+            // projection over MEASURE(), a sort, a filter) builds its own schema
+            // and drops it. The span outlives the whole plan, so consumers that
+            // report freshness read it from there instead.
             if let Some(span_id) = &span_id {
-                if let Some(last_refresh_time) = data.schema().metadata().get("lastRefreshTime") {
+                let schema = data.schema();
+                let metadata = schema.metadata();
+
+                if let Some(last_refresh_time) = metadata.get("lastRefreshTime") {
                     if let Ok(last_refresh_time) = DateTime::parse_from_rfc3339(last_refresh_time) {
                         span_id
                             .set_last_refresh_time(last_refresh_time.with_timezone(&Utc))
                             .await;
                     }
                 }
+
+                span_id
+                    .set_external(
+                        metadata
+                            .get("external")
+                            .map(|v| v == "true")
+                            .unwrap_or(false),
+                    )
+                    .await;
             }
 
             match (options.max_records, data.num_rows()) {

--- a/rust/cubesql/cubesql/src/transport/service.rs
+++ b/rust/cubesql/cubesql/src/transport/service.rs
@@ -86,6 +86,7 @@ pub struct SpanId {
     span_start: SystemTime,
     is_data_query: RWLockAsync<bool>,
     last_refresh_time: RWLockAsync<Option<DateTime<Utc>>>,
+    external: RWLockAsync<Option<bool>>,
 }
 
 impl SpanId {
@@ -96,6 +97,7 @@ impl SpanId {
             span_start: SystemTime::now(),
             is_data_query: tokio::sync::RwLock::new(false),
             last_refresh_time: tokio::sync::RwLock::new(None),
+            external: tokio::sync::RwLock::new(None),
         }
     }
 
@@ -123,6 +125,28 @@ impl SpanId {
     pub async fn last_refresh_time(&self) -> Option<String> {
         let read = self.last_refresh_time.read().await;
         read.map(|t| t.to_rfc3339_opts(SecondsFormat::Millis, true))
+    }
+
+    /// Records whether a load result contributing to this span was served from
+    /// an external (CubeStore) pre-aggregation. A span may cover several load
+    /// requests (e.g. a join of cube scans); the span counts as external only
+    /// when *every* one of them was, matching how the flag is folded elsewhere
+    /// (`usages.iter().all(..)` in cubesqlplanner's `base_query`). Otherwise a
+    /// join of one pre-aggregated and one live scan would claim the whole result
+    /// came from a pre-aggregation, while `last_refresh_time` above reports the
+    /// oldest of the two — the two would disagree on the same result.
+    ///
+    /// `None` means no load has reported yet, which is distinct from a load
+    /// having reported `false`.
+    pub async fn set_external(&self, external: bool) {
+        let mut write = self.external.write().await;
+        *write = Some(write.unwrap_or(true) && external);
+    }
+
+    /// `None` when no load has reported yet, so callers can tell a span that
+    /// is silent from one that deliberately folded to `false`.
+    pub async fn external(&self) -> Option<bool> {
+        *self.external.read().await
     }
 
     pub fn duration(&self) -> u64 {
@@ -1099,5 +1123,32 @@ mod tests {
             span_id.last_refresh_time().await,
             Some("2024-01-01T00:00:00.000Z".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn span_id_external_only_when_every_load_is_external() {
+        // No load has reported yet — distinct from a load reporting `false`,
+        // so that consumers can fall back to another source when silent
+        let span_id = SpanId::new("test".to_string(), serde_json::json!({}));
+        assert_eq!(span_id.external().await, None);
+
+        // A single external load makes the whole span external
+        span_id.set_external(true).await;
+        assert_eq!(span_id.external().await, Some(true));
+
+        // ...but one live load anywhere in the span clears it, and a later
+        // external load must not bring it back
+        span_id.set_external(false).await;
+        assert_eq!(span_id.external().await, Some(false));
+        span_id.set_external(true).await;
+        assert_eq!(span_id.external().await, Some(false));
+    }
+
+    #[tokio::test]
+    async fn span_id_external_reports_false_for_a_single_live_load() {
+        let span_id = SpanId::new("test".to_string(), serde_json::json!({}));
+
+        span_id.set_external(false).await;
+        assert_eq!(span_id.external().await, Some(false));
     }
 }


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required


**Description of Changes Made**

This PR makes the SQL API return `lastRefreshTime` for queries whose plan has post-processing nodes over the cube scan (calculated projections over `MEASURE()`, sorts, filters) and for SQL pushdown queries, both of which silently dropped it. Related test is included.
