### PR TITLE
docs: document KPI per-block styling/format and is empty/is not empty filter operators

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
@@ -29,6 +29,7 @@ Displays a single value from your query result.
 | **Row** | Which row of the result to read from |
 | **Format** | Number formatting (currency, percent, etc.) |
 | **Font size / color** | Text appearance |
+| **Background** | Background color for the block |
 | **Alignment** | Left, center, or right |
 
 {/* TODO screenshot: Number block (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
@@ -42,7 +43,7 @@ Displays a current value alongside a previous value with a calculated difference
 | **Current field / row** | The primary value |
 | **Previous field / row** | The value to compare against — can be a different column or a different row from the same column |
 | **Difference format** | Absolute, percentage, or both |
-| **Positive color / Negative color** | Colors applied based on whether the change is positive or negative |
+| **Positive / negative / neutral color** | Colors applied based on whether the change is positive, negative, or unchanged |
 
 To compare to a static goal, add a column to your query that always returns the same number (e.g. a calculated field with a constant), then select it as the **Previous** field.
 
@@ -58,6 +59,8 @@ Shows a value relative to a target as a progress bar or circle. Useful for goal 
 | **Target field / row** | The goal or maximum value |
 | **Style** | Bar or circle |
 | **Color** | Fill color for the progress indicator |
+| **Format** | Number formatting for the displayed value |
+| **Background** | Background color for the block |
 
 <Tip>
 To compare against a static number like a quarterly goal, add a calculated field that always returns that number and use it as the **Target** field.
@@ -77,6 +80,8 @@ Renders a compact trend chart — either a bar or line — within the KPI tile. 
 | **Height / Width** | Dimensions of the sparkline in the tile |
 | **Max points** | Limits the number of data points rendered |
 | **Colors** | Line/fill colors |
+| **Format** | Number formatting for the displayed value |
+| **Background** | Background color for the block |
 
 {/* TODO screenshot: Sparkline block showing a trend line (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -90,7 +95,7 @@ Use text blocks for short labels and headings inside the KPI. For complex layout
 
 ### HTML
 
-A free-form HTML block rendered inside the KPI tile. Use this for advanced custom layouts that go beyond what the other block types support.
+A free-form HTML block rendered inside the KPI tile. Use this for advanced custom layouts that go beyond what the other block types support. Like the other block types, it accepts a background color.
 
 {/* TODO screenshot: HTML block with custom content (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -18,9 +18,11 @@ The available operators depend on the type of the underlying dimension:
 
 | Dimension type | Operators |
 |---|---|
-| **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null` |
+| **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null`, `is empty`, `is not empty` |
 | **Number** | `is`, `is not`, `greater than`, `greater than or equal`, `less than`, `less than or equal`, `is null`, `is not null` |
 | **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `is null`, `is not null` |
+
+`is empty` and `is not empty` test for an empty string and are distinct from `is null` / `is not null`, which test for a missing value.
 
 ### Single vs. multiple selection
 


### PR DESCRIPTION
## Summary

Two small, shipped console-ui features found undocumented while cross-checking recent `cubejs-enterprise` changes against these docs:

- **KPI chart per-block styling controls** (cubedevinc/cubejs-enterprise#13162, #13113, #13540 — merged, live). The KPI chart builder's Style tab now exposes a **Background** color on every block type (Number, Comparison, Progress bar, Sparkline, HTML), a **Neutral** color alongside Positive/Negative on Comparison blocks, and a per-block **Format** override on Progress bar and Sparkline blocks (previously Number-only). Updated `docs/explore-analyze/charts/chart-types/kpi.mdx`'s block-type tables accordingly. (The circular-ring Progress style was already documented as "Bar or circle".)
- **`is empty` / `is not empty` filter operators** (cubedevinc/cubejs-enterprise#13456 — merged, live, and already in the in-app changelog). These are first-class value-less operators for string dimensions in dashboard filter widgets, distinct from the existing `is null` / `is not null` checks. Added them to the operators table in `docs/explore-analyze/dashboards/widgets/controls.mdx` with a one-line clarification of the semantic difference.

Both changes were verified against the shipped console-ui source and the in-app changelog copy in `cubejs-enterprise` before writing, per the customer-facing criteria in that repo's `.claude/shared/customer-facing-criteria.md`.

Not included: the "dashboard apps" authoring editor work (CUB-3544/3494/3588) — per its own design doc, that feature is gated by a tenant flag that is **not enabled on any tenant** and is explicitly an internal experiment, so it doesn't meet the bar for customer docs yet.

## Test plan

- [x] Read the current `kpi.mdx` and `controls.mdx` pages and cross-checked the additions against the actual commits/changelog copy in `cubejs-enterprise`
- [ ] Docs site preview (Mintlify) renders the updated tables correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QTe1Pp6rwEtSckrNTL3smf


---
_Generated by [Claude Code](https://claude.ai/code/session_01QTe1Pp6rwEtSckrNTL3smf)_