### PR TITLE
fix(cubestore): cast aggregating index aggregation results back to the declared column types

### DIFF
--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -294,6 +294,10 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
         ),
         t("aggregate_index_errors", aggregate_index_errors),
         t("aggregate_index_decimal", aggregate_index_decimal),
+        t(
+            "aggregate_index_decimal_overflow",
+            aggregate_index_decimal_overflow,
+        ),
         t("inline_tables", inline_tables),
         t("inline_tables_2x", inline_tables_2x),
         t("build_range_end", build_range_end),
@@ -398,6 +402,7 @@ lazy_static::lazy_static! {
         "aggregate_index_errors",
         // Old versions panic building an aggregating index over a decimal measure.
         "aggregate_index_decimal",
+        "aggregate_index_decimal_overflow",
         "create_table_with_location_invalid_digit",
         "create_table_with_url",
         "hyperloglog_inserts",
@@ -8911,6 +8916,37 @@ async fn aggregate_index_decimal(service: Box<dyn SqlClient>) -> Result<(), Cube
             ],
         ]
     );
+    Ok(())
+}
+
+async fn aggregate_index_decimal_overflow(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA s").await?;
+    service
+        .exec_query(
+            "CREATE TABLE s.Orders(k varchar, v decimal(18, 5))
+                     AGGREGATIONS(sum(v))
+                     AGGREGATE INDEX k_agg (k)",
+        )
+        .await?;
+
+    // Each value fits Decimal128(18, 5) (13 integer digits), but the per-key sum does
+    // not. The aggregating index build runs that sum, and the cast back to the declared
+    // type uses safe: false, so the overflow must surface as a diagnosable error — not a
+    // panic in a background task and not a silently stored NULL.
+    let res = service
+        .exec_query("INSERT INTO s.Orders (k, v) VALUES ('a', 9000000000000), ('a', 9000000000000)")
+        .await;
+    match res {
+        Ok(_) => panic!("a sum overflowing the declared decimal precision must fail the insert"),
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("too large to store"),
+                "expected a decimal overflow error, got: {}",
+                msg
+            );
+        }
+    }
     Ok(())
 }
 

--- a/rust/cubestore/cubestore-sql-tests/src/tests.rs
+++ b/rust/cubestore/cubestore-sql-tests/src/tests.rs
@@ -293,6 +293,7 @@ pub fn sql_tests(prefix: &str) -> Vec<(&'static str, TestFn)> {
             aggregate_index_with_hll_bytes,
         ),
         t("aggregate_index_errors", aggregate_index_errors),
+        t("aggregate_index_decimal", aggregate_index_decimal),
         t("inline_tables", inline_tables),
         t("inline_tables_2x", inline_tables_2x),
         t("build_range_end", build_range_end),
