### PR TITLE
fix(cubestore): advertise INCR, not INC, in the CACHE unknown-command error

### DIFF
--- a/rust/cubestore/cubestore/src/sql/parser.rs
+++ b/rust/cubestore/cubestore/src/sql/parser.rs
@@ -508,7 +508,7 @@ impl<'a> CubeStoreParser<'a> {
             "clear" => CacheCommand::Clear {},
             other => {
                 return Err(ParserError::ParserError(format!(
-                    "Unknown cache command: {}, available: SET|GET|KEYS|INC|REMOVE|CLEAR",
+                    "Unknown cache command: {}, available: SET|GET|KEYS|INCR|REMOVE|CLEAR",
                     other
                 )))
             }


### PR DESCRIPTION
## Issue

The `CACHE` command parser accepts `incr`, but the error it emits for an unknown subcommand advertises `INC` — a keyword that doesn't parse. An operator who follows the error message gets a second error:

```
$ CACHE FOO bar;
Unknown cache command: foo, available: SET|GET|KEYS|INC|REMOVE|CLEAR

$ CACHE INC bar;
Unknown cache command: inc, available: SET|GET|KEYS|INC|REMOVE|CLEAR
```

The accepted set is exactly `SET|GET|KEYS|INCR|REMOVE|CLEAR`, so `INC` is the only inaccurate entry. This is the only enumerated-keyword error message in the parser — the other unknown-command arms emit a bare "Unknown … command" with no list.

## Description of Change

Corrects the advertised keyword to `INCR`.
