### PR TITLE
docs: remove table chart Table options section for a tab and controls that do not exist

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -26,19 +26,6 @@ Pivot behavior:
 - Pivot columns can also be sorted by row values — click a row number to sort by that row, including the totals row.
 - Pivoted columns can be hidden, but hiding is indexed to the specific value (e.g. hiding `status: returned`), not position.
 
-## Table options
-
-The **Table** tab in the configuration panel controls layout and display settings:
-
-| Option | Description |
-|---|---|
-| **Header text** | Controls whether long column headers **truncate** or **wrap** to the next line |
-| **View names** | When enabled, the view/cube name is shown in the column header |
-| **Row numbers** | Adds a row number column on the left |
-| **Group dimensions** | Groups multiple dimensions per row into a collapsible section for subtotaling |
-
-Column widths are configured **per column** — see [Column width](#column-width) below.
-
 ## Column field options
 
 Configure individual columns in the **Columns** section of the **Style** tab (or via the dropdown arrow on a field in the **Fields** section):

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -250,7 +250,7 @@ Use **Reset** in the section header to clear all border settings.
 
 ## Conditional formatting
 
-The **Conditional formatting** tab applies cell or row styling based on conditions you define. Configure:
+The **Formatting** tab applies cell or row styling based on conditions you define. Configure:
 
 1. The field to evaluate
 2. The condition (e.g. greater than, contains, is null)
@@ -299,7 +299,7 @@ The scale is normalized **per column** — each targeted column uses its own val
 
 ## Totals
 
-Enable column totals and row totals from the **Table** configuration tab. Totals rows and columns are styled separately from body cells.
+Enable column totals and row totals from the **Totals** section of the **Style** tab. Totals rows and columns are styled separately from body cells.
 
 ### Subtotals
 


### PR DESCRIPTION
## Summary

The table chart page documented a **Table** tab that the chart doesn't have, listing four options under it. The chart's tabs are **Fields**, **Style**, and **Formatting**.

Of the four options in that table:

- **View names** and **Group dimensions** don't exist — no spec field, no control, no string for either anywhere in the product. Dimension grouping is unbuilt work, so that row described a feature we don't ship.
- **Header text** and **Row numbers** do exist, but as **Overflow** and a **Row numbers** toggle in the Style tab's Headers and Values sections — both already documented correctly further down the page, under *Style options*.

So the section was either wrong or duplicated, and the two correct rows named the controls by labels the UI doesn't use. Removed it. The `Column width` pointer it ended on is redundant with the **Width** row in *Column field options* immediately below, which already links to the same section.

Same class of fix as #11320, one section further up the page.

## Test plan

- Verified against the shipped chart: `TableChartSpecSchema` has no view-name or dimension-grouping field; the builder renders exactly three tabs; exhaustive search for `showViewNames` / `viewNames` / `groupDimensions` and the literal labels returns nothing for the table chart.
- Confirmed **Row numbers** and **Overflow** are documented under *Style options*, so no content is lost.
- No page linked to the removed `#table-options` anchor.
- `mint broken-links` clean; the page renders without MDX errors on a local Mintlify server.
