### PR TITLE
docs: document credentials_base64 and add Google Cloud Storage monitoring guide

### DIFF
--- a/docs-mintlify/admin/monitoring/monitoring-integrations/gcs.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/gcs.mdx
@@ -1,0 +1,174 @@
+---
+title: Integration with Google Cloud Storage
+sidebarTitle: Google Cloud Storage
+description: Google Cloud Storage is a popular object storage system. This guide demonstrates how to set up Cube to export logs and Query History data to a Google Cloud Storage bucket.
+---
+
+[Google Cloud Storage](https://cloud.google.com/storage) is a popular object
+storage system. This guide demonstrates how to set up Cube to export logs and
+[Query History][ref-query-history-export] data to a Google Cloud Storage bucket.
+
+## Configuration
+
+First, enable [monitoring integrations][ref-monitoring-integrations].
+
+### Authentication
+
+The [`gcp_cloud_storage`][vector-docs-sinks-gcs] sink authenticates on its own,
+independently from the credentials of your [data sources][ref-data-sources]. A
+deployment that queries BigQuery does not reuse its BigQuery service account for
+log export, so you have to provide credentials for the sink explicitly.
+
+<Info>
+
+The Vector agent runs inside Cube's infrastructure, so the fallbacks that Google
+Cloud client libraries usually rely on—the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable and the service account of the underlying compute
+instance—do not resolve to a service account in your Google Cloud project. Use
+the `credentials_base64` option described below.
+
+</Info>
+
+<Steps>
+
+<Step title="Create a service account">
+
+Create a [service account][google-docs-create-svc-account] in the Google Cloud
+project that owns the bucket and grant it a role that allows writing objects to
+the bucket, e.g. **Storage Object Creator** (`roles/storage.objectCreator`).
+Then, create a JSON key for that service account.
+
+</Step>
+
+<Step title="Encode the key file">
+
+Encode the JSON key file using Base64:
+
+```bash
+cat /path/to/my/keyfile.json | base64
+```
+
+</Step>
+
+<Step title="Store the key as an environment variable">
+
+Add the result as an [environment variable][ref-env-vars] to your deployment,
+using a name prefixed with `CUBE_CLOUD_MONITORING_`, e.g.
+`CUBE_CLOUD_MONITORING_GCS_CREDENTIALS`. This keeps the key out of your
+repository.
+
+</Step>
+
+<Step title="Reference the credentials from the sink">
+
+Use the [`credentials_base64`][ref-monitoring-integrations-creds] option to
+reference the environment variable, and point the sink's `credentials_path`
+option at the file that Cube mounts for you.
+
+</Step>
+
+</Steps>
+
+### Exporting logs
+
+To export logs to Google Cloud Storage, start by creating a bucket for your
+logs.
+
+Then, configure the [`gcp_cloud_storage`][vector-docs-sinks-gcs] sink in your
+[`vector.toml` configuration file][ref-monitoring-integrations-conf].
+
+Example configuration:
+
+```toml
+[sinks.gcs]
+type = "gcp_cloud_storage"
+inputs = [
+  "cubejs-server",
+  "refresh-scheduler",
+  "warmup-job",
+  "cubestore"
+]
+bucket = "your-gcs-bucket-name"
+credentials_base64 = "$CUBE_CLOUD_MONITORING_GCS_CREDENTIALS"
+credentials_path = "/etc/credentials/gcs.json"
+compression = "gzip"
+
+[sinks.gcs.encoding]
+codec = "json"
+
+[sinks.gcs.healthcheck]
+enabled = false
+```
+
+Note that `credentials_path` matches the name of the sink: because the sink above
+is named `gcs`, its credentials are mounted at `/etc/credentials/gcs.json`. See
+[credentials files][ref-monitoring-integrations-creds] for details.
+
+Commit the configuration for Vector, it should take effect in a minute. Then,
+navigate to your bucket and watch the logs coming.
+
+### Exporting Query History
+
+To export [Query History][ref-query-history] data to the same bucket, add the
+`query-history` input to the sink configuration:
+
+```toml
+[sinks.gcs]
+type = "gcp_cloud_storage"
+inputs = [
+  "query-history"
+]
+bucket = "your-gcs-bucket-name"
+credentials_base64 = "$CUBE_CLOUD_MONITORING_GCS_CREDENTIALS"
+credentials_path = "/etc/credentials/gcs.json"
+compression = "gzip"
+
+[sinks.gcs.encoding]
+codec = "json"
+
+[sinks.gcs.healthcheck]
+enabled = false
+```
+
+See [Query History export][ref-query-history-export-conf] for the list of
+exported fields.
+
+## Troubleshooting
+
+### Credentials are not picked up
+
+If the sink reports authentication errors, or Vector logs show that it is falling
+back to an instance service account, check the following:
+
+- The environment variable referenced by `credentials_base64` exists in the
+  deployment and contains Base64-encoded JSON. Cube ignores the option if the
+  decoded value does not parse as JSON.
+- `credentials_path` matches the name of the sink, e.g.
+  `/etc/credentials/gcs.json` for a sink named `gcs`.
+- The name of the sink contains only lowercase letters, numbers, and dashes.
+  Names with underscores, e.g. `gcp_cloud_storage`, are not supported for sinks
+  that use `credentials_base64`.
+
+### Permission denied on the bucket
+
+Make sure the service account has a role that allows writing objects to the
+bucket, and that the bucket named in the `bucket` option belongs to the same
+Google Cloud project as the service account.
+
+If you keep the sink's healthcheck enabled, the service account also needs
+permission to read the bucket's metadata, e.g. **Storage Legacy Bucket Reader**
+(`roles/storage.legacyBucketReader`).
+
+
+[ref-monitoring-integrations]: /admin/monitoring/monitoring-integrations
+[ref-monitoring-integrations-conf]: /admin/monitoring/monitoring-integrations#configuration
+[ref-monitoring-integrations-creds]: /admin/monitoring/monitoring-integrations#credentials-files
+[ref-query-history]: /admin/monitoring/query-history
+[ref-query-history-export]: /admin/monitoring/query-history-export
+[ref-query-history-export-conf]: /admin/monitoring/monitoring-integrations#query-history-export
+[ref-data-sources]: /admin/connect-to-data/data-sources
+[ref-env-vars]: /admin/deployment#environment-variables
+[vector-docs-sinks-gcs]:
+  https://vector.dev/docs/reference/configuration/sinks/gcp_cloud_storage/
+[google-docs-create-svc-account]:
+  https://cloud.google.com/iam/docs/service-accounts-create

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -54,6 +54,9 @@ following guides and configuration examples to get tool-specific instructions:
   <Card title="Datadog" href="/admin/monitoring/monitoring-integrations/datadog">
     Export logs and metrics to Datadog.
   </Card>
+  <Card title="Google Cloud Storage" href="/admin/monitoring/monitoring-integrations/gcs">
+    Archive logs to a Google Cloud Storage bucket.
+  </Card>
   <Card title="Grafana Cloud" href="/admin/monitoring/monitoring-integrations/grafana-cloud">
     Export logs and metrics to Grafana Cloud.
   </Card>
@@ -94,6 +97,46 @@ Example configuration for exporting logs to
 type = "datadog_logs"
 default_api_key = "$CUBE_CLOUD_MONITORING_DATADOG_API_KEY"
 ```
+
+### Credentials files
+
+Some sinks authenticate with a credentials file rather than with individual
+parameters. The [`gcp_cloud_storage`][vector-docs-sinks-gcs] sink, for example,
+reads a service account key from the path given in its `credentials_path`
+option.
+
+Since you can't upload files to a deployment, use the `credentials_base64`
+option to have Cube create such a file for you. It accepts a Base64-encoded
+JSON credentials file, either inline or as a reference to an [environment
+variable][ref-env-vars]:
+
+```toml
+[sinks.gcs]
+type = "gcp_cloud_storage"
+bucket = "my-logs"
+credentials_base64 = "$CUBE_CLOUD_MONITORING_GCS_CREDENTIALS"
+credentials_path = "/etc/credentials/gcs.json"
+```
+
+Cube decodes the value, validates that it's JSON, and mounts it into the Vector
+agent at `/etc/credentials/<sink name>.json`. In the example above, the sink is
+named `gcs`, so its credentials file is mounted at `/etc/credentials/gcs.json`,
+which is where `credentials_path` points.
+
+<Info>
+
+Sinks that use `credentials_base64` must be named with lowercase letters,
+numbers, and dashes only. Names that contain underscores, e.g.
+`gcp_cloud_storage`, are not supported.
+
+</Info>
+
+Sinks authenticate independently from the [data sources][ref-data-sources] of
+your deployment. Credentials configured for a data source—including a BigQuery
+service account—are never reused for log export, even when both point to the
+same cloud provider.
+
+See [Integration with Google Cloud Storage][ref-gcs] for a complete example.
 
 ### Inputs for logs
 
@@ -376,3 +419,6 @@ Query History export.
 [ref-security-context]: /docs/data-modeling/access-control/context
 [ref-cache-type]: /docs/pre-aggregations#cache-type
 [ref-query-history-export-recipe]: /admin/monitoring/query-history-export
+[ref-gcs]: /admin/monitoring/monitoring-integrations/gcs
+[ref-data-sources]: /admin/connect-to-data/data-sources
+[ref-env-vars]: /admin/deployment#environment-variables

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -382,6 +382,7 @@
                   "admin/monitoring/monitoring-integrations/cloudwatch",
                   "admin/monitoring/monitoring-integrations/s3",
                   "admin/monitoring/monitoring-integrations/datadog",
+                  "admin/monitoring/monitoring-integrations/gcs",
                   "admin/monitoring/monitoring-integrations/grafana-cloud",
                   "admin/monitoring/monitoring-integrations/new-relic"
                 ]


### PR DESCRIPTION
## Problem

Google Cloud Storage is listed as a supported sink on the [Monitoring Integrations](https://docs.cube.dev/admin/monitoring/monitoring-integrations) page, but the docs never explain how to authenticate it.

The `gcp_cloud_storage` sink reads a service account key from a **file path** (`credentials_path`), and falls back to `GOOGLE_APPLICATION_CREDENTIALS` or the instance service account. None of those are actionable for a customer: you can't upload a file to a deployment, and the Vector agent runs in Cube's infrastructure, so the instance service account isn't in the customer's GCP project.

The supported mechanism — the `credentials_base64` sink option — was undocumented, so the feature was effectively undiscoverable. This came up in a customer question that also surfaced a related misconception: that the BigQuery data source service account is reused for log export.

## Changes

**New page** — `admin/monitoring/monitoring-integrations/gcs.mdx`, following the structure of the existing S3 and CloudWatch guides: service account setup, log export, Query History export, and troubleshooting.

**Overview page** — new `Credentials files` section documenting `credentials_base64` generically, since the option is sink-agnostic (only `credentials_path` is GCP-specific). It accepts a Base64-encoded JSON credentials file, either inline or as a `$CUBE_CLOUD_MONITORING_*` environment variable reference, and is mounted into the Vector agent at `/etc/credentials/<sink name>.json`.

Also documented, because both generate support tickets:

- Sinks using `credentials_base64` must be named with lowercase letters, numbers, and dashes only — the sink name becomes a Kubernetes object name, so `[sinks.gcp_cloud_storage]` silently fails.
- Sinks authenticate independently from data sources. A BigQuery service account is never reused for log export.

**Navigation** — registered in `docs.json` and added a card to the overview card group.

## Verification

- `docs.json` parses as valid JSON; the diff is a single added line.
- `scripts/check_links.py` reports no broken links in either changed file. (It reports many pre-existing failures elsewhere in the repo, unrelated to this change.)
- No legacy Nextra components; Mintlify components only.
- Anchor targets (`#credentials-files`, `#query-history-export`, `#environment-variables`) verified to exist.

Behavior documented here was read off the `credentials_base64` handling in the Cube Cloud operator rather than inferred, including the accepted value forms, the JSON validation step, the mount path, and the sink naming constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)