### PR TITLE
docs: document undocumented recent Cube Cloud features

### DIFF
--- a/docs-mintlify/admin/connect-to-data/multiple-data-sources.mdx
+++ b/docs-mintlify/admin/connect-to-data/multiple-data-sources.mdx
@@ -23,9 +23,11 @@ the driver's error and saves nothing.
 ## Editing and deleting
 
 Use the **Edit** action on a row to update credentials, or the **Delete**
-action to remove a named source. The **default** source can be edited but
-not deleted — to remove it, clear the bare `CUBEJS_DB_*` variables from
-[**Settings → Environment Variables**][ref-config-ref-env] by hand.
+action to remove a source — including the **default** source. Deleting the
+default source clears only its connection variables (`CUBEJS_DB_*` and
+equivalent driver-specific prefixes); deployment-wide variables and other
+sources are left untouched. Cubes that don't set an explicit `data_source`
+stop resolving until a new default source is added.
 
 ## Source name rules
 

--- a/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
+++ b/docs-mintlify/admin/monitoring/monitoring-integrations/index.mdx
@@ -340,6 +340,14 @@ Query History export.
 
 </Note>
 
+### Redacting exported query values
+
+To keep filter values and SQL literals from leaving through Query History export,
+enable **Redact filter values in Query History Export** under **Settings →
+Monitoring Integrations** (shown once log export is on). With this toggle on, the
+exported `api_query` field has filter values and SQL literals stripped; it's off
+by default.
+
 
 [ref-autosuspend]: /admin/deployment/auto-suspension#effects-on-experience
 [self-sinks-for-metrics]: #configuration-sinks-for-metrics

--- a/docs-mintlify/admin/users-and-permissions/manage-users.mdx
+++ b/docs-mintlify/admin/users-and-permissions/manage-users.mdx
@@ -102,6 +102,15 @@ You cannot delete your own account. Deleting a user is irreversible.
 
 </Warning>
 
+## Effective access
+
+A user's page shows a read-only **Effective access** section listing which source
+grants each piece of access the user has — a default role, a directly assigned
+role, a directly assigned policy, or a group. This is useful for answering "why
+can this user do that?" without piecing it together from the roles, groups, and
+policies pages separately. Admins can view this for any user; users can view it
+for themselves.
+
 ## Provisioning users via SCIM
 
 If your organization uses an identity provider such as [Okta][ref-okta] or

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
@@ -58,9 +58,10 @@ Shows a value relative to a target as a progress bar or circle. Useful for goal 
 | **Target field / row** | The goal or maximum value |
 | **Style** | Bar or circle |
 | **Color** | Fill color for the progress indicator |
+| **Format** | Number formatting applied to the target/goal text |
 
 <Tip>
