### PR TITLE
docs: grant policy-version actions in the AWS BYOC IAM policy

### DIFF
--- a/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
+++ b/docs-mintlify/admin/deployment/dedicated/aws/byoc.mdx
@@ -33,7 +33,7 @@ In addition to that, you'll need to make sure you have sufficient access to crea
 the `CubeCloudBYOC` IAM role that would allow Cube to:
 - Create and manage a VPC
 - Create one or more EKS clusters
-- Create necessary IAM roles and policies
+- Create and maintain necessary IAM roles and policies
 - Configure VPC networking
 - Run ec2 instances
 - Manage ec2 autoscaling
@@ -144,11 +144,13 @@ actual account ID.
                 "iam:CreateInstanceProfile",
                 "iam:CreateOpenIDConnectProvider",
                 "iam:CreatePolicy",
+                "iam:CreatePolicyVersion",
                 "iam:CreateRole",
                 "iam:CreateServiceLinkedRole",
                 "iam:DeleteInstanceProfile",
                 "iam:DeleteOpenIDConnectProvider",
                 "iam:DeletePolicy",
+                "iam:DeletePolicyVersion",
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
                 "iam:DeleteServiceLinkedRole",


### PR DESCRIPTION
## Problem

The published `CubeCloudBYOC` policy on the [Deploying Cube BYOC on AWS](https://cube.dev/docs/admin/deployment/dedicated/aws/byoc) page grants `iam:CreatePolicy` but not `iam:CreatePolicyVersion`. Cube can therefore create an IAM policy in the customer's account and then never change it — every subsequent update fails:

```
aws:iam:Policy (cubeapp-autoscaling-policy): updating failed
AccessDenied: ... is not authorized to perform: iam:CreatePolicyVersion
on resource: policy/cubeapp-autoscaling-policy-...
```

That aborts the entire provisioning run, so an unrelated one-line policy change blocks every other update to that account until the customer widens the role by hand. We hit this rolling out a cluster-autoscaler permission to an existing BYOC deployment.

## Change

Adds two actions to the IAM statement that already covers policy management:

- **`iam:CreatePolicyVersion`** — updating a managed policy *is* creating a new version of it; there is no separate "update policy" action.
- **`iam:DeletePolicyVersion`** — IAM caps a managed policy at five versions, and the provisioner prunes the oldest before adding a new one. Without it, updates work exactly four times and then start failing.

Also reworded one prerequisites bullet from "Create necessary IAM roles and policies" to "Create and maintain …", since maintaining them is the part that was missing.

## Notes

- Both actions are already present in the canonical role definition shipped with the customer-deployable BYOC Terraform; this page had drifted behind it.
- The statement they join is already scoped to `CubeCloud*` / `cubeapp-*` / `cube-store-*` ARNs and conditioned on the `Created-By=CubeCloud` resource tag, so this widens what Cube can do to policies it created — not to anything else in the account.
- Existing BYOC customers are unaffected by the doc change itself; they need the same two actions added to their `CubeCloudBYOC` policy before the next policy update can reach them.
- The deprecated `/docs` Nextra copy of this page carries the same gap and was left alone per `docs/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)