### PR TITLE
docs: hide the DAX API pages

### DIFF
--- a/docs-mintlify/admin/account-billing/pricing.mdx
+++ b/docs-mintlify/admin/account-billing/pricing.mdx
@@ -118,7 +118,7 @@ requests through [APIs & integrations][ref-apis] under the following tiers:
 | Tier | <nobr>CCUs per hour</nobr> | <nobr>CPU and memory</nobr> | Dependent features |
 | ---- | :--- | --- | --- |
 | S    | <nobr>4 — _for Dedicated deployment_</nobr><br/><nobr>1 — _for Shared deployment_</nobr><br/><nobr>1 — _for Cube API Instance_</nobr> | 100% | — |
-| M    | <nobr>8 — _for Dedicated deployment_</nobr><br/><nobr>2 — _for Shared deployment_</nobr><br/><nobr>2 — _for Cube API Instance_</nobr> | 200% | [DAX API][ref-dax-api]|
+| M    | <nobr>8 — _for Dedicated deployment_</nobr><br/><nobr>2 — _for Shared deployment_</nobr><br/><nobr>2 — _for Cube API Instance_</nobr> | 200% | DAX API|
 
 You can upgrade to a chosen tier in the
 **Settings** of your deployment.
@@ -325,7 +325,6 @@ for the AI token consumption at the **Billing** page of their Cube Cloud account
 [ref-development-instance]: /admin/deployment/deployment-types#shared
 [ref-apis]: /reference
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-cube-store-architecture]: /docs/pre-aggregations/running-in-production#architecture
 [ref-data-at-rest-encryption]: /docs/pre-aggregations/running-in-production#data-at-rest-encryption
 [ref-customer-managed-keys]: /admin/deployment/encryption-keys

--- a/docs-mintlify/admin/connect-to-data/data-sources/ksqldb.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/ksqldb.mdx
@@ -28,7 +28,7 @@ See how you can use ksqlDB and Cube Cloud to power real-time analytics in Power 
 <Info>
 
 In this video, the SQL API is used to connect to Power BI.
-Currently, it's recommended to use the [DAX API][ref-dax-api].
+Currently, it's recommended to use the DAX API.
 
 </Info>
 
