### PR TITLE
fix(cubesql): Fail instead of returning NULL for out-of-range timestamps

### DIFF
--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -233,6 +233,33 @@ Example:
 SET cube_cache = 'must-revalidate';
 ```
 
+## Limitations
+
+### Timestamp range
+
+The SQL API represents timestamps with nanosecond precision, so it can only return
+values between `1677-09-21 00:12:43.145224192` and `2262-04-11 23:47:16.854775807`.
+Selecting a time dimension whose value falls outside that range fails with
+`Timestamp out of range for column '<name>'`.
+
+Values outside the range are legal in most data sources and easy to acquire
+accidentally: a `9999-12-31` end-of-time sentinel in a slowly changing dimension table,
+a bad ETL default, or a mis-parsed date. To query such a column, either read it as a
+date, which has a far wider range:
+
+```sql
+SELECT MIN(valid_to::date) FROM customers;
+```
+
+or clamp the sentinel value in the [data model][ref-data-model-concepts].
+
+<Info>
+
+Earlier versions returned an out-of-range value as `NULL` rather than raising an error,
+which made the wrong answer indistinguishable from a genuine `NULL`.
+
+</Info>
+
 ## Troubleshooting
 
 ### `Can't find rewrite`

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -432,6 +432,12 @@ impl ColumnarValueObject for LiteralRowsValueObject {
     }
 }
 
