### PR TITLE
docs: Snowflake cancellation, KPI block styling, filter operators, Python-on-dashboards

### DIFF
--- a/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
+++ b/docs-mintlify/admin/connect-to-data/data-sources/snowflake.mdx
@@ -226,6 +226,16 @@ module.exports = {
 The tag is set once per connection, not per query — all queries issued over
 that connection carry the same tag.
 
+### Query cancellation
+
+When Cube cancels a query against Snowflake — for example, an orphaned or
+timed-out query, or a request cancelled through the
+[`/v1/running-query/{requestId}`][ref-rest-api-cancel] REST (JSON) API
+endpoint — the Snowflake driver also cancels the underlying statement, so the
+warehouse stops running (and billing for) it instead of continuing in the
+background.
+
+[ref-rest-api-cancel]: /reference/core-data-apis/rest-api/reference#base_path/v1/running-query/requestid
 [ref-dedicated-infra]: /admin/deployment/infrastructure#dedicated-infrastructure
 [ref-cloud-conf-vpc]: /admin/deployment/dedicated
 ## Environment Variables

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
@@ -29,6 +29,7 @@ Displays a single value from your query result.
 | **Row** | Which row of the result to read from |
 | **Format** | Number formatting (currency, percent, etc.) |
 | **Font size / color** | Text appearance |
+| **Background** | Fill color for the block |
 | **Alignment** | Left, center, or right |
 
 {/* TODO screenshot: Number block (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
@@ -42,7 +43,7 @@ Displays a current value alongside a previous value with a calculated difference
 | **Current field / row** | The primary value |
 | **Previous field / row** | The value to compare against — can be a different column or a different row from the same column |
 | **Difference format** | Absolute, percentage, or both |
-| **Positive color / Negative color** | Colors applied based on whether the change is positive or negative |
+| **Positive / Negative / Neutral color** | Colors applied based on whether the change is positive, negative, or zero |
 
 To compare to a static goal, add a column to your query that always returns the same number (e.g. a calculated field with a constant), then select it as the **Previous** field.
 
@@ -58,6 +59,7 @@ Shows a value relative to a target as a progress bar or circle. Useful for goal 
 | **Target field / row** | The goal or maximum value |
 | **Style** | Bar or circle |
 | **Color** | Fill color for the progress indicator |
+| **Background** | Fill color for the block |
 
 <Tip>
 To compare against a static number like a quarterly goal, add a calculated field that always returns that number and use it as the **Target** field.
@@ -77,6 +79,8 @@ Renders a compact trend chart — either a bar or line — within the KPI tile. 
 | **Height / Width** | Dimensions of the sparkline in the tile |
 | **Max points** | Limits the number of data points rendered |
 | **Colors** | Line/fill colors |
+| **Format** | Number formatting override for the headline value shown alongside the sparkline |
+| **Background** | Fill color for the block |
 
 {/* TODO screenshot: Sparkline block showing a trend line (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -91,6 +95,10 @@ Use text blocks for short labels and headings inside the KPI. For complex layout
 ### HTML
 
 A free-form HTML block rendered inside the KPI tile. Use this for advanced custom layouts that go beyond what the other block types support.
+
+| Setting | Description |
+|---|---|
+| **Background** | Fill color for the block |
 
 {/* TODO screenshot: HTML block with custom content (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -18,7 +18,7 @@ The available operators depend on the type of the underlying dimension:
 
 | Dimension type | Operators |
 |---|---|
-| **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null` |
+| **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is empty`, `is not empty`, `is null`, `is not null` |
 | **Number** | `is`, `is not`, `greater than`, `greater than or equal`, `less than`, `less than or equal`, `is null`, `is not null` |
 | **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `is null`, `is not null` |
 

--- a/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
+++ b/docs-mintlify/docs/explore-analyze/workbooks/python-analysis.mdx
@@ -114,16 +114,18 @@ The code panel is editable in place, with line numbers.
 - **A failed run keeps the previous chart.** The error and the script's
   stdout/stderr surface in the UI while the last good result stays rendered.
 
-**Run is the only way the saved result changes.** Opening the report, reloading the
-page, or viewing a dashboard never re-runs anything on its own.
+**In a workbook tab, Run is the only way the result changes.** Opening the report or
+reloading the page never re-runs anything on its own. On dashboards, behavior is
+different — see [On dashboards](#on-dashboards) below.
 
 {/* TODO: screenshot — the code panel showing the Outdated tag */}
 
 ## On dashboards
 
-Python reports render their **saved output** on dashboards. Nothing re-runs on
-dashboard load, so a dashboard full of Python reports costs no compute to open —
-each widget shows whatever the last **Run** produced.
+A Python widget on a dashboard (in the dashboard builder, and on published or
+embedded dashboards) runs live for each viewer, the same way a SQL widget does —
+it's no longer just replaying the last saved **Run**. The result is cached per
+viewer identity and isn't persisted back to the report.
 
 A python widget can be opened in [Explore](/docs/explore-analyze/explore) from a
 dashboard and run from there.
@@ -144,6 +146,10 @@ is narrower.
 
 Take this into account when deciding who can run and publish Python reports, the
 same way you would for any other saved result shared through a workbook.
+
+On dashboards, this changes: each viewer's live run applies row-level security for
+**their own** identity, the same as a SQL widget — it isn't the Run author's access
+persisted for everyone who views the dashboard.
 
 ## Limits
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available
- [ ] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet

**Description of Changes Made**

A batch of small documentation gaps found by cross-checking recent shipped changes against docs-mintlify:

- **Snowflake driver query cancellation** (cube-js/cube#11428): Cube-initiated cancellation (orphaned/timeout or the `/v1/running-query/{requestId}` endpoint) now cancels the underlying Snowflake statement so the warehouse stops billing for it. Added a short note to the Snowflake data source page.
- **KPI block styling** (cubejs-enterprise #13162, #13113): the KPI chart builder shipped per-block Background fill color (Number, Progress bar, Sparkline, HTML blocks), a Neutral comparison color alongside Positive/Negative, and a per-block value-format override for Progress bar and Sparkline blocks. Added the missing rows to the KPI chart-type reference.
- **Dashboard filter `is empty` / `is not empty` operators** (cubejs-enterprise #13456): first-class value-less operators for string dimensions, distinct from the null checks. Added to the filter widget's operators-by-dimension-type table.
- **Python analysis on dashboards** (cubejs-enterprise #13499): the "On dashboards" section was factually stale. Python widgets on dashboards (builder, published, and embedded) now run live per viewer — like SQL widgets — instead of replaying the last saved Run. Corrected the behavior description and its row-level-security implications.