-To compare against a static number like a quarterly goal, add a calculated field that always returns that number and use it as the **Target** field.
+To compare against a static number like a quarterly goal, toggle **Use custom goal** and enter the number directly — no calculated field needed.
 </Tip>
 
 {/* TODO screenshot: Progress bar block (bar style) and circle style (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
@@ -77,6 +78,7 @@ Renders a compact trend chart — either a bar or line — within the KPI tile. 
 | **Height / Width** | Dimensions of the sparkline in the tile |
 | **Max points** | Limits the number of data points rendered |
 | **Colors** | Line/fill colors |
+| **Format** | Number formatting applied to the headline value |
 
 {/* TODO screenshot: Sparkline block showing a trend line (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/color-and-stacking.mdx
@@ -94,3 +94,5 @@ The legend appears when a Color channel is assigned. Configure it in the **Legen
 | **Hidden** | Remove the legend entirely |
 
 {/* TODO screenshot: legend position options (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+Click a legend item to hide that category from the chart — the chart rescales over what's left, and the hidden item stays in the legend, dimmed. Click it again to bring it back. This is view-only: it doesn't change the underlying query, and reloading the page restores every category.

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -121,9 +121,16 @@ page, or viewing a dashboard never re-runs anything on its own.
 
 ## On dashboards
 
-Python reports render their **saved output** on dashboards. Nothing re-runs on
-dashboard load, so a dashboard full of Python reports costs no compute to open —
-each widget shows whatever the last **Run** produced.
+A python widget re-runs its script under the **viewer's own security context** when
+a dashboard is opened, rather than showing the report's saved output — this keeps
+row-level security correct, since a stored result would otherwise leak whatever
+rows the person who last pressed **Run** could see. Dashboard filters and time
+grains flow into the re-run as well, on the builder, published dashboards, and
+embeds.
+
+This has a real compute cost: the first person to open a dashboard triggers a
+sandbox run per python widget. Repeat views within 5 minutes reuse a cached
+result, shared across viewers with the same filters and identity.
 
 A python widget can be opened in [Explore](/docs/explore-analyze/explore) from a
 dashboard and run from there.

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -294,7 +294,7 @@ can change their values, switch operators, or remove them entirely.
 
 Each entry has a `member` (a dimension or measure exposed by the view), an
 `operator`, and a list of `values` — or a single `value`, which is natural for
-single-value operators. Null-check operators take no value.
+single-value operators. Null-check and empty-check operators take no value.
 
 <Info>
 
@@ -369,7 +369,7 @@ Operators use the same labels data consumers see in the workbook filter bar —
 what you see in the filter bar is what you type: `is`, `is not`, `after date`,
 `after or on date`, `before date`, `before or on date`, `between`, `contains`,
 `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`,
-`is null`, `is not null`.
+`is null`, `is not null`, `is empty`, `is not empty`.
 
 Operators are case-insensitive and whitespace-tolerant. Internal type names and
 REST API aliases (e.g. `equals`, `gte`, `inDateRange`) are also accepted.


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available (N/A — docs only)
- [x] Linter has been run for changed code (N/A — docs only)
- [x] Tests for the changes have been added if not covered yet (N/A — docs only)
- [x] Docs have been added / updated if required

**Description of Changes Made**

Periodic sweep of recently-shipped `cubejs-enterprise` product changes cross-checked against `docs-mintlify` for gaps, filtered through the customer-facing criteria used by the docs/changelog routine. Each item below was verified against its source PR before writing — small, surgical edits to existing pages only, no new pages needed this cycle.

- `reference/data-modeling/view.mdx` — add `is empty` / `is not empty` to the `default_ui_filters` operator list (cubedevinc/cubejs-enterprise#13456).
- `docs/explore-analyze/charts/chart-types/kpi.mdx` — document the per-block **Format** setting on the Progress bar and Sparkline blocks (cubedevinc/cubejs-enterprise#13113), and fix a stale Tip that recommended a calculated-constant workaround for a static goal — a native **Use custom goal** toggle exists now.
- `docs/explore-analyze/charts/configuration/color-and-stacking.mdx` — document the click-a-legend-item-to-hide-that-category interaction (cubedevinc/cubejs-enterprise#13386).
- `docs/explore-analyze/workbooks/python-analysis.mdx` — rewrite the stale "On dashboards" section: Python widgets now re-run under the viewer's own security context on view (for RLS correctness) and pick up dashboard filters, rather than rendering a stored snapshot with zero compute cost (cubedevinc/cubejs-enterprise#13470, #13499).
- `admin/users-and-permissions/manage-users.mdx` — document the new read-only **Effective access** panel on a user's page (cubedevinc/cubejs-enterprise#13447).
- `admin/connect-to-data/multiple-data-sources.mdx` — update the stale claim that the default data source can't be deleted from the UI; it can now (cubedevinc/cubejs-enterprise#13401).
- `admin/monitoring/monitoring-integrations/index.mdx` — document the **Redact filter values in Query History Export** toggle (cubedevinc/cubejs-enterprise#13452).

No new nav entries needed — all edits are to existing `docs.json`-registered pages.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SxmFho1mRuVMzwwnkbVbHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxmFho1mRuVMzwwnkbVbHe)_