@@ -395,6 +396,8 @@ lazy_static::lazy_static! {
     static ref MIGRATION_TEST_EXCLUSION_SET: HashSet<String> = [
         // Tests that would fail and are useless as a migration test.
         "aggregate_index_errors",
+        // Old versions panic building an aggregating index over a decimal measure.
+        "aggregate_index_decimal",
         "create_table_with_location_invalid_digit",
         "create_table_with_url",
         "hyperloglog_inserts",
@@ -8824,6 +8827,90 @@ async fn aggregate_index_errors(service: Box<dyn SqlClient>) -> Result<(), CubeE
         )
         .await
         .expect_err("Aggregate function MERGE not allowed for column type integer");
+    Ok(())
+}
+
+async fn aggregate_index_decimal(service: Box<dyn SqlClient>) -> Result<(), CubeError> {
+    service.exec_query("CREATE SCHEMA s").await?;
+
+    // Building an aggregating index runs sum() over the chunk data, and DataFusion widens a
+    // decimal sum's precision. The result must be cast back to the declared column type
+    // instead of failing the chunk build.
+    let file = write_tmp_file(indoc! {"
+        k,v,i
+        books,900.00000,10
+        books,100.50000,20
+        toys,90.00000,5
+        toys,9.50000,7
+    "})?;
+    let path = file.path().to_string_lossy();
+    service
+        .exec_query(
+            format!(
+                "CREATE TABLE s.Orders(k varchar, v decimal, i int)
+                     AGGREGATIONS(sum(v), sum(i))
+                     AGGREGATE INDEX k_agg (k)
+                     LOCATION '{}'",
+                path
+            )
+            .as_str(),
+        )
+        .await?;
+
+    let res = service
+        .exec_query("SELECT k, sum(v), sum(i) FROM s.Orders GROUP BY 1 ORDER BY 1")
+        .await?;
+    assert_eq!(
+        to_rows(&res),
+        [
+            [
+                TableValue::String("books".to_string()),
+                TableValue::Decimal(Decimal::new(100050000)),
+                TableValue::Int(30)
+            ],
+            [
+                TableValue::String("toys".to_string()),
+                TableValue::Decimal(Decimal::new(9950000)),
+                TableValue::Int(12)
+            ],
+        ]
+    );
+
+    // The same shape over INSERT-ed data exercises the in-memory ingestion path.
+    service
+        .exec_query(
+            "CREATE TABLE s.OrdersIns(k varchar, v decimal, i int)
+                     AGGREGATIONS(sum(v), sum(i))
+                     AGGREGATE INDEX k_agg (k)",
+        )
+        .await?;
+    service
+        .exec_query(
+            "INSERT INTO s.OrdersIns (k, v, i) VALUES ('books', 900.00000, 10), \
+                                                      ('books', 100.50000, 20), \
+                                                      ('toys', 90.00000, 5), \
+                                                      ('toys', 9.50000, 7)",
+        )
+        .await?;
+
+    let res = service
+        .exec_query("SELECT k, sum(v), sum(i) FROM s.OrdersIns GROUP BY 1 ORDER BY 1")
+        .await?;
+    assert_eq!(
+        to_rows(&res),
+        [
+            [
+                TableValue::String("books".to_string()),
+                TableValue::Decimal(Decimal::new(100050000)),
+                TableValue::Int(30)
+            ],
+            [
+                TableValue::String("toys".to_string()),
+                TableValue::Decimal(Decimal::new(9950000)),
+                TableValue::Int(12)
+            ],
+        ]
+    );
     Ok(())
 }
 

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -23,9 +23,10 @@ use crate::CubeError;
 use async_trait::async_trait;
 use chrono::Utc;
 use datafusion::arrow::array::UInt64Array;
-use datafusion::arrow::compute::{concat_batches, SortOptions};
+use datafusion::arrow::compute::{concat_batches, CastOptions, SortOptions};
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::display::FormatOptions;
 use datafusion::config::TableParquetOptions;
 use datafusion::cube_ext;
 use datafusion::datasource::listing::PartitionedFile;
@@ -40,7 +41,8 @@ use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
 use datafusion::physical_plan::common::collect;
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::expressions::{Column, Literal};
+use datafusion::physical_plan::expressions::{CastExpr, Column, Literal};
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr, SendableRecordBatchStream};
@@ -310,7 +312,7 @@ impl CompactionServiceImpl {
             )
             .await?;
             let batches = collect(batches_stream).await?;
-            let batch = concat_batches(&schema, &batches).unwrap();
+            let batch = concat_batches(&schema, &batches)?;
 
             let oldest_insert_at = group_chunks
                 .iter()
@@ -413,7 +415,7 @@ impl CompactionServiceImpl {
             self.meta_store.deactivate_chunks(old_chunk_ids).await?;
             return Ok(());
         }
-        let batch = concat_batches(&schema, &batches).unwrap();
+        let batch = concat_batches(&schema, &batches)?;
 
         let (chunk, file_size) = self
             .chunk_store
@@ -1555,6 +1557,49 @@ pub(crate) async fn write_chunks_split_into_children(
         .unwrap())
 }
 
