### PR TITLE
docs: add Python analysis screenshot, document the static.cube.dev flow

### DIFF
--- a/docs-mintlify/CLAUDE.md
+++ b/docs-mintlify/CLAUDE.md
@@ -319,8 +319,61 @@ expose internal feature-flag names in public docs.
 
 ## Images and screenshots
 
-Wrap screenshots in `<Frame>` and store assets under `images/`. When a screenshot is
-needed but not yet available, leave an MDX comment placeholder: `{/* TODO: screenshot — ... */}`.
+**Do not commit images or other binaries to the repo.** Editorial media — screenshots,
+diagrams, logos, video — is uploaded to the `cube-dev-websites-shared` S3 bucket and
+served from `https://static.cube.dev/<key>`. Reference that URL from the `.mdx`.
+
+Wrap screenshots in `<Frame>`. When a screenshot is needed but not yet available, leave
+an MDX comment placeholder: `{/* TODO: screenshot — ... */}`.
+
+> The `images/` directory holds a handful of older assets that predate this rule. Don't
+> add to it — and don't take it as precedent.
+
+### Uploading
+
+Run from `docs-mintlify/` (**not** `pnpm upload-asset` — that's the landing repo's
+wrapper; this repo uses the script directly):
+
+```bash
+./scripts/upload-asset.sh <local-file> <dest-key>
+```
+
+It prints the `https://static.cube.dev/<key>` URL and copies it to the clipboard on
+macOS. Full setup and the complete path table are in `scripts/README.md`.
+
+Key prefixes — use kebab-case filenames:
+
+| Prefix | Purpose |
+| --- | --- |
+| `docs/<section>/<slug>/<file>` | Screenshots for a specific docs page |
+| `icons/<slug>.svg` | Provider / integration logos for `<Card>` |
+| `diagrams/<slug>.svg` | Architecture / flow diagrams |
+| `recipes/<slug>/<file>` | Recipe-specific screenshots |
+
+**Verify every upload before editing any `.mdx`:**
+
+```bash
+curl -sI https://static.cube.dev/<key>
+```
+
+Expect `200`, the right `content-type`, and a `content-length` matching the local file.
+Cheaper than finding a bad upload after rewriting ten pages.
+
+**Compress before uploading.** Nothing resizes these — the blog's image optimizer only
+rewrites Uploadcare (`ucarecdn.com`) URLs, and `static.cube.dev` passes through
+untouched. Retina screenshots straight from CleanShot are often 3000px+ and multiple
+megabytes; scale them down first. Prefer PNG for UI screenshots, WebP for large ones,
+SVG for logos.
+
+**Paths are immutable.** The script refuses to overwrite an existing key; upload a new
+one with a version suffix (`foo-v2.png`) and update the reference in the same PR.
+`--force` exists but objects carry `Cache-Control: max-age=31536000, immutable`, so an
+overwrite can sit stale in caches for a year — avoid it for anything already live.
+
+Credentials: AWS CLI plus a `cube-static` profile (region `us-west-2`) with
+`s3:PutObject` and `s3:HeadObject`. Check with
+`aws sts get-caller-identity --profile cube-static`. If it isn't configured, ask —
+don't guess credentials.
 
 ## AI / agent docs structure
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -19,6 +19,10 @@ transcript into a saved, re-runnable, shareable report.
 Use it for work SQL can't express — forecasting, regression, cohort analysis,
 statistical tests, clustering, and anomaly detection.
 
+<Frame>
+  <img src="https://static.cube.dev/docs/explore-analyze/workbooks/python-analysis/code-panel-forecast.png" alt="A workbook report with the Python code panel open, showing a Prophet forecast script above a chart plotting actual monthly orders alongside the forecast and its confidence interval" />
+</Frame>
+
 ## Adding Python to a report
 
 ### From Analytics Chat


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Follow-up to #11398, which shipped the Python analysis page with screenshot placeholders.

**1. Screenshot.** Adds a hero image below the intro showing a workbook report with the Python code panel open — a Prophet forecast script — above the chart rendering its output. It illustrates the page's core point (the chart renders the script's *output*, not the raw SQL rows) better than prose does, and it shows the lead use case from the intro.

Hosted at `https://static.cube.dev/docs/explore-analyze/workbooks/python-analysis/code-panel-forecast.png`, uploaded via `docs-mintlify/scripts/upload-asset.sh`. Downscaled from the original 3164px / 915 KB retina capture to 2000px / 605 KB first, since nothing resizes `static.cube.dev` assets. Verified with `curl -sI` — 200, `image/png`, `content-length` matching the local file — and confirmed rendering from the CDN against the local Mintlify server.

**2. `docs-mintlify/CLAUDE.md` fix.** The "Images and screenshots" section said to *store assets under `images/`*. That's wrong, and it's what sent me down the wrong path on the first attempt at this PR: editorial media belongs in the `cube-dev-websites-shared` bucket, not the repo. The section now documents the upload command, key prefixes, the `curl -sI` verification step, compression, and path immutability — so an agent or contributor reading `CLAUDE.md` alone gets the conventions rather than just a pointer to `.cursor/rules/`, which Claude Code doesn't auto-load.

The `images/` directory still holds a few older assets; the new text calls it legacy and says not to add to it. Worth a follow-up to re-host those and delete the directory, but that's out of scope here.

**Reviewer note:** this branch was force-pushed to drop an earlier commit that added the PNG to the repo, so the binary never enters `master`'s history. The diff is now two text files.

**Still outstanding:** the page keeps one `{/* TODO */}` placeholder for the **Add Python** tab menu entry, and the code panel's **Outdated** tag is still uncaptured — this screenshot shows the panel in its normal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)