### PR TITLE
docs: document assigning roles to user groups (preview)

### DIFF
--- a/docs-mintlify/admin/users-and-permissions/user-groups.mdx
+++ b/docs-mintlify/admin/users-and-permissions/user-groups.mdx
@@ -20,7 +20,29 @@ To create a user group:
   <img src="https://lgo0ecceic.ucarecd.net/f66feb98-feee-478e-8371-e3b37602eb4a/" alt="User Groups interface" />
 </Frame>
 
+## Assigning roles to groups
+
+<Warning>
+
+Assigning roles to groups is currently in preview, and the user experience may still
+change. Reach out to the [Cube support team](/admin/account-billing/support) to activate
+this feature for your account.
+
+</Warning>
+
+Open a group and use the **Roles** section to assign [roles][ref-roles] to it. Every member
+of the group gains the access that role grants, and removing the role from the group revokes
+it from all members immediately.
+
+Roles only ever add permissions — there is no precedence and no deny. A user with a Viewer
+role who belongs to a group assigned Developer holds both, and is effectively a Developer.
+This includes Admin: anyone who can edit a group's roles can grant administrative access
+through it.
+
+The **Effective access** section on a user's page lists the roles a user holds directly and
+the roles conferred by a group, with the group named.
 
 [ref-user-attributes]: /admin/users-and-permissions/user-attributes
+[ref-roles]: /admin/users-and-permissions/roles-and-permissions
 [ref-rls]: /docs/data-modeling/access-control/row-level-security
 [ref-dap]: /docs/data-modeling/data-access-policies


### PR DESCRIPTION
**Check List**
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Documents the new group → role assignment feature. One new section on the existing
`admin/users-and-permissions/user-groups` page — no new pages.

Covers:

- Where to assign roles (the **Roles** section on a group), and that removing a role
  from a group revokes it from every member immediately.
- That permissions are a **union** — no precedence, no deny. A Viewer in a group
  assigned Developer is effectively a Developer. This is the misconception most likely
  to bite admins.
- That Admin can be conferred through a group, so anyone who can edit a group's roles
  can grant administrative access.
- The read-only **Effective access** section on the user page.

Marked as **preview** with the standard `<Warning>` callout, since the feature is off by
default and enabled per account. The internal flag name is not exposed. If the rollout
decision lands on default-on, the callout should be removed.

**Notes for the reviewer**

- Behaviour and UI labels verified against merged code in `cubejs-enterprise`:
  `GroupRolesList.tsx`, `EffectiveAccessSection.tsx`, and the `users.effectiveAccess` /
  `userGroups.rolesTitle` strings in `en-US/admin.json`.
- Deliberately omitted: the **SSO active-role selector** notice (single-customer feature
  behind its own flag, historically kept out of public docs) — say the word if it should
  be mentioned.
- No screenshot yet: the Effective access section is hidden unless the user has a
  group-conferred role, so capturing it needs a tenant with the feature on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)