### PR TITLE
docs: clarify which cells define a table color scale's range

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -306,7 +306,7 @@ For the computed anchors (Minimum, Maximum, Midpoint, Average, Median), the drop
 
 Use **Reverse color scale** to swap the Start and End colors. **Treat nulls as zero** is on by default, coloring null/blank cells as zero; turn it off to leave them uncolored.
 
-The scale is normalized **per column** — each targeted column uses its own value range.
+The scale is normalized **per column** — each targeted column uses its own value range, taken from the column's data cells. Row totals and subtotal columns are colored by that scale but do not define it, so the gradient still spans the underlying values rather than the totals that aggregate them.
 
 {/* TODO screenshot: table with a color scale applied to a numeric column (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -306,7 +306,7 @@ For the computed anchors (Minimum, Maximum, Midpoint, Average, Median), the drop
 
 Use **Reverse color scale** to swap the Start and End colors. **Treat nulls as zero** is on by default, coloring null/blank cells as zero; turn it off to leave them uncolored.
 
-The scale is normalized **per column** — each targeted column uses its own value range, taken from the column's data cells. Row totals and subtotal columns are colored by that scale but do not define it, so the gradient still spans the underlying values rather than the totals that aggregate them.
+The scale is normalized **per column** — each targeted column uses its own value range, taken from the column's data cells only. With [totals](#totals) enabled, the row totals and subtotal columns are still colored by the scale of the measure they aggregate, but they don't widen its range: a total above the column **Maximum** takes the **End** color. Cells in the column totals row are never colored by a scale, since totals rows don't take conditional formatting.
 
 {/* TODO screenshot: table with a color scale applied to a numeric column (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -306,7 +306,7 @@ For the computed anchors (Minimum, Maximum, Midpoint, Average, Median), the drop
 
 Use **Reverse color scale** to swap the Start and End colors. **Treat nulls as zero** is on by default, coloring null/blank cells as zero; turn it off to leave them uncolored.
 
-The scale is normalized **per column** — each targeted column uses its own value range, taken from the column's data cells only. With [totals](#totals) enabled, the row totals and subtotal columns are still colored by the scale of the measure they aggregate, but they don't widen its range: a total above the column **Maximum** takes the **End** color. Cells in the column totals row are never colored by a scale, since totals rows don't take conditional formatting.
+The scale is normalized **per column** — each targeted column uses its own value range, taken from the column's data cells only. With [totals](#totals) enabled, the row totals and subtotal columns are still colored by the scale of the measure they aggregate, but they don't widen its range: a total past the column's highest stop is clamped to that stop's color. Cells in the column totals row are never colored by a scale, since totals rows don't take formatting rules.
 
 {/* TODO screenshot: table with a color scale applied to a numeric column (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 


### PR DESCRIPTION
## Summary

The table chart's color-scale section said the scale is normalized per column, but not which cells make up that range — which matters once row totals or subtotal columns are enabled, since those sit in the same columns. Spells out that totals are colored by the scale but do not define it.