@@ -987,7 +987,6 @@ the source column through a scalar function (e.g.,
 `CAST(id AS VARCHAR) AS id`), but not through arbitrary expressions.
 
 [ref-data-source-concurrency]: /admin/connect-to-data/concurrency#data-source-concurrency
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-streaming-pre-aggs]: /docs/pre-aggregations/using-pre-aggregations#streaming-pre-aggregations
 [ref-decorated-env-vars]: /admin/connect-to-data/multiple-data-sources#under-the-hood
 [ref-cube-data-source]: /reference/data-modeling/cube#data_source

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
@@ -45,7 +45,7 @@ To find your MDX API credentials, go to the [Integrations][ref-integrations-apis
 **API credentials**, and choose the **MDX API** tab. Use the full MDX API URL, including
 the `/cubejs-api/v2/mdx` path, as the server name.
 
-The MDX API supports the same Kerberos and NTLM
+The MDX API supports the same [Kerberos][ref-kerberos] and [NTLM][ref-ntlm]
 authentication methods as the DAX API, configured on the **Settings → Power BI** page
 of your deployment.
 
@@ -62,3 +62,5 @@ add-in and [authenticate][ref-cube-cloud-for-excel-authentication] to Cube Cloud
 [ref-cube-cloud-for-excel-authentication]: /docs/integrations/microsoft-excel#authentication
 [ref-integrations-tools]: /admin/connect-to-data/visualization-tools
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
+[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/excel.mdx
@@ -45,9 +45,8 @@ To find your MDX API credentials, go to the [Integrations][ref-integrations-apis
 **API credentials**, and choose the **MDX API** tab. Use the full MDX API URL, including
 the `/cubejs-api/v2/mdx` path, as the server name.
 
-The MDX API supports the same [Kerberos][ref-kerberos] and [NTLM][ref-ntlm]
-authentication methods as the DAX API, configured on the **Settings → Power BI** page
-of your deployment.
+The MDX API supports Kerberos and NTLM authentication, configured on the
+**Settings → Power BI** page of your deployment.
 
 ### Cube Cloud for Excel
 
@@ -62,5 +61,3 @@ add-in and [authenticate][ref-cube-cloud-for-excel-authentication] to Cube Cloud
 [ref-cube-cloud-for-excel-authentication]: /docs/integrations/microsoft-excel#authentication
 [ref-integrations-tools]: /admin/connect-to-data/visualization-tools
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
-[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
-[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/admin/connect-to-data/visualization-tools/powerbi.mdx
+++ b/docs-mintlify/admin/connect-to-data/visualization-tools/powerbi.mdx
@@ -83,9 +83,9 @@ than the DAX API. However, this is the only option when using Cube Core.
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-sls]: /docs/integrations/semantic-layer-sync
-[ref-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-ntlm]: /docs/integrations/power-bi/ntlm
-[ref-ntlm-desktop]: /docs/integrations/power-bi/ntlm#power-bi-desktop
+[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm
+[ref-ntlm-desktop]: /reference/core-data-apis/dax-api/ntlm#power-bi-desktop
 [link-powerbi-live]: https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-directquery-about#live-connections
 [link-powerbi-directquery]: https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-directquery-about
-[ref-opdg]: /docs/integrations/power-bi/ntlm#configuration
+[ref-opdg]: /reference/core-data-apis/dax-api/ntlm#configuration

--- a/docs-mintlify/admin/deployment/providers/azure.mdx
+++ b/docs-mintlify/admin/deployment/providers/azure.mdx
@@ -26,7 +26,6 @@ Cube Cloud integrates with the following [data sources](/admin/connect-to-data/d
 
 Cube Cloud integrates with the following [data visualization tools](/admin/connect-to-data/visualization-tools):
 
-- Microsoft Power BI via the [DAX API][ref-dax-api]
 - [Microsoft Excel][ref-excel] via [Cube Cloud for Excel][ref-cube-cloud-for-excel]
 
 ## Storage
@@ -54,6 +53,5 @@ Cube Cloud integrates with the following [data visualization tools](/admin/conne
 [Azure Virtual Network](https://azure.microsoft.com/en-us/products/virtual-network) can be used for [secure networking](/admin/deployment/dedicated/azure).
 
 
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -205,14 +205,7 @@
             "pages": [
               "docs/integrations/slack",
               "docs/integrations/tableau",
-              {
-                "group": "Power BI",
-                "root": "docs/integrations/power-bi/index",
-                "pages": [
-                  "docs/integrations/power-bi/kerberos",
-                  "docs/integrations/power-bi/ntlm"
-                ]
-              },
+              "docs/integrations/power-bi/index",
               "docs/integrations/microsoft-excel",
               "docs/integrations/google-sheets",
               "docs/integrations/snowflake-semantic-views",
@@ -536,6 +529,8 @@
                 "root": "reference/core-data-apis/dax-api/index",
                 "pages": [
                   "reference/core-data-apis/dax-api/cross-view-filter",
+                  "reference/core-data-apis/dax-api/kerberos",
+                  "reference/core-data-apis/dax-api/ntlm",
                   "reference/core-data-apis/dax-api/reference"
                 ]
               }
@@ -1144,6 +1139,14 @@
     {
       "source": "/docs/deployment/cloud/scalability",
       "destination": "/admin/deployment/scalability"
+    },
+    {
+      "source": "/docs/integrations/power-bi/kerberos",
+      "destination": "/reference/core-data-apis/dax-api/kerberos"
+    },
+    {
+      "source": "/docs/integrations/power-bi/ntlm",
+      "destination": "/reference/core-data-apis/dax-api/ntlm"
     }
   ]
 }

--- a/docs-mintlify/docs/data-modeling/concepts/syntax.mdx
+++ b/docs-mintlify/docs/data-modeling/concepts/syntax.mdx
@@ -84,7 +84,7 @@ Common rules apply to names of entities within the data model. All names must:
 - Start with a letter.
 - Consist of letters, numbers, and underscore (`_`) symbols only.
 - Not be a [reserved keyword in Python][link-python-reserved-words], e.g., `from`, `return`, or `yield`.
-- When using the DAX API, not clash with the names of columns in [date hierarchies][ref-dax-api-date-hierarchies].
+- When using the DAX API, not clash with the names of columns in date hierarchies.
 - Be unique within their scope. Cube and view names must be unique across the data
   model; members (measures, dimensions, segments, pre-aggregations, hierarchies) must
   be unique within their cube; and folder names must be unique within their view. Cube
@@ -1014,7 +1014,6 @@ string values in time dimensions.
 [ref-data-blending]: /docs/data-modeling/concepts/data-blending
 [link-js-template-literals]: https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Scripting/Strings#embedding_javascript
 [link-python-reserved-words]: https://docs.python.org/3/reference/lexical_analysis.html#keywords
-[ref-dax-api-date-hierarchies]: /reference/core-data-apis/dax-api#date-hierarchies
 [ref-time-dimension]: /docs/data-modeling/dimensions#time-dimensions
 [ref-recipe-string-time-dimensions]: /recipes/data-modeling/string-time-dimensions
 [ref-view-groups]: /reference/data-modeling/view-group

--- a/docs-mintlify/docs/integrations/power-bi/index.mdx
+++ b/docs-mintlify/docs/integrations/power-bi/index.mdx
@@ -76,9 +76,9 @@ than the DAX API. However, this is the only option when using Cube Core.
 [ref-integrations-apis]: /admin/connect-to-data/visualization-tools
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-sls]: /docs/integrations/semantic-layer-sync
-[ref-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-ntlm]: /docs/integrations/power-bi/ntlm
-[ref-ntlm-desktop]: /docs/integrations/power-bi/ntlm#power-bi-desktop
+[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm
+[ref-ntlm-desktop]: /reference/core-data-apis/dax-api/ntlm#power-bi-desktop
 [link-powerbi-live]: https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-directquery-about#live-connections
 [link-powerbi-directquery]: https://learn.microsoft.com/en-us/power-bi/connect-data/desktop-directquery-about
-[ref-opdg]: /docs/integrations/power-bi/ntlm#configuration
+[ref-opdg]: /reference/core-data-apis/dax-api/ntlm#configuration

--- a/docs-mintlify/recipes/data-modeling/xirr.mdx
+++ b/docs-mintlify/recipes/data-modeling/xirr.mdx
@@ -12,7 +12,7 @@ flows that is not necessarily periodic.
 ## Data modeling
 
 XIRR calculation is enabled by the `XIRR` function, implemented in [SQL API][ref-sql-api]
-and [DAX API][ref-dax-api]. It means that queries to any of these APIs can use the this function.
+and DAX API. It means that queries to any of these APIs can use the this function.
 
 The `XIRR` function is also implemented in Cube Store, meaning that queries to the SQL API
 or the [REST (JSON) API][ref-rest-api] that hit pre-aggregations can also use this function.
@@ -183,7 +183,6 @@ All queries above would yield the same result:
 
 
 [ref-sql-api]: /reference/core-data-apis/sql-api/reference#custom-functions
-[ref-dax-api]: /reference/core-data-apis/dax-api/reference#financial-functions
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-query-wpp]: /reference/core-data-apis/queries#query-with-post-processing
 [ref-query-regular]: /reference/core-data-apis/queries#regular-query

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -1302,7 +1302,7 @@ module.exports = {
 </CodeGroup>
 
 You can also check for the protocol and the authentication method as follows. This can
-be useful for handling the NTLM authentication in the [DAX API][ref-dax-api]:
+be useful for handling the [NTLM][ref-ntlm] authentication in the [DAX API][ref-dax-api]:
 
 <CodeGroup>
 
@@ -1523,3 +1523,4 @@ module.exports = {
 [ref-auth-integration]: /docs/data-modeling/access-control#authentication-integration
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-environments]: /admin/deployment/environments
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/configuration/config.mdx
+++ b/docs-mintlify/reference/configuration/config.mdx
@@ -1302,7 +1302,7 @@ module.exports = {
 </CodeGroup>
 
 You can also check for the protocol and the authentication method as follows. This can
-be useful for handling the [NTLM][ref-ntlm] authentication in the [DAX API][ref-dax-api]:
+be useful for handling the NTLM authentication in the DAX API:
 
 <CodeGroup>
 
@@ -1521,6 +1521,4 @@ module.exports = {
 [ref-dap]: /docs/data-modeling/data-access-policies
 [ref-dap-roles]: /docs/data-modeling/data-access-policies#data-access-roles
 [ref-auth-integration]: /docs/data-modeling/access-control#authentication-integration
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-environments]: /admin/deployment/environments
-[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1580,8 +1580,8 @@ If `true`, the DAX API will expose time dimensions as calendar hierarchies.
 
 ## `CUBEJS_DAX_SINGLE_PERSPECTIVE`
 
-If `true`, the [DAX API][ref-dax-api] exposes all views as part of a single
-perspective, enabling [cross-view filtering][ref-dax-cross-view-filter].
+If `true`, the DAX API exposes all views as part of a single
+perspective, enabling cross-view filtering.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |
@@ -2149,8 +2149,6 @@ The port for a Cube deployment to listen to API connections on.
 [wiki-tz-database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [ref-sql-api]: /reference/core-data-apis/sql-api
 [ref-sql-api-streaming]: /reference/core-data-apis/sql-api#streaming
-[ref-dax-api]: /reference/core-data-apis/dax-api
-[ref-dax-cross-view-filter]: /reference/core-data-apis/dax-api/cross-view-filter
 [ref-row-limit]: /reference/core-data-apis/queries#row-limit
 [mysql-server-tz-support]: https://dev.mysql.com/doc/refman/8.4/en/time-zone-support.html
 [ref-schema-ref-preagg-allownonstrict]: /reference/data-modeling/pre-aggregations#allow_non_strict_date_range_match

--- a/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/cross-view-filter.mdx
@@ -1,6 +1,7 @@
 ---
 title: Cross-view filtering
 description: "Enable cross-view filtering in the DAX API to build dashboards that span multiple views in Power BI."
+hidden: true
 ---
 
 By default, the [DAX API][ref-dax-api] exposes each [view][ref-views] as a

--- a/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: DAX API
 description: "Connect Microsoft Power BI to Cube natively using the DAX API for superior feature support over the SQL API."
+hidden: true
 ---
 
  DAX API

--- a/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/index.mdx
@@ -59,7 +59,7 @@ in the same cube or view), that would cause a conflict.
 
 ## Authentication
 
-The DAX API supports Kerberos and NTLM authentication
+The DAX API supports [Kerberos][ref-kerberos] and [NTLM][ref-ntlm] authentication
 methods, as well as user name and password authentication.
 
 While NTLM can be used for testing purposes, we strongly recommend configuring
@@ -96,3 +96,5 @@ and use it.
 [ref-ref-dax-api]: /reference/core-data-apis/dax-api/reference
 [ref-views]: /docs/data-modeling/views
 [ref-time-dimensions]: /docs/data-modeling/dimensions#time-dimensions
+[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/core-data-apis/dax-api/kerberos.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/kerberos.mdx
@@ -1,7 +1,7 @@
 ---
 title: Kerberos authentication
+sidebarTitle: Kerberos
 description: "Kerberos is the most common authentication method for Windows environments. It can be used to authenticate requests to the DAX API and MDX API."
-hidden: true
 ---
 
 [Kerberos][link-kerberos] is the most common authentication method for Windows environments.
@@ -155,8 +155,8 @@ format, e.g., `cube-pbi-svc-account@CUBE.DEV`. The match is case-sensitive, so k
 same letter case as the principal — the realm is typically uppercase. A NetBIOS format
 like `CUBE\cube-pbi-svc-account` will not match.
 
-Once the deployment is ready, you can test the Kerberos authentication by [connecting
-from Power BI][ref-power-bi] to the DAX API.
+Once the deployment is ready, you can test the Kerberos authentication by connecting
+to the DAX API from Power BI.
 
 ## Provisioning users with SCIM
 
@@ -248,10 +248,9 @@ connection actually used: `method=kerberos` vs. `method=ntlm`.
 [link-setspn]: https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731241(v=ws.11)
 [link-keytab-file]: https://web.mit.edu/Kerberos/krb5-1.16/doc/basic/keytab_def.html
 [link-ktpass]: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/ktpass
-[ref-power-bi]: /admin/connect-to-data/visualization-tools/powerbi#connect-to-the-dax-api
 [link-kerberos]: https://en.wikipedia.org/wiki/Kerberos_(protocol)#Microsoft_Windows
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
-[ref-ntlm]: /docs/integrations/power-bi/ntlm
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm
 [link-power-bi-opdg]: https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
 [ref-scim]: /admin/sso/microsoft-entra-id/scim

--- a/docs-mintlify/reference/core-data-apis/dax-api/kerberos.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/kerberos.mdx
@@ -2,6 +2,7 @@
 title: Kerberos authentication
 sidebarTitle: Kerberos
 description: "Kerberos is the most common authentication method for Windows environments. It can be used to authenticate requests to the DAX API and MDX API."
+hidden: true
 ---
 
 [Kerberos][link-kerberos] is the most common authentication method for Windows environments.

--- a/docs-mintlify/reference/core-data-apis/dax-api/ntlm.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/ntlm.mdx
@@ -1,7 +1,7 @@
 ---
 title: NTLM authentication
+sidebarTitle: NTLM
 description: "NTLM is an authentication method developed by Microsoft that can be used to authenticate requests to the DAX API and MDX API."
-hidden: true
 ---
 
 [NTLM][link-ntlm] is an authentication method developed by Microsoft that can be used to
@@ -109,6 +109,6 @@ check.
 [ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
 [link-power-bi-opdg]: https://learn.microsoft.com/en-us/power-bi/connect-data/service-gateway-onprem
-[ref-kerberos]: /docs/integrations/power-bi/kerberos
-[ref-kerberos-scim]: /docs/integrations/power-bi/kerberos#provisioning-users-with-scim
+[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-kerberos-scim]: /reference/core-data-apis/dax-api/kerberos#provisioning-users-with-scim
 [ref-config-can-switch-sql-user]: /reference/configuration/config#can_switch_sql_user

--- a/docs-mintlify/reference/core-data-apis/dax-api/ntlm.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/ntlm.mdx
@@ -2,6 +2,7 @@
 title: NTLM authentication
 sidebarTitle: NTLM
 description: "NTLM is an authentication method developed by Microsoft that can be used to authenticate requests to the DAX API and MDX API."
+hidden: true
 ---
 
 [NTLM][link-ntlm] is an authentication method developed by Microsoft that can be used to

--- a/docs-mintlify/reference/core-data-apis/dax-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/dax-api/reference.mdx
@@ -1,6 +1,7 @@
 ---
 title: DAX API reference
 description: "The DAX API supports the following functions."
+hidden: true
 ---
 
 <Info>

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -10,8 +10,6 @@ Core Data APIs enable you to query and retrieve data from your Cube semantic lay
 
 ## Choosing the Right API
 
-* To connect to Microsoft Power BI, use the [DAX API][ref-dax-api]
-
 * To connect to [Microsoft Excel][ref-excel], use [Cube Cloud for Excel][ref-cube-cloud-for-excel]
 
 * To connect to [Google Sheets][ref-sheets], use [Cube Cloud for Sheets][ref-cube-cloud-for-sheets]
@@ -61,8 +59,8 @@ tools][ref-viz-tools]:
 
 | Method | ✅ Supported in |
 | --- | --- |
-| [User name and password][ref-auth-user-pass] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api]<br/>[SQL API][ref-sql-api] |
-| [Kerberos][ref-auth-kerberos] and [NTLM][ref-auth-ntlm] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api] |
+| [User name and password][ref-auth-user-pass] | [MDX API][ref-mdx-api]<br/>[SQL API][ref-sql-api] |
+| Kerberos and NTLM | [MDX API][ref-mdx-api] |
 | [Identity provider][ref-auth-idp] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
 | [JSON Web Token][ref-auth-jwt] | [REST (JSON) API][ref-rest-api]<br/>[GraphQL API][ref-graphql-api] |
 
@@ -71,7 +69,6 @@ tools][ref-viz-tools]:
 [cube-rta]: https://cube.dev/use-cases/real-time-analytics
 [ref-queries]: /reference/core-data-apis/queries
 [ref-sql-api]: /reference/core-data-apis/sql-api
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
 [ref-rest-api]: /reference/core-data-apis/rest-api
 [ref-graphql-api]: /reference/core-data-apis/graphql-api
@@ -93,5 +90,3 @@ tools][ref-viz-tools]:
 [ref-groups]: /admin/users-and-permissions/user-groups
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
 [ref-dap]: /docs/data-modeling/data-access-policies
-[ref-auth-kerberos]: /reference/core-data-apis/dax-api/kerberos
-[ref-auth-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/core-data-apis/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/index.mdx
@@ -62,7 +62,7 @@ tools][ref-viz-tools]:
 | Method | ✅ Supported in |
 | --- | --- |
 | [User name and password][ref-auth-user-pass] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api]<br/>[SQL API][ref-sql-api] |
-| Kerberos and NTLM | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api] |
+| [Kerberos][ref-auth-kerberos] and [NTLM][ref-auth-ntlm] | [DAX API][ref-dax-api]<br/>[MDX API][ref-mdx-api] |
 | [Identity provider][ref-auth-idp] | [Cube Cloud for Excel][ref-cube-cloud-for-excel]<br/>[Cube Cloud for Sheets][ref-cube-cloud-for-sheets] |
 | [JSON Web Token][ref-auth-jwt] | [REST (JSON) API][ref-rest-api]<br/>[GraphQL API][ref-graphql-api] |
 
@@ -93,3 +93,5 @@ tools][ref-viz-tools]:
 [ref-groups]: /admin/users-and-permissions/user-groups
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
 [ref-dap]: /docs/data-modeling/data-access-policies
+[ref-auth-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-auth-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/core-data-apis/mdx-api.mdx
+++ b/docs-mintlify/reference/core-data-apis/mdx-api.mdx
@@ -218,7 +218,7 @@ This is going to be harmonized in the future.
 ## Authentication and authorization
 
 The MDX API shares its authentication layer with the [DAX API][ref-dax-api]:
-Kerberos and NTLM are supported, as well as user name and
+[Kerberos][ref-kerberos] and [NTLM][ref-ntlm] are supported, as well as user name and
 password authentication. Configuration is done on the **Settings → Power BI** page of
 your deployment — the same XMLA service account, SPN, and keytab setup applies to both
 APIs.
@@ -236,3 +236,5 @@ APIs.
 [ref-pre-aggregations]: /docs/pre-aggregations/using-pre-aggregations
 [ref-rollup-only-mode]: /docs/pre-aggregations/using-pre-aggregations#rollup-only-mode
 [ref-measure-format]: /reference/data-modeling/measures#format
+[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
+[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/core-data-apis/mdx-api.mdx
+++ b/docs-mintlify/reference/core-data-apis/mdx-api.mdx
@@ -217,15 +217,12 @@ This is going to be harmonized in the future.
 
 ## Authentication and authorization
 
-The MDX API shares its authentication layer with the [DAX API][ref-dax-api]:
-[Kerberos][ref-kerberos] and [NTLM][ref-ntlm] are supported, as well as user name and
+The MDX API supports Kerberos and NTLM authentication, as well as user name and
 password authentication. Configuration is done on the **Settings → Power BI** page of
-your deployment — the same XMLA service account, SPN, and keytab setup applies to both
-APIs.
+your deployment, which manages the XMLA service account, SPN, and keytab setup.
 
 [ref-excel]: /admin/connect-to-data/visualization-tools/excel
 [ref-time-dimensions]: /docs/data-modeling/dimensions#time-dimensions
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [link-mdx]: https://learn.microsoft.com/en-us/analysis-services/multidimensional-models/mdx/multidimensional-model-data-access-analysis-services-multidimensional-data?view=asallproducts-allversions#bkmk_querylang
 [link-pivottable]: https://support.microsoft.com/en-us/office/create-a-pivottable-to-analyze-worksheet-data-a9a84538-bfe9-40a9-a8e9-f99134456576
 [ref-cube-cloud-for-excel]: /docs/integrations/microsoft-excel
@@ -236,5 +233,3 @@ APIs.
 [ref-pre-aggregations]: /docs/pre-aggregations/using-pre-aggregations
 [ref-rollup-only-mode]: /docs/pre-aggregations/using-pre-aggregations#rollup-only-mode
 [ref-measure-format]: /reference/data-modeling/measures#format
-[ref-kerberos]: /reference/core-data-apis/dax-api/kerberos
-[ref-ntlm]: /reference/core-data-apis/dax-api/ntlm

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -244,7 +244,6 @@ Use the following environment variables to allocate more resources for query pla
 
 
 [link-postgres]: https://www.postgresql.org
-[ref-dax-api]: /reference/core-data-apis/dax-api
 [ref-mdx-api]: /reference/core-data-apis/mdx-api
 [ref-sql-api-auth]: /reference/core-data-apis/sql-api/security
 [ref-config-checksqlauth]: /reference/configuration/config#checksqlauth


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Follow-up to #11406. Hides the DAX API documentation so it no longer appears in the menu or in search, while staying reachable by direct link — the same treatment given to the Power BI, Tableau, and Semantic Layer Sync pages.

### Pages hidden

All five pages in the DAX API group get `hidden: true`, which Mintlify turns into `noindex` (sidebar, site search, sitemap, search-engine indexing, AI assistant context):

- `reference/core-data-apis/dax-api/index.mdx` — overview
- `reference/core-data-apis/dax-api/cross-view-filter.mdx`
- `reference/core-data-apis/dax-api/reference.mdx` — DAX function reference
- `reference/core-data-apis/dax-api/kerberos.mdx`
- `reference/core-data-apis/dax-api/ntlm.mdx`

The sidebar under **APIs** now reads SQL API, REST (JSON) API, GraphQL API, with the DAX API group gone and no empty group header left behind.

### References removed

Verified programmatically that no visible page links into the group any more.

- **`reference/core-data-apis/index.mdx`** — the DAX API bullet dropped from the "Choosing the Right API" chooser; DAX API removed from both rows of the authentication table, so the Kerberos/NTLM row now lists only the MDX API.
- **`admin/deployment/providers/azure.mdx`** — the "Microsoft Power BI via the DAX API" bullet removed from the visualization tools list.
- **`reference/core-data-apis/mdx-api.mdx`** — the auth section no longer cross-references the DAX API; rewritten to state the MDX API's own support directly.

### Unlinked rather than deleted — worth a look

Five spots where deleting the mention would empty a table cell or strip the subject out of a sentence. The API name is kept as plain text and only the hyperlink is dropped:

- **`admin/account-billing/pricing.mdx`** — the M deployment tier's "Dependent features" cell. The tier exists *because* of the DAX API; an empty cell would read as "no dependent features", which is wrong.
- **`reference/configuration/environment-variables.mdx`** — the `CUBEJS_DAX_*` option descriptions.
- **`docs/data-modeling/concepts/syntax.mdx`** — the member-naming constraint about clashing with date hierarchy columns.
- **`recipes/data-modeling/xirr.mdx`** — which APIs implement the `XIRR` function.
- **`admin/connect-to-data/data-sources/ksqldb.mdx`** — the note recommending the DAX API over the SQL API for the linked video.

### Note on the two commits

The first commit moves the Kerberos and NTLM pages out of the (hidden) Power BI section and under the DAX API, to close the gap where their setup instructions were unreachable from menu and search. The second commit then hides the DAX API group, which re-hides them — so the net effect of the branch is that those two pages moved from one hidden location to another, plus redirects from their old URLs.

The redirects are worth keeping on their own (links already shared with customers keep working), but happy to squash the two commits or drop the move if the churn isn't wanted.

### Known gap

Kerberos/NTLM setup is now undocumented in navigable docs. `mdx-api.mdx` still says authentication is configured on the **Settings → Power BI** page, but no reachable page explains how to do it. Note that `mdx-api.mdx` is itself already absent from `docs.json` — out of the sidebar, though still indexable — so the authentication table's remaining "MDX API" entry points at a page users can't navigate to either. Worth deciding separately where this content should live.

### Verification

- All five pages return 200 and emit `<meta name="robots" content="noindex">`; the `/docs/integrations/power-bi/kerberos` redirect still resolves to the moved page.
- No visible page references the hidden group, and no reference-style link was left dangling (diffed against `master` across all 16 changed files).
- `yarn broken-links` reports 16 broken links, all pre-existing anchor issues in `embedding/iframe/events.mdx` and `localization.mdx` — files untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)