### PR TITLE
fix: Exclude out-of-range rollupLambda partitions

### DIFF
--- a/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
+++ b/packages/cubejs-query-orchestrator/src/orchestrator/PreAggregationPartitionRangeLoader.ts
@@ -274,7 +274,11 @@ export class PreAggregationPartitionRangeLoader {
         }
         const rollupLambdaResults = this.preAggregationsTablesToTempTables.filter(tempTableResult => tempTableResult[1].rollupLambdaId === this.preAggregation.rollupLambdaId);
         const filteredResults = loadResults.filter(
-          r => (this.preAggregation.lastRollupLambda || reformatInIsoLocal(r.buildRangeEnd) === reformatInIsoLocal(r.partitionRange[1])) &&
+          r => (!this.preAggregation.matchedTimeDimensionDateRange || !!PreAggregationPartitionRangeLoader.intersectDateRanges(
+            r.partitionRange,
+            this.preAggregation.matchedTimeDimensionDateRange
+          )) &&
+            (this.preAggregation.lastRollupLambda || reformatInIsoLocal(r.buildRangeEnd) === reformatInIsoLocal(r.partitionRange[1])) &&
             rollupLambdaResults.every(result => !result[1].buildRangeEnd || reformatInIsoLocal(result[1].buildRangeEnd) < reformatInIsoLocal(r.partitionRange[0]))
         );
         if (filteredResults.length === 0) {

--- a/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
+++ b/packages/cubejs-query-orchestrator/test/unit/PreAggregations.test.ts
@@ -93,14 +93,18 @@ const mockPreAggregation = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 });
 
-const createLoader = (overrides: Record<string, any> = {}, options: Record<string, any> = {}) => {
+const createLoader = (
+  overrides: Record<string, any> = {},
+  options: Record<string, any> = {},
+  preAggregationsTablesToTempTables: any[] = [],
+) => {
   const loader = new PreAggregationPartitionRangeLoader(
     {} as any, // driverFactory
     {} as any, // logger
     { options: {} } as any, // queryCache
     {} as any, // preAggregations
     mockPreAggregation(overrides) as any,
-    [], // preAggregationsTablesToTempTables
+    preAggregationsTablesToTempTables,
     {} as any, // loadCache
     options as any,
   );
@@ -578,6 +582,103 @@ describe('PreAggregations', () => {
         ['2024-01-01T00:00:00', '2024-01-31T23:59:59.999'], // incorrect format
         ['2024-01-01T00:00:00.000', '2024-01-31T23:59:59.999']
       )).toThrow('Date range expected to be in YYYY-MM-DDTHH:mm:ss.SSS format');
+    });
+  });
+
+  describe('rollupLambda partition filtering', () => {
+    let loadPreAggregationMock: jest.SpyInstance;
+
+    beforeEach(() => {
+      loadPreAggregationMock = jest.spyOn(PreAggregationLoader.prototype, 'loadPreAggregation').mockResolvedValue({
+        targetTableName: 'hot_partition',
+        refreshKeyValues: [],
+        lastUpdatedAt: 1,
+        buildRangeEnd: '2024-02-01T23:59:59.999',
+      });
+    });
+
+    afterEach(() => {
+      loadPreAggregationMock.mockRestore();
+    });
+
+    test('should return an empty result for an out-of-range last rollupLambda partition', async () => {
+      const loader = createLoader({
+        rollupLambdaId: 'orders.lambda',
+        lastRollupLambda: true,
+        matchedTimeDimensionDateRange: ['2024-01-01T00:00:00.000', '2024-01-31T23:59:59.999'],
+      });
+      jest.spyOn(loader as any, 'partitionRanges').mockResolvedValue({
+        buildRange: ['2024-02-01T00:00:00.000', '2024-02-01T23:59:59.999'],
+        partitionRanges: [['2024-02-01T00:00:00.000', '2024-02-01T23:59:59.999']],
+      });
+
+      const result = await loader.loadPreAggregations();
+
+      expect(result.targetTableName).toBe('(SELECT * FROM hot_partition WHERE 1 = 0)');
+      expect(result.buildRangeEnd).toBeFalsy();
+    });
+
+    test('should retain a last rollupLambda partition that overlaps the requested range', async () => {
+      const loader = createLoader(
+        {
+          rollupLambdaId: 'orders.lambda',
+          lastRollupLambda: true,
+          matchedTimeDimensionDateRange: ['2024-01-30T12:00:00.000', '2024-01-31T23:59:59.999'],
+        },
+        {},
+        [[
+          'batch_rollup',
+          {
+            targetTableName: 'batch_partition',
+            refreshKeyValues: [],
+            lastUpdatedAt: 1,
+            buildRangeEnd: '2024-01-30T23:59:59.999',
+            rollupLambdaId: 'orders.lambda',
+          },
+        ]],
+      );
+      jest.spyOn(loader as any, 'partitionRanges').mockResolvedValue({
+        buildRange: ['2024-01-31T00:00:00.000', '2024-02-01T23:59:59.999'],
+        partitionRanges: [['2024-01-31T00:00:00.000', '2024-02-01T23:59:59.999']],
+      });
+
+      const result = await loader.loadPreAggregations();
+
+      expect(result.targetTableName).toBe('hot_partition');
+      expect(result.buildRangeEnd).toBe('2024-02-01T23:59:59.999');
+    });
+
+    test('should retain existing rollupLambda filtering without a matched range', async () => {
+      const loader = createLoader({
+        rollupLambdaId: 'orders.lambda',
+        lastRollupLambda: true,
+      });
+      jest.spyOn(loader as any, 'partitionRanges').mockResolvedValue({
+        buildRange: ['2024-02-01T00:00:00.000', '2024-02-01T23:59:59.999'],
+        partitionRanges: [['2024-02-01T00:00:00.000', '2024-02-01T23:59:59.999']],
+      });
+
+      const result = await loader.loadPreAggregations();
+
+      expect(result.targetTableName).toBe('hot_partition');
+      expect(result.buildRangeEnd).toBe('2024-02-01T23:59:59.999');
+    });
+
+    test('should retain a rollupLambda partition that touches the requested range boundary', async () => {
+      const loader = createLoader({
+        rollupLambdaId: 'orders.lambda',
+        lastRollupLambda: true,
+        matchedTimeDimensionDateRange: ['2024-01-31T00:00:00.000', '2024-02-01T00:00:00.000'],
+      });
+      jest.spyOn(loader as any, 'partitionRanges').mockResolvedValue({
+        buildRange: ['2024-02-01T00:00:00.000', '2024-02-01T23:59:59.999'],
+        partitionRanges: [['2024-02-01T00:00:00.000', '2024-02-01T23:59:59.999']],
+      });
+
+      const result = await loader.loadPreAggregations();
+
+      expect(result.targetTableName).toBe('hot_partition');
+      expect(result.buildRangeEnd).toBe('2024-02-01T23:59:59.999');
     });
   });
 


