### PR TITLE
docs: document the Python analysis environment and pre-installed packages

### DIFF
--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -86,6 +86,10 @@ These packages are pre-installed, along with their dependencies:
 | `prophet` | Time series forecasting with seasonality and holidays |
 | `matplotlib`, `seaborn`, `plotly` | Plotting |
 
+Figures are not a supported output. The report's chart is built from `output.json`, and
+anything a script writes to disk is discarded with the sandbox — so the plotting
+libraries are importable, but a saved figure has nowhere to go.
+
 <Info>
 
 Installing your own packages is not supported yet. Because the sandbox is recreated

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -68,10 +68,31 @@ The script runs in a sandbox against a fixed contract:
 A top-level dict or object is rejected — flatten any nested structure into one
 array of uniform rows.
 
-These libraries are available: pandas, numpy, scipy, scikit-learn, statsmodels,
-prophet, matplotlib, seaborn, plotly.
-
 {/* TODO: screenshot — the Add Python tab menu entry */}
+
+## Python environment
+
+Every run gets a fresh, isolated sandbox running **Python 3.11**. It is created for
+the run and destroyed when the run finishes — nothing carries over between runs.
+
+These packages are pre-installed, along with their dependencies:
+
+| Package | Use |
+| --- | --- |
+| `pandas`, `numpy` | Dataframes and numerical computing |
+| `scipy` | Statistical tests, optimization, interpolation |
+| `scikit-learn` | Regression, classification, clustering, anomaly detection |
+| `statsmodels` | ARIMA, exponential smoothing, econometric models |
+| `prophet` | Time series forecasting with seasonality and holidays |
+| `matplotlib`, `seaborn`, `plotly` | Plotting |
+
+<Info>
+
+Installing your own packages is not supported yet. Because the sandbox is recreated
+for every run, anything a script installs is discarded when the run ends. Support for
+adding packages to the environment is coming.
+
+</Info>
 
 ## Running and refreshing
 


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Adds a **Python environment** section to the Python analysis page. This is the most
common question we get about the feature (what can I import? can I add my own
packages?) and the page previously answered it with a single comma-separated line
buried inside "Writing the script".

The new section covers:

- The runtime — a fresh, isolated Python 3.11 sandbox created per run and destroyed after.
- The pre-installed package set, as a table with what each package is for:
  `pandas`, `numpy`, `scipy`, `scikit-learn`, `statsmodels`, `prophet`, `matplotlib`,
  `seaborn`, `plotly`.
- That installing custom packages is not supported yet, why (the sandbox is recreated
  per run, so anything a script installs is discarded), and that support is coming.

The old one-line list is removed so the package set is stated once.

**Reviewer notes**

Package **versions are deliberately omitted.** The sandbox template installs these
unpinned (`pip install pandas numpy …`, no `==`) and the build is idempotent and cached
per region, so two regions can be running different versions with nothing recording
either. Any version table published today would be inaccurate. Pinning the set in the
runtime is filed separately; versions can be documented once that lands.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)