### PR TITLE
fix(cubestore): keep the projection schema when rewriting a rolling window

### DIFF
--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -5770,6 +5770,37 @@ LIMIT
     Ok(())
 }
 
+/// Fails unless the physical plan for `query` mentions `expected`. Result assertions alone cannot
+/// tell an optimized plan from the fallback it degrades to, so shapes whose whole point is that a
+/// rewrite fires need to say so explicitly.
+async fn assert_plan_contains(
+    service: &Box<dyn SqlClient>,
+    query: &str,
+    expected: &str,
+) -> Result<(), CubeError> {
+    let res = service
+        .exec_query(&format!("EXPLAIN ANALYZE {}", query))
+        .await?;
+    let plans = res
+        .get_rows()
+        .iter()
+        .flat_map(|r| r.values().iter())
+        .filter_map(|v| match v {
+            TableValue::String(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if !plans.iter().any(|p| p.contains(expected)) {
+        return Err(CubeError::internal(format!(
+            "`{}` not found in the plan for {}:\n{}",
+            expected,
+            query,
+            plans.join("\n")
+        )));
+    }
+    Ok(())
+}
+
 async fn rolling_window_unused_partition_by(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
     service.exec_query("CREATE SCHEMA s").await?;
     service
@@ -5819,10 +5850,11 @@ ORDER BY 1 ASC, 2 ASC"
     ]);
 
     // A calc-group style constant: the source column is not nullable, but the empty bucket at day 7
-    // still has to report a null key for it.
-    let r = service
-        .exec_query(&query("'R12'", "`b`.`win` `win`,", "`q`.`day`, `q`.`num`"))
-        .await?;
+    // still has to report a null key for it. The rewrite has to restore the projection's output on
+    // top of the rolling node here, since `win` is grouped by but not selected.
+    let pruned = query("'R12'", "`b`.`win` `win`,", "`q`.`day`, `q`.`num`");
+    assert_plan_contains(&service, &pruned, "RollingWindowAgg").await?;
+    let r = service.exec_query(&pruned).await?;
     assert_eq!(to_rows(&r), without_partition);
 
     // Same, but the projection omits the partition-by column outright instead of leaving it to
@@ -5834,13 +5866,13 @@ ORDER BY 1 ASC, 2 ASC"
 
     // Several partitions, all of them asked for: the rewrite outputs exactly what the projection
     // did, so nothing has to be restored on top of it.
-    let r = service
-        .exec_query(&query(
-            "name",
-            "`b`.`win` `win`,",
-            "`q`.`day`, `q`.`win`, `q`.`num`",
-        ))
-        .await?;
+    let selected = query(
+        "name",
+        "`b`.`win` `win`,",
+        "`q`.`day`, `q`.`win`, `q`.`num`",
+    );
+    assert_plan_contains(&service, &selected, "RollingWindowAgg").await?;
+    let r = service.exec_query(&selected).await?;
     assert_eq!(
         to_rows(&r),
         rows(&[

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -218,6 +218,10 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
             "rolling_window_unused_partition_by",
             rolling_window_unused_partition_by,
         ),
+        t(
+            "rolling_window_two_aggregates",
+            rolling_window_two_aggregates,
+        ),
         t("decimal_index", decimal_index),
         t("decimal_order", decimal_order),
         t("float_index", float_index),
@@ -5770,18 +5774,11 @@ LIMIT
     Ok(())
 }
 
-/// Fails unless the physical plan for `query` mentions `expected`. Result assertions alone cannot
-/// tell an optimized plan from the fallback it degrades to, so shapes whose whole point is that a
-/// rewrite fires need to say so explicitly.
-async fn assert_plan_contains(
-    service: &Box<dyn SqlClient>,
-    query: &str,
-    expected: &str,
-) -> Result<(), CubeError> {
+async fn plan_strings(service: &Box<dyn SqlClient>, query: &str) -> Result<String, CubeError> {
     let res = service
         .exec_query(&format!("EXPLAIN ANALYZE {}", query))
         .await?;
-    let plans = res
+    Ok(res
         .get_rows()
         .iter()
         .flat_map(|r| r.values().iter())
@@ -5789,13 +5786,37 @@ async fn assert_plan_contains(
             TableValue::String(s) => Some(s.as_str()),
             _ => None,
         })
-        .collect::<Vec<_>>();
-    if !plans.iter().any(|p| p.contains(expected)) {
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+/// Result assertions alone cannot tell an optimized plan from the fallback it degrades to, so
+/// shapes whose whole point is whether a rewrite fires need to say so about the plan itself.
+async fn assert_plan_contains(
+    service: &Box<dyn SqlClient>,
+    query: &str,
+    expected: &str,
+) -> Result<(), CubeError> {
+    let plan = plan_strings(service, query).await?;
+    if !plan.contains(expected) {
         return Err(CubeError::internal(format!(
             "`{}` not found in the plan for {}:\n{}",
-            expected,
-            query,
-            plans.join("\n")
+            expected, query, plan
+        )));
+    }
+    Ok(())
+}
+
+async fn assert_plan_omits(
+    service: &Box<dyn SqlClient>,
+    query: &str,
+    unexpected: &str,
+) -> Result<(), CubeError> {
+    let plan = plan_strings(service, query).await?;
+    if plan.contains(unexpected) {
+        return Err(CubeError::internal(format!(
+            "`{}` unexpectedly present in the plan for {}:\n{}",
+            unexpected, query, plan
         )));
     }
     Ok(())
@@ -5912,6 +5933,42 @@ ORDER BY 1 ASC, 2 ASC"
         ])
     );
 
+    Ok(())
+}
+
+async fn rolling_window_two_aggregates(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA s").await?;
+    service
+        .exec_query("CREATE TABLE s.Data(day int, n int, m int)")
+        .await?;
+    service
+        .exec_query("INSERT INTO s.Data(day, n, m) VALUES (1, 10, 100), (3, 3, 300), (5, 5, 500)")
+        .await?;
+
+    // The rolling executor advances one group counter across all of its aggregates while each of
+    // them accumulates into its own group space, so with two of them every aggregate past the
+    // first reads slots the others left empty and answers null. Until that is fixed the rewrite
+    // declines, and the query runs as a plain aggregate over the range join.
+    let query = "SELECT `q`.`day`, `q`.`sn`, `q`.`sm` FROM (
+  SELECT `s0`.`date_from` `day`, sum(`b`.`n`) `sn`, sum(`b`.`m`) `sm`
+  FROM (SELECT date_from `date_from`, date_from + 1 `date_to`
+        FROM (select unnest(generate_series(1, 5, 1))) AS series(date_from)) `s0`
+  LEFT JOIN (SELECT day `d`, n `n`, m `m` FROM s.Data) `b`
+    ON `b`.`d` > `s0`.`date_to` - 1 AND `b`.`d` <= `s0`.`date_to`
+  GROUP BY 1) `q`
+ORDER BY 1 ASC";
+    assert_plan_omits(&service, query, "RollingWindowAgg").await?;
+    let r = service.exec_query(query).await?;
+    assert_eq!(
+        to_rows(&r),
+        rows(&[
+            (1i64, None, None),
+            (2, Some(3i64), Some(300i64)),
+            (3, None, None),
+            (4, Some(5), Some(500)),
+            (5, None, None),
+        ])
+    );
     Ok(())
 }
 

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -214,6 +214,10 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
         t("rolling_window_offsets", rolling_window_offsets),
         t("rolling_window_filtered", rolling_window_filtered),
         t("rolling_window_no_aggregates", rolling_window_no_aggregates),
+        t(
+            "rolling_window_unused_partition_by",
+            rolling_window_unused_partition_by,
+        ),
         t("decimal_index", decimal_index),
         t("decimal_order", decimal_order),
         t("float_index", float_index),
@@ -5763,6 +5767,119 @@ LIMIT
         )
         .await?;
     assert_eq!(to_rows(&r), rows(&[1i64, 2, 3, 4, 5]));
+    Ok(())
+}
+
+async fn rolling_window_unused_partition_by(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA s").await?;
+    service
+        .exec_query("CREATE TABLE s.Data(day int, name text, n int)")
+        .await?;
+    service
+        .exec_query(
+            "INSERT INTO s.Data(day, name, n) VALUES (1, 'john', 10), \
+                                                     (1, 'sara', 7), \
+                                                     (3, 'sara', 3), \
+                                                     (3, 'john', 9), \
+                                                     (3, 'john', 11), \
+                                                     (5, 'timmy', 5)",
+        )
+        .await?;
+
+    // A rolling window over a series of 7 points, grouped by a partition-by column. Bucket `d`
+    // covers days `d - 1` and `d`, so day 7 has no rows at all and every partition key there is
+    // null. `partition_expr` is how the source produces that column, `inner_partition` is how the
+    // projection above the aggregate exposes it (empty when it only groups by it), and `outer` is
+    // what the consumer selects.
+    let query = |partition_expr: &str, inner_partition: &str, outer: &str| {
+        format!(
+            "SELECT {outer} FROM (
+  SELECT `s0`.`date_from` `day`, {inner_partition} sum(`b`.`num`) `num`
+  FROM (SELECT date_from `date_from`, date_from + 1 `date_to`
+        FROM (select unnest(generate_series(1, 7, 1))) AS series(date_from)) `s0`
+  LEFT JOIN (SELECT day `d`, {partition_expr} `win`, SUM(n) `num` FROM s.Data GROUP BY 1, 2) `b`
+    ON `b`.`d` > `s0`.`date_to` - 1 AND `b`.`d` <= `s0`.`date_to`
+  GROUP BY 1, `b`.`win`) `q`
+ORDER BY 1 ASC, 2 ASC"
+        )
+    };
+
+    // The rolling window always emits dimension + partition_by + rolling aggregates, so a GROUP BY
+    // column the projection it replaces did not select reappears in its output. The rewrite must
+    // not widen the schema of the node it replaces, or every ancestor keeps resolving its columns
+    // against the old one and planning fails with `No field named ...`.
+    let without_partition = rows(&[
+        (1i64, Some(17i64)),
+        (2, Some(17)),
+        (3, Some(23)),
+        (4, Some(23)),
+        (5, Some(5)),
+        (6, Some(5)),
+        (7, None),
+    ]);
+
+    // A calc-group style constant: the source column is not nullable, but the empty bucket at day 7
+    // still has to report a null key for it.
+    let r = service
+        .exec_query(&query("'R12'", "`b`.`win` `win`,", "`q`.`day`, `q`.`num`"))
+        .await?;
+    assert_eq!(to_rows(&r), without_partition);
+
+    // Same, but the projection omits the partition-by column outright instead of leaving it to
+    // projection pruning.
+    let r = service
+        .exec_query(&query("'R12'", "", "`q`.`day`, `q`.`num`"))
+        .await?;
+    assert_eq!(to_rows(&r), without_partition);
+
+    // Several partitions, all of them asked for: the rewrite outputs exactly what the projection
+    // did, so nothing has to be restored on top of it.
+    let r = service
+        .exec_query(&query(
+            "name",
+            "`b`.`win` `win`,",
+            "`q`.`day`, `q`.`win`, `q`.`num`",
+        ))
+        .await?;
+    assert_eq!(
+        to_rows(&r),
+        rows(&[
+            (1i64, Some("john"), Some(10i64)),
+            (1, Some("sara"), Some(7)),
+            (2, Some("john"), Some(10)),
+            (2, Some("sara"), Some(7)),
+            (3, Some("john"), Some(20)),
+            (3, Some("sara"), Some(3)),
+            (4, Some("john"), Some(20)),
+            (4, Some("sara"), Some(3)),
+            (5, Some("timmy"), Some(5)),
+            (6, Some("timmy"), Some(5)),
+            (7, None, None),
+        ])
+    );
+
+    // Several partitions, none of them asked for: the per-partition rows survive, which pins that
+    // the restored projection picks the aggregate and not one of the partition keys.
+    let r = service
+        .exec_query(&query("name", "", "`q`.`day`, `q`.`num`"))
+        .await?;
+    assert_eq!(
+        to_rows(&r),
+        rows(&[
+            (1i64, Some(7i64)),
+            (1, Some(10)),
+            (2, Some(7)),
+            (2, Some(10)),
+            (3, Some(3)),
+            (3, Some(20)),
+            (4, Some(3)),
+            (4, Some(20)),
+            (5, Some(5)),
+            (6, Some(5)),
+            (7, None),
+        ])
+    );
+
     Ok(())
 }
 

