### PR TITLE
docs: remove preview banner from Python analysis page

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -3,14 +3,6 @@ title: Python analysis
 description: Attach a Python script to a report to run forecasting, regression, cohort, and other analysis that SQL can't express, and save the result as a re-runnable report.
 ---
 
-<Warning>
-
-Python analysis is currently in preview, and the user experience and file format may
-still change. Reach out to the [Cube support team](/admin/account-billing/support)
-to activate this feature for your account.
-
-</Warning>
-
 A report can carry an attached **Python script** that transforms the report's SQL
 result. The report's chart then renders the script's **output** instead of the raw
 SQL rows. This turns an analysis that would otherwise scroll away in a chat


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Python analysis is no longer in preview, so the `<Warning>` callout at the top of
`docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx` — telling users the
feature may still change and to contact Cube support to activate it — has been removed.
The page now opens directly with the body content.

Docs-only change; it was the only "preview" mention in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)