### PR TITLE
docs: pre-aggregation matching for switch dimensions (follow-up to #11346)

### DIFF
--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -92,6 +92,16 @@ dimension, then a matching pre-aggregation with the same custom granularity will
 be used even if there is also an matching pre-aggregation with a default
 granularity (e.g., `day` or `month`).
 
+<Note>
+
+Provide the date range via [`timeDimensions`][ref-time-dimensions-format] rather
+than an [`inDateRange` filter][ref-in-date-range]. A date range expressed as a
+filter is applied as a generic dimension filter, so it matches only when that
+time dimension is also listed in the pre-aggregation's `dimensions` — the
+granularity matching rules above don't apply to it.
+
+</Note>
+
 ### Matching ungrouped queries
 
 There are extra considerations that apply to matching [ungrouped
@@ -169,16 +179,6 @@ filter pins only one of them; the others fall back to their full set of values,
 and each value emits its own row — so the query returns extra rows.
 Pre-aggregations match either way, so they accelerate that result rather than
 preventing it.
-
-<Note>
-
-Provide the date range via [`timeDimensions`][ref-time-dimensions-format] rather
-than an [`inDateRange` filter][ref-in-date-range]. A date range expressed as a
-filter is applied as a generic dimension filter, so it matches only when that
-time dimension is also listed in the pre-aggregation's `dimensions` — the
-granularity matching rules don't apply to it.
-
-</Note>
 
 ## Matching multi-fact and multi-stage queries
 

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -161,27 +161,22 @@ v1.7.0, it was not enabled by default.
 
 </Warning>
 
-Two modeling considerations apply when `case` measures span multiple cubes:
-
-- **Define the `switch` dimension on a single shared cube joined into every fact
-cube**, rather than defining a separate one on each cube. All `case` measures
-then dispatch on the same dimension, so one filter resolves every measure. With
-a `switch` dimension per cube, a single filter pins only one of them; the others
-fall back to their full set of values, and each value emits its own row — so the
-query returns extra rows. Pre-aggregations match either way, so they accelerate
-that result rather than preventing it.
-- **Key every pre-aggregation on the time dimension the query groups by.** If a
-query joins two cubes and one pre-aggregation is keyed on its own cube's time
-dimension while the query groups by the other's, that pre-aggregation can't
-serve the query — and since matching is all-or-nothing across the query, the
-other pre-aggregation is dropped too and the query runs against the upstream
-data source. Results stay correct; only the acceleration is lost.
+When `case` measures span multiple cubes, **define the `switch` dimension on a
+single shared cube joined into every fact cube**, rather than defining a separate
+one on each cube. All `case` measures then dispatch on the same dimension, so one
+filter resolves every measure. With a `switch` dimension per cube, a single
+filter pins only one of them; the others fall back to their full set of values,
+and each value emits its own row — so the query returns extra rows.
+Pre-aggregations match either way, so they accelerate that result rather than
+preventing it.
 
 <Note>
 
-Provide the date range via [`timeDimensions`][ref-time-dimensions-format]
-rather than an [`inDateRange` filter][ref-in-date-range]. A date range expressed
-as a filter prevents matching, even when `timeDimensions` is also present.
+Provide the date range via [`timeDimensions`][ref-time-dimensions-format] rather
+than an [`inDateRange` filter][ref-in-date-range]. A date range expressed as a
+filter is applied as a generic dimension filter, so it matches only when that
+time dimension is also listed in the pre-aggregation's `dimensions` — the
+granularity matching rules don't apply to it.
 
 </Note>
 
@@ -193,6 +188,14 @@ with [multi-stage measures][ref-multi-stage] runs a subquery per stage. Cube
 matches a pre-aggregation to each subquery independently, so a single query can
 be served by several pre-aggregations at once — one per subquery — rather than
 requiring a single pre-aggregation that covers the whole query.
+
+Matching is all-or-nothing across the query, though: if any subquery can't be
+served, the pre-aggregations matched for the others are dropped too and the whole
+query runs against the upstream data source. A common cause is a pre-aggregation
+keyed on its own cube's time dimension while the query groups by another cube's —
+the two are equal by the join condition, but matching only considers members the
+pre-aggregation stores. Key every pre-aggregation on the time dimension the query
+groups by. Results stay correct either way; only the acceleration is lost.
 
 <Warning>
 

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -163,6 +163,11 @@ cube(`sales`, {
 Pre-aggregations that *do* include the `switch` dimension keep matching as well,
 so existing definitions are unaffected.
 
+Matching is unaffected by how the `switch` dimension is modeled across cubes. If
+a query returns more rows than expected, that's a modeling concern — see
+[`case` measures][ref-case] — and pre-aggregations accelerate that result rather
+than preventing it.
+
 <Warning>
 
 `switch` dimensions and `case` measures are powered by Tesseract, the
@@ -170,11 +175,6 @@ so existing definitions are unaffected.
 v1.7.0, it was not enabled by default.
 
 </Warning>
-
-Matching is unaffected by how the `switch` dimension is modeled across cubes. If
-a query returns more rows than expected, that's a modeling concern — see
-[`case` measures][ref-case] — and pre-aggregations accelerate that result rather
-than preventing it.
 
 ## Matching multi-fact and multi-stage queries
 

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -52,7 +52,8 @@ measures defined as `{sum} / {count}`), then referenced leaf measures will be
 checked for additivity.
 - **Does every member of the query exist in the pre-aggregation?** Cube checks
 that the pre-aggregation contains all dimensions, filter dimensions, and leaf
-measures from the query.
+measures from the query. [`switch` dimensions](#matching-switch-dimensions) are
+an exception: they don't have to be included in the pre-aggregation.
 - **Are any query measures multiplied in the cube's data model?** Cube checks
 if any measures are multiplied via a [`one_to_many`
 relationship][ref-schema-joins-rel] between cubes in the query.
@@ -60,8 +61,6 @@ relationship][ref-schema-joins-rel] between cubes in the query.
 that the time dimension granularity is set in the query.
 - **Are query filter dimensions included in its own dimensions?** Cube checks
 that all filter dimensions are also included as dimensions in the query.
-- **Does every member in the query exist in the pre-aggregation?** Cube checks
-that the pre-aggregation contains all dimensions and measures used in the query.
 
 ### Matching time dimensions
 
@@ -102,6 +101,89 @@ queries][ref-ungrouped-queries]:
 cubes involved in the query.
 - If multiple cubes are referenced in the query, the pre-aggregation should
 include only members of these cubes.
+
+### Matching switch dimensions
+
+A [`switch` dimension][ref-switch] holds a predefined set of values rather than
+data from the upstream data source, and [`case` measures][ref-case] dispatch on
+the selected value. Because its values are known from the data model, a
+pre-aggregation **does not need to include a `switch` dimension** to match a
+query that uses one: the selected value is applied over the pre-aggregation scan.
+
+Leaving the `switch` dimension out keeps the pre-aggregation small — including
+it multiplies the rows by every value in the set:
+
+<CodeGroup>
+
+```yaml title="YAML"
+cubes:
+  - name: sales
+    # ...
+
+    pre_aggregations:
+      - name: rolling
+        measures:
+          - total
+          - r3_amount
+          - ytd_amount
+        dimensions:
+          - account
+          - product
+        time_dimension: date
+        granularity: month
+```
+
+```javascript title="JavaScript"
+cube(`sales`, {
+  // ...
+
+  pre_aggregations: {
+    rolling: {
+      measures: [total, r3_amount, ytd_amount],
+      dimensions: [account, product],
+      time_dimension: date,
+      granularity: `month`
+    }
+  }
+});
+```
+
+</CodeGroup>
+
+Pre-aggregations that *do* include the `switch` dimension keep matching as well,
+so existing definitions are unaffected.
+
+<Warning>
+
+`switch` dimensions and `case` measures are powered by Tesseract, the
+[next-generation data modeling engine][link-tesseract]. In versions before
+v1.7.0, it was not enabled by default.
+
+</Warning>
+
+Two modeling considerations apply when `case` measures span multiple cubes:
+
+- **Define the `switch` dimension on a single shared cube joined into every fact
+cube**, rather than defining a separate one on each cube. All `case` measures
+then dispatch on the same dimension, so one filter resolves every measure. With
+a `switch` dimension per cube, a single filter pins only one of them; the others
+fall back to their full set of values, and each value emits its own row — so the
+query returns extra rows. Pre-aggregations match either way, so they accelerate
+that result rather than preventing it.
+- **Key every pre-aggregation on the time dimension the query groups by.** If a
+query joins two cubes and one pre-aggregation is keyed on its own cube's time
+dimension while the query groups by the other's, that pre-aggregation can't
+serve the query — and since matching is all-or-nothing across the query, the
+other pre-aggregation is dropped too and the query runs against the upstream
+data source. Results stay correct; only the acceleration is lost.
+
+<Note>
+
+Provide the date range via [`timeDimensions`][ref-time-dimensions-format]
+rather than an [`inDateRange` filter][ref-in-date-range]. A date range expressed
+as a filter prevents matching, even when `timeDimensions` is also present.
+
+</Note>
 
 ## Matching multi-fact and multi-stage queries
 
@@ -159,4 +241,8 @@ configuration option.
 [ref-views]: /docs/data-modeling/views
 [ref-multi-fact-views]: /docs/data-modeling/multi-fact-views
 [ref-multi-stage]: /docs/data-modeling/measures#multi_stage
+[ref-switch]: /reference/data-modeling/dimensions#type
+[ref-case]: /reference/data-modeling/measures#case
+[ref-time-dimensions-format]: /reference/core-data-apis/rest-api/query-format#time-dimensions-format
+[ref-in-date-range]: /reference/core-data-apis/rest-api/query-format#indaterange
 [link-tesseract]: https://cube.dev/blog/introducing-tesseract

--- a/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
+++ b/docs-mintlify/docs/pre-aggregations/matching-pre-aggregations.mdx
@@ -171,14 +171,10 @@ v1.7.0, it was not enabled by default.
 
 </Warning>
 
-When `case` measures span multiple cubes, **define the `switch` dimension on a
-single shared cube joined into every fact cube**, rather than defining a separate
-one on each cube. All `case` measures then dispatch on the same dimension, so one
-filter resolves every measure. With a `switch` dimension per cube, a single
-filter pins only one of them; the others fall back to their full set of values,
-and each value emits its own row — so the query returns extra rows.
-Pre-aggregations match either way, so they accelerate that result rather than
-preventing it.
+Matching is unaffected by how the `switch` dimension is modeled across cubes. If
+a query returns more rows than expected, that's a modeling concern — see
+[`case` measures][ref-case] — and pre-aggregations accelerate that result rather
+than preventing it.
 
 ## Matching multi-fact and multi-stage queries
 

--- a/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
+++ b/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
@@ -415,9 +415,9 @@ have to be included: [pre-aggregation matching][ref-matching-switch-dimensions]
 applies the selected value over the rollup scan. Leaving it out also keeps the
 rollup small — including it would multiply the rows by every window in the set.
 
-Include the per-window measures rather than the four `case` measures: the `case`
-measures are [multi-stage][ref-multi-stage] and dispatch to the per-window ones,
-which is what actually gets aggregated.
+List the per-window measures, not the four `case` measures: the `case` measures
+are [multi-stage][ref-multi-stage] and dispatch to the per-window ones, and it's
+those that the rollup has to name to be matched.
 
 <CodeGroup>
 
@@ -431,7 +431,6 @@ cubes:
     pre_aggregations:
       - name: rolling
         measures:
-          - gross_sales
           {%- for months in windows %}
           - r{{ months }}_gross_sales
           {%- endfor %}
@@ -447,10 +446,7 @@ cube(`gross_sales`, {
 
   pre_aggregations: {
     rolling: {
-      measures: [
-        `gross_sales`,
-        ...windows.map(months => `r${months}_gross_sales`)
-      ],
+      measures: windows.map(months => CUBE[`r${months}_gross_sales`]),
       time_dimension: month,
       granularity: `month`
     }

--- a/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
+++ b/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
@@ -407,6 +407,64 @@ ORDER BY 1;
 | 9m            |                2610 |                810 |
 | 12m           |                3300 |               1440 |
 
+## Pre-aggregations
+
+Add a [`rollup`][ref-rollup] over the per-window measures to accelerate these
+queries. `growth_window` is a [`switch` dimension][ref-switch], so it does not
+have to be included: [pre-aggregation matching][ref-matching-switch-dimensions]
+applies the selected value over the rollup scan. Leaving it out also keeps the
+rollup small — including it would multiply the rows by every window in the set.
+
+Include the per-window measures rather than the four `case` measures: the `case`
+measures are [multi-stage][ref-multi-stage] and dispatch to the per-window ones,
+which is what actually gets aggregated.
+
+<CodeGroup>
+
+```yaml title="YAML"
+{%- set windows = [3, 6, 9, 12] -%}
+
+cubes:
+  - name: gross_sales
+    # ...
+
+    pre_aggregations:
+      - name: rolling
+        measures:
+          - gross_sales
+          {%- for months in windows %}
+          - r{{ months }}_gross_sales
+          {%- endfor %}
+        time_dimension: month
+        granularity: month
+```
+
+```javascript title="JavaScript"
+const windows = [3, 6, 9, 12];
+
+cube(`gross_sales`, {
+  // ...
+
+  pre_aggregations: {
+    rolling: {
+      measures: [
+        `gross_sales`,
+        ...windows.map(months => `r${months}_gross_sales`)
+      ],
+      time_dimension: month,
+      granularity: `month`
+    }
+  }
+});
+```
+
+</CodeGroup>
+
+Query the view exactly as above; provide the date range through
+[`timeDimensions`][ref-time-dimensions-format] (a `WHERE` clause on the time
+dimension in the SQL API) rather than an [`inDateRange` filter][ref-in-date-range],
+which prevents matching.
+
 ## Related recipes
 
 - If you need a single fixed window rather than a consumer-selectable one, see
@@ -423,6 +481,11 @@ ORDER BY 1;
 
 [ref-switch]: /reference/data-modeling/dimensions#type
 [ref-case]: /reference/data-modeling/measures#case
+[ref-rollup]: /reference/data-modeling/pre-aggregations#rollup
+[ref-multi-stage]: /reference/data-modeling/measures#multi_stage
+[ref-matching-switch-dimensions]: /docs/pre-aggregations/matching-pre-aggregations#matching-switch-dimensions
+[ref-time-dimensions-format]: /reference/core-data-apis/rest-api/query-format#time-dimensions-format
+[ref-in-date-range]: /reference/core-data-apis/rest-api/query-format#indaterange
 [ref-rolling-window]: /reference/data-modeling/measures#rolling_window
 [ref-time-shift]: /reference/data-modeling/measures#time_shift
 [ref-view]: /reference/data-modeling/view

--- a/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
+++ b/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
@@ -419,6 +419,11 @@ List the per-window measures, not the four `case` measures: the `case` measures
 are [multi-stage][ref-multi-stage] and dispatch to the per-window ones, and it's
 those that the rollup has to name to be matched.
 
+In the JavaScript model, reference them through `CUBE[...]` rather than by name
+as strings. Cube resolves member references by recording them as they're
+accessed, so a string never registers as one — the rollup compiles with an empty
+measure list and silently matches nothing.
+
 <CodeGroup>
 
 ```yaml title="YAML"

--- a/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
+++ b/docs-mintlify/recipes/data-modeling/dynamic-rolling-windows.mdx
@@ -460,10 +460,11 @@ cube(`gross_sales`, {
 
 </CodeGroup>
 
-Query the view exactly as above; provide the date range through
-[`timeDimensions`][ref-time-dimensions-format] (a `WHERE` clause on the time
-dimension in the SQL API) rather than an [`inDateRange` filter][ref-in-date-range],
-which prevents matching.
+Query the view exactly as above. When querying through the REST (JSON) API,
+provide the date range via [`timeDimensions`][ref-time-dimensions-format] rather
+than an [`inDateRange` filter][ref-in-date-range] — a filter is matched as a
+generic dimension filter, which requires the time dimension to be listed in the
+rollup's `dimensions`.
 
 ## Related recipes
 

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -927,7 +927,7 @@ a dimension. A dimension can only have one type.
 | `string` | Text fields containing letters or special characters. |
 | `number` | Numeric or integer fields. |
 | `boolean` | Boolean fields or data coercible to boolean. |
-| `switch` | Predefined set of allowed values (enum-like), listed in the `values` sub-parameter instead of `sql`. Useful for [`case` measures][ref-case-measures]. [Pre-aggregations][ref-matching-switch-dimensions] don't need to include it. Tesseract only. |
+| `switch` | Predefined set of allowed values (enum-like). Requires a `values` sub-parameter and doesn't accept `sql`. Useful for [`case` measures][ref-case-measures]. [Pre-aggregations][ref-matching-switch-dimensions] don't need to include it. Tesseract only. |
 | `geo` | Geographic coordinates. Requires `latitude` and `longitude` sub-parameters instead of `sql`. |
 
 <Warning>
@@ -961,7 +961,7 @@ cubes:
         sql: is_enabled
         type: boolean
 
-      - name: rolling_window
+      - name: growth_window
         type: switch
         values:
           - 3m
@@ -1001,7 +1001,7 @@ cube(`orders`, {
       type: `boolean`
     },
 
-    rolling_window: {
+    growth_window: {
       type: `switch`,
       values: [`3m`, `6m`, `12m`]
     },

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -927,7 +927,7 @@ a dimension. A dimension can only have one type.
 | `string` | Text fields containing letters or special characters. |
 | `number` | Numeric or integer fields. |
 | `boolean` | Boolean fields or data coercible to boolean. |
-| `switch` | Predefined set of allowed values (enum-like). Requires a `values` sub-parameter and doesn't accept `sql`. Useful for [`case` measures][ref-case-measures]. [Pre-aggregations][ref-matching-switch-dimensions] don't need to include it. Tesseract only. |
+| `switch` | Predefined set of allowed values (enum-like). Takes only a `values` sub-parameter — no `sql`, and no other parameters such as `title` or `public`. Useful for [`case` measures][ref-case-measures]. [Pre-aggregations][ref-matching-switch-dimensions] don't need to include it. Tesseract only. |
 | `geo` | Geographic coordinates. Requires `latitude` and `longitude` sub-parameters instead of `sql`. |
 
 <Warning>

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -927,7 +927,7 @@ a dimension. A dimension can only have one type.
 | `string` | Text fields containing letters or special characters. |
 | `number` | Numeric or integer fields. |
 | `boolean` | Boolean fields or data coercible to boolean. |
-| `switch` | Predefined set of allowed values (enum-like). Useful for [`case` measures][ref-case-measures]. Tesseract only. |
+| `switch` | Predefined set of allowed values (enum-like), listed in the `values` sub-parameter instead of `sql`. Useful for [`case` measures][ref-case-measures]. [Pre-aggregations][ref-matching-switch-dimensions] don't need to include it. Tesseract only. |
 | `geo` | Geographic coordinates. Requires `latitude` and `longitude` sub-parameters instead of `sql`. |
 
 <Warning>
@@ -961,6 +961,13 @@ cubes:
         sql: is_enabled
         type: boolean
 
+      - name: rolling_window
+        type: switch
+        values:
+          - 3m
+          - 6m
+          - 12m
+
       - name: location
         type: geo
         latitude:
@@ -992,6 +999,11 @@ cube(`orders`, {
     is_enabled: {
       sql: `is_enabled`,
       type: `boolean`
+    },
+
+    rolling_window: {
+      type: `switch`,
+      values: [`3m`, `6m`, `12m`]
     },
 
     location: {
@@ -1335,6 +1347,7 @@ cube(`fiscal_calendar`, {
 [link-d3-time-format]: https://d3js.org/d3-time-format
 [link-tesseract]: https://cube.dev/blog/introducing-next-generation-data-modeling-engine
 [ref-case-measures]: /reference/data-modeling/measures#case
+[ref-matching-switch-dimensions]: /docs/pre-aggregations/matching-pre-aggregations#matching-switch-dimensions
 [ref-meta-api]: /reference/core-data-apis/rest-api/reference#base_path/v1/meta
 [ref-string-time-dims]: /recipes/data-modeling/string-time-dimensions
 [ref-workbooks]: /docs/explore-analyze/workbooks

--- a/docs-mintlify/reference/data-modeling/measures.mdx
+++ b/docs-mintlify/reference/data-modeling/measures.mdx
@@ -1289,6 +1289,13 @@ cube(`orders`, {
 
 </CodeGroup>
 
+When `case` measures span multiple cubes, define the `switch` dimension on a
+single shared cube joined into every fact cube, rather than defining a separate
+one on each cube. All `case` measures then dispatch on the same dimension, so one
+filter resolves every measure. With a `switch` dimension per cube, a single
+filter pins only one of them; the others fall back to their full set of values,
+and each value emits its own row — so the query returns extra rows.
+
 ### `format`
 
 `format` is an optional parameter. It controls how measure values are


### PR DESCRIPTION
## Summary

Pre-aggregations can match queries that use `switch` dimensions without storing them, but nothing in the docs covered the interaction — `switch`/calc-group dimensions had zero mentions on the pre-aggregation pages.

- **`docs/pre-aggregations/matching-pre-aggregations.mdx`** — new `### Matching switch dimensions` section: a rollup doesn't need to include a `switch` dimension (and stays smaller for leaving it out), plus the two modeling constraints that apply when `case` measures span cubes — define the `switch` on one shared cube, and key every rollup on the time dimension the query groups by. Also qualifies the "contains all dimensions" matching bullet, which was stated twice and is now stated once.
- **`reference/data-modeling/dimensions.mdx`** — `switch` was the only dimension type without a code example; added one to both variants of the `type` `<CodeGroup>`, and documented the `values` sub-parameter.
- **`recipes/data-modeling/dynamic-rolling-windows.mdx`** — new `## Pre-aggregations` section; the recipe had no rollup example, and its "always include the `switch` dimension in the query" note is where the rollup question arises.

## Test plan

- Every example compiles: both the YAML and JavaScript variant of all three changes, via `prepareYamlCompiler` / `prepareJsCompiler`. The JS rollup in the recipe needed string member names — bare `CUBE[...]` references don't resolve inside a transpiled `measures` array.
- `mint broken-links --check-anchors`: zero failures in the touched pages; the 16 reported are pre-existing in `embedding/iframe/`.
- All three pages render (HTTP 200) under `mint dev`.