--- a/rust/cubestore/cubestore-sql-tests/tests/migration.rs
+++ b/rust/cubestore/cubestore-sql-tests/tests/migration.rs
@@ -33,6 +33,8 @@ fn main() {
         "--skip".to_string(),
         "rolling_window_unused_partition_by".to_string(),
         "--skip".to_string(),
+        "rolling_window_two_aggregates".to_string(),
+        "--skip".to_string(),
         "cross_join_empty_sort_on".to_string(),
     ];
     run_sql_tests("migration", extra_args, move |test_name, test_fn| {

--- a/rust/cubestore/cubestore-sql-tests/tests/migration.rs
+++ b/rust/cubestore/cubestore-sql-tests/tests/migration.rs
@@ -31,6 +31,8 @@ fn main() {
         "--skip".to_string(),
         "rolling_window_no_aggregates".to_string(),
         "--skip".to_string(),
+        "rolling_window_unused_partition_by".to_string(),
+        "--skip".to_string(),
         "cross_join_empty_sort_on".to_string(),
     ];
     run_sql_tests("migration", extra_args, move |test_name, test_fn| {

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
@@ -2,7 +2,9 @@ use crate::queryplanner::rolling::RollingWindowAggregate;
 use datafusion::arrow::array::Array;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::tree_node::Transformed;
-use datafusion::common::{Column, DataFusionError, JoinType, ScalarValue, TableReference};
+use datafusion::common::{
+    Column, DFSchema, DataFusionError, JoinType, ScalarValue, TableReference,
+};
 use datafusion::functions::datetime::date_part::DatePartFunc;
 use datafusion::functions::datetime::date_trunc::DateTruncFunc;
 use datafusion::logical_expr::expr::{
@@ -90,26 +92,37 @@ impl RollingOptimizerRule {
                     from,
                     to,
                     every,
-                    rolling_aggs_alias: expr
-                        .iter()
-                        .flat_map(|e| match e {
-                            Expr::Alias(Alias {
-                                expr,
-                                relation: _,
-                                name,
-                            }) => match expr.as_ref() {
-                                Expr::Column(col)
-                                    if &col.name != &from_col.name
-                                        && &col.name != &to_col.name
-                                        && !partition_by.iter().any(|p| &p.name == &col.name) =>
-                                {
-                                    Some(name.clone())
-                                }
+                    rolling_aggs_alias: {
+                        let aliases = expr
+                            .iter()
+                            .flat_map(|e| match e {
+                                Expr::Alias(Alias {
+                                    expr,
+                                    relation: _,
+                                    name,
+                                }) => match expr.as_ref() {
+                                    Expr::Column(col)
+                                        if &col.name != &from_col.name
+                                            && &col.name != &to_col.name
+                                            && !partition_by
+                                                .iter()
+                                                .any(|p| &p.name == &col.name) =>
+                                    {
+                                        Some(name.clone())
+                                    }
+                                    _ => None,
+                                },
                                 _ => None,
-                            },
-                            _ => None,
-                        })
-                        .collect(),
+                            })
+                            .collect::<Vec<_>>();
+                        // The schema pairs aggregates with these names positionally and a short
+                        // list silently drops the trailing aggregates from the output. Leave such
+                        // a projection alone instead of building a node that cannot describe it.
+                        if aliases.len() < rolling_aggs.len() {
+                            return None;
+                        }
+                        aliases
+                    },
                     partition_by,
                     rolling_aggs,
                     group_by_dimension,
@@ -165,6 +178,13 @@ impl RollingOptimizerRule {
         }
     }
 
+    fn output_columns(schema: &DFSchema) -> Vec<Column> {
+        schema
+            .iter()
+            .map(|(relation, field)| Column::new(relation.cloned(), field.name()))
+            .collect()
+    }
+
     pub fn extract_rolling_window_aggregate(
         node: &LogicalPlan,
     ) -> Option<RollingWindowAggregateExtractorResult> {
@@ -178,19 +198,35 @@ impl RollingOptimizerRule {
                 let rolling_aggs = aggr_expr
                     .iter()
                     .map(|e| match e {
-                        Expr::AggregateFunction(AggregateFunction {
-                            func,
-                            params: AggregateFunctionParams { args, .. },
-                        }) => Some(Expr::AggregateFunction(AggregateFunction {
-                            func: func.clone(),
-                            params: AggregateFunctionParams {
-                                args: args.clone(),
-                                distinct: false,
-                                filter: None,
-                                order_by: None,
-                                null_treatment: None,
-                            },
-                        })),
+                        Expr::AggregateFunction(AggregateFunction { func, params }) => {
+                            let AggregateFunctionParams {
+                                args,
+                                distinct,
+                                filter,
+                                order_by,
+                                null_treatment,
+                            } = params;
+                            // The rolling executor evaluates the aggregate over its own window and
+                            // honours none of these, so rebuilding without them would silently
+                            // answer a different question.
+                            if *distinct
+                                || filter.is_some()
+                                || order_by.is_some()
+                                || null_treatment.is_some()
+                            {
+                                return None;
+                            }
+                            Some(Expr::AggregateFunction(AggregateFunction {
+                                func: func.clone(),
+                                params: AggregateFunctionParams {
+                                    args: args.clone(),
+                                    distinct: false,
+                                    filter: None,
+                                    order_by: None,
+                                    null_treatment: None,
+                                },
+                            }))
+                        }
                         _ => None,
                     })
                     .collect::<Option<Vec<_>>>()?;
@@ -840,16 +876,27 @@ impl OptimizerRule for RollingOptimizerRule {
         _config: &dyn OptimizerConfig,
     ) -> datafusion::common::Result<Transformed<LogicalPlan>, DataFusionError> {
         if let Some(rolling) = Self::extract_rolling_window_projection(&plan) {
+            let projection_output = Self::output_columns(plan.schema());
+            let schema = match RollingWindowAggregate::schema_from(
+                &rolling.input,
+                &rolling.dimension,
+                &rolling.partition_by,
+                &rolling.rolling_aggs,
+                &rolling.dimension_alias,
+                &rolling.rolling_aggs_alias,
+                &rolling.from,
+            ) {
+                Ok(schema) => schema,
+                Err(e) => {
+                    // The rolling node cannot describe its own output for this shape (colliding
+                    // aliases, say). Run the query as a plain aggregate/range-join rather than
+                    // failing to plan it.
+                    log::debug!("Not rewriting a rolling window, no schema for it: {}", e);
+                    return Ok(Transformed::no(plan));
+                }
+            };
             let rolling_window = RollingWindowAggregate {
-                schema: RollingWindowAggregate::schema_from(
-                    &rolling.input,
-                    &rolling.dimension,
-                    &rolling.partition_by,
-                    &rolling.rolling_aggs,
-                    &rolling.dimension_alias,
-                    &rolling.rolling_aggs_alias,
-                    &rolling.from,
-                )?,
+                schema,
                 input: rolling.input,
                 dimension: rolling.dimension,
                 dimension_alias: rolling.dimension_alias,
@@ -865,9 +912,39 @@ impl OptimizerRule for RollingOptimizerRule {
                 upper_bound: rolling.upper_bound,
                 offset_to_end: rolling.offset_to_end,
             };
-            Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+            let rolling_output = Self::output_columns(&rolling_window.schema);
+            let rolling_plan = LogicalPlan::Extension(Extension {
                 node: Arc::new(rolling_window),
-            })))
+            });
+
+            if rolling_output == projection_output {
+                return Ok(Transformed::yes(rolling_plan));
+            }
+
+            // The rolling node always emits dimension + partition_by + rolling aggregates, so a
+            // GROUP BY column the replaced projection did not select reappears in the output.
+            // A rewrite must not change the schema of the node it replaces: ancestors keep
+            // resolving their columns by position against the old one. Restore the original
+            // output with a projection on top, and leave the plan alone when it cannot be
+            // expressed from the rolling node's output.
+            let rolling_schema = rolling_plan.schema();
+            if let Some(missing) = projection_output
+                .iter()
+                .find(|c| rolling_schema.maybe_index_of_column(c).is_none())
+            {
+                log::debug!(
+                    "Not rewriting a rolling window, it does not output {}",
+                    missing
+                );
+                return Ok(Transformed::no(plan));
+            }
+            let exprs = projection_output
+                .into_iter()
+                .map(Expr::Column)
+                .collect_vec();
+            Ok(Transformed::yes(LogicalPlan::Projection(
+                Projection::try_new(exprs, Arc::new(rolling_plan))?,
+            )))
         } else {
             Ok(Transformed::no(plan))
         }

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
@@ -1013,3 +1013,217 @@ pub struct RollingWindowSeriesProjectionResult {
     pub from_col: Column,
     pub to_col: Column,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::Field;
+    use datafusion::common::DFSchema;
+    use datafusion::functions_aggregate::sum::sum_udaf;
+    use datafusion::logical_expr::expr::AggregateFunctionParams;
+    use datafusion::logical_expr::{build_join_schema, col, lit, EmptyRelation, JoinConstraint};
+    use datafusion::optimizer::OptimizerContext;
+    use std::collections::HashMap;
+
+    /// A stand-in for the rolling source: only its schema matters to the rule.
+    fn source() -> LogicalPlan {
+        let schema = DFSchema::new_with_metadata(
+            ["d", "win", "n"]
+                .iter()
+                .map(|name| {
+                    (
+                        Some(TableReference::bare("rs")),
+                        Arc::new(Field::new(*name, DataType::Int64, true)),
+                    )
+                })
+                .collect(),
+            HashMap::new(),
+        )
+        .unwrap();
+        LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(schema),
+        })
+    }
+
+    /// `UNION ALL` of literal `date_from`/`date_to` pairs, the shape the series extractor accepts.
+    fn series() -> LogicalPlan {
+        let point = |from: i64| {
+            let exprs = vec![lit(from).alias("date_from"), lit(from + 1).alias("date_to")];
+            Arc::new(LogicalPlan::Projection(
+                Projection::try_new(
+                    exprs,
+                    Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
+                        produce_one_row: true,
+                        schema: Arc::new(DFSchema::empty()),
+                    })),
+                )
+                .unwrap(),
+            ))
+        };
+        let inputs = vec![point(1), point(2)];
+        let schema = Arc::clone(inputs[0].schema());
+        let union = LogicalPlan::Union(Union { inputs, schema });
+        LogicalPlan::SubqueryAlias(
+            SubqueryAlias::try_new(Arc::new(union), TableReference::bare("s0")).unwrap(),
+        )
+    }
+
+    fn sum_of(column: &str, distinct: bool, filter: Option<Expr>) -> Expr {
+        Expr::AggregateFunction(AggregateFunction {
+            func: sum_udaf(),
+            params: AggregateFunctionParams {
+                args: vec![col(Column::new(Some(TableReference::bare("rs")), column))],
+                distinct,
+                filter: filter.map(Box::new),
+                order_by: None,
+                null_treatment: None,
+            },
+        })
+    }
+
+    /// `Projection(projection) -> Aggregate(group_by, [agg]) -> series LEFT JOIN source`, the shape
+    /// `RollingOptimizerRule` is meant to rewrite.
+    fn rolling_plan(agg: Expr, group_by: Vec<Expr>, projection: Vec<Expr>) -> LogicalPlan {
+        let (left, right) = (series(), source());
+        let join_schema =
+            build_join_schema(left.schema(), right.schema(), &JoinType::Left).unwrap();
+        let dim = col(Column::new(Some(TableReference::bare("rs")), "d"));
+        let date_to = col(Column::new(Some(TableReference::bare("s0")), "date_to"));
+        let join = LogicalPlan::Join(datafusion::logical_expr::Join {
+            left: Arc::new(left),
+            right: Arc::new(right),
+            on: vec![],
+            filter: Some(
+                dim.clone()
+                    .gt(date_to.clone() - lit(1))
+                    .and(dim.lt_eq(date_to)),
+            ),
+            join_type: JoinType::Left,
+            join_constraint: JoinConstraint::On,
+            schema: Arc::new(join_schema),
+            null_equals_null: false,
+        });
+        let aggregate =
+            Aggregate::try_new(Arc::new(join), group_by, vec![agg]).map(LogicalPlan::Aggregate);
+        LogicalPlan::Projection(
+            Projection::try_new(projection, Arc::new(aggregate.unwrap())).unwrap(),
+        )
+    }
+
+    /// The column an aggregate is read back as, i.e. the name the aggregate node gives its output.
+    /// Hardcoding it makes the "declines" tests pass whether or not the rule really declines.
+    fn agg_col(agg: &Expr) -> Expr {
+        col(agg.schema_name().to_string())
+    }
+
+    fn date_from() -> Expr {
+        col(Column::new(Some(TableReference::bare("s0")), "date_from"))
+    }
+
+    fn win() -> Expr {
+        col(Column::new(Some(TableReference::bare("rs")), "win"))
+    }
+
+    fn rewrite(plan: LogicalPlan) -> Transformed<LogicalPlan> {
+        RollingOptimizerRule {}
+            .rewrite(plan, &OptimizerContext::new())
+            .unwrap()
+    }
+
+    fn is_rolling(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::Extension(e) if e.node.name() == "RollingWindowAggregate")
+    }
+
+    /// Whatever the rule does, the node it produces has to answer to the same column names as the
+    /// projection it replaced -- ancestors keep resolving against their own cached schema.
+    fn assert_output_preserved(before: &LogicalPlan, after: &LogicalPlan) {
+        let names = |plan: &LogicalPlan| {
+            plan.schema()
+                .iter()
+                .map(|(q, f)| format!("{:?}.{}", q.map(|q| q.to_string()), f.name()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(before), names(after));
+    }
+
+    #[test]
+    fn rewrites_when_the_projection_keeps_every_group_by_column() {
+        let agg = sum_of("n", false, None);
+        let plan = rolling_plan(
+            agg.clone(),
+            vec![date_from(), win()],
+            vec![date_from().alias("mon"), win(), agg_col(&agg).alias("num")],
+        );
+        let rewritten = rewrite(plan.clone());
+        assert!(rewritten.transformed);
+        assert!(
+            is_rolling(&rewritten.data),
+            "expected a bare rolling node, got {}",
+            rewritten.data.display_indent()
+        );
+        assert_output_preserved(&plan, &rewritten.data);
+    }
+
+    #[test]
+    fn restores_the_output_when_a_group_by_column_is_not_projected() {
+        let agg = sum_of("n", false, None);
+        let plan = rolling_plan(
+            agg.clone(),
+            vec![date_from(), win()],
+            vec![date_from().alias("mon"), agg_col(&agg).alias("num")],
+        );
+        let rewritten = rewrite(plan.clone());
+        assert!(rewritten.transformed);
+        // `win` is grouped by, so the rolling node emits it; a projection has to take it back out.
+        match &rewritten.data {
+            LogicalPlan::Projection(p) => assert!(
+                is_rolling(&p.input),
+                "expected the projection to sit on the rolling node, got {}",
+                p.input.display_indent()
+            ),
+            other => panic!("expected a projection, got {}", other.display_indent()),
+        }
+        assert_output_preserved(&plan, &rewritten.data);
+    }
+
+    // Two independent things decline the next two shapes: the explicit modifier guard, and the
+    // fact that stripping a modifier changes the aggregate's name, so the projection no longer
+    // reads it under the name the rolling node would emit. The tests pin the behaviour, not which
+    // of the two gets there first.
+
+    #[test]
+    fn declines_a_distinct_aggregate() {
+        // The executor evaluates the aggregate over its own window and cannot honour DISTINCT.
+        let agg = sum_of("n", true, None);
+        let plan = rolling_plan(
+            agg.clone(),
+            vec![date_from(), win()],
+            vec![date_from().alias("mon"), win(), agg_col(&agg).alias("num")],
+        );
+        assert!(!rewrite(plan).transformed);
+    }
+
+    #[test]
+    fn declines_a_filtered_aggregate() {
+        let agg = sum_of("n", false, Some(win().gt(lit(0))));
+        let plan = rolling_plan(
+            agg.clone(),
+            vec![date_from(), win()],
+            vec![date_from().alias("mon"), win(), agg_col(&agg).alias("num")],
+        );
+        assert!(!rewrite(plan).transformed);
+    }
+
+    #[test]
+    fn declines_when_an_aggregate_has_no_name_in_the_projection() {
+        // Nothing reads the aggregate under its own name, so the rolling node would have no name
+        // to give the column and would silently drop it from its schema.
+        let plan = rolling_plan(
+            sum_of("n", false, None),
+            vec![date_from(), win()],
+            vec![date_from().alias("mon"), win()],
+        );
+        assert!(!rewrite(plan).transformed);
+    }
+}

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
@@ -92,37 +92,28 @@ impl RollingOptimizerRule {
                     from,
                     to,
                     every,
-                    rolling_aggs_alias: {
-                        let aliases = expr
-                            .iter()
-                            .flat_map(|e| match e {
+                    // The schema pairs these names with `rolling_aggs` positionally, so resolve each
+                    // one from the aggregate it belongs to rather than from the order the
+                    // projection happens to list them in. An aggregate the projection does not
+                    // read under its own name has no name to output, so decline the rewrite
+                    // instead of building a node that cannot describe its own output.
+                    rolling_aggs_alias: rolling_aggs
+                        .iter()
+                        .map(|agg| {
+                            let agg_name = agg.schema_name().to_string();
+                            expr.iter().find_map(|e| match e {
                                 Expr::Alias(Alias {
                                     expr,
                                     relation: _,
                                     name,
                                 }) => match expr.as_ref() {
-                                    Expr::Column(col)
-                                        if &col.name != &from_col.name
-                                            && &col.name != &to_col.name
-                                            && !partition_by
-                                                .iter()
-                                                .any(|p| &p.name == &col.name) =>
-                                    {
-                                        Some(name.clone())
-                                    }
+                                    Expr::Column(col) if col.name == agg_name => Some(name.clone()),
                                     _ => None,
                                 },
                                 _ => None,
                             })
-                            .collect::<Vec<_>>();
-                        // The schema pairs aggregates with these names positionally and a short
-                        // list silently drops the trailing aggregates from the output. Leave such
-                        // a projection alone instead of building a node that cannot describe it.
-                        if aliases.len() < rolling_aggs.len() {
-                            return None;
-                        }
-                        aliases
-                    },
+                        })
+                        .collect::<Option<Vec<_>>>()?,
                     partition_by,
                     rolling_aggs,
                     group_by_dimension,

--- a/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/optimizations/rolling_optimizer.rs
@@ -233,6 +233,15 @@ impl RollingOptimizerRule {
                     return None;
                 }
 
+                // The executor advances one shared group counter per (aggregate, dimension point),
+                // while each aggregate accumulates into its own group space. With more than one
+                // aggregate they interleave, so every aggregate past the first reads the slots the
+                // others left empty and comes back null. Serve these as a plain aggregate until
+                // that accounting is fixed.
+                if rolling_aggs.len() > 1 {
+                    return None;
+                }
+
                 let RollingWindowJoinExtractorResult {
                     input,
                     dimension,
@@ -1085,6 +1094,14 @@ mod tests {
     /// `Projection(projection) -> Aggregate(group_by, [agg]) -> series LEFT JOIN source`, the shape
     /// `RollingOptimizerRule` is meant to rewrite.
     fn rolling_plan(agg: Expr, group_by: Vec<Expr>, projection: Vec<Expr>) -> LogicalPlan {
+        rolling_plan_with_aggs(vec![agg], group_by, projection)
+    }
+
+    fn rolling_plan_with_aggs(
+        aggs: Vec<Expr>,
+        group_by: Vec<Expr>,
+        projection: Vec<Expr>,
+    ) -> LogicalPlan {
         let (left, right) = (series(), source());
         let join_schema =
             build_join_schema(left.schema(), right.schema(), &JoinType::Left).unwrap();
@@ -1105,14 +1122,14 @@ mod tests {
             null_equals_null: false,
         });
         let aggregate =
-            Aggregate::try_new(Arc::new(join), group_by, vec![agg]).map(LogicalPlan::Aggregate);
+            Aggregate::try_new(Arc::new(join), group_by, aggs).map(LogicalPlan::Aggregate);
         LogicalPlan::Projection(
             Projection::try_new(projection, Arc::new(aggregate.unwrap())).unwrap(),
         )
     }
 
-    /// The column an aggregate is read back as, i.e. the name the aggregate node gives its output.
-    /// Hardcoding it makes the "declines" tests pass whether or not the rule really declines.
+    /// The column an aggregate is read back as. Derived rather than written out, because a
+    /// hardcoded name that does not match makes every "declines" case pass for the wrong reason.
     fn agg_col(agg: &Expr) -> Expr {
         col(agg.schema_name().to_string())
     }
@@ -1211,6 +1228,26 @@ mod tests {
             agg.clone(),
             vec![date_from(), win()],
             vec![date_from().alias("mon"), win(), agg_col(&agg).alias("num")],
+        );
+        assert!(!rewrite(plan).transformed);
+    }
+
+    #[test]
+    fn declines_more_than_one_rolling_aggregate() {
+        // The executor shares one group counter across the aggregates, so the second one reads
+        // empty slots and answers null. Two aggregates also make the shape where positional and
+        // name-based alias pairing could disagree, so declining keeps that question unobservable.
+        let n_total = sum_of("n", false, None);
+        let d_total = sum_of("d", false, None);
+        let plan = rolling_plan_with_aggs(
+            vec![n_total.clone(), d_total.clone()],
+            vec![date_from(), win()],
+            vec![
+                date_from().alias("mon"),
+                win(),
+                agg_col(&n_total).alias("n_total"),
+                agg_col(&d_total).alias("d_total"),
+            ],
         );
         assert!(!rewrite(plan).transformed);
     }

--- a/rust/cubestore/cubestore/src/queryplanner/rolling.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/rolling.rs
@@ -182,6 +182,26 @@ impl RollingWindowAggregate {
             input,
         )?;
 
+        // Dimension values missing from the input still produce a row, with null partition keys.
+        // The keys inherit their nullability from the input columns, which are often non-nullable
+        // (a calc-group dimension stored as a literal, say), so relax them or building the output
+        // batch fails on "declared as non-nullable but contains null values".
+        let partition_by_range = 1..1 + partition_by.len();
+        let fields = fields
+            .into_iter()
+            .enumerate()
+            .map(|(i, (relation, field))| {
+                if partition_by_range.contains(&i) && !field.is_nullable() {
+                    (
+                        relation,
+                        Arc::new(field.as_ref().clone().with_nullable(true)),
+                    )
+                } else {
+                    (relation, field)
+                }
+            })
+            .collect_vec();
+
         Ok(Arc::new(DFSchema::new_with_metadata(
             fields,
             input.schema().metadata().clone(),

--- a/rust/cubestore/cubestore/src/queryplanner/rolling.rs
+++ b/rust/cubestore/cubestore/src/queryplanner/rolling.rs
@@ -186,6 +186,13 @@ impl RollingWindowAggregate {
         // The keys inherit their nullability from the input columns, which are often non-nullable
         // (a calc-group dimension stored as a literal, say), so relax them or building the output
         // batch fails on "declared as non-nullable but contains null values".
+        //
+        // The range below addresses the partition keys by position, so pin the layout the chain
+        // above produces: the dimension, then one field per partition key, then the aggregates.
+        debug_assert_eq!(
+            fields.len(),
+            1 + partition_by.len() + rolling_aggs.len().min(rolling_aggs_alias.len())
+        );
         let partition_by_range = 1..1 + partition_by.len();
         let fields = fields
             .into_iter()


### PR DESCRIPTION
## Summary

A rolling-window query whose consumer does not select one of the GROUP BY columns failed to plan in CubeStore with `Optimizer rule 'optimize_projections' failed / Schema error: No field named ...`. The error points at DataFusion, but the defect is ours: `RollingOptimizerRule` replaces a projection with a node that has a different schema.

This blocks a customer model where a `type: switch` (calc group) dimension dispatches rolling-window measures through `case` entrypoints served from rollups — the calc-group column is exactly the unselected GROUP BY column, so every such query fails in a rollup-only deployment.

## Changes

- **Do not widen the schema of the replaced node.** `RollingWindowAggregate` always emits `dimension + partition_by + rolling aggregates`, and `partition_by` comes from the aggregate's GROUP BY — so a column the projection dropped reappeared in the output. Ancestors keep resolving columns by position against their cached schema, hence the failure. The rewrite now restores the original output with a projection on top, and declines when it cannot be expressed from the rolling node.
- **Make partition keys nullable.** Planning these queries reached a second, independent defect: dimension values missing from the input still produce a row with null partition keys, but the keys inherited nullability from the input columns. A calc-group dimension stored as a literal is not nullable, so any window with an empty bucket died at execution with `declared as non-nullable but contains null values`.
- **Decline instead of building a node the rule cannot describe.** A short alias list silently truncated the schema, and `distinct` / `filter` / `order_by` / `null_treatment` were dropped from the aggregate although the executor honours none of them. Both now leave the plain aggregate/range-join in place. The destructure is exhaustive over `AggregateFunctionParams`, so a future DataFusion upgrade that adds a modifier fails to compile here rather than silently dropping it.
- **Graceful degradation** where the old code aborted planning: a `schema_from` failure now declines the rewrite instead of failing the query.

## Testing

New `rolling_window_unused_partition_by` in `cubestore-sql-tests` — four cases over a 7-point series so one bucket is genuinely empty: the partition column pruned by the consumer, omitted by the projection outright, several real partitions selected, and several partitions dropped. Expected values were checked against the window model rather than recorded from the implementation. It runs in all three configurations (in-process, multi-process, 2-node cluster), so the worker-side schema reconstruction is covered too.

- Each fix is independently pinned: reverting only `rolling_optimizer.rs` reproduces the planning failure, reverting only `rolling.rs` reproduces the nullability failure.
- Full SQL suite 185/185; `cargo fmt` clean; no clippy findings on the changed files.
- Mutation check: disabling the rule entirely fails 10 of 14 rolling tests, so a silently lost rewrite is caught by the existing result assertions.
- Traced the rule on the Tesseract switch/calc-group end-to-end tests: 13 matches → 13 rewrites, 0 bail-outs, 7 of them through the new path on the calc-group column. Those tests run each query twice — from a CubeStore rollup and from source Postgres with pre-aggregations off — and the results agree cell for cell.

Known, unrelated and out of scope: aggregate `FILTER` is broken in CubeStore generally (`SELECT sum(n) FILTER (WHERE ...) FROM t` fails on column resolution), and the multi-rolling-aggregate executor path has a pre-existing group-index bug not reachable from Cube-generated SQL.