### PR DESCRIPTION
## Summary

A `rollupLambda` query can treat the last member's most-recent partition as valid even when that member's build range has no overlap with the requested date range.

Extend the rollup-lambda result filter in `PreAggregationPartitionRangeLoader.loadPreAggregations()` so a candidate with a `partitionRange` is retained only when that range intersects `matchedTimeDimensionDateRange`, while preserving current behavior when no matched query range is supplied. Keep the existing `lastRollupLambda` completeness exception and prior-member boundary ordering intact for genuinely overlapping partitions; removing that exception alone does not reject a fully built but irrelevant placeholder. When every candidate is out of range, reuse the existing `emptyResult` path so Cube still exposes a structurally compatible table expression guarded by `WHERE 1 = 0` rather than unioning the placeholder as data. Add direct loader regression coverage using the existing mocks in `PreAggregations.test.ts`, without introducing a helper or seam used only by tests.

## Why this matters

A `rollupLambda` query can treat the last member's most-recent partition as valid even when that member's build range has no overlap with the requested date range. `partitionRanges()` deliberately supplies that partition as a structural placeholder, but `loadPreAggregations()` currently filters only for build completeness and ordering against earlier lambda members. Because `lastRollupLambda` bypasses the completeness half of that predicate, the irrelevant placeholder can enter the union and contribute to silent empty or incomplete results when another member is stale. The issue is reproducible across partition granularities and database drivers, and a maintainer has confirmed the loader-level root cause.

## Testing

- A fully built last `rollupLambda` member whose placeholder partition is wholly after the requested batch-only range is rejected, and its returned target expression is guarded by `WHERE 1 = 0` rather than treated as a valid union contributor.
- A last-member partition that overlaps the requested range remains eligible, including a range that straddles the batch/hot boundary, so valid hot data is not removed.
- A load without `matchedTimeDimensionDateRange` preserves the existing lambda filtering behavior instead of treating the absent range as non-overlap.
- Boundary-touching ranges continue to count as an intersection under the loader's inclusive date-range semantics.

**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [ ] Docs have been added / updated if required

Fixes #11317
