### PR TITLE
docs(workbooks): document reference line labels and their placement controls

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/line.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/line.mdx
@@ -27,7 +27,7 @@ A horizontal reference line marks a target, threshold, or benchmark. Added via t
 
 ## Reference lines
 
-Add a horizontal reference line in the **Y axis** section of the Style tab. Set the value, label, color, and line style (solid, dashed, or dotted). Multiple reference lines are supported.
+Add a horizontal reference line in the **Y axis** section of the Style tab. Set the value, label, color, and line style (solid, dashed, or dotted). A labelled line also takes horizontal (start / middle / end) and vertical (above / below) placement for its text. Multiple reference lines are supported.
 
 {/* Screenshot: reference line configuration panel open — value field, label field, style dropdown. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/axes.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/axes.mdx
@@ -55,6 +55,27 @@ To add a reference line:
 
 You can add multiple reference lines to the same axis. Each is configured independently.
 
+### Reference line labels
+
+A reference line with no label renders as a bare rule — the reader has to already know what it
+means. Type text into **Label** to name it, for example `Target 18k`.
+
+Once a label is set, two alignment controls appear next to it:
+
+| Control | Options | Description |
+|---|---|---|
+| **Horizontal** | Start / Middle / End | Where along the line the text sits |
+| **Vertical** | Above / Below | Which side of the line the text sits on |
+
+New labels start at **End** and **Above** — the right end of the line, clear of the bars. The label
+takes the line's color, so it always reads as part of that line. Clearing the label removes the text
+and leaves the line itself untouched.
+
+<Tip>
+A label on a line near the top or bottom edge of the plot flips to the other side of the line
+automatically, so the text stays inside the chart area.
+</Tip>
+
 <Note>
 Reference lines are only available on the left Y axis. For right-axis reference lines, use a [custom Vega-Lite spec](/docs/explore-analyze/charts/custom).
 </Note>


### PR DESCRIPTION
## Summary

- The reference-line docs already described a **Label** field that the product did not have. Cube Cloud now supports one, so this makes the existing prose true and documents what ships alongside it.
- Adds a **Reference line labels** subsection to the Axes page: the free-text label, the two placement controls (horizontal start / middle / end, vertical above / below), the end/above defaults, and the fact that the label takes the line's colour.
- Notes that a label on a line near the top or bottom of the plot flips to the other side of the line automatically, so the text stays inside the chart area.
- Extends the line-chart page's one-line reference to mention the placement controls.

## Test plan

- [x] Rendered locally with `mint dev`; both pages return 200 and the new content renders (tables, `<Tip>`)
- [x] Uses components and table styles already present on the Axes page
- [ ] CI must pass
