### PR TITLE
refactor(tesseract): unify MemberSymbol dependency traversal behind a single declaration

### DIFF
--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_call.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/sql_call.rs
@@ -1,3 +1,4 @@
+use super::symbols::deps::{DepVisitor, DepVisitorMut, SymbolDeps};
 use super::symbols::MemberSymbol;
 use crate::cube_bridge::member_sql::{FilterParamsColumn, SecutityContextProps, SqlTemplate};
 use crate::physical_plan::sql_nodes::{SqlNode, SqlNodesFactory};
@@ -281,9 +282,10 @@ impl SqlCall {
     }
 
     pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut result = vec![];
-        self.extract_cube_refs(&mut result);
-        result
+        self.deps
+            .iter()
+            .filter_map(|d| d.as_cube_ref().cloned())
+            .collect()
     }
 
     fn prepare_template_params(
@@ -528,37 +530,28 @@ impl SqlCall {
                     _ => false,
                 })
     }
+}
 
-    pub fn extract_symbol_deps(&self, result: &mut Vec<Rc<MemberSymbol>>) {
+impl SymbolDeps for Rc<SqlCall> {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> std::ops::ControlFlow<()> {
         for dep in self.deps.iter() {
-            if let Some(s) = dep.as_symbol() {
-                result.push(s.clone())
+            match dep {
+                SqlDependency::Symbol(s) => visitor.symbol(s)?,
+                SqlDependency::CubeRef(cr) => visitor.cube_ref(cr)?,
             }
         }
+        std::ops::ControlFlow::Continue(())
     }
 
-    pub fn extract_cube_refs(&self, result: &mut Vec<CubeRef>) {
-        for dep in self.deps.iter() {
-            if let SqlDependency::CubeRef(cr) = dep {
-                result.push(cr.clone());
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        let mut call = (**self).clone();
+        for dep in call.deps.iter_mut() {
+            if let SqlDependency::Symbol(s) = dep {
+                visitor.symbol(s)?;
             }
         }
-    }
-
-    /// Returns a new `SqlCall` with `f` applied recursively to every
-    /// member-symbol dependency. Cube refs and other placeholders
-    /// pass through unchanged.
-    pub fn apply_recursive<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Rc<Self>, CubeError> {
-        let mut result = self.clone();
-        for dep in result.deps.iter_mut() {
-            if let SqlDependency::Symbol(ref s) = dep {
-                *dep = SqlDependency::Symbol(s.apply_recursive(f)?);
-            }
-        }
-        Ok(Rc::new(result))
+        *self = Rc::new(call);
+        Ok(())
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/case.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/case.rs
@@ -1,13 +1,15 @@
+use super::super::deps::{symbol_deps, DepVisitor, DepVisitorMut, SymbolDeps};
 use crate::planner::filter::FilterItem;
 use crate::{
     cube_bridge::{
         case_switch_definition::CaseSwitchDefinition as NativeCaseSwitchDefinition,
         case_variant::CaseVariant, string_or_sql::StringOrSql,
     },
-    planner::{find_value_restriction, Compiler, CubeRef, MemberSymbol, SqlCall},
+    planner::{find_value_restriction, Compiler, MemberSymbol, SqlCall},
 };
 use cubenativeutils::CubeError;
 use itertools::Itertools;
+use std::ops::ControlFlow;
 use std::rc::Rc;
 
 #[derive(Clone)]
@@ -16,10 +18,33 @@ pub enum CaseLabel {
     Sql(Rc<SqlCall>),
 }
 
+impl SymbolDeps for CaseLabel {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        match self {
+            Self::String(_) => ControlFlow::Continue(()),
+            Self::Sql(sql) => sql.visit_deps(visitor),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::String(_) => Ok(()),
+            Self::Sql(sql) => sql.visit_deps_mut(visitor),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct CaseWhenItem {
     pub sql: Rc<SqlCall>,
     pub label: CaseLabel,
+}
+
+symbol_deps! {
+    CaseWhenItem {
+        sql: dep,
+        label: dep,
+    }
 }
 
 #[derive(Clone)]
@@ -28,56 +53,14 @@ pub struct CaseDefinition {
     pub else_label: CaseLabel,
 }
 
+symbol_deps! {
+    CaseDefinition {
+        items: dep,
+        else_label: dep,
+    }
+}
+
 impl CaseDefinition {
-    fn extract_cube_refs(&self, result: &mut Vec<CubeRef>) {
-        for itm in self.items.iter() {
-            itm.sql.extract_cube_refs(result);
-            if let CaseLabel::Sql(sql) = &itm.label {
-                sql.extract_cube_refs(result);
-            }
-        }
-        if let CaseLabel::Sql(sql) = &self.else_label {
-            sql.extract_cube_refs(result);
-        }
-    }
-
-    fn extract_symbol_deps(&self, result: &mut Vec<Rc<MemberSymbol>>) {
-        for itm in self.items.iter() {
-            itm.sql.extract_symbol_deps(result);
-            if let CaseLabel::Sql(sql) = &itm.label {
-                sql.extract_symbol_deps(result);
-            }
-        }
-        if let CaseLabel::Sql(sql) = &self.else_label {
-            sql.extract_symbol_deps(result);
-        }
-    }
-    fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let items = self
-            .items
-            .iter()
-            .map(|itm| -> Result<_, CubeError> {
-                let label = match &itm.label {
-                    CaseLabel::String(_) => itm.label.clone(),
-                    CaseLabel::Sql(sql_call) => CaseLabel::Sql(sql_call.apply_recursive(f)?),
-                };
-                Ok(CaseWhenItem {
-                    sql: itm.sql.apply_recursive(f)?,
-                    label,
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let else_label = match &self.else_label {
-            CaseLabel::String(_) => self.else_label.clone(),
-            CaseLabel::Sql(sql_call) => CaseLabel::Sql(sql_call.apply_recursive(f)?),
-        };
-        let res = CaseDefinition { items, else_label };
-        Ok(res)
-    }
-
     fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         Box::new(self.items.iter().map(|item| &item.sql))
     }
@@ -97,38 +80,36 @@ pub struct CaseSwitchWhenItem {
     pub sql: Rc<SqlCall>,
 }
 
+symbol_deps! {
+    CaseSwitchWhenItem {
+        value: skip,
+        sql: dep,
+    }
+}
+
 #[derive(Clone)]
 pub enum CaseSwitchItem {
     Sql(Rc<SqlCall>),
     Member(Rc<MemberSymbol>),
 }
 
+impl SymbolDeps for CaseSwitchItem {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        match self {
+            Self::Sql(sql_call) => sql_call.visit_deps(visitor),
+            Self::Member(member) => visitor.symbol(member),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::Sql(sql_call) => sql_call.visit_deps_mut(visitor),
+            Self::Member(member) => visitor.symbol(member),
+        }
+    }
+}
+
 impl CaseSwitchItem {
-    fn extract_cube_refs(&self, result: &mut Vec<CubeRef>) {
-        match self {
-            CaseSwitchItem::Sql(sql_call) => sql_call.extract_cube_refs(result),
-            CaseSwitchItem::Member(_) => {}
-        }
-    }
-
-    fn extract_symbol_deps(&self, result: &mut Vec<Rc<MemberSymbol>>) {
-        match self {
-            CaseSwitchItem::Sql(sql_call) => sql_call.extract_symbol_deps(result),
-            CaseSwitchItem::Member(member_symbol) => result.push(member_symbol.clone()),
-        }
-    }
-
-    fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let res = match self {
-            CaseSwitchItem::Sql(sql_call) => CaseSwitchItem::Sql(sql_call.apply_recursive(f)?),
-            CaseSwitchItem::Member(member) => CaseSwitchItem::Member(member.apply_recursive(f)?),
-        };
-        Ok(res)
-    }
-
     fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         match self {
             CaseSwitchItem::Sql(sql_call) => Box::new(std::iter::once(sql_call)),
@@ -144,17 +125,15 @@ pub struct CaseSwitchDefinition {
     pub else_sql: Option<Rc<SqlCall>>,
 }
 
-impl CaseSwitchDefinition {
-    fn extract_cube_refs(&self, result: &mut Vec<CubeRef>) {
-        self.switch.extract_cube_refs(result);
-        for itm in self.items.iter() {
-            itm.sql.extract_cube_refs(result);
-        }
-        if let Some(else_sql) = &self.else_sql {
-            else_sql.extract_cube_refs(result);
-        }
+symbol_deps! {
+    CaseSwitchDefinition {
+        switch: dep,
+        items: dep,
+        else_sql: dep,
     }
+}
 
+impl CaseSwitchDefinition {
     pub fn try_new(
         cube_name: &String,
         definition: Rc<dyn NativeCaseSwitchDefinition>,
@@ -219,15 +198,6 @@ impl CaseSwitchDefinition {
         owned
     }
 
-    fn extract_symbol_deps(&self, result: &mut Vec<Rc<MemberSymbol>>) {
-        self.switch.extract_symbol_deps(result);
-        for itm in self.items.iter() {
-            itm.sql.extract_symbol_deps(result);
-        }
-        if let Some(else_sql) = &self.else_sql {
-            else_sql.extract_symbol_deps(result);
-        }
-    }
     fn get_switch_values(&self) -> Option<Vec<String>> {
         if let CaseSwitchItem::Member(member) = &self.switch {
             if let Ok(switch_dim) = member.as_dimension() {
@@ -293,33 +263,6 @@ impl CaseSwitchDefinition {
         }
         None
     }
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let switch = self.switch.apply_to_deps(f)?;
-        let items = self
-            .items
-            .iter()
-            .map(|itm| -> Result<_, CubeError> {
-                Ok(CaseSwitchWhenItem {
-                    sql: itm.sql.apply_recursive(f)?,
-                    value: itm.value.clone(),
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let else_sql = if let Some(else_sql) = &self.else_sql {
-            Some(else_sql.apply_recursive(f)?)
-        } else {
-            None
-        };
-        let res = CaseSwitchDefinition {
-            switch,
-            items,
-            else_sql,
-        };
-        Ok(res)
-    }
 }
 
 /// Body of a case-defined member, mapped from the `case` field of
@@ -377,19 +320,6 @@ impl Case {
         Ok(res)
     }
 
-    pub fn extract_cube_refs(&self, result: &mut Vec<CubeRef>) {
-        match self {
-            Case::Case(def) => def.extract_cube_refs(result),
-            Case::CaseSwitch(def) => def.extract_cube_refs(result),
-        }
-    }
-
-    pub fn extract_symbol_deps(&self, result: &mut Vec<Rc<MemberSymbol>>) {
-        match self {
-            Case::Case(def) => def.extract_symbol_deps(result),
-            Case::CaseSwitch(def) => def.extract_symbol_deps(result),
-        }
-    }
     pub fn case_switch_dimension(&self) -> Option<Rc<MemberSymbol>> {
         if let Case::CaseSwitch(case) = &self {
             if let CaseSwitchItem::Member(member) = &case.switch {
@@ -406,16 +336,6 @@ impl Case {
                 .apply_static_filter(filters)
                 .map(|r| Case::CaseSwitch(r)),
         }
-    }
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let res = match self {
-            Case::Case(case) => Case::Case(case.apply_to_deps(f)?),
-            Case::CaseSwitch(case) => Case::CaseSwitch(case.apply_to_deps(f)?),
-        };
-        Ok(res)
     }
     pub fn is_single_value(&self) -> bool {
         match self {
@@ -434,6 +354,22 @@ impl Case {
         match self {
             Case::Case(case) => case.is_owned_by_cube(),
             Case::CaseSwitch(case) => case.is_owned_by_cube(),
+        }
+    }
+}
+
+impl SymbolDeps for Case {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        match self {
+            Case::Case(def) => def.visit_deps(visitor),
+            Case::CaseSwitch(def) => def.visit_deps(visitor),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Case::Case(def) => def.visit_deps_mut(visitor),
+            Case::CaseSwitch(def) => def.visit_deps_mut(visitor),
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/multi_stage.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/common/multi_stage.rs
@@ -117,45 +117,6 @@ impl MultiStageProperties {
             time_shift: None,
         }))
     }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let map_refs = |refs: &Option<Vec<Rc<MemberSymbol>>>| -> Result<_, CubeError> {
-            match refs {
-                Some(items) => Ok(Some(items.iter().map(f).collect::<Result<Vec<_>, _>>()?)),
-                None => Ok(None),
-            }
-        };
-
-        let filter = match &self.filter {
-            Some(f_old) => Some(MultiStageFilter {
-                mode: f_old.mode.clone(),
-                exclude: map_refs(&f_old.exclude)?,
-                keep_only: map_refs(&f_old.keep_only)?,
-                // include_* items are FilterItems that already hold their own
-                // resolved member references; transformations of dependency
-                // chains apply at the symbol level, so we keep them as-is.
-                include_dimension: f_old.include_dimension.clone(),
-                include_time_dimension: f_old.include_time_dimension.clone(),
-                include_measure: f_old.include_measure.clone(),
-            }),
-            None => None,
-        };
-
-        let grain = MultiStageGrain {
-            exclude: map_refs(&self.grain.exclude)?,
-            keep_only: map_refs(&self.grain.keep_only)?,
-            include: map_refs(&self.grain.include)?,
-        };
-
-        Ok(Self {
-            grain,
-            filter,
-            time_shift: self.time_shift.clone(),
-        })
-    }
 }
 
 fn resolve_reference_paths(

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/deps.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/deps.rs
@@ -1,0 +1,221 @@
+//! Single mechanism for enumerating and transforming symbol dependencies.
+//!
+//! A *dependency* of a symbol is another member symbol (or a cube
+//! reference) whose rendered SQL becomes part of that symbol's SQL.
+//! Symbol references that only name members without rendering them —
+//! multi-stage grain / filter member lists, time-shift targets — are
+//! annotations, not dependencies: they are matched by `full_name` and
+//! are invisible to the traversals defined here.
+//!
+//! Every node of a symbol's body declares its dependency slots exactly
+//! once — with the [`symbol_deps!`] macro for structs, or a hand-written
+//! [`SymbolDeps`] impl for enums (an exhaustive `match` gives the same
+//! new-variant safety the macro's full destructuring gives for new
+//! fields). Both the read-side walk ([`collect_deps`],
+//! [`collect_cube_refs`]) and the rebuild-side transform
+//! ([`apply_recursive`], [`apply_to_deps`]) are derived from that one
+//! declaration, so they can never disagree on what the dependencies are.
+//!
+//! Slots are visited in declaration order; the order is a contract —
+//! a reference symbol resolves to its *first* dependency.
+
+use super::MemberSymbol;
+use crate::planner::CubeRef;
+use cubenativeutils::CubeError;
+use std::ops::ControlFlow;
+use std::rc::Rc;
+
+/// Read-side sink for dependency slots.
+pub trait DepVisitor {
+    fn symbol(&mut self, symbol: &Rc<MemberSymbol>) -> ControlFlow<()>;
+
+    fn cube_ref(&mut self, _cube_ref: &CubeRef) -> ControlFlow<()> {
+        ControlFlow::Continue(())
+    }
+}
+
+/// Rebuild-side sink for dependency slots: receives every direct
+/// member-symbol slot and may replace it.
+pub trait DepVisitorMut {
+    fn symbol(&mut self, slot: &mut Rc<MemberSymbol>) -> Result<(), CubeError>;
+}
+
+/// A node whose dependency slots can be walked (read) or rebuilt
+/// (transform) from the same declaration.
+pub trait SymbolDeps {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()>;
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError>;
+}
+
+impl<T: SymbolDeps> SymbolDeps for Option<T> {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        if let Some(item) = self {
+            item.visit_deps(visitor)?;
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        if let Some(item) = self {
+            item.visit_deps_mut(visitor)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: SymbolDeps> SymbolDeps for Vec<T> {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        for item in self.iter() {
+            item.visit_deps(visitor)?;
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        for item in self.iter_mut() {
+            item.visit_deps_mut(visitor)?;
+        }
+        Ok(())
+    }
+}
+
+/// Declares the dependency slots of a struct once, generating both
+/// `SymbolDeps` methods from the same field list.
+///
+/// Every field must be listed with one of the modes:
+/// - `dep` — a dependency slot; delegates to the field's `SymbolDeps`
+///   impl (`Rc<SqlCall>`, composite bodies, `Option` / `Vec` of those).
+/// - `dep_symbol` — a direct `Rc<MemberSymbol>` dependency: emitted as
+///   a leaf on read, offered for replacement on rebuild.
+/// - `dep_transparent` — an `Rc<MemberSymbol>` the node is a view of:
+///   read looks through it (emits the symbol's own dependencies, not
+///   the symbol), rebuild offers the slot itself for replacement.
+/// - `skip` — not a dependency (plain data or an annotation).
+///
+/// The generated code destructures the struct without `..`, so adding
+/// a field fails to compile until it is classified here.
+macro_rules! symbol_deps {
+    ($ty:ident { $($field:ident: $mode:ident),+ $(,)? }) => {
+        impl $crate::planner::symbols::deps::SymbolDeps for $ty {
+            fn visit_deps(
+                &self,
+                visitor: &mut dyn $crate::planner::symbols::deps::DepVisitor,
+            ) -> ::std::ops::ControlFlow<()> {
+                let Self { $($field),+ } = self;
+                $($crate::planner::symbols::deps::symbol_deps!(@visit $mode, $field, visitor);)+
+                ::std::ops::ControlFlow::Continue(())
+            }
+
+            fn visit_deps_mut(
+                &mut self,
+                visitor: &mut dyn $crate::planner::symbols::deps::DepVisitorMut,
+            ) -> Result<(), ::cubenativeutils::CubeError> {
+                let Self { $($field),+ } = self;
+                $($crate::planner::symbols::deps::symbol_deps!(@visit_mut $mode, $field, visitor);)+
+                Ok(())
+            }
+        }
+    };
+
+    (@visit skip, $field:ident, $visitor:ident) => {
+        let _ = $field;
+    };
+    (@visit dep, $field:ident, $visitor:ident) => {
+        $crate::planner::symbols::deps::SymbolDeps::visit_deps($field, $visitor)?;
+    };
+    (@visit dep_symbol, $field:ident, $visitor:ident) => {
+        $visitor.symbol($field)?;
+    };
+    (@visit dep_transparent, $field:ident, $visitor:ident) => {
+        $crate::planner::symbols::deps::SymbolDeps::visit_deps($field.as_ref(), $visitor)?;
+    };
+
+    (@visit_mut skip, $field:ident, $visitor:ident) => {
+        let _ = $field;
+    };
+    (@visit_mut dep, $field:ident, $visitor:ident) => {
+        $crate::planner::symbols::deps::SymbolDeps::visit_deps_mut($field, $visitor)?;
+    };
+    (@visit_mut dep_symbol, $field:ident, $visitor:ident) => {
+        $visitor.symbol($field)?;
+    };
+    (@visit_mut dep_transparent, $field:ident, $visitor:ident) => {
+        $visitor.symbol($field)?;
+    };
+}
+pub(crate) use symbol_deps;
+
+/// All direct member-symbol dependencies of a node, in slot
+/// declaration order.
+pub fn collect_deps(node: &dyn SymbolDeps) -> Vec<Rc<MemberSymbol>> {
+    struct Collector(Vec<Rc<MemberSymbol>>);
+
+    impl DepVisitor for Collector {
+        fn symbol(&mut self, symbol: &Rc<MemberSymbol>) -> ControlFlow<()> {
+            self.0.push(symbol.clone());
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut collector = Collector(vec![]);
+    let _ = node.visit_deps(&mut collector);
+    collector.0
+}
+
+/// All cube references of a node, in slot declaration order.
+pub fn collect_cube_refs(node: &dyn SymbolDeps) -> Vec<CubeRef> {
+    struct Collector(Vec<CubeRef>);
+
+    impl DepVisitor for Collector {
+        fn symbol(&mut self, _symbol: &Rc<MemberSymbol>) -> ControlFlow<()> {
+            ControlFlow::Continue(())
+        }
+
+        fn cube_ref(&mut self, cube_ref: &CubeRef) -> ControlFlow<()> {
+            self.0.push(cube_ref.clone());
+            ControlFlow::Continue(())
+        }
+    }
+
+    let mut collector = Collector(vec![]);
+    let _ = node.visit_deps(&mut collector);
+    collector.0
+}
+
+struct ApplyVisitor<'a, F> {
+    f: &'a F,
+}
+
+impl<F> DepVisitorMut for ApplyVisitor<'_, F>
+where
+    F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>,
+{
+    fn symbol(&mut self, slot: &mut Rc<MemberSymbol>) -> Result<(), CubeError> {
+        *slot = apply_recursive(slot, self.f)?;
+        Ok(())
+    }
+}
+
+/// Applies `f` to this symbol, then recurses into the dependencies of
+/// the result returned by `f` — not of the original symbol. `f` is
+/// applied to every symbol node exactly once.
+pub fn apply_recursive<F>(symbol: &Rc<MemberSymbol>, f: &F) -> Result<Rc<MemberSymbol>, CubeError>
+where
+    F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>,
+{
+    let result = f(symbol)?;
+    apply_to_deps(&result, f)
+}
+
+/// Rebuilds the symbol with every dependency replaced by
+/// `apply_recursive` of itself; the symbol's own node is not passed
+/// to `f`.
+pub fn apply_to_deps<F>(symbol: &Rc<MemberSymbol>, f: &F) -> Result<Rc<MemberSymbol>, CubeError>
+where
+    F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>,
+{
+    let mut result = symbol.as_ref().clone();
+    result.visit_deps_mut(&mut ApplyVisitor { f })?;
+    Ok(Rc::new(result))
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/case_dimension.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/case_dimension.rs
@@ -1,7 +1,6 @@
 use super::super::common::{Case, DimensionType};
-use super::super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
-use cubenativeutils::CubeError;
+use super::super::deps::symbol_deps;
+use crate::planner::SqlCall;
 use std::rc::Rc;
 
 /// Dimension whose value is defined via the `case` field of the
@@ -12,6 +11,14 @@ pub struct CaseDimension {
     dimension_type: DimensionType,
     case: Case,
     member_sql: Option<Rc<SqlCall>>,
+}
+
+symbol_deps! {
+    CaseDimension {
+        dimension_type: skip,
+        member_sql: dep,
+        case: dep,
+    }
 }
 
 impl CaseDimension {
@@ -43,42 +50,8 @@ impl CaseDimension {
         }
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        if let Some(member_sql) = &self.member_sql {
-            member_sql.extract_symbol_deps(&mut deps);
-        }
-        self.case.extract_symbol_deps(&mut deps);
-        deps
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let member_sql = if let Some(sql) = &self.member_sql {
-            Some(sql.apply_recursive(f)?)
-        } else {
-            None
-        };
-        Ok(Self {
-            dimension_type: self.dimension_type,
-            case: self.case.apply_to_deps(f)?,
-            member_sql,
-        })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         Box::new(self.member_sql.iter().chain(self.case.iter_sql_calls()))
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        if let Some(member_sql) = &self.member_sql {
-            member_sql.extract_cube_refs(&mut refs);
-        }
-        self.case.extract_cube_refs(&mut refs);
-        refs
     }
 
     pub fn is_owned_by_cube(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/geo.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/geo.rs
@@ -1,6 +1,5 @@
-use super::super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
-use cubenativeutils::CubeError;
+use super::super::deps::symbol_deps;
+use crate::planner::SqlCall;
 use std::rc::Rc;
 
 /// `type: geo` dimension from the data model: a geographic dimension
@@ -9,6 +8,13 @@ use std::rc::Rc;
 pub struct GeoDimension {
     latitude: Rc<SqlCall>,
     longitude: Rc<SqlCall>,
+}
+
+symbol_deps! {
+    GeoDimension {
+        latitude: dep,
+        longitude: dep,
+    }
 }
 
 impl GeoDimension {
@@ -27,32 +33,8 @@ impl GeoDimension {
         &self.longitude
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        self.latitude.extract_symbol_deps(&mut deps);
-        self.longitude.extract_symbol_deps(&mut deps);
-        deps
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        Ok(Self {
-            latitude: self.latitude.apply_recursive(f)?,
-            longitude: self.longitude.apply_recursive(f)?,
-        })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         Box::new(std::iter::once(&self.latitude).chain(std::iter::once(&self.longitude)))
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        self.latitude.extract_cube_refs(&mut refs);
-        self.longitude.extract_cube_refs(&mut refs);
-        refs
     }
 
     pub fn is_owned_by_cube(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/mod.rs
@@ -9,9 +9,10 @@ pub use regular::*;
 pub use switch::*;
 
 use super::common::DimensionType;
-use super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
+use super::deps::{DepVisitor, DepVisitorMut, SymbolDeps};
+use crate::planner::SqlCall;
 use cubenativeutils::CubeError;
+use std::ops::ControlFlow;
 use std::rc::Rc;
 
 /// Form of a dimension's value, classified from its data-model
@@ -32,43 +33,33 @@ pub enum DimensionKind {
     Case(CaseDimension),
 }
 
-impl DimensionKind {
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
+impl SymbolDeps for DimensionKind {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
         match self {
-            Self::Regular(r) => r.get_dependencies(),
-            Self::Geo(g) => g.get_dependencies(),
-            Self::Switch(s) => s.get_dependencies(),
-            Self::Case(c) => c.get_dependencies(),
+            Self::Regular(r) => r.visit_deps(visitor),
+            Self::Geo(g) => g.visit_deps(visitor),
+            Self::Switch(s) => s.visit_deps(visitor),
+            Self::Case(c) => c.visit_deps(visitor),
         }
     }
 
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        Ok(match self {
-            Self::Regular(r) => Self::Regular(r.apply_to_deps(f)?),
-            Self::Geo(g) => Self::Geo(g.apply_to_deps(f)?),
-            Self::Switch(s) => Self::Switch(s.apply_to_deps(f)?),
-            Self::Case(c) => Self::Case(c.apply_to_deps(f)?),
-        })
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::Regular(r) => r.visit_deps_mut(visitor),
+            Self::Geo(g) => g.visit_deps_mut(visitor),
+            Self::Switch(s) => s.visit_deps_mut(visitor),
+            Self::Case(c) => c.visit_deps_mut(visitor),
+        }
     }
+}
 
+impl DimensionKind {
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         match self {
             Self::Regular(r) => r.iter_sql_calls(),
             Self::Geo(g) => g.iter_sql_calls(),
             Self::Switch(s) => s.iter_sql_calls(),
             Self::Case(c) => c.iter_sql_calls(),
-        }
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        match self {
-            Self::Regular(r) => r.get_cube_refs(),
-            Self::Geo(g) => g.get_cube_refs(),
-            Self::Switch(s) => s.get_cube_refs(),
-            Self::Case(c) => c.get_cube_refs(),
         }
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/regular.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/regular.rs
@@ -1,7 +1,6 @@
 use super::super::common::DimensionType;
-use super::super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
-use cubenativeutils::CubeError;
+use super::super::deps::symbol_deps;
+use crate::planner::SqlCall;
 use std::rc::Rc;
 
 /// Plain dimension from the data model — a single `sql` expression
@@ -10,6 +9,13 @@ use std::rc::Rc;
 pub struct RegularDimension {
     dimension_type: DimensionType,
     member_sql: Rc<SqlCall>,
+}
+
+symbol_deps! {
+    RegularDimension {
+        dimension_type: skip,
+        member_sql: dep,
+    }
 }
 
 impl RegularDimension {
@@ -26,26 +32,6 @@ impl RegularDimension {
 
     pub fn member_sql(&self) -> &Rc<SqlCall> {
         &self.member_sql
-    }
-
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        self.member_sql.extract_symbol_deps(&mut deps);
-        deps
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        self.member_sql.get_cube_refs()
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        Ok(Self {
-            dimension_type: self.dimension_type,
-            member_sql: self.member_sql.apply_recursive(f)?,
-        })
     }
 
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/switch.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_kinds/switch.rs
@@ -1,6 +1,5 @@
-use super::super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
-use cubenativeutils::CubeError;
+use super::super::deps::symbol_deps;
+use crate::planner::SqlCall;
 use std::rc::Rc;
 
 /// `type: switch` dimension from the data model: an enum with a
@@ -12,6 +11,13 @@ use std::rc::Rc;
 pub struct SwitchDimension {
     values: Vec<String>,
     member_sql: Option<Rc<SqlCall>>,
+}
+
+symbol_deps! {
+    SwitchDimension {
+        values: skip,
+        member_sql: dep,
+    }
 }
 
 impl SwitchDimension {
@@ -34,39 +40,8 @@ impl SwitchDimension {
         self.member_sql.is_none()
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        if let Some(member_sql) = &self.member_sql {
-            member_sql.extract_symbol_deps(&mut deps);
-        }
-        deps
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let member_sql = if let Some(sql) = &self.member_sql {
-            Some(sql.apply_recursive(f)?)
-        } else {
-            None
-        };
-        Ok(Self {
-            values: self.values.clone(),
-            member_sql,
-        })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         Box::new(self.member_sql.iter())
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        if let Some(member_sql) = &self.member_sql {
-            member_sql.extract_cube_refs(&mut refs);
-        }
-        refs
     }
 
     pub fn is_owned_by_cube(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/dimension_symbol.rs
@@ -1,6 +1,7 @@
 use super::common::Case;
 use super::common::CompiledMemberPath;
 use super::common::MultiStageProperties;
+use super::deps::{self, symbol_deps};
 use super::dimension_kinds::{
     CaseDimension, DimensionKind, GeoDimension, RegularDimension, SwitchDimension,
 };
@@ -13,7 +14,7 @@ use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::planner::GranularityHelper;
 use crate::planner::SqlInterval;
 use crate::planner::TimeDimensionSymbol;
-use crate::planner::{Compiler, CubeRef, SqlCall};
+use crate::planner::{Compiler, SqlCall};
 use cubenativeutils::CubeError;
 use std::rc::Rc;
 
@@ -43,6 +44,22 @@ pub struct DimensionSymbol {
     is_sub_query: bool,
     propagate_filters_to_sub_query: bool,
     mask_sql: Option<Rc<SqlCall>>,
+}
+
+symbol_deps! {
+    DimensionSymbol {
+        kind: dep,
+        mask_sql: dep,
+        compiled_path: skip,
+        is_reference: skip,
+        is_view: skip,
+        multi_stage: skip,
+        time_shift: skip,
+        time_shift_pk_full_name: skip,
+        is_self_time_shift_pk: skip,
+        is_sub_query: skip,
+        propagate_filters_to_sub_query: skip,
+    }
 }
 
 impl DimensionSymbol {
@@ -220,26 +237,11 @@ impl DimensionSymbol {
         if !self.is_reference() {
             return None;
         }
-        let deps = self.get_dependencies();
-        if deps.is_empty() {
-            return None;
-        }
-        deps.first().cloned()
+        self.get_dependencies().first().cloned()
     }
 
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Rc<MemberSymbol>, CubeError> {
-        let mut result = self.clone();
-        result.kind = self.kind.apply_to_deps(f)?;
-        if let Some(mask) = &self.mask_sql {
-            result.mask_sql = Some(mask.apply_recursive(f)?);
-        }
-        if let Some(ms) = &self.multi_stage {
-            result.multi_stage = Some(ms.apply_to_deps(f)?);
-        }
-        Ok(MemberSymbol::new_dimension(Rc::new(result)))
+    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
+        deps::collect_deps(self)
     }
 
     /// SQL calls inside the kind body. `mask_sql` is intentionally
@@ -249,24 +251,6 @@ impl DimensionSymbol {
     /// cube-ref validation would produce false foreign-cube errors.
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         self.kind.iter_sql_calls()
-    }
-
-    /// All member dependencies of the dimension.
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = self.kind.get_dependencies();
-        if let Some(mask) = &self.mask_sql {
-            mask.extract_symbol_deps(&mut deps);
-        }
-        deps
-    }
-
-    /// All cube references of the dimension.
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = self.kind.get_cube_refs();
-        if let Some(mask) = &self.mask_sql {
-            mask.extract_cube_refs(&mut refs);
-        }
-        refs
     }
 
     pub fn cube_name(&self) -> String {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/aggregated.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/aggregated.rs
@@ -1,7 +1,6 @@
-use super::super::super::MemberSymbol;
 use super::super::common::AggregationType;
-use crate::planner::{CubeRef, SqlCall};
-use cubenativeutils::CubeError;
+use super::super::deps::symbol_deps;
+use crate::planner::SqlCall;
 use std::rc::Rc;
 
 /// `Aggregated` measure kind. `sql` may be absent when the measure
@@ -10,6 +9,13 @@ use std::rc::Rc;
 pub struct AggregatedMeasure {
     agg_type: AggregationType,
     member_sql: Option<Rc<SqlCall>>,
+}
+
+symbol_deps! {
+    AggregatedMeasure {
+        agg_type: skip,
+        member_sql: dep,
+    }
 }
 
 impl AggregatedMeasure {
@@ -35,38 +41,8 @@ impl AggregatedMeasure {
         self.member_sql.as_ref()
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        if let Some(sql) = &self.member_sql {
-            sql.extract_symbol_deps(&mut deps);
-        }
-        deps
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        Ok(Self {
-            agg_type: self.agg_type,
-            member_sql: self
-                .member_sql
-                .as_ref()
-                .map(|sql| sql.apply_recursive(f))
-                .transpose()?,
-        })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         Box::new(self.member_sql.iter())
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        if let Some(sql) = &self.member_sql {
-            sql.extract_cube_refs(&mut refs);
-        }
-        refs
     }
 
     pub fn is_owned_by_cube(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/calculated.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/calculated.rs
@@ -1,6 +1,5 @@
-use super::super::super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
-use cubenativeutils::CubeError;
+use super::super::deps::symbol_deps;
+use crate::planner::SqlCall;
 use std::rc::Rc;
 
 /// Value type of a calculated (non-aggregating) measure as declared
@@ -42,6 +41,13 @@ pub struct CalculatedMeasure {
     member_sql: Option<Rc<SqlCall>>,
 }
 
+symbol_deps! {
+    CalculatedMeasure {
+        calc_type: skip,
+        member_sql: dep,
+    }
+}
+
 impl CalculatedMeasure {
     pub fn new(calc_type: CalculatedMeasureType, member_sql: Rc<SqlCall>) -> Self {
         Self {
@@ -65,38 +71,8 @@ impl CalculatedMeasure {
         self.member_sql.as_ref()
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        if let Some(sql) = &self.member_sql {
-            sql.extract_symbol_deps(&mut deps);
-        }
-        deps
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        Ok(Self {
-            calc_type: self.calc_type,
-            member_sql: self
-                .member_sql
-                .as_ref()
-                .map(|sql| sql.apply_recursive(f))
-                .transpose()?,
-        })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         Box::new(self.member_sql.iter())
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        if let Some(sql) = &self.member_sql {
-            sql.extract_cube_refs(&mut refs);
-        }
-        refs
     }
 
     pub fn is_owned_by_cube(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/count.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/count.rs
@@ -1,6 +1,7 @@
-use super::super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
+use super::super::deps::{symbol_deps, DepVisitor, DepVisitorMut, SymbolDeps};
+use crate::planner::SqlCall;
 use cubenativeutils::CubeError;
+use std::ops::ControlFlow;
 use std::rc::Rc;
 
 /// Source of a `Count` measure's SQL.
@@ -14,12 +15,34 @@ pub enum CountSql {
     Explicit(Rc<SqlCall>),
 }
 
+impl SymbolDeps for CountSql {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        match self {
+            Self::Auto(pk_sqls) => pk_sqls.visit_deps(visitor),
+            Self::Explicit(sql) => sql.visit_deps(visitor),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::Auto(pk_sqls) => pk_sqls.visit_deps_mut(visitor),
+            Self::Explicit(sql) => sql.visit_deps_mut(visitor),
+        }
+    }
+}
+
 /// `Count` measure kind: counts rows of the underlying source.
 /// Without an explicit `sql` falls back to counting the cube's
 /// primary-key tuples.
 #[derive(Clone)]
 pub struct CountMeasure {
     sql: CountSql,
+}
+
+symbol_deps! {
+    CountMeasure {
+        sql: dep,
+    }
 }
 
 impl CountMeasure {
@@ -38,54 +61,11 @@ impl CountMeasure {
         matches!(&self.sql, CountSql::Auto(pks) if !pks.is_empty())
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        match &self.sql {
-            CountSql::Explicit(sql) => sql.extract_symbol_deps(&mut deps),
-            CountSql::Auto(pk_sqls) => {
-                for pk in pk_sqls {
-                    pk.extract_symbol_deps(&mut deps);
-                }
-            }
-        }
-        deps
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let sql = match &self.sql {
-            CountSql::Explicit(sql) => CountSql::Explicit(sql.apply_recursive(f)?),
-            CountSql::Auto(pk_sqls) => {
-                let new_pks = pk_sqls
-                    .iter()
-                    .map(|pk| pk.apply_recursive(f))
-                    .collect::<Result<Vec<_>, _>>()?;
-                CountSql::Auto(new_pks)
-            }
-        };
-        Ok(Self { sql })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         match &self.sql {
             CountSql::Explicit(sql) => Box::new(std::iter::once(sql)),
             CountSql::Auto(pk_sqls) => Box::new(pk_sqls.iter()),
         }
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        match &self.sql {
-            CountSql::Explicit(sql) => sql.extract_cube_refs(&mut refs),
-            CountSql::Auto(pk_sqls) => {
-                for pk in pk_sqls {
-                    pk.extract_cube_refs(&mut refs);
-                }
-            }
-        }
-        refs
     }
 
     pub fn is_owned_by_cube(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_kinds/mod.rs
@@ -7,9 +7,10 @@ pub use calculated::*;
 pub use count::*;
 
 use super::common::AggregationType;
-use super::MemberSymbol;
-use crate::planner::{CubeRef, SqlCall};
+use super::deps::{DepVisitor, DepVisitorMut, SymbolDeps};
+use crate::planner::SqlCall;
 use cubenativeutils::CubeError;
+use std::ops::ControlFlow;
 use std::rc::Rc;
 
 /// How a measure kind wraps its inner SQL when rendered: no wrapper
@@ -77,43 +78,12 @@ impl MeasureKind {
         }
     }
 
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        match self {
-            Self::Count(c) | Self::MultipliedCount(c) => c.get_dependencies(),
-            Self::Aggregated(a) => a.get_dependencies(),
-            Self::Calculated(c) => c.get_dependencies(),
-            Self::Rank => vec![],
-        }
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        Ok(match self {
-            Self::Count(c) => Self::Count(c.apply_to_deps(f)?),
-            Self::MultipliedCount(c) => Self::MultipliedCount(c.apply_to_deps(f)?),
-            Self::Aggregated(a) => Self::Aggregated(a.apply_to_deps(f)?),
-            Self::Calculated(c) => Self::Calculated(c.apply_to_deps(f)?),
-            Self::Rank => Self::Rank,
-        })
-    }
-
     pub fn iter_sql_calls(&self) -> Box<dyn Iterator<Item = &Rc<SqlCall>> + '_> {
         match self {
             Self::Count(c) | Self::MultipliedCount(c) => c.iter_sql_calls(),
             Self::Aggregated(a) => a.iter_sql_calls(),
             Self::Calculated(c) => c.iter_sql_calls(),
             Self::Rank => Box::new(std::iter::empty()),
-        }
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        match self {
-            Self::Count(c) | Self::MultipliedCount(c) => c.get_cube_refs(),
-            Self::Aggregated(a) => a.get_cube_refs(),
-            Self::Calculated(c) => c.get_cube_refs(),
-            Self::Rank => vec![],
         }
     }
 
@@ -278,6 +248,26 @@ impl MeasureKind {
             Self::Count(c) if c.convertible_to_distinct() => Some(Self::MultipliedCount(c.clone())),
             Self::Aggregated(a) if a.agg_type().is_distinct() => Some(self.clone()),
             _ => None,
+        }
+    }
+}
+
+impl SymbolDeps for MeasureKind {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        match self {
+            Self::Count(c) | Self::MultipliedCount(c) => c.visit_deps(visitor),
+            Self::Aggregated(a) => a.visit_deps(visitor),
+            Self::Calculated(c) => c.visit_deps(visitor),
+            Self::Rank => ControlFlow::Continue(()),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::Count(c) | Self::MultipliedCount(c) => c.visit_deps_mut(visitor),
+            Self::Aggregated(a) => a.visit_deps_mut(visitor),
+            Self::Calculated(c) => c.visit_deps_mut(visitor),
+            Self::Rank => Ok(()),
         }
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/measure_symbol.rs
@@ -1,4 +1,5 @@
 use super::common::{Case, CompiledMemberPath, MultiStageProperties};
+use super::deps::{self, symbol_deps};
 use super::measure_kinds::{CalculatedMeasure, CalculatedMeasureType, MeasureKind};
 use super::SymbolPath;
 use super::{MemberSymbol, SymbolFactory};
@@ -8,7 +9,7 @@ use crate::cube_bridge::member_sql::MemberSql;
 use crate::planner::collectors::find_owned_by_cube_child;
 use crate::planner::sql_templates::PlanSqlTemplates;
 use crate::planner::SqlInterval;
-use crate::planner::{Compiler, CubeRef, SqlCall};
+use crate::planner::{Compiler, SqlCall};
 use cubenativeutils::CubeError;
 use itertools::Itertools;
 use std::cmp::{Eq, PartialEq};
@@ -34,12 +35,15 @@ impl MeasureOrderBy {
         &self.sql_call
     }
 
-    pub fn set_sql_call(&mut self, sql_call: Rc<SqlCall>) {
-        self.sql_call = sql_call;
-    }
-
     pub fn direction(&self) -> &String {
         &self.direction
+    }
+}
+
+symbol_deps! {
+    MeasureOrderBy {
+        sql_call: dep,
+        direction: skip,
     }
 }
 
@@ -94,6 +98,23 @@ pub struct MeasureSymbol {
     measure_order_by: Vec<MeasureOrderBy>,
     is_splitted_source: bool,
     mask_sql: Option<Rc<SqlCall>>,
+}
+
+symbol_deps! {
+    MeasureSymbol {
+        kind: dep,
+        measure_filters: dep,
+        measure_drill_filters: dep,
+        measure_order_by: dep,
+        case: dep,
+        mask_sql: dep,
+        compiled_path: skip,
+        rolling_window: skip,
+        multi_stage: skip,
+        is_reference: skip,
+        is_view: skip,
+        is_splitted_source: skip,
+    }
 }
 
 impl MeasureSymbol {
@@ -279,40 +300,6 @@ impl MeasureSymbol {
         }
     }
 
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Rc<MemberSymbol>, CubeError> {
-        let mut result = self.clone();
-        result.kind = result.kind.apply_to_deps(f)?;
-
-        for sql in result.measure_filters.iter_mut() {
-            *sql = sql.apply_recursive(f)?
-        }
-
-        for sql in result.measure_drill_filters.iter_mut() {
-            *sql = sql.apply_recursive(f)?
-        }
-
-        for order in result.measure_order_by.iter_mut() {
-            order.set_sql_call(order.sql_call().apply_recursive(f)?);
-        }
-
-        if let Some(case) = &self.case {
-            result.case = Some(case.apply_to_deps(f)?)
-        }
-
-        if let Some(mask) = &self.mask_sql {
-            result.mask_sql = Some(mask.apply_recursive(f)?);
-        }
-
-        if let Some(ms) = &self.multi_stage {
-            result.multi_stage = Some(ms.apply_to_deps(f)?);
-        }
-
-        Ok(MemberSymbol::new_measure(Rc::new(result)))
-    }
-
     /// SQL calls inside the measure's kind and `case` body.
     /// `mask_sql` is intentionally excluded: it is compiled against
     /// the cube that owns the measure, which differs from the symbol's
@@ -326,46 +313,6 @@ impl MeasureSymbol {
             .iter_sql_calls()
             .chain(self.case.iter().flat_map(|case| case.iter_sql_calls()));
         Box::new(result)
-    }
-
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = self.kind.get_dependencies();
-        for filter in self.measure_filters.iter() {
-            filter.extract_symbol_deps(&mut deps);
-        }
-        for filter in self.measure_drill_filters.iter() {
-            filter.extract_symbol_deps(&mut deps);
-        }
-        for order in self.measure_order_by.iter() {
-            order.sql_call().extract_symbol_deps(&mut deps);
-        }
-        if let Some(case) = &self.case {
-            case.extract_symbol_deps(&mut deps);
-        }
-        if let Some(mask) = &self.mask_sql {
-            mask.extract_symbol_deps(&mut deps);
-        }
-        deps
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = self.kind.get_cube_refs();
-        for filter in self.measure_filters.iter() {
-            filter.extract_cube_refs(&mut refs);
-        }
-        for filter in self.measure_drill_filters.iter() {
-            filter.extract_cube_refs(&mut refs);
-        }
-        for order in self.measure_order_by.iter() {
-            order.sql_call().extract_cube_refs(&mut refs);
-        }
-        if let Some(case) = &self.case {
-            case.extract_cube_refs(&mut refs);
-        }
-        if let Some(mask) = &self.mask_sql {
-            mask.extract_cube_refs(&mut refs);
-        }
-        refs
     }
 
     /// Render form of this measure when it sits under a row-multiplying
@@ -427,11 +374,11 @@ impl MeasureSymbol {
         if !self.is_reference() {
             return None;
         }
-        let deps = self.get_dependencies();
-        if deps.is_empty() {
-            return None;
-        }
-        deps.first().cloned()
+        self.get_dependencies().first().cloned()
+    }
+
+    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
+        deps::collect_deps(self)
     }
 
     pub fn measure_type(&self) -> &str {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_expression_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_expression_symbol.rs
@@ -1,8 +1,9 @@
 use super::common::CompiledMemberPath;
+use super::deps::{self, symbol_deps, DepVisitor, DepVisitorMut, SymbolDeps};
 use super::MemberSymbol;
 use crate::planner::collectors::member_childs;
 use crate::planner::sql_templates::PlanSqlTemplates;
-use crate::planner::{CubeRef, CubeTableSymbol, SqlCall};
+use crate::planner::{CubeTableSymbol, SqlCall};
 use crate::utils::debug::DebugSql;
 use cubenativeutils::CubeError;
 use itertools::Itertools;
@@ -18,6 +19,22 @@ use std::rc::Rc;
 pub enum MemberExpressionExpression {
     SqlCall(Rc<SqlCall>),
     PatchedSymbol(Rc<MemberSymbol>),
+}
+
+impl SymbolDeps for MemberExpressionExpression {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> std::ops::ControlFlow<()> {
+        match self {
+            Self::SqlCall(sql_call) => sql_call.visit_deps(visitor),
+            Self::PatchedSymbol(symbol) => visitor.symbol(symbol),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::SqlCall(sql_call) => sql_call.visit_deps_mut(visitor),
+            Self::PatchedSymbol(symbol) => visitor.symbol(symbol),
+        }
+    }
 }
 
 /// `MemberSymbol::MemberExpression` body: a synthetic member built
@@ -36,6 +53,17 @@ pub struct MemberExpressionSymbol {
     /// selected dimension (in a pre-aggregation). Such a boolean must be
     /// wrapped per dialect when projected/grouped (e.g. MSSQL `BIT`).
     is_segment: bool,
+}
+
+symbol_deps! {
+    MemberExpressionSymbol {
+        expression: dep,
+        compiled_path: skip,
+        definition: skip,
+        is_reference: skip,
+        parenthesized: skip,
+        is_segment: skip,
+    }
 }
 
 impl MemberExpressionSymbol {
@@ -125,50 +153,11 @@ impl MemberExpressionSymbol {
         if !self.is_reference() {
             return None;
         }
-        let deps = self.get_dependencies();
-        if deps.is_empty() {
-            return None;
-        }
-        deps.first().cloned()
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Rc<MemberSymbol>, CubeError> {
-        let mut result = self.clone();
-        match &mut result.expression {
-            MemberExpressionExpression::SqlCall(sql_call) => {
-                *sql_call = sql_call.apply_recursive(f)?
-            }
-            MemberExpressionExpression::PatchedSymbol(member_symbol) => {
-                *member_symbol = f(member_symbol)?
-            }
-        }
-
-        Ok(MemberSymbol::new_member_expression(Rc::new(result)))
+        self.get_dependencies().first().cloned()
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        match &self.expression {
-            MemberExpressionExpression::SqlCall(sql_call) => {
-                sql_call.extract_symbol_deps(&mut deps)
-            }
-            MemberExpressionExpression::PatchedSymbol(member_symbol) => {
-                deps.push(member_symbol.clone())
-            }
-        }
-        deps
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        match &self.expression {
-            MemberExpressionExpression::SqlCall(sql_call) => sql_call.extract_cube_refs(&mut refs),
-            MemberExpressionExpression::PatchedSymbol(_) => {}
-        }
-        refs
+        deps::collect_deps(self)
     }
 
     /// If every leaf member referenced by the expression is a

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/member_symbol.rs
@@ -4,8 +4,10 @@ use itertools::Itertools;
 use crate::planner::{Case, CubeRef, SqlCall};
 
 use super::common::CompiledMemberPath;
+use super::deps::{self, DepVisitor, DepVisitorMut, SymbolDeps};
 use super::{DimensionSymbol, MeasureSymbol, MemberExpressionSymbol, TimeDimensionSymbol};
 use std::fmt::Debug;
+use std::ops::ControlFlow;
 use std::rc::Rc;
 
 /// First-class business object of the planner: the atomic unit of
@@ -23,6 +25,7 @@ use std::rc::Rc;
 /// Indivisible: renders as a single SQL expression. A symbol may depend
 /// on other symbols (`get_dependencies`); whether those deps are
 /// inlined or pushed into a CTE / subquery is a physical-plan decision.
+#[derive(Clone)]
 pub enum MemberSymbol {
     Dimension(Rc<DimensionSymbol>),
     TimeDimension(Rc<TimeDimensionSymbol>),
@@ -154,38 +157,15 @@ impl MemberSymbol {
         self: &Rc<Self>,
         f: &F,
     ) -> Result<Rc<MemberSymbol>, CubeError> {
-        let result = f(self)?;
-        result.apply_to_deps(f)
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        self: &Rc<Self>,
-        f: &F,
-    ) -> Result<Rc<MemberSymbol>, CubeError> {
-        match self.as_ref() {
-            Self::Dimension(d) => d.apply_to_deps(f),
-            Self::TimeDimension(d) => d.apply_to_deps(f),
-            Self::Measure(m) => m.apply_to_deps(f),
-            Self::MemberExpression(e) => e.apply_to_deps(f),
-        }
+        deps::apply_recursive(self, f)
     }
 
     pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        match self {
-            Self::Dimension(d) => d.get_dependencies(),
-            Self::TimeDimension(d) => d.get_dependencies(),
-            Self::Measure(m) => m.get_dependencies(),
-            Self::MemberExpression(e) => e.get_dependencies(),
-        }
+        deps::collect_deps(self)
     }
 
     pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        match self {
-            Self::Dimension(d) => d.get_cube_refs(),
-            Self::TimeDimension(d) => d.get_cube_refs(),
-            Self::Measure(m) => m.get_cube_refs(),
-            Self::MemberExpression(e) => e.get_cube_refs(),
-        }
+        deps::collect_cube_refs(self)
     }
 
     /// True if the symbol is a transparent alias for another member, with
@@ -401,6 +381,43 @@ impl MemberSymbol {
         } else {
             Ok(())
         }
+    }
+}
+
+impl SymbolDeps for MemberSymbol {
+    fn visit_deps(&self, visitor: &mut dyn DepVisitor) -> ControlFlow<()> {
+        match self {
+            Self::Dimension(d) => d.as_ref().visit_deps(visitor),
+            Self::TimeDimension(d) => d.as_ref().visit_deps(visitor),
+            Self::Measure(m) => m.as_ref().visit_deps(visitor),
+            Self::MemberExpression(e) => e.as_ref().visit_deps(visitor),
+        }
+    }
+
+    fn visit_deps_mut(&mut self, visitor: &mut dyn DepVisitorMut) -> Result<(), CubeError> {
+        match self {
+            Self::Dimension(d) => {
+                let mut body = (**d).clone();
+                body.visit_deps_mut(visitor)?;
+                *d = Rc::new(body);
+            }
+            Self::TimeDimension(d) => {
+                let mut body = (**d).clone();
+                body.visit_deps_mut(visitor)?;
+                *d = Rc::new(body);
+            }
+            Self::Measure(m) => {
+                let mut body = (**m).clone();
+                body.visit_deps_mut(visitor)?;
+                *m = Rc::new(body);
+            }
+            Self::MemberExpression(e) => {
+                let mut body = (**e).clone();
+                body.visit_deps_mut(visitor)?;
+                *e = Rc::new(body);
+            }
+        }
+        Ok(())
     }
 }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 mod cube_symbol;
+pub mod deps;
 pub mod dimension_kinds;
 mod dimension_symbol;
 pub mod measure_kinds;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/time_dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/symbols/time_dimension_symbol.rs
@@ -1,9 +1,9 @@
 use super::common::CompiledMemberPath;
+use super::deps::{self, symbol_deps};
 use super::MemberSymbol;
 use crate::planner::query_tools::QueryTools;
 use crate::planner::state::State;
 use crate::planner::time_dimension::Granularity;
-use crate::planner::CubeRef;
 use crate::planner::{GranularityHelper, QueryDateTime, QueryDateTimeHelper};
 use chrono::Duration;
 use chrono_tz::Tz;
@@ -23,6 +23,18 @@ pub struct TimeDimensionSymbol {
     date_range: Option<(String, String)>,
     alias_suffix: String,
     alias_override: Option<String>,
+}
+
+symbol_deps! {
+    TimeDimensionSymbol {
+        granularity_obj: dep,
+        base_symbol: dep_transparent,
+        compiled_path: skip,
+        granularity: skip,
+        date_range: skip,
+        alias_suffix: skip,
+        alias_override: skip,
+    }
 }
 
 impl TimeDimensionSymbol {
@@ -165,13 +177,18 @@ impl TimeDimensionSymbol {
         self.base_symbol.owned_by_cube()
     }
 
+    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
+        deps::collect_deps(self)
+    }
+
     pub fn date_range_vec(&self) -> Option<Vec<String>> {
         self.date_range.clone().map(|(from, to)| vec![from, to])
     }
 
-    /// Like `get_dependencies`, but wraps any time-dimension dep in
-    /// a `TimeDimensionSymbol` carrying this symbol's granularity and
-    /// date range. Non-time-dimension deps pass through unchanged.
+    /// Dependencies of this symbol, with any time-dimension dep
+    /// wrapped in a `TimeDimensionSymbol` carrying this symbol's
+    /// granularity and date range. Non-time-dimension deps pass
+    /// through unchanged.
     pub fn get_dependencies_as_time_dimensions(&self) -> Vec<Rc<MemberSymbol>> {
         self.get_dependencies()
             .into_iter()
@@ -193,41 +210,6 @@ impl TimeDimensionSymbol {
                 _ => s.clone(),
             })
             .collect()
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Rc<MemberSymbol>, CubeError> {
-        let mut result = self.clone();
-        if let Some(granularity_obj) = &self.granularity_obj {
-            result.granularity_obj = Some(granularity_obj.apply_to_deps(f)?);
-        }
-        result.base_symbol = f(&self.base_symbol)?;
-        Ok(MemberSymbol::new_time_dimension(Rc::new(result)))
-    }
-
-    pub fn get_dependencies(&self) -> Vec<Rc<MemberSymbol>> {
-        let mut deps = vec![];
-        if let Some(granularity_obj) = &self.granularity_obj {
-            if let Some(calendar_sql) = granularity_obj.calendar_sql() {
-                calendar_sql.extract_symbol_deps(&mut deps);
-            }
-        }
-
-        deps.append(&mut self.base_symbol.get_dependencies());
-        deps
-    }
-
-    pub fn get_cube_refs(&self) -> Vec<CubeRef> {
-        let mut refs = vec![];
-        if let Some(granularity_obj) = &self.granularity_obj {
-            if let Some(calendar_sql) = granularity_obj.calendar_sql() {
-                calendar_sql.extract_cube_refs(&mut refs);
-            }
-        }
-        refs.append(&mut self.base_symbol.get_cube_refs());
-        refs
     }
 
     pub fn cube_name(&self) -> String {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/granularity.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/planner/time_dimension/granularity.rs
@@ -1,6 +1,7 @@
 use super::{GranularityHelper, QueryDateTime, SqlInterval};
 use crate::planner::sql_templates::PlanSqlTemplates;
-use crate::planner::{MemberSymbol, SqlCall};
+use crate::planner::symbols::deps::symbol_deps;
+use crate::planner::SqlCall;
 use chrono_tz::Tz;
 use cubenativeutils::CubeError;
 use std::rc::Rc;
@@ -15,6 +16,18 @@ pub struct Granularity {
     is_predefined_granularity: bool,
     is_natural_aligned: bool,
     calendar_sql: Option<Rc<SqlCall>>,
+}
+
+symbol_deps! {
+    Granularity {
+        calendar_sql: dep,
+        granularity: skip,
+        granularity_interval: skip,
+        granularity_offset: skip,
+        origin: skip,
+        is_predefined_granularity: skip,
+        is_natural_aligned: skip,
+    }
 }
 
 impl Granularity {
@@ -81,17 +94,6 @@ impl Granularity {
             is_natural_aligned,
             calendar_sql,
         })
-    }
-
-    pub fn apply_to_deps<F: Fn(&Rc<MemberSymbol>) -> Result<Rc<MemberSymbol>, CubeError>>(
-        &self,
-        f: &F,
-    ) -> Result<Self, CubeError> {
-        let mut result = self.clone();
-        if let Some(calendar_sql) = &self.calendar_sql {
-            result.calendar_sql = Some(calendar_sql.apply_recursive(f)?);
-        }
-        Ok(result)
     }
 
     pub fn is_natural_aligned(&self) -> bool {

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/integration_multi_stage.yaml
@@ -91,6 +91,40 @@ cubes:
                 - R3
                 - YTD
 
+          # Case-switch dimension over a regular string dimension: a filter
+          # on `status` statically prunes the branches.
+          - name: status_case_label
+            type: string
+            case:
+                switch: "{CUBE.status}"
+                when:
+                    - value: completed
+                      sql: "'done'"
+                    - value: pending
+                      sql: "'waiting'"
+                else:
+                    sql: "'other'"
+
+          # Calc group: an abstract enumeration with no backing column.
+          - name: group_mode
+            type: switch
+            values:
+                - by_status
+                - by_category
+
+          # Case-switch dimension driven by the calc group.
+          - name: group_mode_label
+            type: string
+            case:
+                switch: "{CUBE.group_mode}"
+                when:
+                    - value: by_status
+                      sql: "{CUBE.status}"
+                    - value: by_category
+                      sql: "{CUBE.category}"
+                else:
+                    sql: "{CUBE.status}"
+
           - name: customer_name
             type: string
             sql: "{customers.name}"
@@ -179,6 +213,44 @@ cubes:
             multi_stage: true
             add_group_by:
                 - orders.id
+
+          # `include` grain refs below carry case-switch / calc-group
+          # dimensions: the planner selects them inside the multi-stage CTE,
+          # so static filter pruning must reach them there.
+          - name: amount_by_status_case
+            type: number
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            add_group_by:
+                - orders.status_case_label
+
+          - name: amount_by_group_mode_label
+            type: number
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            add_group_by:
+                - orders.group_mode_label
+
+          - name: amount_by_group_mode
+            type: number
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            add_group_by:
+                - orders.group_mode
+
+          # Case pruning must follow the leaf's own filters: the `exclude`
+          # directive drops the status filter inside this measure's CTEs, so
+          # the case dimension from `include` must stay unpruned there.
+          - name: amount_by_status_case_unfiltered
+            type: sum
+            sql: "{CUBE.total_amount}"
+            multi_stage: true
+            grain:
+                include:
+                    - orders.status_case_label
+            filter:
+                exclude:
+                    - orders.status
 
           - name: amount_by_category
             type: number

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/include_switch.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/include_switch.rs
@@ -1,0 +1,118 @@
+//! Multi-stage `include` grain refs carrying switch / case-switch
+//! dimensions. The planner selects these inside the multi-stage CTEs,
+//! and case pruning / calc-group value resolution must follow each
+//! leaf's own filters — not the outer query's.
+
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use indoc::indoc;
+
+fn create_context() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/integration_multi_stage.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+const SEED: &str = "integration_multi_stage_tables.sql";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_include_case_switch_dim() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_status_case
+        dimensions:
+          - orders.status_case_label
+        filters:
+          - member: orders.status
+            operator: equals
+            values:
+              - completed
+        order:
+          - id: orders.status_case_label
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert!(
+        !sql.contains("CASE"),
+        "a filter restricting the switch to one value prunes the case everywhere, including the include copy inside the CTE"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_include_case_switch_dim_with_filter_excluded_from_leaf() {
+    let ctx = create_context();
+
+    // The `exclude` filter directive drops the status filter inside the
+    // measure's CTEs, so the include copy of the case dimension must stay
+    // unpruned there: every row keeps its real label.
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_status_case_unfiltered
+        filters:
+          - member: orders.status
+            operator: equals
+            values:
+              - completed
+    "#};
+
+    let sql = ctx.build_sql(query).unwrap();
+    assert!(
+        sql.contains("CASE"),
+        "the leaf runs without the status filter, so its case dimension must keep all branches"
+    );
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_include_case_over_calc_group() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_group_mode_label
+        dimensions:
+          - orders.group_mode_label
+        filters:
+          - member: orders.group_mode
+            operator: equals
+            values:
+              - by_status
+        order:
+          - id: orders.group_mode_label
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_include_calc_group_dim() {
+    let ctx = create_context();
+
+    let query = indoc! {r#"
+        measures:
+          - orders.amount_by_group_mode
+        filters:
+          - member: orders.group_mode
+            operator: equals
+            values:
+              - by_status
+    "#};
+
+    ctx.build_sql(query).unwrap();
+
+    if let Some(result) = ctx.try_execute_pg(query, SEED).await {
+        insta::assert_snapshot!(result);
+    }
+}

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/mod.rs
@@ -8,6 +8,7 @@ mod filter_directive;
 mod filters;
 mod granularities;
 mod group_by;
+mod include_switch;
 mod joins;
 mod multi_fact;
 mod multiple_measures;

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_calc_group_dim.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_calc_group_dim.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/include_switch.rs
+assertion_line: 116
+expression: result
+---
+orders__amount_by_group_mode
+----------------------------
+2250.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_case_over_calc_group.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_case_over_calc_group.snap
@@ -1,0 +1,10 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/include_switch.rs
+assertion_line: 95
+expression: result
+---
+orders__group_mode_label | orders__amount_by_group_mode_label
+-------------------------+-----------------------------------
+cancelled                | 200.00                            
+completed                | 1400.00                           
+pending                  | 650.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_case_switch_dim.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_case_switch_dim.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/include_switch.rs
+assertion_line: 42
+expression: result
+---
+orders__status_case_label | orders__amount_by_status_case
+--------------------------+------------------------------
+done                      | 1400.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_case_switch_dim_with_filter_excluded_from_leaf.snap
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/snapshots/cubesqlplanner__tests__integration__multi_stage__include_switch__include_case_switch_dim_with_filter_excluded_from_leaf.snap
@@ -1,0 +1,8 @@
+---
+source: cubesqlplanner/cubesqlplanner/src/tests/integration/multi_stage/include_switch.rs
+assertion_line: 70
+expression: result
+---
+orders__amount_by_status_case_unfiltered
+----------------------------------------
+2250.00

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/mod.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod no_query_tools_leak;
 mod positional_params;
 mod string_measures;
 mod subquery_dimensions;
+mod time_dimension_symbol;
 mod utils;
 mod view_default_filters;
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/time_dimension_symbol.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/tests/time_dimension_symbol.rs
@@ -1,0 +1,164 @@
+//! Tests for the TimeDimensionSymbol dependency contract.
+//!
+//! A time dimension is a granularity view of its base dimension, not a
+//! consumer of it: the read side looks through the base (emits the
+//! base's dependencies, never the base itself), while the transform
+//! side receives the base as a replaceable slot.
+
+use crate::planner::MemberSymbol;
+use crate::test_fixtures::cube_bridge::MockSchema;
+use crate::test_fixtures::test_utils::TestContext;
+use itertools::Itertools;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn ctx() -> TestContext {
+    let schema = MockSchema::from_yaml_file("common/visitors.yaml");
+    TestContext::new(schema).unwrap()
+}
+
+#[test]
+fn deps_of_plain_base_are_empty() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.created_at", Some("day"))
+        .unwrap();
+
+    assert_eq!(td.full_name(), "visitors.created_at_day");
+    assert!(
+        td.get_dependencies().is_empty(),
+        "the base dimension is not a dependency of its time dimension"
+    );
+
+    assert!(
+        td.get_cube_refs().is_empty(),
+        "a bare-column base carries no cube refs, so neither does its time dimension"
+    );
+}
+
+#[test]
+fn cube_refs_look_through_base() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.visitor_id", Some("day"))
+        .unwrap();
+
+    let cube_refs = td.get_cube_refs();
+    assert_eq!(cube_refs.len(), 1);
+    assert_eq!(cube_refs[0].cube_name(), "visitors");
+}
+
+#[test]
+fn deps_look_through_base() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.minVisitorCheckinDate", Some("day"))
+        .unwrap();
+
+    let dep_names = td
+        .get_dependencies()
+        .iter()
+        .map(|d| d.full_name())
+        .collect_vec();
+    assert_eq!(
+        dep_names,
+        vec!["visitor_checkins.minDate".to_string()],
+        "deps are the base's dependencies; the base itself is not emitted"
+    );
+}
+
+#[test]
+fn deps_as_time_dimensions_wrap_time_deps() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.minVisitorCheckinDate", Some("day"))
+        .unwrap();
+
+    let wrapped = td
+        .as_time_dimension()
+        .unwrap()
+        .get_dependencies_as_time_dimensions();
+    assert_eq!(wrapped.len(), 1);
+    let dep = wrapped[0].as_time_dimension().unwrap();
+    assert_eq!(wrapped[0].full_name(), "visitor_checkins.minDate_day");
+    assert_eq!(dep.granularity(), &Some("day".to_string()));
+    assert_eq!(dep.base_symbol().full_name(), "visitor_checkins.minDate");
+}
+
+#[test]
+fn transform_visits_base_node_once() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.minVisitorCheckinDate", Some("day"))
+        .unwrap();
+
+    let visited = RefCell::new(Vec::new());
+    td.apply_recursive(&|node| {
+        visited.borrow_mut().push(node.full_name());
+        Ok(node.clone())
+    })
+    .unwrap();
+
+    let visited = visited.into_inner();
+    assert_eq!(
+        visited,
+        vec![
+            "visitors.minVisitorCheckinDate_day".to_string(),
+            "visitors.minVisitorCheckinDate".to_string(),
+            "visitor_checkins.minDate".to_string(),
+        ],
+        "the transform sees the base as a node even though deps look through it"
+    );
+}
+
+#[test]
+fn transform_replaces_base_slot_and_keeps_wrapper_identity() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.minVisitorCheckinDate", Some("day"))
+        .unwrap();
+    let replacement = ctx.create_dimension("visitors.created_at").unwrap();
+
+    let result = td
+        .apply_recursive(&|node: &Rc<MemberSymbol>| {
+            if node.full_name() == "visitors.minVisitorCheckinDate" {
+                Ok(replacement.clone())
+            } else {
+                Ok(node.clone())
+            }
+        })
+        .unwrap();
+
+    let result_td = result.as_time_dimension().unwrap();
+    assert_eq!(result_td.base_symbol().full_name(), "visitors.created_at");
+    assert_eq!(
+        result.full_name(),
+        "visitors.minVisitorCheckinDate_day",
+        "replacing the base redirects rendering; the wrapper keeps its own identity"
+    );
+    assert!(result.get_dependencies().is_empty());
+}
+
+#[test]
+fn read_and_transform_agree_on_slots() {
+    let ctx = ctx();
+    let td = ctx
+        .create_time_dimension("visitors.minVisitorCheckinDate", Some("day"))
+        .unwrap();
+
+    let rebuilt = td.apply_recursive(&|node| Ok(node.clone())).unwrap();
+
+    assert_eq!(rebuilt.full_name(), td.full_name());
+    assert_eq!(
+        rebuilt
+            .get_dependencies()
+            .iter()
+            .map(|d| d.full_name())
+            .collect_vec(),
+        td.get_dependencies()
+            .iter()
+            .map(|d| d.full_name())
+            .collect_vec(),
+        "an identity transform preserves the dependency list and its order"
+    );
+}


### PR DESCRIPTION
## Summary

Unifies how `MemberSymbol` dependencies are enumerated and transformed in Tesseract. Previously every symbol node hand-implemented up to six parallel traversals (`get_dependencies`, `extract_symbol_deps`, `get_cube_refs`, `extract_cube_refs`, `apply_to_deps`, `SqlCall::apply_recursive`) that each enumerated the same child slots independently — and had already drifted apart. Now each node declares its dependency slots exactly once, and both the read side and the rebuild side are derived from that single declaration, so they can never disagree.

## Changes

- New `planner/symbols/deps.rs`: `SymbolDeps` trait (`visit_deps` / `visit_deps_mut`), `DepVisitor` / `DepVisitorMut` sinks, and generic algorithms (`collect_deps`, `collect_cube_refs`, `apply_recursive`, `apply_to_deps`) written once.
- `symbol_deps!` macro for struct nodes: one field list with modes `dep` / `dep_symbol` / `dep_transparent` / `skip`, generating both visit methods. Full destructuring without `..` makes adding a struct field a compile error until the field is classified. Enum nodes implement the trait with exhaustive `match`es.
- All 18 nodes converted; ~90 hand-written traversal bodies deleted. Old public signatures remain as thin wrappers, so call sites are untouched.
- A dependency is defined as a symbol / cube ref whose rendered SQL enters the node's SQL. Multi-stage `grain` / `filter` member lists are annotations matched by `full_name`, not dependencies — `apply_to_deps` no longer rewrites them (`MultiStageProperties::apply_to_deps` deleted).
- `TimeDimensionSymbol::base_symbol` is a `dep_transparent` slot: reads emit the base's dependencies (never the base itself), transforms receive the slot — codifying the semantics every collector already assumed.
- Transform semantics unified: `f` is applied to every node exactly once, recursion is handled by the algorithm.
- Slot order is a contract (declaration order = emission order); reference symbols resolve to their first dependency.
- `iter_sql_calls`/`validate`, `owned_by_cube` and `DebugSql` intentionally stay bespoke.
- New tests pin the TimeDimension dependency contract (look-through reads, base as a transform slot, wrapper identity preservation, read/transform slot agreement).

## Testing

- `cargo test -p cubesqlplanner`: 1083 passed.
- Full schema-compiler postgres integration suite under `CUBEJS_TESSERACT_SQL_PLANNER=true`: 43/43 suites, 496 tests passed.
- `cargo check --workspace` clean; slot order and composition verified against the removed code node-by-node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)