+/// Wraps `plan` into a projection that casts every column whose type diverged from `schema`
+/// back to the declared type. DataFusion widens some aggregate output types (e.g. a decimal
+/// SUM gains 10 digits of precision), while chunk data must keep the index schema.
+pub fn cast_plan_to_schema(
+    plan: Arc<dyn ExecutionPlan>,
+    schema: &Arc<Schema>,
+) -> Result<Arc<dyn ExecutionPlan>, CubeError> {
+    let plan_schema = plan.schema();
+    if plan_schema.fields().len() != schema.fields().len() {
+        return Err(CubeError::internal(format!(
+            "Cannot cast plan schema {} to {}: different number of columns",
+            plan_schema, schema
+        )));
+    }
+    let mut exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::with_capacity(schema.fields().len());
+    let mut needs_cast = false;
+    for (i, target) in schema.fields().iter().enumerate() {
+        let source = plan_schema.field(i);
+        let col: Arc<dyn PhysicalExpr> = Arc::new(Column::new(source.name().as_str(), i));
+        let expr: Arc<dyn PhysicalExpr> = if source.data_type() == target.data_type() {
+            col
+        } else {
+            needs_cast = true;
+            // safe: false so a value that doesn't fit the declared type (e.g. a sum
+            // overflowing the declared decimal precision) fails the job instead of
+            // silently becoming NULL.
+            Arc::new(CastExpr::new(
+                col,
+                target.data_type().clone(),
+                Some(CastOptions {
+                    safe: false,
+                    format_options: FormatOptions::default(),
+                }),
+            ))
+        };
+        exprs.push((expr, target.name().clone()));
+    }
+    if !needs_cast {
+        return Ok(plan);
+    }
+    Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+}
+
 /// Builds a `SendableRecordBatchStream` merging the persistent partition data `l` with the
 /// already-sorted chunk inputs `r` (one sorted ExecutionPlan per chunk). Inputs are merged with a
 /// k-way `SortPreservingMergeExec` instead of being concatenated and re-sorted.
@@ -1608,8 +1653,9 @@ pub async fn merge_chunks(
             aggregates,
             vec![None; aggregates_len],
             res.clone(),
-            schema,
+            schema.clone(),
         )?);
