### PR TITLE
fix(docs): drop trailing slashes from three redirect sources so they resolve

### DIFF
--- a/docs-mintlify/scripts/build_old_site_redirects.py
+++ b/docs-mintlify/scripts/build_old_site_redirects.py
@@ -248,15 +248,22 @@ def resolve_destination(old_dest: str, page_map: dict) -> str:
 
 
 def build_redirects(old_redirects: list, page_map: dict) -> list:
-    out, seen = [], set()
+    out, seen = [], {}
 
     def add(source: str, dest: str):
         # Next strips a trailing slash before matching redirects, so a slash-terminated
         # source can never fire — the normalized path matches no rule and 404s.
         source = source.rstrip("/") or "/"
         if source in seen:
+            # First writer wins: a legacy alias deliberately outranks the canonical
+            # page_map entry for the same path. Only report the cases that actually
+            # lose a distinct destination, so a dropped redirect is visible rather
+            # than silent. Not fatal — the precedence itself is intended.
+            if seen[source] != dest:
+                print(f"  note: {source} already redirects to {seen[source]}, "
+                      f"dropping {dest}", file=sys.stderr)
             return
-        seen.add(source)
+        seen[source] = dest
         out.append({"source": source, "destination": dest, "permanent": True})
 
     # 1. Legacy aliases from the old redirects.json.

--- a/docs-mintlify/scripts/build_old_site_redirects.py
+++ b/docs-mintlify/scripts/build_old_site_redirects.py
@@ -251,6 +251,9 @@ def build_redirects(old_redirects: list, page_map: dict) -> list:
     out, seen = [], set()
 
     def add(source: str, dest: str):
+        # Next strips a trailing slash before matching redirects, so a slash-terminated
+        # source can never fire — the normalized path matches no rule and 404s.
+        source = source.rstrip("/") or "/"
         if source in seen:
             return
         seen.add(source)

--- a/docs/redirects-new-docs.json
+++ b/docs/redirects-new-docs.json
@@ -635,7 +635,7 @@
     "permanent": true
   },
   {
-    "source": "/cloud/access-control/",
+    "source": "/cloud/access-control",
     "destination": "https://docs.cube.dev/admin/users-and-permissions/custom-roles",
     "permanent": true
   },
@@ -650,7 +650,7 @@
     "permanent": true
   },
   {
-    "source": "/cloud/dev-tools/alerts/",
+    "source": "/cloud/dev-tools/alerts",
     "destination": "https://docs.cube.dev/docs/introduction",
     "permanent": true
   },
@@ -735,7 +735,7 @@
     "permanent": true
   },
   {
-    "source": "/workspace/sso/",
+    "source": "/workspace/sso",
     "destination": "https://docs.cube.dev/admin/sso",
     "permanent": true
   },


### PR DESCRIPTION
Three entries in the `cube.dev/docs` redirect table have `source` values that only exist in trailing-slash form, so they never fire and the URL 404s.

Next normalizes the trailing slash *before* matching redirects, so the request lands on the slash-less path, which matches no rule:

```
https://cube.dev/docs/workspace/sso/   ->  308  https://cube.dev/docs/workspace/sso
https://cube.dev/docs/workspace/sso    ->  404
```

Same for `/cloud/access-control/` and `/cloud/dev-tools/alerts/`. The sibling rule `/workspace/sso/okta` carries no trailing slash and resolves correctly — that's the working shape.

## What changed

- **`docs/redirects-new-docs.json`** — dropped the trailing slash from the three affected `source` values. Not slash-less duplicates: nothing else in the table claims those paths.
- **`docs-mintlify/scripts/build_old_site_redirects.py`** — normalize `source` in `add()`. The slashes originate in the generator's input (`docs/redirects.json`) and were copied through verbatim, so fixing only the generated table would let the next regeneration silently reintroduce all three.

## Verification

Built the redirect config against a running Next 16.2.12 server and replayed the table:

- **Before:** all three slash-less paths 404, reproducing production exactly.
- **After:** all three resolve in *both* slash forms, and **771/771** enumerated rules land on their exact stated destination (was 768/771).
- The catch-all `/product/:path*` still resolves and still loses to enumerated rules; rule order and count (772) unchanged.
- Re-running the generator now reproduces the committed table's sources byte-for-byte, in order, with zero trailing-slash sources — so the artifact and the generator agree.

All three destinations return 200.
