### PR TITLE
docs: hide Tableau, Power BI, and Semantic Layer Sync pages

### DIFF
--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -50,8 +50,7 @@ You can review its [support terms][ref-free-tier-support] and [limits][ref-cloud
 
 It offers a [Dedicated deployment][ref-cloud-deployment-prod-cluster], the ability
 to use third-party packages from the npm registry, AWS, GCP, and Azure support in
-select regions, pre-aggregations of up to 150GB in size, auto-suspend controls, and
-[Semantic Layer Sync][ref-sls] with a single BI tool (such as Preset or Metabase).
+select regions, pre-aggregations of up to 150GB in size, and auto-suspend controls.
 
 You can review its [pricing][cube-pricing], [support
 terms][ref-starter-tier-support], and [limits][ref-cloud-limits].
@@ -73,8 +72,7 @@ terms][ref-premium-tier-support], and [limits][ref-cloud-limits].
 **Enterprise product tier is suitable for high-scale or mission-critical production
 deployments with more significant security and compliance needs.**
 
-It offers everything in the [Premium product tier](#premium) as well as [Semantic Layer
-Sync][ref-sls] with unlimited supported BI tools, SAML
+It offers everything in the [Premium product tier](#premium) as well as SAML
 support for [single sign-on][ref-sso], [dedicated
 infrastructure][ref-dedicated-infra], [VPC peering][ref-cloud-vpc-peering],
 [monitoring integrations][ref-monitoring-integrations], and [role-based access
@@ -313,7 +311,6 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 [ref-cloud-deployment-prod-multicluster]: /admin/deployment/deployment-types#multi-cluster
 [ref-cloud-custom-domains]: /admin/deployment/custom-domains
 [ref-cloud-vpc-peering]: /admin/deployment/dedicated
-[ref-sls]: /docs/integrations/semantic-layer-sync
 [ref-support]: /admin/account-billing/support
 [ref-free-tier-support]: /admin/account-billing/support#free
 [ref-starter-tier-support]: /admin/account-billing/support#starter

--- a/docs-mintlify/admin/connect-to-data/data-sources/ksqldb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/ksqldb.mdx
@@ -27,7 +27,7 @@ See how you can use ksqlDB and Cube Cloud to power real-time analytics in Power 
 
 <Info>
 
-In this video, the SQL API is used to connect to [Power BI][ref-powerbi].
+In this video, the SQL API is used to connect to Power BI.
 Currently, it's recommended to use the [DAX API][ref-dax-api].
 
 </Info>
@@ -987,7 +987,6 @@ the source column through a scalar function (e.g.,
 `CAST(id AS VARCHAR) AS id`), but not through arbitrary expressions.
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency
-[ref-powerbi]: /docs/integrations/power-bi
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-streaming-pre-aggs]: /docs/pre-aggregations/using-pre-aggregations#streaming-pre-aggregations
 [ref-decorated-env-vars]: /admin/connect-to-data/multiple-data-sources#under-the-hood

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
@@ -45,7 +45,7 @@ To find your MDX API credentials, go to the [Integrations][ref-integrations-apis
 **API credentials**, and choose the **MDX API** tab. Use the full MDX API URL, including
 the `/cubejs-api/v2/mdx` path, as the server name.
 
-The MDX API supports the same [Kerberos][ref-kerberos] and [NTLM][ref-ntlm]
+The MDX API supports the same Kerberos and NTLM
 authentication methods as the DAX API, configured on the **Settings → Power BI** page
 of your deployment.
 
@@ -62,5 +62,3 @@ add-in and [authenticate][ref-cube-cloud-for-excel-authentication] to Cube Cloud
 [ref-cube-cloud-for-excel-authentication]: /docs/integrations/microsoft-excel#authentication
 [ref-integrations-tools]: /admin/connect-to-data/visualization-tools
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
-[ref-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-ntlm]: /docs/integrations/power-bi/ntlm

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/index.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/index.mdx
@@ -19,8 +19,6 @@ page, please [file an issue](https://github.com/cube-js/cube/issues) on GitHub.
 <CardGroup cols={2}>
   <Card title="Amazon QuickSight" img="https://static.cube.dev/icons/quicksight.svg" href="/admin/connect-to-data/visualization-tools/quicksight">
   </Card>
-  <Card title="Apache Superset" img="https://static.cube.dev/icons/superset.svg" href="/admin/connect-to-data/visualization-tools/superset">
-  </Card>
   <Card title="Hashboard" img="https://static.cube.dev/icons/hashboard.svg" href="/admin/connect-to-data/visualization-tools/hashboard">
   </Card>
   <Card title="Klipfolio" img="https://static.cube.dev/icons/klipfolio-light.svg" href="/admin/connect-to-data/visualization-tools/klipfolio">
@@ -29,10 +27,6 @@ page, please [file an issue](https://github.com/cube-js/cube/issues) on GitHub.
   </Card>
   <Card title="Metabase" img="https://static.cube.dev/icons/metabase.svg" href="/admin/connect-to-data/visualization-tools/metabase">
   </Card>
-  <Card title="Microsoft Power BI" img="https://static.cube.dev/icons/power-bi-dark.svg" href="/admin/connect-to-data/visualization-tools/powerbi">
-  </Card>
-  <Card title="Preset" img="https://static.cube.dev/icons/preset.svg" href="/admin/connect-to-data/visualization-tools/superset">
-  </Card>
   <Card title="Push.ai" img="https://static.cube.dev/icons/push-ai-light.svg" href="/admin/connect-to-data/visualization-tools/push-ai">
   </Card>
   <Card title="Qlik Sense" img="https://static.cube.dev/icons/qlik-sense.svg" href="/admin/connect-to-data/visualization-tools/qlik-sense">
@@ -40,8 +34,6 @@ page, please [file an issue](https://github.com/cube-js/cube/issues) on GitHub.
   <Card title="Sigma" img="https://static.cube.dev/icons/sigma.svg" href="/admin/connect-to-data/visualization-tools/sigma">
   </Card>
   <Card title="Steep" img="https://static.cube.dev/icons/steep-light.svg" href="/admin/connect-to-data/visualization-tools/steep">
-  </Card>
-  <Card title="Tableau" img="https://static.cube.dev/icons/tableau.svg" href="/admin/connect-to-data/visualization-tools/tableau">
   </Card>
   <Card title="ThoughtSpot" img="https://static.cube.dev/icons/thoughtspot.svg" href="/admin/connect-to-data/visualization-tools/thoughtspot">
   </Card>

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/powerbi.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/powerbi.mdx
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Power BI
 description: "Microsoft Power BI is a popular business intelligence tool."
+hidden: true
 ---
 
 [Microsoft Power BI][link-powerbi] is a popular business intelligence tool.

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/superset.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/superset.mdx
@@ -1,6 +1,7 @@
 ---
 title: Apache Superset / Preset
 description: "Apache Superset is a popular open-source data exploration and visualization platform. Preset is a fully-managed service for Superset."
+hidden: true
 ---
 
 [Apache Superset][superset] is a popular open-source data exploration and

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/tableau.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/tableau.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tableau
 description: Tableau is a popular visual analytics platform.
+hidden: true
 ---
 
 [Tableau](https://www.tableau.com) is a popular visual analytics platform.

--- a/docs-mintlify/admin/deployment/auto-suspension.mdx
+++ b/docs-mintlify/admin/deployment/auto-suspension.mdx
@@ -55,8 +55,6 @@ When a deployment is auto-suspended:
 API instances are de-provisioned.
 - [Refresh worker][ref-refresh-worker] is suspended, which stops pre-aggregation
 builds and prevents the pre-aggregations from being kept up-to-date.
-- [Semantic Layer Sync][ref-sls] is suspended, which prevents scheduled syncs
-from running.
 - [Monitoring integrations][ref-monitoring] are also suspended, which prevents
 the export of metrics and logs.
 
@@ -123,5 +121,4 @@ response times to be significantly longer than usual.
 [ref-multitenancy]: /embedding/multitenancy
 [self-effects]: #effects-on-experience
 [ref-refresh-worker]: /cube-core/architecture#refresh-worker
-[ref-sls]: /docs/integrations/semantic-layer-sync#on-schedule
 [ref-cube-version]: /admin/deployment#cube-version

--- a/docs-mintlify/admin/deployment/providers/azure.mdx
+++ b/docs-mintlify/admin/deployment/providers/azure.mdx
@@ -26,7 +26,7 @@ Cube Cloud integrates with the following [data sources](/admin/connect-to-data/d
 
 Cube Cloud integrates with the following [data visualization tools](/admin/connect-to-data/visualization-tools):
 
-- [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api]
+- Microsoft Power BI via the [DAX API][ref-dax-api]
 - [Microsoft Excel][ref-excel] via [Cube Cloud for Excel][ref-cube-cloud-for-excel]
 
 ## Storage
@@ -54,7 +54,6 @@ Cube Cloud integrates with the following [data visualization tools](/admin/conne
 [Azure Virtual Network](https://azure.microsoft.com/en-us/products/virtual-network) can be used for [secure networking](/admin/deployment/dedicated/azure).
 
 
-[ref-powerbi]: /admin/connect-to-data/visualization-tools/powerbi
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel

--- a/docs-mintlify/docs/integrations/power-bi/index.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Microsoft Power BI
 description: "Microsoft Power BI is a popular business intelligence tool."
+hidden: true
 ---
 
 [Microsoft Power BI][link-powerbi] is a popular business intelligence tool.

--- a/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/kerberos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Kerberos authentication
 description: "Kerberos is the most common authentication method for Windows environments. It can be used to authenticate requests to the DAX API and MDX API."
+hidden: true
 ---
 
 [Kerberos][link-kerberos] is the most common authentication method for Windows environments.

--- a/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/ntlm.mdx
@@ -1,6 +1,7 @@
 ---
 title: NTLM authentication
 description: "NTLM is an authentication method developed by Microsoft that can be used to authenticate requests to the DAX API and MDX API."
+hidden: true
 ---
 
 [NTLM][link-ntlm] is an authentication method developed by Microsoft that can be used to

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Semantic Layer Sync
 description: Automatically synchronize your Cube data model into BI tools like Superset, Metabase, Preset, and Tableau.
+hidden: true
 ---
 
  Semantic Layer Sync

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/preset.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/preset.mdx
@@ -2,6 +2,7 @@
 title: Semantic Layer Sync with Preset
 sidebarTitle: Preset
 description: This page details the support for Preset in Semantic Layer Sync.
+hidden: true
 ---
 
 This page details the support for [Preset](https://preset.io)

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/superset.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/superset.mdx
@@ -2,6 +2,7 @@
 title: Semantic Layer Sync with Apache Superset
 sidebarTitle: Superset
 description: This page details the support for Apache Superset in Semantic Layer Sync.
+hidden: true
 ---
 
 This page details the support for [Apache Superset](https://superset.apache.org)

--- a/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
+++ b/docs-mintlify/docs/integrations/semantic-layer-sync/tableau.mdx
@@ -2,6 +2,7 @@
 title: Semantic Layer Sync with Tableau
 sidebarTitle: Tableau
 description: This page details the support for Tableau in Semantic Layer Sync.
+hidden: true
 ---
 
 This page details the support for [Tableau](https://www.tableau.com)

--- a/docs-mintlify/docs/integrations/tableau.mdx
+++ b/docs-mintlify/docs/integrations/tableau.mdx
@@ -2,6 +2,7 @@
 title: Tableau Integration
 sidebarTitle: Tableau
 description: Connect Tableau to Cube using Semantic Layer Sync to programmatically create and update Tableau data sources.
+hidden: true
 ---
 
  Tableau

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -1302,7 +1302,7 @@ module.exports = {
 </CodeGroup>
 
 You can also check for the protocol and the authentication method as follows. This can
-be useful for handling the [NTLM][ref-ntlm] authentication in the [DAX API][ref-dax-api]:
+be useful for handling the NTLM authentication in the [DAX API][ref-dax-api]:
 
 <CodeGroup>
 
@@ -1522,5 +1522,4 @@ module.exports = {
 [ref-dap-roles]: /docs/data-modeling/data-access-policies#data-access-roles
 [ref-auth-integration]: /docs/data-modeling/access-control#authentication-integration
 [ref-dax-api]: /reference/core-data-apis/dax-api
-[ref-ntlm]: /docs/integrations/power-bi/ntlm
 [ref-environments]: /admin/deployment/environments

--- a/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
@@ -4,7 +4,7 @@ description: "Enable cross-view filtering in the DAX API to build dashboards tha
 ---
 
 By default, the [DAX API][ref-dax-api] exposes each [view][ref-views] as a
-separate perspective in [Power BI][ref-powerbi]. Visualizations from different
+separate perspective in Power BI. Visualizations from different
 views can't share the same filters, and a single report can't combine measures
 and dimensions across views.
 
@@ -76,4 +76,3 @@ Dimensions are not prefixed and are referenced by their column name.
 
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-views]: /docs/data-modeling/views
-[ref-powerbi]: /admin/connect-to-data/visualization-tools/powerbi

--- a/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
@@ -5,7 +5,7 @@ description: "Connect Microsoft Power BI to Cube natively using the DAX API for 
 
  DAX API
 
-The DAX API enables Cube to connect to [Microsoft Power BI][ref-powerbi].
+The DAX API enables Cube to connect to Microsoft Power BI.
 It derives its name from [data analysis expressions][link-dax], a query language
 for Power BI and SQL Server Analysis Services.
 
@@ -49,7 +49,7 @@ in the Cube Cloud sidebar, then **Configuration**, and then toggle the
 ### Date hierarchies
 
 By default, the DAX API exposes all [time dimensions][ref-time-dimensions] as _date
-hierarchies_ in [Power BI][ref-power-bi]. You can set the [`CUBEJS_DAX_CREATE_DATE_HIERARCHIES`](/reference/configuration/environment-variables#cubejs_dax_create_date_hierarchies)
+hierarchies_ in Power BI. You can set the [`CUBEJS_DAX_CREATE_DATE_HIERARCHIES`](/reference/configuration/environment-variables#cubejs_dax_create_date_hierarchies)
 environment variable to `false` to disable this behavior.
 
 Note that each date hierarchy will include additional columns, suffixed by `_year`,
@@ -59,7 +59,7 @@ in the same cube or view), that would cause a conflict.
 
 ## Authentication
 
-The DAX API supports [Kerberos][ref-kerberos] and [NTLM][ref-ntlm] authentication
+The DAX API supports Kerberos and NTLM authentication
 methods, as well as user name and password authentication.
 
 While NTLM can be used for testing purposes, we strongly recommend configuring
@@ -90,13 +90,9 @@ See [Cross-view filtering][ref-cross-view-filter] for details on how to enable
 and use it.
 
 
-[ref-powerbi]: /admin/connect-to-data/visualization-tools/powerbi
 [ref-cross-view-filter]: /reference/core-data-apis/dax-api/cross-view-filter
 [link-dax]: https://learn.microsoft.com/en-us/dax/
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-ref-dax-api]: /reference/core-data-apis/dax-api/reference
 [ref-views]: /docs/data-modeling/views
 [ref-time-dimensions]: /docs/data-modeling/dimensions#time-dimensions
-[ref-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-ntlm]: /docs/integrations/power-bi/ntlm
-[ref-power-bi]: /admin/connect-to-data/visualization-tools/powerbi

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -10,7 +10,7 @@ Core Data APIs enable you to query and retrieve data from your Cube semantic lay
 
 ## Choosing the Right API
 
-* To connect to [Microsoft Power BI][ref-powerbi], use the [DAX API][ref-dax-api]
+* To connect to Microsoft Power BI, use the [DAX API][ref-dax-api]
 
 * To connect to [Microsoft Excel][ref-excel], use [Cube Cloud for Excel][ref-cube-cloud-for-excel]
 
@@ -18,7 +18,7 @@ Core Data APIs enable you to query and retrieve data from your Cube semantic lay
 
 * To connect to AI assistants, use the [Model Context Protocol (MCP) server][ref-mcp-server]
 
-* For internal or self-serve [business intelligence][cube-issbi], use [Semantic Layer Sync][ref-sls] if it supports your BI tools. Otherwise, connect via the [SQL API][ref-sql-api] directly
+* For internal or self-serve [business intelligence][cube-issbi], connect via the [SQL API][ref-sql-api]
 
 * For [embedded analytics][cube-ea] and [real-time analytics][cube-rta], use [REST (JSON) API][ref-rest-api] or [GraphQL API][ref-graphql-api]. When using the REST (JSON) API, the [JavaScript SDK][ref-js-sdk] can simplify integration with your front-end code
 
@@ -38,9 +38,8 @@ tools][ref-viz-tools]. Some of the features with partial support are listed belo
 
 | Feature | ✅ Supported in |
 | --- | --- |
-| [Hierarchies][ref-hierarchies] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api]<br/>[Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/>[Tableau][ref-tableau] via [Semantic Layer Sync][ref-sls]<br/><br/>Also, supported in [Playground][ref-playground] |
-| Flat [folders][ref-folders] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api]<br/>[Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/>[Tableau][ref-tableau] via [Semantic Layer Sync][ref-sls]<br/>[Apache Superset][ref-superset] via [Semantic Layer Sync][ref-sls]<br/>[Preset][ref-preset] via [Semantic Layer Sync][ref-sls]<br/><br/>Also, supported in [Playground][ref-playground] |
-| Nested [folders][ref-folders] | [Microsoft Power BI][ref-powerbi] via the [DAX API][ref-dax-api] |
+| [Hierarchies][ref-hierarchies] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
+| Flat [folders][ref-folders] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets]<br/><br/>Also, supported in [Playground][ref-playground] |
 | [Custom time formats][ref-custom-time-formats] | [Playground][ref-playground] and [Workbooks][ref-workbooks] |
 
 ## Personal Core Data API Token
@@ -62,8 +61,8 @@ tools][ref-viz-tools]:
 
 | Method | ✅ Supported in |
 | --- | --- |
-| [User name and password][ref-auth-user-pass] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api]<br/>[Semantic Layer Sync][ref-sls]<br/>[SQL API][ref-sql-api] |
-| [Kerberos][ref-auth-kerberos] and [NTLM][ref-auth-ntlm] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api] |
+| [User name and password][ref-auth-user-pass] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api]<br/>[SQL API][ref-sql-api] |
+| Kerberos and NTLM | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api] |
 | [Identity provider][ref-auth-idp] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
 | [JSON Web Token][ref-auth-jwt] | [REST (JSON) API][ref-rest-api]<br/>[GraphQL API][ref-graphql-api] |
 
@@ -76,7 +75,6 @@ tools][ref-viz-tools]:
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-graphql-api]: /reference/core-data-apis/graphql-api
-[ref-sls]: /docs/integrations/semantic-layer-sync
 [ref-js-sdk]: /reference/javascript-sdk
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel
 [ref-cube-cloud-for-sheets]: /docs/integrations/google-sheets
@@ -84,17 +82,11 @@ tools][ref-viz-tools]:
 [ref-viz-tools]: /admin/connect-to-data/visualization-tools
 [ref-hierarchies]: /reference/data-modeling/hierarchies
 [ref-folders]: /reference/data-modeling/view#folders
-[ref-powerbi]: /admin/connect-to-data/visualization-tools/powerbi
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [ref-sheets]: /admin/connect-to-data/visualization-tools/google-sheets
-[ref-tableau]: /admin/connect-to-data/visualization-tools/tableau
 [ref-auth-user-pass]: /embedding/authentication/jwt
 [ref-auth-idp]: /embedding/authentication/jwt
 [ref-auth-jwt]: /embedding/authentication/jwt
-[ref-auth-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-auth-ntlm]: /docs/integrations/power-bi/ntlm
-[ref-superset]: /admin/connect-to-data/visualization-tools/superset
-[ref-preset]: /admin/connect-to-data/visualization-tools/superset
 [ref-playground]: /docs/explore-analyze/playground
 [ref-custom-time-formats]: /reference/data-modeling/dimensions#format
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/reference/core-data-apis/mdx-api.mdx
+++ b/docs-mintlify/reference/core-data-apis/mdx-api.mdx
@@ -218,7 +218,7 @@ This is going to be harmonized in the future.
 ## Authentication and authorization
 
 The MDX API shares its authentication layer with the [DAX API][ref-dax-api]:
-[Kerberos][ref-kerberos] and [NTLM][ref-ntlm] are supported, as well as user name and
+Kerberos and NTLM are supported, as well as user name and
 password authentication. Configuration is done on the **Settings → Power BI** page of
 your deployment — the same XMLA service account, SPN, and keytab setup applies to both
 APIs.
@@ -226,8 +226,6 @@ APIs.
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [ref-time-dimensions]: /docs/data-modeling/dimensions#time-dimensions
 [ref-dax-api]: /reference/core-data-apis/dax-api
-[ref-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-ntlm]: /docs/integrations/power-bi/ntlm
 [link-mdx]: https://learn.microsoft.com/en-us/analysis-services/multidimensional-models/mdx/multidimensional-model-data-access-analysis-services-multidimensional-data?view=asallproducts-allversions#bkmk_querylang
 [link-pivottable]: https://support.microsoft.com/en-us/office/create-a-pivottable-to-analyze-worksheet-data-a9a84538-bfe9-40a9-a8e9-f99134456576
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel

--- a/docs-mintlify/reference/core-data-apis/queries.mdx
+++ b/docs-mintlify/reference/core-data-apis/queries.mdx
@@ -383,7 +383,7 @@ Additionally, note that ungrouped queries have additional requirements for
 
 You might encounter the following error when running an [ungrouped query](#ungrouped-query)
 that includes `HAVING COUNT(1) > 0` (or a similar expression) against a cube or a view that
-have no measure called `count`. [Tableau][ref-tableau] is knows to generate such queries.
+have no measure called `count`. Some BI tools are known to generate such queries.
 
 ```text
 Failed to deserialize: invalid type: unit value, expected struct JoinDefinitionStatic
@@ -417,4 +417,3 @@ called `count` to be defined in the cube or view. Please add one to resolve this
 [ref-query-rewrite]: /reference/configuration/config#query_rewrite
 [blog-compare-date-range]: https://cube.dev/blog/comparing-data-over-different-time-periods
 [ref-sql-api-streaming]: /reference/core-data-apis/sql-api#streaming
-[ref-tableau]: /admin/connect-to-data/visualization-tools/tableau

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -246,7 +246,6 @@ Use the following environment variables to allocate more resources for query pla
 [link-postgres]: https://www.postgresql.org
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
-[ref-sls]: /docs/integrations/semantic-layer-sync
 [ref-sql-api-auth]: /reference/core-data-apis/sql-api/security
 [ref-config-checksqlauth]: /reference/configuration/config#checksqlauth
 [ref-config-canswitchsqluser]: /reference/configuration/config#canswitchsqluser

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -1134,8 +1134,7 @@ Cube would not use such a pre-aggregation.
 
 With this flag set to `true`, that strict check is lifted. It allows queries from BI tools
 to still match pre-aggregations at the cost of a slight potential data discrepancy.
-This is convenient when using Cube with visualization tools such as [Tableau][ref-config-downstream-tableau]
-or [Apache Superset][ref-config-downstream-superset] that use loose date ranges.
+This is convenient when using Cube with visualization tools that use loose date ranges.
 
 <CodeGroup>
 
@@ -1811,7 +1810,6 @@ cube(`orders`, {
 [ref-caching-lambda-preaggs]: /docs/pre-aggregations/lambda-pre-aggregations
 [ref-caching-partitioning]: /docs/pre-aggregations/using-pre-aggregations#partitioning
 [ref-caching-preaggs-target]: /docs/pre-aggregations/matching-pre-aggregations#matching-algorithm
-[ref-config-downstream-superset]: /admin/connect-to-data/visualization-tools/superset
 [ref-cube-refreshkey]: /reference/data-modeling/cube#refresh_key
 [ref-production-checklist-refresh]: /cube-core/running-in-production#set-up-refresh-worker
 [ref-recipe-funnels]: /recipes/data-modeling/funnels
@@ -1842,4 +1840,3 @@ cube(`orders`, {
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-custom-granularity]: /reference/data-modeling/dimensions#granularities
 [ref-env-allow-non-strict]: /reference/configuration/environment-variables#cubejs-pre-aggregations-allow-non-strict-date-range-match
-[ref-config-downstream-tableau]: /admin/connect-to-data/visualization-tools/tableau


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Hides the Tableau, Power BI, and Semantic Layer Sync documentation so it no longer appears in the menu or in search, while staying reachable by direct link.

### Pages hidden

`hidden: true` in frontmatter — Mintlify implies `noindex` from it, which covers the sidebar, site search, sitemap, search-engine indexing, and AI assistant context in one flag. `docs.json` is left untouched, matching the existing pattern in `admin/deployment/auto-suspension.mdx` and keeping an unhide a one-line revert per page.

| Group | Files |
| --- | --- |
| Tableau | `docs/integrations/tableau.mdx` |
| Power BI | `docs/integrations/power-bi/{index,kerberos,ntlm}.mdx` |
| Semantic Layer Sync | `docs/integrations/semantic-layer-sync/{index,superset,preset,tableau}.mdx` |
| Duplicates | `admin/connect-to-data/visualization-tools/{powerbi,tableau,superset}.mdx` |

That last row is a second, near-duplicate set of BI pages. The whole `visualization-tools/` directory was already absent from `docs.json`, but omitting a page from the navigation turns out **not** to apply `noindex` in practice — those three still rendered without a robots tag, so a search for "Power BI" or "Tableau" would have kept hitting them. They needed the explicit flag too.

### References removed

All 34 links into the hidden pages were removed from the docs that remain visible. Notable content changes:

- **`pricing.mdx`** — Semantic Layer Sync dropped from the Starter ("with a single BI tool") and Enterprise ("unlimited supported BI tools") feature lists. Reviewers may want to confirm this matches what the plans should advertise.
- **`reference/core-data-apis/index.mdx`** — Power BI / Tableau / Superset / Preset stripped from the Hierarchies and Flat folders rows; the **Nested folders row was deleted entirely**, since Power BI via the DAX API was its only entry and it would otherwise render an empty cell.
- **`visualization-tools/index.mdx`** — Superset, Power BI, Preset, and Tableau cards removed from the BI card grid.
- Tableau/Superset genericized to "visualization tools" / "some BI tools" in `pre-aggregations.mdx` and `queries.mdx`.

### Unlinked rather than deleted — worth a look

In six places, deleting the mention outright would have left a sentence with no object or an API with no stated purpose. The product name is kept as plain text and only the hyperlink is dropped:

- `dax-api/index.mdx` — "The DAX API enables Cube to connect to Microsoft Power BI." The API exists solely for Power BI.
- `dax-api/cross-view-filter.mdx` — the feature is described entirely in terms of Power BI perspectives.
- `core-data-apis/index.mdx` — the "Choosing the Right API" bullet; removing it would drop the DAX API from the chooser.
- **Kerberos / NTLM** in `mdx-api.mdx`, `visualization-tools/excel.mdx`, `config.mdx`, and the auth table — generic auth methods of the DAX/MDX APIs that merely happen to be documented on the hidden Power BI pages.

### Known follow-up

The DAX/MDX API pages still say authentication is configured on the **Settings → Power BI** page, but the Kerberos/NTLM setup instructions now live only on hidden pages. That configuration is effectively undocumented for anyone without the direct link — relocating it is probably worth a separate change.

### Verification

- Integrations sidebar now reads: Slack, Cube Cloud for Excel, Cube Cloud for Sheets, Snowflake Semantic Views, dbt, MCP server. Both nested groups disappear cleanly, with no empty group headers left behind.
- All 11 hidden URLs return 200 and emit `<meta name="robots" content="noindex">`.
- Verified programmatically that no visible page references a hidden page, and that no reference-style link was left dangling (diffed against `master`).
- `yarn broken-links` reports 16 broken links, all pre-existing anchor issues in `embedding/iframe/events.mdx` and `localization.mdx` — files untouched here.

Sitemap and search-index exclusion are deploy-time behaviors and can't be confirmed locally; the `noindex` tag is the mechanism behind both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)