### PR TITLE
feat(cubesql): Separate env var for non-streaming query max row limit

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1079,7 +1079,9 @@ specified in an API query.
 
 The maximum [row limit][ref-row-limit] in the result set. An explicit limit in a
 query cannot exceed this value, except for [SQL API][ref-sql-api] queries when
-[streaming mode][ref-sql-api-streaming] is enabled.
+[streaming mode][ref-sql-api-streaming] is enabled. SQL API queries that are not
+streamed can be capped separately, at a lower value, with
+[`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`](#cubesql_non_streaming_query_max_row_limit).
 
 | Possible Values           | Default in Development | Default in Production |
 | ------------------------- | ---------------------- | --------------------- |
@@ -1506,7 +1508,8 @@ If `true`, enables query pushdown in the [SQL API][ref-sql-api].
 If `true`, enables the [streaming mode][ref-sql-api-streaming] in the [SQL API][ref-sql-api].
 When enabled, SQL API queries with an explicit `LIMIT` clause can exceed the
 maximum row limit set by
-[`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit).
+[`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`](#cubesql_non_streaming_query_max_row_limit)
+and are streamed instead.
 Queries without an explicit `LIMIT` still use [`CUBEJS_DB_QUERY_DEFAULT_LIMIT`](#cubejs_db_query_default_limit).
 
 | Possible Values | Default in Development | Default in Production |
@@ -1527,6 +1530,30 @@ Set to `0` to disable splitting.
 | Possible Values                | Default in Development | Default in Production |
 | ------------------------------ | ---------------------- | --------------------- |
 | A non-negative integer number  | `65536`                | `65536`               |
+
+## `CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`
+
+The maximum [row limit][ref-row-limit] for [SQL API][ref-sql-api] queries that are
+not streamed. A larger `LIMIT` is reduced to this value, unless
+[streaming mode][ref-sql-api-streaming] is enabled, in which case the query is
+streamed instead.
+
+| Possible Values           | Default in Development                            | Default in Production                             |
+| ------------------------- | ------------------------------------------------- | ------------------------------------------------- |
+| A positive integer number | [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit) | [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit) |
+
+Set it below `CUBEJS_DB_QUERY_LIMIT` to let other APIs return large result sets
+while keeping SQL API responses small enough to fit in a single batch, or streamed
+if streaming mode is enabled. Buffering very large non-streamed responses can
+exhaust memory and break the client connection.
+
+<Warning>
+
+This value should not exceed
+[`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit). Non-streamed queries above that
+limit are rejected before they reach the data source.
+
+</Warning>
 
 ## `CUBESQL_SQL_NO_IMPLICIT_ORDER`
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1549,9 +1549,10 @@ exhaust memory and break the client connection.
 
 <Warning>
 
-This value should not exceed
-[`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit). Non-streamed queries above that
-limit are rejected before they reach the data source.
+This value cannot exceed [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit). If you
+set it higher, Cube logs a warning at startup and falls back to
+`CUBEJS_DB_QUERY_LIMIT`, because non-streamed queries above that limit are rejected
+before they reach the data source.
 
 </Warning>
 

--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1540,7 +1540,7 @@ streamed instead.
 
 | Possible Values           | Default in Development                            | Default in Production                             |
 | ------------------------- | ------------------------------------------------- | ------------------------------------------------- |
-| A positive integer number | [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit) | [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit) |
+| A positive integer number | [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit) (`50000`) | [`CUBEJS_DB_QUERY_LIMIT`](#cubejs_db_query_limit) (`50000`) |
 
 Set it below `CUBEJS_DB_QUERY_LIMIT` to let other APIs return large result sets
 while keeping SQL API responses small enough to fit in a single batch, or streamed

--- a/docs-mintlify/reference/core-data-apis/queries.mdx
+++ b/docs-mintlify/reference/core-data-apis/queries.mdx
@@ -44,7 +44,9 @@ environment variable to override it. You can also implement
 If you're using the [SQL API][ref-sql-api], you can enable
 [streaming mode][ref-sql-api-streaming] to bypass the maximum row limit for
 queries with an explicit `LIMIT` clause. Without an explicit `LIMIT`,
-`CUBEJS_DB_QUERY_DEFAULT_LIMIT` still applies even in streaming mode.
+`CUBEJS_DB_QUERY_DEFAULT_LIMIT` still applies even in streaming mode. SQL API
+queries that are not streamed can also be capped separately with
+[`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`](/reference/configuration/environment-variables#cubesql_non_streaming_query_max_row_limit).
 
 ### Time zone
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/index.mdx
@@ -214,6 +214,11 @@ explicit `LIMIT`, increase `CUBEJS_DB_QUERY_DEFAULT_LIMIT` as needed.
 
 </Info>
 
+Queries that are not streamed are capped by
+[`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`](/reference/configuration/environment-variables#cubesql_non_streaming_query_max_row_limit),
+which defaults to the value of `CUBEJS_DB_QUERY_LIMIT`. It also acts as the threshold
+above which a query is streamed rather than loaded in a single batch.
+
 ### Session limit
 
 Each concurrent connection to the SQL API consumes some resources and attempting

--- a/rust/cubesql/cubesql/src/config/mod.rs
+++ b/rust/cubesql/cubesql/src/config/mod.rs
@@ -184,7 +184,13 @@ impl ConfigObjImpl {
             push_down_pull_up_split: env_optparse("CUBESQL_PUSH_DOWN_PULL_UP_SPLIT")
                 .unwrap_or(sql_push_down),
             stream_mode: env_parse("CUBESQL_STREAM_MODE", false),
-            non_streaming_query_max_row_limit: env_parse("CUBEJS_DB_QUERY_LIMIT", 50000),
+            // Cap on rows a non-streaming (one-shot) query may fetch, and the threshold
+            // above which CUBESQL_STREAM_MODE switches a query to streaming.
+            non_streaming_query_max_row_limit: env_optparse(
+                "CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT",
+            )
+            .or_else(|| env_optparse("CUBEJS_DB_QUERY_LIMIT"))
+            .unwrap_or(50000),
             cube_scan_max_batch_rows: env_parse("CUBESQL_CUBE_SCAN_MAX_BATCH_ROWS", 65536),
             max_sessions: env_parse("CUBEJS_MAX_SESSIONS", 1024),
             no_implicit_order: env_parse("CUBESQL_SQL_NO_IMPLICIT_ORDER", true),

--- a/rust/cubesql/cubesql/src/config/mod.rs
+++ b/rust/cubesql/cubesql/src/config/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     CubeError,
 };
 use futures::future::join_all;
-use log::error;
+use log::{error, warn};
 
 use std::{
     env,
@@ -153,6 +153,22 @@ impl ConfigObjImpl {
             .map(|v| v.parse::<u64>().unwrap())
             .unwrap_or(120);
         let sql_push_down = env_parse("CUBESQL_SQL_PUSH_DOWN", true);
+
+        let db_query_limit: i32 = env_parse("CUBEJS_DB_QUERY_LIMIT", 50000);
+        let non_streaming_query_max_row_limit =
+            match env_optparse("CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT") {
+                Some(limit) if limit > db_query_limit => {
+                    warn!(
+                        "CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT ({}) exceeds \
+                        CUBEJS_DB_QUERY_LIMIT ({}), falling back to the latter",
+                        limit, db_query_limit
+                    );
+                    db_query_limit
+                }
+                Some(limit) => limit,
+                None => db_query_limit,
+            };
+
         Self {
             bind_address: env::var("CUBESQL_BIND_ADDR").ok().or_else(|| {
                 env::var("CUBESQL_PORT")
@@ -184,13 +200,7 @@ impl ConfigObjImpl {
             push_down_pull_up_split: env_optparse("CUBESQL_PUSH_DOWN_PULL_UP_SPLIT")
                 .unwrap_or(sql_push_down),
             stream_mode: env_parse("CUBESQL_STREAM_MODE", false),
-            // Cap on rows a non-streaming (one-shot) query may fetch, and the threshold
-            // above which CUBESQL_STREAM_MODE switches a query to streaming.
-            non_streaming_query_max_row_limit: env_optparse(
-                "CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT",
-            )
-            .or_else(|| env_optparse("CUBEJS_DB_QUERY_LIMIT"))
-            .unwrap_or(50000),
+            non_streaming_query_max_row_limit,
             cube_scan_max_batch_rows: env_parse("CUBESQL_CUBE_SCAN_MAX_BATCH_ROWS", 65536),
             max_sessions: env_parse("CUBEJS_MAX_SESSIONS", 1024),
             no_implicit_order: env_parse("CUBESQL_SQL_NO_IMPLICIT_ORDER", true),


### PR DESCRIPTION
`CUBEJS_DB_QUERY_LIMIT` was read by two layers, which mean different things by it:

- the API gateway rejects non-streaming queries above it
- cubesql uses it as `non_streaming_query_max_row_limit`, which is both the clamp on one-shot queries *and* the threshold above which `CUBESQL_STREAM_MODE` switches a query to streaming