### PR TITLE
docs: sync docs with recently shipped Cube Cloud features

### DIFF
--- a/docs-mintlify/admin/connect-to-data/multiple-data-sources.mdx
+++ b/docs-mintlify/admin/connect-to-data/multiple-data-sources.mdx
@@ -23,9 +23,11 @@ the driver's error and saves nothing.
 ## Editing and deleting
 
 Use the **Edit** action on a row to update credentials, or the **Delete**
-action to remove a named source. The **default** source can be edited but
-not deleted — to remove it, clear the bare `CUBEJS_DB_*` variables from
-[**Settings → Environment Variables**][ref-config-ref-env] by hand.
+action to remove a source — including the **default** source (the demo data
+source is the only one that can't be deleted). Deleting a source clears only
+its own connection env vars (the bare `CUBEJS_DB_*` variables for the default
+source, or `CUBEJS_DS_<NAME>_*` for a named one); deployment-wide globals and
+other sources' variables are left untouched.
 
 ## Source name rules
 

--- a/docs-mintlify/admin/users-and-permissions/roles-and-permissions.mdx
+++ b/docs-mintlify/admin/users-and-permissions/roles-and-permissions.mdx
@@ -7,6 +7,8 @@ Cube has four built-in default roles: Admin, Developer, Explorer, and Viewer. Ea
 
 The Enterprise tier allows creation of custom roles with a customized set of permissions tailored to your organization's specific needs.
 
+A role can also be conferred on a whole [user group][ref-user-groups], including Admin — every member of the group then gets the role in addition to their own.
+
 ## Permissions matrix
 
 | Permission                          | Admin | Developer | Explorer | Viewer |
@@ -55,3 +57,4 @@ This feature should not be used as a security measure. Configure [access policie
 
 
 [ref-data-access-policies]: /docs/data-modeling/data-access-policies
+[ref-user-groups]: /admin/users-and-permissions/user-groups

--- a/docs-mintlify/admin/users-and-permissions/user-groups.mdx
+++ b/docs-mintlify/admin/users-and-permissions/user-groups.mdx
@@ -20,7 +20,16 @@ To create a user group:
   <img src="https://lgo0ecceic.ucarecd.net/f66feb98-feee-478e-8371-e3b37602eb4a/" alt="User Groups interface" />
 </Frame>
 
+## Group roles
+
+A group can also confer a [role][ref-roles] on its members. Open a group's
+**Roles** section to assign it one or more roles, including Admin. Everyone in
+the group gets the role in addition to whatever role is assigned to them
+individually — the group doesn't replace a user's own role. Assigning the
+Admin role to a group asks for confirmation, since it grants admin access to
+every current and future member of that group.
 
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
 [ref-rls]: /docs/data-modeling/access-control/row-level-security
 [ref-dap]: /docs/data-modeling/data-access-policies
+[ref-roles]: /admin/users-and-permissions/roles-and-permissions

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -36,9 +36,12 @@ are never saved to the dashboard — see
     [workbook][ref-workbooks]: creating reports, building and editing
     dashboards, and running analysis.
 
-  The published Dashboard Agent can adjust **your own view** — filters and time
-  granularity, for your session only — but intentionally cannot author or change
-  the **saved** dashboard.
+  For most viewers, the published Dashboard Agent can adjust **your own view**
+  — filters and time granularity, for your session only — but intentionally
+  cannot author or change the **saved** dashboard. If you have edit access to
+  the dashboard's workbook, though, the Dashboard Agent on that published
+  dashboard gives you the same authoring capability as the Workbook Agent —
+  see [For editors](#for-editors) below.
 </Note>
 
 ## Opening the agent
@@ -114,10 +117,25 @@ contents — text, PDF, ZIP, and image files are supported.
   supported. Confirm this in your deployment before relying on it.
 </Note>
 
+## For editors
+
+<Note>
+
+If you have edit access to the dashboard's workbook, the Dashboard Agent on
+that published dashboard gets the **same tools and sub-agents as the
+[Workbook Agent][ref-workbook-agent]** — it can edit the data model, create
+reports and drill-downs, publish, and use skills and sub-agents, in addition
+to everything described below. Viewers without workbook-edit access, and
+public or embedded viewers, keep the read-only-plus capabilities described in
+this page.
+
+</Note>
+
 ## What the Dashboard Agent can and can't do
 
 The published Dashboard Agent can answer questions and adjust your own view, but
-it never changes the **saved** dashboard.
+it never changes the **saved** dashboard — unless you're an editor with
+workbook-edit access; see [For editors](#for-editors) above.
 
 **It can:**
 
@@ -133,7 +151,7 @@ it never changes the **saved** dashboard.
 - Look up the values available for a dimension
 - Read the contents of [attachments](#attachments) you add to the chat
 
-**It can't:**
+**It can't** (unless you're an editor — see [For editors](#for-editors)):
 
 - Save its filter or time-granularity changes to the dashboard — they apply to
   your session only and never change what other viewers see
@@ -141,7 +159,8 @@ it never changes the **saved** dashboard.
 - Create reports or workbooks
 - Change the data model
 
-If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
+If you need any of those and aren't an editor of the dashboard's workbook, use
+the [Workbook Agent][ref-workbook-agent] instead.
 
 ## Limitations
 
@@ -151,9 +170,11 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
   applies to your session only — it is never saved to the dashboard. If you ask
   it to change something with no control on the dashboard, it explains the
   current state instead of applying a change.
-- **No authoring on published dashboards.** The published Dashboard Agent
-  cannot create reports or build dashboards, edit the saved dashboard, or change
-  the data model. Those live in the [Workbook Agent][ref-workbook-agent].
+- **No authoring on published dashboards for most viewers.** The published
+  Dashboard Agent cannot create reports or build dashboards, edit the saved
+  dashboard, or change the data model — unless you have edit access to the
+  dashboard's workbook, in which case it has the same authoring capability as
+  the [Workbook Agent][ref-workbook-agent]; see [For editors](#for-editors).
 - **Report search covers published reports only.** When the agent searches for
   existing reports, it sees published reports.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/charts.mdx
@@ -21,6 +21,8 @@ If some controls are incompatible with a chart's query, the chart skips them and
 
 Charts on a published dashboard reflect the most recent published version of the workbook. To change the query, switch the chart type, or restyle the visualization, edit the underlying report in the workbook and publish a new version of the dashboard.
 
+If you have edit access to the backing workbook, a chart's menu (`⋮`) includes an **Edit in Workbook** shortcut that opens the underlying report in the workbook directly, so you don't have to find it yourself. Viewers without edit access to the workbook don't see this item.
+
 ## Title
 
 Each chart shows the name of the underlying workbook tab as its title. To rename it, open the tab in the workbook, rename the tab, and republish the dashboard — the new name flows through to every chart backed by that tab.

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -105,8 +105,15 @@ page, or viewing a dashboard never re-runs anything on its own.
 ## On dashboards
 
 Python reports render their **saved output** on dashboards. Nothing re-runs on
-dashboard load, so a dashboard full of Python reports costs no compute to open —
-each widget shows whatever the last **Run** produced.
+dashboard load, so an unfiltered dashboard full of Python reports costs no
+compute to open — each widget shows whatever the last **Run** produced.
+
+If the dashboard applies a filter or time granularity to a Python report, Cube
+re-runs the Python analysis against the filtered SQL and shows that result
+instead of the saved output. This works both in the dashboard builder and on
+published, viewed dashboards. It's not yet supported on the anonymous public
+embed or the signed embedded-app dashboard, which continue to show the saved
+result regardless of filters.
 
 A python widget can be opened in [Explore](/docs/explore-analyze/explore) from a
 dashboard and run from there.


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Routine sweep cross-checking recent `cubejs-enterprise` and `cube-js/cube` changes against `docs-mintlify`, filtered through the customer-facing criteria in `cubejs-enterprise/.claude/shared/customer-facing-criteria.md`. Found five small doc gaps (one stale/incorrect, four missing) and fixed them all here:

- **`docs/explore-analyze/workbooks/python-analysis.mdx`** — the "On dashboards" section said Python reports *never* re-run on dashboard load. That's no longer accurate: a dashboard filter or time-grain change now re-runs the Python analysis against the filtered SQL, on both the dashboard builder and published/viewing surfaces (not yet on anonymous/embedded-app dashboards). Corrected the claim and added the exception.
- **`admin/users-and-permissions/user-groups.mdx`** + **`roles-and-permissions.mdx`** — a user group can now be assigned a role (including Admin), conferring it on every member. Added a "Group roles" section and a cross-reference.
- **`admin/connect-to-data/multiple-data-sources.mdx`** — said the default data source "can be edited but not deleted." It can now be deleted from the UI like any named source (only the demo source can't be). Corrected the section.
- **`docs/explore-analyze/dashboards/widgets/charts.mdx`** — chart widgets on published dashboards gained an **Edit in Workbook** shortcut in their `⋮` menu (visible to users with workbook-edit access). Added a sentence documenting it.
- **`docs/explore-analyze/dashboards/dashboard-agent.mdx`** — for users with workbook-edit access, the Dashboard Agent on a published dashboard now has the same authoring capability as the Workbook Agent (data model edits, reports, drill-downs, publish, skills/sub-agents) — not just filter/time-grain changes. Added a "For editors" section and updated the can/can't list and the two-surfaces note accordingly.

No code changes; docs only.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VjvAuTt42TokPntg4qSykj

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjvAuTt42TokPntg4qSykj)_