+/// Bounds of `DataType::Timestamp(TimeUnit::Nanosecond, _)`: an i64 count of
+/// nanoseconds since the epoch. Quoted back to the user so the error says what
+/// range a value has to fall into.
+const MIN_NANOSECOND_TIMESTAMP: &str = "1677-09-21 00:12:43.145224192";
+const MAX_NANOSECOND_TIMESTAMP: &str = "2262-04-11 23:47:16.854775807";
+
 macro_rules! build_column {
     ($data_type:expr, $builder_ty:ty, $response:expr, $field_name:expr, { $($builder_block:tt)* }, { $($scalar_block:tt)* }) => {{
         let len = $response.len()?;
@@ -1075,15 +1081,20 @@ macro_rules! transform_response_body {
                             (FieldValue::String(s), builder) => {
                                 let timestamp = parse_date_str(s.as_ref())?;
                                 // TODO switch parsing to microseconds
-                                if let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() {
-                                    builder.append_value(nanos)?;
-                                } else {
-                                    log::error!(
-                                        "Unable to cast timestamp value to nanoseconds: {}",
-                                        timestamp
-                                    );
-                                    builder.append_null()?;
-                                }
+                                let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() else {
+                                    // Appending NULL here would hand the client an
+                                    // undetectable wrong answer: `MIN(ts)` comes back
+                                    // NULL for a column that holds no NULLs. Fail the
+                                    // query instead, the way an unparseable value
+                                    // already does just above.
+                                    return Err(CubeError::user(format!(
+                                        "Timestamp out of range: {}. Timestamps are \
+                                         represented with nanosecond precision and must be \
+                                         between {} and {}",
+                                        timestamp, MIN_NANOSECOND_TIMESTAMP, MAX_NANOSECOND_TIMESTAMP
+                                    )));
+                                };
+                                builder.append_value(nanos)?;
                             },
                         },
                         {
@@ -1474,6 +1485,47 @@ mod tests {
         assert_eq!(d.value(1), "plain");
     }
 
+    #[test]
+    fn convert_transport_response_errors_on_out_of_range_timestamp() {
+        // A timestamp the source can represent but `Timestamp(Nanosecond)` can't
+        // used to become NULL, so `MIN(t)` returned NULL over a column holding no
+        // NULLs — a wrong answer with nothing downstream able to spot it.
+        for value in ["0202-01-01 00:00:00.000", "9999-12-31 00:00:00.000"] {
+            let raw = format!(
+                r#"
+                {{
+                    "results": [{{
+                        "annotation": {{
+                            "measures": [],
+                            "dimensions": [],
+                            "segments": [],
+                            "timeDimensions": []
+                        }},
+                        "data": {{"members": ["t"], "columns": [["2024-01-01 00:00:00.000", "{value}"]]}}
+                    }}]
+                }}
+            "#
+            );
+            let response: V1LoadResponse<V1LoadResultDataColumnar> =
+                serde_json::from_str(&raw).unwrap();
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "t",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            )]));
+            let member_fields = vec![MemberField::regular("t".to_string())];
+
+            let error = convert_transport_response(response, schema, member_fields)
+                .expect_err(&format!("{value} should not be silently nulled"));
+
+            assert!(
+                error.message.contains("Timestamp out of range"),
+                "unexpected error for {value}: {}",
+                error.message
+            );
+        }
+    }
+
     fn get_test_load_meta(protocol: DatabaseProtocol) -> LoadRequestMeta {
         LoadRequestMeta::new(
             protocol.get_name().to_string(),
@@ -1540,7 +1592,7 @@ mod tests {
                                 [null, 5, "5", null, null],
                                 [null, 5.05, "5.05", null, null],
                                 [null, true, false, "true", "false"],
-                                [null, "2022-01-01 00:00:00.000", "2023-01-01 00:00:00.000", "9999-12-31 00:00:00.000", null],
+                                [null, "2022-01-01 00:00:00.000", "2023-01-01 00:00:00.000", "2262-04-11 00:00:00.000", null],
                                 [null, "2022-01-01", "2023-01-01", "9999-12-31", null],
                                 ["City 1", "City 2", "City 3", "City 4", null]
                             ]
@@ -1711,7 +1763,7 @@ mod tests {
                         None,
                         Some(1640995200000000000),
                         Some(1672531200000000000),
-                        None,
+                        Some(9223286400000000000),
                         None
                     ])) as ArrayRef,
                     Arc::new(BooleanArray::from(vec![

--- a/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
+++ b/rust/cubesql/cubesql/src/compile/engine/df/scan.rs
@@ -1087,11 +1087,21 @@ macro_rules! transform_response_body {
                                     // NULL for a column that holds no NULLs. Fail the
                                     // query instead, the way an unparseable value
                                     // already does just above.
-                                    return Err(CubeError::user(format!(
-                                        "Timestamp out of range: {}. Timestamps are \
-                                         represented with nanosecond precision and must be \
-                                         between {} and {}",
-                                        timestamp, MIN_NANOSECOND_TIMESTAMP, MAX_NANOSECOND_TIMESTAMP
+                                    //
+                                    // Name the column and quote the value as it
+                                    // arrived, not as re-rendered by chrono, so the
+                                    // message can be matched against the source data
+                                    // when a query selects several time dimensions.
+                                    return Err(CubeError::post_processing(format!(
+                                        "Timestamp out of range for column '{}': '{}'. \
+                                         Timestamps are represented with nanosecond \
+                                         precision and must be between '{}' and '{}'. \
+                                         Reading the column as a date rather than a \
+                                         timestamp avoids this limit.",
+                                        schema_field.name(),
+                                        s,
+                                        MIN_NANOSECOND_TIMESTAMP,
+                                        MAX_NANOSECOND_TIMESTAMP
                                     )));
                                 };
                                 builder.append_value(nanos)?;
@@ -1490,32 +1500,18 @@ mod tests {
         // A timestamp the source can represent but `Timestamp(Nanosecond)` can't
         // used to become NULL, so `MIN(t)` returned NULL over a column holding no
         // NULLs — a wrong answer with nothing downstream able to spot it.
-        for value in ["0202-01-01 00:00:00.000", "9999-12-31 00:00:00.000"] {
-            let raw = format!(
-                r#"
-                {{
-                    "results": [{{
-                        "annotation": {{
-                            "measures": [],
-                            "dimensions": [],
-                            "segments": [],
-                            "timeDimensions": []
-                        }},
-                        "data": {{"members": ["t"], "columns": [["2024-01-01 00:00:00.000", "{value}"]]}}
-                    }}]
-                }}
-            "#
-            );
-            let response: V1LoadResponse<V1LoadResultDataColumnar> =
-                serde_json::from_str(&raw).unwrap();
-            let schema = Arc::new(Schema::new(vec![Field::new(
-                "t",
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-                true,
-            )]));
-            let member_fields = vec![MemberField::regular("t".to_string())];
-
-            let error = convert_transport_response(response, schema, member_fields)
+        //
+        // The last two are one nanosecond outside the range. Together with
+        // `convert_transport_response_accepts_boundary_timestamps` they pin both
+        // constants: move either bound by a nanosecond and one of the two tests
+        // fails.
+        for value in [
+            "0202-01-01 00:00:00.000",
+            "9999-12-31 00:00:00.000",
+            "1677-09-21 00:12:43.145224191",
+            "2262-04-11 23:47:16.854775808",
+        ] {
+            let error = timestamp_column_response(value)
                 .expect_err(&format!("{value} should not be silently nulled"));
 
             assert!(
@@ -1523,7 +1519,74 @@ mod tests {
                 "unexpected error for {value}: {}",
                 error.message
             );
+            // The column has to be named: a query can select several time
+            // dimensions and the message is the only thing pointing at the
+            // offending one.
+            assert!(
+                error.message.contains("column 't'"),
+                "error should name the column for {value}: {}",
+                error.message
+            );
+            // The value has to appear exactly as it arrived, so it can be matched
+            // against the source data rather than chrono's rendering of it.
+            assert!(
+                error.message.contains(value),
+                "error should quote the offending value for {value}: {}",
+                error.message
+            );
         }
+    }
+
+    /// The bounds are inclusive, and they are exactly `i64::MIN` / `i64::MAX`
+    /// nanoseconds. Both parse through chrono rather than the fast path, which
+    /// only accepts a 3-digit fraction.
+    #[test]
+    fn convert_transport_response_accepts_boundary_timestamps() {
+        for (value, expected) in [
+            (MIN_NANOSECOND_TIMESTAMP, i64::MIN),
+            (MAX_NANOSECOND_TIMESTAMP, i64::MAX),
+        ] {
+            let batches = timestamp_column_response(value)
+                .unwrap_or_else(|e| panic!("{value} is in range but failed: {}", e.message));
+
+            let column = batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .expect("column should be TimestampNanosecond");
+
+            assert!(!column.is_null(1), "{} should not be null", value);
+            assert_eq!(column.value(1), expected, "wrong nanoseconds for {value}");
+        }
+    }
+
+    /// One `Timestamp(Nanosecond)` column holding an in-range value and `value`.
+    fn timestamp_column_response(value: &str) -> Result<Vec<RecordBatch>, CubeError> {
+        let raw = format!(
+            r#"
+            {{
+                "results": [{{
+                    "annotation": {{
+                        "measures": [],
+                        "dimensions": [],
+                        "segments": [],
+                        "timeDimensions": []
+                    }},
+                    "data": {{"members": ["t"], "columns": [["2024-01-01 00:00:00.000", "{value}"]]}}
+                }}]
+            }}
+        "#
+        );
+        let response: V1LoadResponse<V1LoadResultDataColumnar> =
+            serde_json::from_str(&raw).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "t",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]));
+        let member_fields = vec![MemberField::regular("t".to_string())];
+
+        convert_transport_response(response, schema, member_fields)
     }
 
     fn get_test_load_meta(protocol: DatabaseProtocol) -> LoadRequestMeta {


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Issue Reference this PR resolves**

#11407

**Description of Changes Made**

`transform_response` materialises a Cube response into Arrow. Time dimensions land in `Timestamp(Nanosecond)`, whose i64 nanosecond count only spans `1677-09-21` to `2262-04-11`. A source value outside that window — legal in every database that stores dates as `date` / `datetime2` / `timestamp` — was logged server-side and appended as NULL:

```rust
if let Some(nanos) = timestamp.and_utc().timestamp_nanos_opt() {
    builder.append_value(nanos)?;
} else {
    log::error!("Unable to cast timestamp value to nanoseconds: {}", timestamp);
    builder.append_null()?;
}
```

The client sees no error. `SELECT MIN(d) FROM t` comes back NULL over a column that holds no NULLs, the row count and the schema are both what the caller expects, and nothing downstream can tell the answer apart from a real one. That is the half of #11407 worth fixing — the other symptom in that issue already fails loudly.

A value that *fails to parse* one line above already aborts the query (`parse_date_str(...)?`). This makes a value that parses but cannot be represented behave the same way, and quotes the representable range so the error says what to do about it. `pg-srv` already rejects out-of-range timestamps on the wire with `Timestamp out of range: '{}'`, so the scan path is now consistent with it.

**Compatibility**

This turns a silent NULL into a hard error, and `9999-12-31` end-of-time sentinels in SCD-2 dimension tables are common enough that some users will notice. That is the intent — today they read NULL and have no way to tell — but if you would rather ship it behind a config flag, or hold it for the `Timestamp(Microsecond)` migration that the `// TODO switch parsing to microseconds` above this branch points at, say the word and I will rework it.

Worth flagging: `test_df_cube_scan_execute` asserted the old behaviour. Its fixture fed `9999-12-31 00:00:00.000` to the timestamp column and expected `None` back, while the `Date32` column in the same fixture round-tripped the same date fine. That fixture value now uses an in-range timestamp near the upper bound, and the out-of-range cases (below and above the range) get a dedicated test.

**Failure shape**

The reasoning above covers the batch path. On the native streaming path the same error is raised per chunk and thrown at `packages/cubejs-backend-native/src/stream.rs:275`, so with `CUBESQL_STREAM_MODE=true` a client can receive several chunks and *then* the error — a partial result followed by a failure. Still better than silently wrong data, but a distinct shape that the tests do not cover.

Any query *projecting* an affected dimension now fails, including a BI tool's opening `SELECT * … LIMIT 100`, and it fails after the source database has already done the work. `COUNT(*)` over the same cube is unaffected. Users are not cornered, which is the main reason I think the hard error is shippable: the same value still succeeds as `Date32` and as `Timestamp(Millisecond)` (`scan.rs:1114`), so `SELECT d::date` keeps working where `SELECT d` now errors, and clamping the sentinel in the data model is a second way out. Both are in the docs note.

**Verification**

```
cargo fmt --all -- --check
cargo clippy --locked --workspace --all-targets --keep-going -- -D warnings
cargo test -p cubesql --lib     # 770 passed, 0 failed
```

