### PR TITLE
docs: clarify which branch CLI data-model writes must target in dev mode

### DIFF
--- a/docs-mintlify/reference/cli.mdx
+++ b/docs-mintlify/reference/cli.mdx
@@ -178,6 +178,16 @@ cube data-model merge-to-default DEPLOYMENT_ID --branch my-branch -m "add orders
 
 `merge-to-default` merges into the deploy branch and rebuilds production.
 
+<Info>
+
+File writes (`put`, `delete`, `rename`) only land on a **dev-mode branch**. With
+`--dev-mode`, `create-branch` (and `dev-mode`) forks a personal `dev-…` branch and
+prints it — pass that printed name via `--branch`, not the name you gave
+`create-branch`, or omit `--branch` to use your active dev-mode branch. Writes
+targeting any other branch are rejected by the API.
+
+</Info>
+
 ## Environment variables
 
 | Variable | Description |


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

`reference/cli.mdx`: clarifies that `cube data-model put/delete/rename --branch` must target the **printed dev-mode branch** — the `dev-…` branch that `create-branch --dev-mode` forks and prints — not the name passed to `create-branch` itself. You can also omit `--branch` to use your active dev-mode branch; writes targeting any other branch are rejected by the API.

Verified against `rust/cube-cli/src/commands/data_model.rs` (#11351). The existing example was ambiguous about which of the two branch names to pass.