+        res = cast_plan_to_schema(res, &schema)?;
     } else if let Some(key_columns) = unique_key_columns {
         res = Arc::new(LastRowByUniqueKeyExec::try_new(
             res.clone(),
@@ -1675,7 +1721,7 @@ mod tests {
     use crate::table::parquet::CubestoreMetadataCacheFactoryImpl;
     use crate::table::{cmp_same_types, Row, TableValue};
     use cuberockstore::rocksdb::{Options, DB};
-    use datafusion::arrow::array::{ArrayRef, Int64Array, StringArray};
+    use datafusion::arrow::array::{ArrayRef, Decimal128Array, Int64Array, StringArray};
     use datafusion::arrow::datatypes::{Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::physical_plan::collect;
@@ -2309,6 +2355,14 @@ mod tests {
             Column::new("foo".to_string(), ColumnType::String, 0),
             Column::new("boo".to_string(), ColumnType::Int, 1),
             Column::new("sum_int".to_string(), ColumnType::Int, 2),
+            Column::new(
+                "sum_dec".to_string(),
+                ColumnType::Decimal {
+                    scale: 5,
+                    precision: 18,
+                },
+                3,
+            ),
         ];
         let table = metastore
             .create_table(
@@ -2325,7 +2379,10 @@ mod tests {
                 None,
                 None,
                 None,
-                Some(vec![("sum".to_string(), "sum_int".to_string())]),
+                Some(vec![
+                    ("sum".to_string(), "sum_int".to_string()),
+                    ("sum".to_string(), "sum_dec".to_string()),
+                ]),
                 None,
                 None,
                 false,
@@ -2356,6 +2413,11 @@ mod tests {
             ])),
             Arc::new(Int64Array::from(vec![1, 10, 2, 20, 10])),
             Arc::new(Int64Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(
+                Decimal128Array::from(vec![100000_i128, 200000, 300000, 400000, 500000])
+                    .with_precision_and_scale(18, 5)
+                    .unwrap(),
+            ),
         ];
         let data2: Vec<ArrayRef> = vec![
             Arc::new(StringArray::from(vec![
@@ -2368,6 +2430,18 @@ mod tests {
             ])),
             Arc::new(Int64Array::from(vec![1, 10, 2, 20, 10, 30])),
             Arc::new(Int64Array::from(vec![10, 20, 30, 40, 50, 60])),
+            Arc::new(
+                Decimal128Array::from(vec![
+                    1000000_i128,
+                    2000000,
+                    3000000,
+                    4000000,
+                    5000000,
+                    6000000,
+                ])
+                .with_precision_and_scale(18, 5)
+                .unwrap(),
+            ),
         ];
 
         let (chunk, _) = chunk_store
@@ -2458,7 +2532,21 @@ mod tests {
         let boos = Arc::new(Int64Array::from(vec![1, 10, 2, 20, 10, 30]));
 
         let sums = Arc::new(Int64Array::from(vec![11, 22, 33, 44, 55, 60]));
-        let expected: Vec<ArrayRef> = vec![foos, boos, sums];
+        // The decimal sum's DataFusion output is wider than the declared Decimal128(18, 5);
+        // compaction must cast it back to the index schema.
+        let dec_sums = Arc::new(
+            Decimal128Array::from(vec![
+                1100000_i128,
+                2200000,
+                3300000,
+                4400000,
+                5500000,
+                6000000,
+            ])
+            .with_precision_and_scale(18, 5)
+            .unwrap(),
+        );
+        let expected: Vec<ArrayRef> = vec![foos, boos, sums, dec_sums];
 
         assert_eq!(res_data.columns(), &expected);
 

--- a/rust/cubestore/cubestore/src/store/compaction.rs
+++ b/rust/cubestore/cubestore/src/store/compaction.rs
@@ -24,7 +24,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use datafusion::arrow::array::UInt64Array;
 use datafusion::arrow::compute::{concat_batches, CastOptions, SortOptions};
-use datafusion::arrow::datatypes::Schema;
+use datafusion::arrow::datatypes::{DataType, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::display::FormatOptions;
 use datafusion::config::TableParquetOptions;
@@ -1579,6 +1579,23 @@ pub fn cast_plan_to_schema(
         let expr: Arc<dyn PhysicalExpr> = if source.data_type() == target.data_type() {
             col
         } else {
+            // Only a precision change of a decimal aggregate is a known-legitimate
+            // divergence. Anything else means the plan output no longer lines up with
+            // the index columns positionally, and casting it would silently corrupt
+            // the stored data — fail loudly instead.
+            let same_scale_decimals = match (source.data_type(), target.data_type()) {
+                (DataType::Decimal128(_, s1), DataType::Decimal128(_, s2)) => s1 == s2,
+                _ => false,
+            };
+            if !same_scale_decimals {
+                return Err(CubeError::internal(format!(
+                    "Cannot cast column {} of type {} to column {} of type {}: only a decimal precision change is expected here",
+                    source.name(),
+                    source.data_type(),
+                    target.name(),
+                    target.data_type()
+                )));
+            }
             needs_cast = true;
             // safe: false so a value that doesn't fit the declared type (e.g. a sum
             // overflowing the declared decimal precision) fails the job instead of

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -2877,14 +2877,14 @@ impl ChunkStore {
                     schema.clone(),
                 )?);
 
-                assert!(aggregate
-                    .properties()
-                    .output_ordering()
-                    .is_some_and(|ordering| ordering.len() == key_size));
-
                 // DataFusion may widen aggregate output types (e.g. a decimal sum gains
                 // precision); cast them back so chunk data keeps the index schema.
                 let plan = cast_plan_to_schema(aggregate, &schema)?;
+
+                assert!(plan
+                    .properties()
+                    .output_ordering()
+                    .is_some_and(|ordering| ordering.len() == key_size));
 
                 let task_context = QueryPlannerImpl::make_execution_context(
                     self.metadata_cache_factory
@@ -2893,7 +2893,14 @@ impl ChunkStore {
                 )
                 .task_ctx();
 
-                let batches = collect(plan, task_context).await?;
+                let batches = collect(plan, task_context).await.map_err(|e| {
+                    CubeError::internal(format!(
+                        "Failed to build aggregating index {} of table {}: {}",
+                        index.get_row().get_name(),
+                        table.get_row().get_table_name(),
+                        e
+                    ))
+                })?;
                 if batches.is_empty() {
                     Ok(vec![])
                 } else if batches.len() == 1 {

--- a/rust/cubestore/cubestore/src/store/mod.rs
+++ b/rust/cubestore/cubestore/src/store/mod.rs
@@ -44,7 +44,9 @@ use crate::metastore::chunks::chunk_file_name;
 use crate::queryplanner::trace_data_loaded::{DataLoadedSize, TraceDataLoadedExec};
 use crate::table::data::{cmp_min_rows, cmp_partition_key};
 use crate::table::parquet::{arrow_schema, CubestoreMetadataCacheFactory, ParquetTableStore};
-use compaction::{merge_chunks, merge_replay_handles, write_chunks_split_into_children};
+use compaction::{
+    cast_plan_to_schema, merge_chunks, merge_replay_handles, write_chunks_split_into_children,
+};
 use datafusion::arrow::array::{Array, ArrayRef, Int64Builder, StringBuilder, UInt64Array};
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -2880,6 +2882,10 @@ impl ChunkStore {
                     .output_ordering()
                     .is_some_and(|ordering| ordering.len() == key_size));
 
+                // DataFusion may widen aggregate output types (e.g. a decimal sum gains
+                // precision); cast them back so chunk data keeps the index schema.
+                let plan = cast_plan_to_schema(aggregate, &schema)?;
+
                 let task_context = QueryPlannerImpl::make_execution_context(
                     self.metadata_cache_factory
                         .cache_factory()
@@ -2887,13 +2893,13 @@ impl ChunkStore {
                 )
                 .task_ctx();
 
-                let batches = collect(aggregate, task_context).await?;
+                let batches = collect(plan, task_context).await?;
                 if batches.is_empty() {
                     Ok(vec![])
                 } else if batches.len() == 1 {
                     Ok(batches[0].columns().to_vec())
                 } else {
-                    let res = concat_batches(&schema, &batches).unwrap();
+                    let res = concat_batches(&schema, &batches)?;
                     Ok(res.columns().to_vec())
                 }
             }


### PR DESCRIPTION
## Summary

Creating a table with an `AGGREGATE INDEX` over a `decimal` measure and actual data failed with `Create table failed: Internal: task N panicked ... InvalidArgumentError("column types must match schema types, expected Decimal128(18, 5) but found Decimal128(28, 5)")`. Any rollup with a decimal measure and an aggregating index hit this, since Cube emits `decimal` for numeric measures.

Building an aggregating index runs the declared aggregations over chunk data, and DataFusion widens a decimal SUM's precision by 10 digits (`Decimal128(18, 5)` → `Decimal128(28, 5)`). The widened batches then failed `RecordBatch` validation against the declared index schema inside `concat_batches(...).unwrap()` — a panic in a spawned task instead of an error.

## Changes

- `cast_plan_to_schema` (store/compaction.rs): wraps the aggregation plan into a projection casting each diverged column back to the declared index schema. The cast uses `safe: false`, so a sum genuinely overflowing the declared precision fails the job instead of silently becoming NULL.
- Applied on both paths that aggregate chunk data: `post_process_columns` (ingestion: CSV `LOCATION` import and `INSERT`) and `merge_chunks` (compaction and repartition).
- Replaced the three `concat_batches(...).unwrap()` calls with error propagation, so a future type mismatch surfaces as a diagnosable error rather than `task N panicked`.

## Testing

- New `aggregate_index_decimal` test in cubestore-sql-tests: the reported repro (CSV `LOCATION` + decimal measure + `AGGREGATE INDEX`) plus an `INSERT` variant, with both decimal and int measures so the widening path stays covered. Added to `MIGRATION_TEST_EXCLUSION_SET` since older versions panic on it.
- Extended the `aggr_index_compaction` unit test with a decimal sum column, covering the `merge_chunks` cast directly.
- Both tests verified to fail without the cast (knockout) and pass with it; all store unit tests and aggregate-index sql tests green.
- End to end: the Tesseract `switch_rolling` integration suite against a release `cubestored` built from this branch — the previously `#[ignore]`d aggregating-index rollup shape now builds and its rollup-backed result matches the raw Postgres source.