### PR TITLE
docs: dimension links render inline in Workbooks

### DIFF
--- a/docs-mintlify/docs/data-modeling/dimensions.mdx
+++ b/docs-mintlify/docs/data-modeling/dimensions.mdx
@@ -520,7 +520,7 @@ working as soon as both sides use the same slug.
   remaining links stay in the cell menu, which still lists every link. In a
   workbook table chart, the **Style** tab can override which declared link
   renders inline for a column; see
-  [Links](/docs/explore-analyze/charts/chart-types/table#links).
+  [Inline links](/docs/explore-analyze/charts/chart-types/table#inline-links).
 - **Drill-in vs external** — a `dashboard:` link navigates **in-app, in the same
   tab** by default; an explicit `target` is honored (`blank` opens a new tab,
   `self` stays in-app), and a Cmd/Ctrl-click always opens a new tab. A `url:`

--- a/docs-mintlify/docs/data-modeling/dimensions.mdx
+++ b/docs-mintlify/docs/data-modeling/dimensions.mdx
@@ -408,6 +408,7 @@ Dimension `links` require Cube **v1.6.53** or newer.
 | `url` | **Either `url` or `dashboard`** | SQL expression that builds an **external** URL per row. May [reference][ref-references] columns and other dimensions. |
 | `dashboard` | **Either `url` or `dashboard`** | The target Cube Cloud dashboard's **slug** (a **drill-in**). Each link sets exactly one of `url` or `dashboard` — never both — but different links on the same dimension can mix the two. |
 | `icon` | Optional | A [Tabler icon][link-tabler] name (see [Icons](#icons)). Defaults to a generic link icon. |
+| `primary` | Optional | Marks the link that renders **inline** on the cell value (see [Behavior](#behavior)). At most one link per dimension may set it. |
 | `target` | Optional | Where to open the link: `blank` (new tab) or `self` (same tab). The default depends on the link kind — `url:` links default to `blank`, `dashboard:` drill-ins default to `self` (in-app). An explicit `target` is honored for both (on `dashboard:` drill-ins this requires Cube **v1.7.5** or newer; see [Behavior](#behavior)). |
 | `params` | Optional | Extra per-row parameters. For `url:` they are appended as query parameters. For `dashboard:` they become **equality filters** on the target dashboard — each `key` is a member of the target dashboard's view (a cube path such as `orders.status` is auto-resolved to the matching view member), and `value` is the per-row value. |
 
@@ -512,6 +513,12 @@ working as soon as both sides use the same slug.
   every results table (dashboard and workbook table charts, embedded dashboards,
   and Explore / SQL results). A left-click on a cell opens the menu listing the
   dimension's links, alongside **Copy value** and, on measures, **Drill down**.
+- **Inline rendering** — the link marked `primary` also renders **inline**, as a
+  clickable link on the cell value itself, with no chart configuration. The
+  remaining links stay in the cell menu, which still lists every link. In a
+  workbook table chart, the **Style** tab can override which declared link
+  renders inline for a column; see
+  [Links](/docs/explore-analyze/charts/chart-types/table#links).
 - **Drill-in vs external** — a `dashboard:` link navigates **in-app, in the same
   tab** by default; an explicit `target` is honored (`blank` opens a new tab,
   `self` stays in-app), and a Cmd/Ctrl-click always opens a new tab. A `url:`

--- a/docs-mintlify/docs/data-modeling/dimensions.mdx
+++ b/docs-mintlify/docs/data-modeling/dimensions.mdx
@@ -453,12 +453,15 @@ cube(`orders`, {
       sql: `status`,
       type: `string`,
       links: [
+        // External link — opens a URL built from the row's value.
+        // `primary` makes it render inline on the cell value.
         {
           name: `search`,
           label: `Search the web`,
           url: `CONCAT('https://www.google.com/search?q=order+', ${CUBE}.status)`,
           icon: `brand-google`,
-          target: `blank`
+          target: `blank`,
+          primary: true
         },
         {
           name: `details`,

--- a/docs-mintlify/docs/data-modeling/dimensions.mdx
+++ b/docs-mintlify/docs/data-modeling/dimensions.mdx
@@ -426,12 +426,14 @@ cubes:
         sql: status
         type: string
         links:
-          # External link — opens a URL built from the row's value
+          # External link — opens a URL built from the row's value.
+          # `primary` makes it render inline on the cell value.
           - name: search
             label: Search the web
             url: "CONCAT('https://www.google.com/search?q=order+', {CUBE}.status)"
             icon: brand-google
             target: blank
+            primary: true
 
           # Drill-in link — opens another Cube Cloud dashboard, filtered by the row
           - name: details

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -106,7 +106,7 @@ There are two ways to get one:
 - **[`links`](/docs/data-modeling/dimensions#links) on the dimension.** The link marked
   `primary` renders inline on the cell value. Every link on the dimension — primary or not
   — stays available from the [cell menu](#cell-menu).
-- **[`format: link`](/docs/data-modeling/dimensions#format) on the dimension**, when the
+- **[`format: link`](/reference/data-modeling/dimensions#format) on the dimension**, when the
   value already *is* a URL. Use the object form to show a label instead of the raw URL.
 
 For a column whose dimension declares links, selecting the link button reveals a picker for

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -118,7 +118,7 @@ cell menu as usual.
 
 ### Inline bars
 
-Display a numeric column as a proportional in-cell bar by selecting **Bars** on the column's card. Each bar's length reflects the value's magnitude within the column's range.
+Display a numeric column as a proportional in-cell bar by selecting the **inline bars** button on the column's card. Each bar's length reflects the value's magnitude within the column's range.
 
 | Option | Description |
 |---|---|
@@ -134,7 +134,7 @@ When a column contains both positive and negative values, bars are drawn in both
 
 ### Sparklines
 
-Display a numeric column as a **sparkline** — a mini trend chart in each cell that plots the measure across a time dimension. Select **Sparkline** on the column's card in the **Columns** section of the **Style** tab.
+Display a numeric column as a **sparkline** — a mini trend chart in each cell that plots the measure across a time dimension. Select the **sparkline** button on the column's card in the **Columns** section of the **Style** tab.
 
 A sparkline needs a time dimension to use as its horizontal axis. When you switch a column to **Sparkline** and pick its horizontal axis time dimension, that dimension is **removed from the table query** (if it was there): the table shows one row per remaining dimension, correctly aggregated, while the sparkline plots the measure's value across the time dimension. Values are always correct for any measure type, including counts of distinct values, averages, and custom measures.
 
@@ -142,7 +142,7 @@ Removing the dimension is a one-way change — turning the sparkline back off do
 
 <Note>
 
-The time dimensions on offer come from the **semantic view the query is built on**, not from the query itself — so **Sparkline** is disabled whenever that view has no time dimension, and equally for a query not built on a view at all, however many time dimensions the query selects.
+The time dimensions on offer come from the **semantic view the query is built on**, not from the query itself — so the **sparkline** button is disabled whenever that view has no time dimension, and equally for a query not built on a view at all, however many time dimensions the query selects.
 
 </Note>
 
@@ -153,7 +153,7 @@ The time dimensions on offer come from the **semantic view the query is built on
 | **Type** | **Area** (filled line, the default), **Line**, or **Bar** (mini columns). |
 | **Line color** / **Area color** | Stroke color for line and bar; fill color for area. |
 | **Line width** | Stroke width in pixels (Line and Area types). |
-| **Show value** | The shared **Value** toggle on the column's card — shows the measure's value for the row, the same number the cell would show without a sparkline, as a headline next to it. Turn it off for a chart-only cell. Its setting carries over when you switch between **Bars** and **Sparkline**. |
+| **Show value** | The shared **Value** toggle on the column's card — shows the measure's value for the row, the same number the cell would show without a sparkline, as a headline next to it. Turn it off for a chart-only cell. Its setting carries over when you switch between inline bars and sparkline. |
 
 A row needs at least two data points to draw a sparkline; cells with fewer fall back to the formatted value.
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -83,24 +83,38 @@ Under a column pivot, a width set on a measure applies to every column generated
 
 </Note>
 
-## Showing columns as bars or sparklines
+## Showing columns as links, bars, or sparklines
 
-By default, a column displays its value. A **numeric** column can also be drawn as an in-cell visualization — an inline bar or a sparkline — from the column's card in the **Columns** section of the **Style** tab.
+By default, a column displays its value. It can also be drawn as an inline link, an inline bar, or a sparkline — from the column's card in the **Columns** section of the **Style** tab.
 
-Each card has a **Value** toggle and, next to it, a **Bars** / **Sparkline** pair:
+Each card has a **Value** toggle and, next to it, a group of icon buttons for **inline bars**, **sparkline**, and **link**:
 
-- **Value** shows the formatted number in the cell. It **composes** with a visualization rather than excluding it — a cell can show a bar and its value together.
-- **Bars** and **Sparkline** are mutually exclusive with each other: picking one replaces the other. Clicking the active one again clears it, returning the column to a plain value.
-- With no visualization active, **Value** is forced on and its toggle disabled — so a plain column always shows its value.
+- **Value** shows the formatted value in the cell. It **composes** with a bar or a sparkline rather than excluding it — a cell can show a bar and its value together.
+- The three icon buttons are mutually exclusive with each other: picking one replaces the other. Clicking the active one again clears it, returning the column to a plain value.
+- With none of them active, **Value** is forced on and its toggle disabled — so a plain column always shows its value.
+- Each button is offered only where it applies: bars and sparklines on **numeric** columns, and **link** only on a column whose dimension declares links or uses `format: link` (see [Inline links](#inline-links)). In link mode the value *is* the link text, so **Value** stays forced on there too.
 
-These controls appear only on numeric columns.
+{/* TODO: screenshot — a column card showing the Value toggle beside the inline bars / sparkline / link buttons */}
 
-{/* TODO: screenshot — a numeric column card showing the Value toggle beside the Bars / Sparkline pair */}
+### Inline links
 
-Bars and sparklines are the only in-cell visualizations the table draws. To turn a
-column's values into clickable links, define [`links` on the
-dimension](/docs/data-modeling/dimensions#links) in the data model — they appear in
-the [cell menu](#cell-menu) rather than in the cell itself.
+A column renders its values as clickable links when the data model says so — links are
+declared in the semantic layer, not authored in the chart.
+
+There are two ways to get one:
+
+- **[`links`](/docs/data-modeling/dimensions#links) on the dimension.** The link marked
+  `primary` renders inline on the cell value. Every link on the dimension — primary or not
+  — stays available from the [cell menu](#cell-menu).
+- **[`format: link`](/docs/data-modeling/dimensions#format) on the dimension**, when the
+  value already *is* a URL. Use the object form to show a label instead of the raw URL.
+
+For a column whose dimension declares links, selecting the link button reveals a picker for
+which of the declared links renders inline (inert when the dimension declares only one).
+Clicking the link text opens it; clicking elsewhere in the cell selects it and opens the
+cell menu as usual.
+
+{/* TODO screenshot: table with an inline link column and the Style tab's link button selected (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ### Inline bars
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/table.mdx
@@ -90,7 +90,7 @@ By default, a column displays its value. It can also be drawn as an inline link,
 Each card has a **Value** toggle and, next to it, a group of icon buttons for **inline bars**, **sparkline**, and **link**:
 
 - **Value** shows the formatted value in the cell. It **composes** with a bar or a sparkline rather than excluding it — a cell can show a bar and its value together.
-- The three icon buttons are mutually exclusive with each other: picking one replaces the other. Clicking the active one again clears it, returning the column to a plain value.
+- The three icon buttons are mutually exclusive: picking one replaces whichever was active. Clicking the active one again clears it, returning the column to a plain value.
 - With none of them active, **Value** is forced on and its toggle disabled — so a plain column always shows its value.
 - Each button is offered only where it applies: bars and sparklines on **numeric** columns, and **link** only on a column whose dimension declares links or uses `format: link` (see [Inline links](#inline-links)). In link mode the value *is* the link text, so **Value** stays forced on there too.
 
@@ -114,7 +114,7 @@ which of the declared links renders inline (inert when the dimension declares on
 Clicking the link text opens it; clicking elsewhere in the cell selects it and opens the
 cell menu as usual.
 
-{/* TODO screenshot: table with an inline link column and the Style tab's link button selected (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+{/* TODO: screenshot — a table with an inline link column and the Style tab's link button selected */}
 
 ### Inline bars
 

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -472,7 +472,7 @@ icon is shown.
 Optionally, one link per dimension might set `primary: true`. In [Workbooks][ref-workbooks]
 that link renders inline on the cell value, so it is reachable in one click while the rest
 stay in the cell context menu. A dimension may mark at most one link as primary. Rows whose
-link URL resolves to an empty value render as plain text.
+primary link URL resolves to an empty value render the cell as plain text.
 
 Optionally, a link might use the `target` parameter to specify [where to open it][link-target]:
 `blank` to open in a new tab/window or `self` to open in the same tab/window. The default

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -319,8 +319,8 @@ cubes:
         sql: "'https://na1.salesforce.com/' || id"
         type: string
         format:
-          label: View in Salesforce
           type: link
+          label: View in Salesforce
 
       - name: created_at
         sql: created_at
@@ -355,8 +355,8 @@ cube(`orders`, {
       sql: `'https://na1.salesforce.com/' || id`,
       type: `string`,
       format: {
-        label: `View in Salesforce`,
-        type: `link`
+        type: `link`,
+        label: `View in Salesforce`
       }
     },
 

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -269,7 +269,22 @@ For `string` dimensions:
 | Format | Description |
 |--------|-------------|
 | `imageUrl` | Display the value as an image |
-| `link` | Display the value as a hyperlink |
+| `link` | Display the value as a hyperlink, using the value itself as the URL |
+
+The `link` format also accepts an object form so the cell shows a label instead of the
+raw URL:
+
+```yaml
+- name: crm_link
+  sql: "'https://na1.salesforce.com/' || id"
+  type: string
+  format:
+    type: link
+    label: View in Salesforce
+```
+
+In [Workbooks][ref-workbooks], a `link`-formatted value renders as a clickable link in
+table cells. Values that aren't `http`, `https`, or `mailto` URLs render as plain text.
 
 For `number` dimensions, you can use the same named formats and custom
 [d3-format][link-d3-format] specifiers as [measures](/reference/data-modeling/measures#format):
@@ -429,8 +444,9 @@ Using it with other dimension types will result in a validation error.
 ### `links`
 
 The `links` parameter allows you to define **one or more** links associated with a
-dimension (it is a list). They can be rendered as HTML links by supporting tools, e.g.,
-[Workbooks][ref-workbooks].
+dimension (it is a list). In [Workbooks][ref-workbooks], every link is available from the
+table **cell context menu**, and the link marked `primary` also renders inline, as a
+clickable link on the cell value itself.
 
 Links are useful to let users navigate to related external resources (e.g., Google
 search), internal tools (e.g., Salesforce), or other pages in a BI tool.
@@ -452,6 +468,11 @@ icon set][link-tabler] to be displayed alongside the link label. Use the icon's 
 name without any prefix (e.g. `brand-google`, `external-link`, `layout-dashboard`, `send`);
 browse the available names at [tabler.io/icons][link-tabler]. When omitted, a default link
 icon is shown.
+
+Optionally, one link per dimension might set `primary: true`. In [Workbooks][ref-workbooks]
+that link renders inline on the cell value, so it is reachable in one click while the rest
+stay in the cell context menu. A dimension may mark at most one link as primary. Rows whose
+link URL resolves to an empty value render as plain text.
 
 Optionally, a link might use the `target` parameter to specify [where to open it][link-target]:
 `blank` to open in a new tab/window or `self` to open in the same tab/window. The default
@@ -475,6 +496,7 @@ cubes:
             url: "CONCAT('https://www.google.com/search?q=', {CUBE}.full_name)"
             icon: brand-google
             target: blank
+            primary: true
           
           - name: salesforce_search
             label: Search in Salesforce

--- a/docs-mintlify/reference/data-modeling/dimensions.mdx
+++ b/docs-mintlify/reference/data-modeling/dimensions.mdx
@@ -271,17 +271,8 @@ For `string` dimensions:
 | `imageUrl` | Display the value as an image |
 | `link` | Display the value as a hyperlink, using the value itself as the URL |
 
-The `link` format also accepts an object form so the cell shows a label instead of the
-raw URL:
-
-```yaml
-- name: crm_link
-  sql: "'https://na1.salesforce.com/' || id"
-  type: string
-  format:
-    type: link
-    label: View in Salesforce
-```
+The `link` format also accepts an object form — `format: { type: link, label: … }` — so the
+cell shows a label instead of the raw URL (see `crm_link` in the example below).
 
 In [Workbooks][ref-workbooks], a `link`-formatted value renders as a clickable link in
 table cells. Values that aren't `http`, `https`, or `mailto` URLs render as plain text.


### PR DESCRIPTION
Makes two documented promises about dimension links specific and true, now that Workbooks renders them.

**`links`.** The page said links "can be rendered as HTML links by supporting tools" without saying what that meant. It now states what actually happens: every link is available from the table cell context menu, and the link marked `primary` also renders inline on the cell value.

**`primary`.** The flag was accepted and validated (at most one per dimension) but never documented. It's now described where `icon` and `target` are, and shown in the YAML example.

**`format: link`.** The table entry now says the value itself is used as the URL, and documents the object form — `format: { type: link, label: … }` — which was already accepted but undocumented. Also notes that values outside `http`, `https` and `mailto` render as plain text.

The table chart page's "Links" section described an older flow (picking a hidden URL column as the source) that doesn't match the product; it now describes declaring links in the data model and choosing which one renders.
