### PR TITLE
docs: numeric-string REST API contract and switch-dimension pre-agg matching

### DIFF
--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -178,6 +178,17 @@ cube data-model merge-to-default DEPLOYMENT_ID --branch my-branch -m "add orders
 
 `merge-to-default` merges into the deploy branch and rebuilds production.
 
+<Info>
+
+`--dev-mode` (on `create-branch` and `dev-mode`) forks a personal `dev-*`
+branch for you rather than writing directly to the named branch, and prints
+the actual forked branch name (e.g. `dev-pavel-ab12cd34`) to pass via
+`--branch` on subsequent commands — or omit `--branch` to use your currently
+active dev-mode session. `put`, `delete`, and `rename` only accept writes to
+the active dev-mode branch; targeting any other branch is rejected.
+
+</Info>
+
 ## Environment variables
 
 | Variable | Description |

--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -98,11 +98,12 @@ Example response:
 
 <Warning>
 
-Currently all fetched numericals are returned in the same format as driver
-returns it without any additional processing. Most of drivers return numerical
-values as strings instead of javascript integer or float to ensure there's no
-loss of significance. Client code should take care of parsing such numerical
-values.
+All numeric values in the response (e.g., `"700"` in the example above) are
+serialized as JSON strings, regardless of the data source driver. This
+guarantees a consistent response contract across all drivers and avoids loss
+of significance for large numbers. Client code should parse numeric strings
+into the appropriate type; the `castNumerics` option in the
+[JavaScript SDKs][ref-cast-numerics] does this automatically.
 
 </Warning>
 
@@ -529,7 +530,7 @@ This endpoint is part of the [Orchestration API][ref-orchestration-api].
 ### Triggering jobs
 
 | Parameter                  | Description                                                    | Required |
-| -------------------------- | -------------------------------------------------------------- | -------- |
+| -------------------------- | ---------------------------------------------------------------- | -------- |
 | `action`                   | Use `post` to trigger jobs                                     | ✅       |
 | `selector.contexts`        | Array of objects, each containing a `securityContext`          | ✅       |
 | `selector.timezones`       | Array of timezones                                             | ✅       |
@@ -1003,7 +1004,9 @@ entities before `offset` and `limit` are applied:
           "type": "string",
           "sql": "${CUBE}.status",
           "is_primary_key": false,
-          "member_references": [],
+          "member_references": [
+            { "cube": "orders", "member": "status" }
+          ],
           "column_references": [
             {
               "data_source": "default",
@@ -1178,3 +1181,4 @@ Keep-Alive: timeout=5
 [link-tzdb]: https://en.wikipedia.org/wiki/Tz_database
 [ref-control-plane-api]: /reference/control-plane-api
 [self-metadata-api]: #metadata-api
+[ref-cast-numerics]: /recipes/core-data-api/cast-numerics

--- a/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
+++ b/docs-mintlify/reference/data-modeling/pre-aggregations.mdx
@@ -575,6 +575,17 @@ cube(`orders`, {
 
 </CodeGroup>
 
+<Note>
+
+[`switch`-type dimensions][ref-switch-dim] don't need to be listed here for a
+query to match this pre-aggregation. Since a `switch` dimension represents a
+predefined set of values rather than stored data, Cube can resolve it from the
+query filter (or the pre-aggregation's built-in dimension enumeration) even
+when it's omitted from the rollup — you no longer need to include it just to
+satisfy matching.
+
+</Note>
+
 ### `time_dimension`
 
 The `time_dimension` property can be any [`dimension`][ref-schema-dimensions] of
@@ -1840,3 +1851,4 @@ cube(`orders`, {
 [ref-ref-cubes]: /reference/data-modeling/cube
 [ref-custom-granularity]: /reference/data-modeling/dimensions#granularities
 [ref-env-allow-non-strict]: /reference/configuration/environment-variables#cubejs-pre-aggregations-allow-non-strict-date-range-match
+[ref-switch-dim]: /reference/data-modeling/dimensions#type


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

This is a docs-only PR closing gaps found while cross-checking recent `cube-js/cube` changes against `/docs-mintlify`.

1. `reference/core-data-apis/rest-api/reference.mdx` — the `/v1/load` response `Warning` still described the pre-#10949 behavior ("most drivers return numerical values as strings"). Since [#10949](https://github.com/cube-js/cube/pull/10949) (**breaking change**, merged into v1.7.0), all numeric values are *always* serialized as JSON strings regardless of driver. Updated the warning to state the new guaranteed contract and link to the `castNumerics` recipe.

2. `reference/data-modeling/pre-aggregations.mdx` — added a note under the `dimensions` parameter that `switch`-type dimensions no longer need to be listed in a rollup's `dimensions` for pre-aggregation matching to succeed, per [#11346](https://github.com/cube-js/cube/pull/11346). Previously this required materializing the dimension into the rollup (cross-joining its value enumeration) purely to satisfy the matcher; that requirement is now gone, and rollups that omit the dimension still match and execute correctly.

3. `reference/cli.mdx` — added a short note to the existing "Data model Git workflow" section clarifying that `--dev-mode` forks and prints a personal `dev-*` branch, and that `put`/`delete`/`rename` only accept writes to the active dev-mode branch, per [#11351](https://github.com/cube-js/cube/pull/11351).

No code changes.

**Test plan**
- [ ] Not applicable — docs content only, verified against the referenced PRs' descriptions and diffs.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LkeKoVdBbUe8eVBRhr7BHJ