### PR TITLE
docs: document Python analysis in workbooks

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -53,6 +53,7 @@
                   "docs/explore-analyze/workbooks/querying-data",
                   "docs/explore-analyze/workbooks/calculated-fields",
                   "docs/explore-analyze/workbooks/source-sql-tabs",
+                  "docs/explore-analyze/workbooks/python-analysis",
                   "docs/explore-analyze/workbooks/workbook-agent"
                 ]
               },

--- a/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
+++ b/docs-mintlify/docs/explore-analyze/analytics-chat.mdx
@@ -13,6 +13,7 @@ The AI agent interprets your questions, generates queries against your semantic 
 
 - **Natural language queries** – Ask questions in plain language without knowing SQL
 - **Multi-query reasoning** – The AI creates and synthesizes multiple queries for complex questions
+- **Python analysis** – For work SQL can't express — forecasting, cohort analysis, statistical tests — the agent can run [Python](/docs/explore-analyze/workbooks/python-analysis) and render the result inline, then save it to a workbook as a re-runnable report (in preview)
 - **Semantic model integration** – All queries run against your semantic model with proper access control and security, honoring the active [security context](/docs/explore-analyze/workbooks/querying-data#applying-a-security-context)—including an override applied by a developer or admin
 - **Queued messages** – Send follow-up messages while the agent is still processing
 - **Save to Workbook** – Export insights to [Workbooks](/docs/explore-analyze/workbooks) for further analysis
@@ -85,6 +86,7 @@ Analytics Chat can be [embedded](/embedding) into your applications for customer
 ## Learn more
 
 - [Workbooks](/docs/explore-analyze/workbooks) – Build and organize reports with AI assistance
+- [Python analysis](/docs/explore-analyze/workbooks/python-analysis) – Save a Python analysis from chat as a re-runnable report
 - [Embedding](/embedding) – Embed analytics in your applications
 - [Cube Agentic Analytics announcement](https://cube.dev/blog/cube-agentic-analytics) – Learn about the vision behind agentic analytics
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -1,0 +1,149 @@
+---
+title: Python analysis
+description: Attach a Python script to a report to run forecasting, regression, cohort, and other analysis that SQL can't express, and save the result as a re-runnable report.
+---
+
+<Warning>
+
+Python analysis is currently in preview, and the user experience and file format may
+still change. Reach out to the [Cube support team](/admin/account-billing/support)
+to activate this feature for your account.
+
+</Warning>
+
+A report can carry an attached **Python script** that transforms the report's SQL
+result. The report's chart then renders the script's **output** instead of the raw
+SQL rows. This turns an analysis that would otherwise scroll away in a chat
+transcript into a saved, re-runnable, shareable report.
+
+Use it for work SQL can't express — forecasting, regression, cohort analysis,
+statistical tests, clustering, and anomaly detection.
+
+## Adding Python to a report
+
+### From Analytics Chat
+
+Ask for the analysis in natural language — "forecast next quarter's revenue",
+"find anomalies in signups" — and the agent runs Python for you, rendering the
+result inline in the [chat thread](/docs/explore-analyze/analytics-chat). This
+result is ephemeral by default.
+
+Ask to **save it to a workbook** and Cube persists both the code and the run result
+onto a report, which then renders the saved output without re-running. Saving
+re-executes the analysis.
+
+<Info>
+
+The agent reaches for Python **only** when the answer genuinely needs a statistics
+or machine-learning library. Ordinary aggregations, top-N, ratios, running totals,
+period-over-period comparisons, and time series all stay in SQL, because a Python
+run costs a re-query plus a sandbox start. If you expected Python and got a plain
+SQL report, that is usually correct behavior.
+
+</Info>
+
+### In a workbook
+
+Open the tab menu and choose **Add Python**. Cube seeds a starter script and
+reveals the code panel. **Remove Python** detaches the script, after which the tab
+behaves like any SQL-backed report again.
+
+Attaching Python clears any existing SQL result: a python-backed report renders its
+last Python run, and a freshly attached script has none until you press **Run**.
+
+### In Explore
+
+Use the **Add Python** button in the header, with the same **Remove Python**
+counterpart.
+
+This is only available on a **saved** [exploration](/docs/explore-analyze/explore).
+On an unsaved one the button is disabled with the tooltip *"Save exploration before
+adding Python."* — **Run** executes server-persisted code, so the analysis needs a
+saved report to live on.
+
+## Writing the script
+
+The script runs in a sandbox against a fixed contract:
+
+- Input data arrives as `data.csv` in the working directory.
+- Write results to `output.json` as a **flat JSON array of row objects**, for
+  example `[{"month": "2026-01", "value": 1.5}, ...]`.
+
+A top-level dict or object is rejected — flatten any nested structure into one
+array of uniform rows.
+
+These libraries are available: pandas, numpy, scipy, scikit-learn, statsmodels,
+prophet, matplotlib, seaborn, plotly.
+
+{/* TODO: screenshot — the Add Python tab menu entry */}
+
+## Running and refreshing
+
+The code panel is editable in place, with line numbers.
+
+- **Edits do not run anything.** They save with the report, and the rendered result
+  keeps showing the previous run.
+- When the code or its input SQL has changed since the last run, the result is
+  marked **Outdated**, with the tooltip *"The Python code or its input SQL changed
+  after the last run. Run to refresh the saved result."*
+- **Run** executes the stored script in the sandbox and persists the refreshed
+  result.
+- The **input SQL panel is read-only** on a python report: that SQL is the
+  sandbox's input, not what gets charted.
+- **A failed run keeps the previous chart.** The error and the script's
+  stdout/stderr surface in the UI while the last good result stays rendered.
+
+**Run is the only way the saved result changes.** Opening the report, reloading the
+page, or viewing a dashboard never re-runs anything on its own.
+
+{/* TODO: screenshot — the code panel showing the Outdated tag */}
+
+## On dashboards
+
+Python reports render their **saved output** on dashboards. Nothing re-runs on
+dashboard load, so a dashboard full of Python reports costs no compute to open —
+each widget shows whatever the last **Run** produced.
+
+A python widget can be opened in [Explore](/docs/explore-analyze/explore) from a
+dashboard and run from there.
+
+## Who the analysis runs as
+
+<Warning>
+
+Python runs with the **security context of the person who pressed Run** — or of the
+chat user who saved the analysis. The result is then persisted on the report, and
+**anyone who can view the workbook can see it**.
+
+Row-level security is applied at **run time**, not at view time. A user with broad
+access can Run, and the stored output is then readable by people whose own access
+is narrower.
+
+</Warning>
+
+Take this into account when deciding who can run and publish Python reports, the
+same way you would for any other saved result shared through a workbook.
+
+## Limits
+
+| Limit | Value |
+| --- | --- |
+| SQL query timeout | 120s |
+| Python execution timeout | 120s |
+| Maximum output rows persisted | 10,000 |
+| Maximum output size | 2 MB |
+| stdout/stderr captured | 16 KB |
+
+Exceeding the output caps means the analysis still returns in chat but **cannot be
+saved to a report**. Aggregate or summarize inside the script so the output stays
+within the caps — analysis results such as forecasts, cohorts, and test statistics
+are small by nature.
+
+## Learn more
+
+- [Analytics Chat](/docs/explore-analyze/analytics-chat) — the standalone
+  conversational analytics experience
+- [Workbook Agent](/docs/explore-analyze/workbooks/workbook-agent) — the authoring
+  assistant inside a workbook
+- [Source SQL tabs](/docs/explore-analyze/workbooks/source-sql-tabs) — query
+  connected data sources directly


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Adds the first public documentation for Python-backed reports. There was previously **zero** public documentation for this feature — nothing under `docs-mintlify/docs/explore-analyze/` mentioned Python.

New page: `docs/explore-analyze/workbooks/python-analysis`, plus its `docs.json` nav entry (between Source SQL tabs and Workbook Agent), plus a cross-link from the Analytics Chat page.

Covers:

- **All three entry points** — Analytics Chat (led with, since it's how most users meet the feature), the workbook tab menu, and the Explore header button (including why it's disabled on an unsaved exploration, the likeliest "why is this greyed out" support question)
- **The script contract** — `data.csv` in, flat JSON array to `output.json` out, and the available libraries
- **Run and staleness semantics** — edits don't run anything, the Outdated tag, and that Run is the only thing that changes a saved result
- **Security** — its own section with a callout: Python runs with the security context of whoever pressed Run, the result is persisted, and row-level security applies at run time rather than view time. This had been flagged as needing user-facing docs since the feature was specced and was never written down.
- **Limits** — the five execution and output caps, and the fact that exceeding an output cap still returns in chat but blocks saving

**Reviewer notes**

- **Marked as preview.** The feature is behind a tenant flag and not yet in production. The page opens with the `<Warning>` callout prescribed by `docs-mintlify/CLAUDE.md`, matching the existing convention (see `reference/core-data-apis/mdx-api.mdx`). No new badge style was invented. **Whether to merge now or hold until the flag rolls out is a product call** — the docs convention's "reach out to Cube support to activate" wording fits a flagged feature, but the decision isn't mine.
- **Dashboard filters and time grains are deliberately out of scope** — that behaviour is actively changing and will be documented in a follow-up. The "On dashboards" section is intentionally short and additive so the follow-up extends it rather than forcing a rewrite.
- **The dashboard→Explore Run path is one sentence on purpose.** The underlying behaviour (a run mutates the shared live report) is known and unresolved, so it's stated plainly without being characterised as an isolated or read-only exploration. Worth an engineering read before expanding.
- **Facts verified against the code**, not the design doc — all five limits, both UI tooltips, the `Add Python` / `Remove Python` labels, the library list, and the output contract were checked against the implementation. Note the internal design doc's staleness wording is itself out of date; the shipped tooltip is what's documented here.
- **Naming is unconfirmed.** The UI only says "Python" and "Add Python"; the page uses "Python analysis" descriptively. Easy to change if there's an official customer-facing name.
- **Two screenshots are left as `{/* TODO */}` placeholders** (the Add Python menu entry, and the code panel showing the Outdated tag), per the docs convention for not-yet-available assets.

**Known gap:** the workbook and Explore entry points are documented on the new page, but `workbooks/index.mdx` and `explore.mdx` don't yet point *to* it the way Analytics Chat now does. Happy to add those one-line pointers here or in a follow-up.

Verified locally against the Mintlify dev server: page renders, sidebar entry lands in the right place, all internal links resolve, no console errors, `docs.json` is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)