### PR TITLE
docs: small multiples (faceted charts) configuration page

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -86,7 +86,8 @@
                     "pages": [
                       "docs/explore-analyze/charts/configuration/series-mapping",
                       "docs/explore-analyze/charts/configuration/series-configuration",
-                      "docs/explore-analyze/charts/configuration/color-and-stacking", "docs/explore-analyze/charts/configuration/small-multiples",
+                      "docs/explore-analyze/charts/configuration/color-and-stacking",
+                      "docs/explore-analyze/charts/configuration/small-multiples",
                       "docs/explore-analyze/charts/configuration/axes",
                       "docs/explore-analyze/charts/configuration/tooltips",
                       "docs/explore-analyze/charts/configuration/data-labels"

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -86,7 +86,7 @@
                     "pages": [
                       "docs/explore-analyze/charts/configuration/series-mapping",
                       "docs/explore-analyze/charts/configuration/series-configuration",
-                      "docs/explore-analyze/charts/configuration/color-and-stacking",
+                      "docs/explore-analyze/charts/configuration/color-and-stacking", "docs/explore-analyze/charts/configuration/small-multiples",
                       "docs/explore-analyze/charts/configuration/axes",
                       "docs/explore-analyze/charts/configuration/tooltips",
                       "docs/explore-analyze/charts/configuration/data-labels"

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/index.mdx
@@ -10,6 +10,7 @@ The chart configuration panel has two tabs — **Fields** and **Style** — avai
 | [Series mapping](/docs/explore-analyze/charts/configuration/series-mapping) | Assigning query columns to chart channels (X, Y, color, size, tooltip) |
 | [Series configuration](/docs/explore-analyze/charts/configuration/series-configuration) | Per-series mark type, color, and individual display options |
 | [Color & stacking](/docs/explore-analyze/charts/configuration/color-and-stacking) | Color palettes, stacking mode, stacked segment sorting, and legend placement |
+| [Small multiples](/docs/explore-analyze/charts/configuration/small-multiples) | Splitting a chart into a grid of panels, one per value of a dimension |
 | [Axes](/docs/explore-analyze/charts/configuration/axes) | Axis titles, grid lines, label formatting, dual Y-axis, and reference lines |
 | [Tooltips](/docs/explore-analyze/charts/configuration/tooltips) | Which fields appear on hover and how they are formatted |
 | [Data labels](/docs/explore-analyze/charts/configuration/data-labels) | Labels shown on chart marks — positioning, formatting, and stacked totals |

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/series-mapping.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/series-mapping.mdx
@@ -15,6 +15,7 @@ Series mapping controls which query columns are assigned to which chart channels
 | **Y** | The vertical axis measure | Bar, line, area, scatter, boxplot |
 | **Color** | Creates one series per unique value; controls stacking behavior | All Vega-based types |
 | **Size** | Scales point radius by a numeric measure | Scatter, map |
+| **Split by** | Repeats the chart once per unique value, as a grid of panels — see [small multiples](/docs/explore-analyze/charts/configuration/small-multiples) | Bar, line, area, scatter |
 | **Tooltip** | Fields shown on hover | All types |
 | **Theta** (pie) | The measure that determines slice size | Pie |
 

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -24,7 +24,7 @@ These options appear once a **Split by** dimension is chosen.
 | Option | What it does |
 |---|---|
 | **Columns** | Panels per row, from 1 to 6. The grid wraps and reflows to fit the chart's width. |
-| **Axis scales** | Whether panels share one set of axes (**Shared**) or each scales to its own data (**Independent**). |
+| **Axis scales** | Whether every panel is drawn against the same scale (**Shared**) or each scales to its own data (**Independent**). |
 | **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
 | **Sort order** | **Ascending** or **Descending**. |
 | **Show panel titles** | Whether each panel is labelled with its dimension value. |
@@ -32,7 +32,9 @@ These options appear once a **Split by** dimension is chosen.
 
 ### Shared vs. independent axis scales
 
-**Shared** is the default, and it is usually what makes small multiples worth using: every panel is drawn against the same axes, so the panels are directly comparable and a taller bar really does mean a bigger number.
+Every panel is labelled with its own x and y axis either way. What the setting changes is the scale those axes are drawn against.
+
+**Shared** is the default, and it is usually what makes small multiples worth using: every panel is drawn against the same scale, so the panels are directly comparable and a taller bar really does mean a bigger number.
 
 Switch to **Independent** when the question is about the *shape* of each series rather than its magnitude — "what does each warehouse's weekly pattern look like", where one high-volume warehouse would otherwise flatten every other panel to a straight line.
 

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -23,12 +23,10 @@ These options appear once a **Split by** dimension is chosen.
 
 | Option | What it does |
 |---|---|
-| **Columns** | Panels per row, from 1 to 6. The grid wraps and reflows to fit the chart's width. |
+| **Grid** | Columns × rows, up to 5 × 4. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
 | **Axis scales** | Whether every panel is drawn against the same scale (**Shared**) or each scales to its own data (**Independent**). |
 | **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
 | **Sort order** | **Ascending** or **Descending**. |
-| **Show panel titles** | Whether each panel is labelled with its dimension value. |
-| **Max panels** | The largest number of panels to draw. Defaults to 12. |
 
 ### Shared vs. independent axis scales
 
@@ -38,13 +36,13 @@ Every panel is labelled with its own x and y axis either way. What the setting c
 
 Switch to **Independent** when the question is about the *shape* of each series rather than its magnitude — "what does each warehouse's weekly pattern look like", where one high-volume warehouse would otherwise flatten every other panel to a straight line.
 
-### Max panels
+### How many panels are drawn
 
-Splitting by a high-cardinality dimension would otherwise draw hundreds of panels, each too small to read. **Max panels** bounds that, defaulting to 12.
+The grid bounds the render: a chart split into 3 × 2 draws at most six panels, so a high-cardinality dimension can never produce hundreds of unreadable ones. The largest grid is 5 × 4, or twenty panels.
 
-When a dimension has more values than the cap, the chart draws the first N in the current sort order and reports how many are hidden. Raising the cap draws more panels; the underlying query is unaffected either way, so no data is lost.
+When a dimension has more values than the grid has tiles, the chart draws the first ones in the current sort order. The underlying query is unaffected, so no data is lost — a bigger grid simply shows more of it.
 
-Sorting interacts with the cap: with **Sort panels by** set to a measure and a descending order, the cap keeps the top N by that measure — which is usually the more useful set than the first N alphabetically.
+Sorting interacts with this: with **Sort panels by** set to a measure and a descending order, the grid keeps the top panels by that measure, which is usually more useful than the first ones alphabetically.
 
 ## Interaction with other settings
 
@@ -54,6 +52,7 @@ A legend is shared across the grid rather than repeated per panel. Clicking a le
 
 ## Limitations
 
-- **One split dimension.** A single grid axis, wrapped into rows by the **Columns** setting. Splitting by two dimensions at once (a row × column matrix) is not supported.
+- **One split dimension.** One dimension fills the grid, wrapping into rows. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
 - **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, map, and HTML charts cannot be split.
-- **Panel title styling** is a visibility toggle; font, size, and color are not configurable.
+- **Panel labels are not configurable.** Each panel is labelled with its dimension value; the font, size, and color are fixed.
+- **Single-view charts only.** A chart with data labels, a reference line, or a second y-axis series cannot be split yet.

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -30,7 +30,7 @@ These options appear once a **Split by** dimension is chosen.
 
 ### Shared vs. independent axis scales
 
-Every panel is labelled with its own x and y axis either way. What the setting changes is the scale those axes are drawn against.
+Every panel is labeled with its own X and Y axes either way. What the setting changes is the scale those axes are drawn against.
 
 **Shared** is the default, and it is usually what makes small multiples worth using: every panel is drawn against the same scale, so the panels are directly comparable and a taller bar really does mean a bigger number.
 
@@ -46,13 +46,15 @@ Sorting interacts with this: with **Sort panels by** set to a measure and a desc
 
 ## Interaction with other settings
 
-Every other chart setting continues to apply, and applies to all panels at once — axis titles and formats, colors and palettes, data labels, tooltips, and reference lines are configured once and drawn in each panel.
+Chart settings apply to all panels at once — axis titles and formats, colors and palettes, and tooltips are configured once and take effect in every panel.
+
+Data labels and reference lines are the exception: a chart using either cannot be split, so the two are never combined. See the limitations below.
 
 A legend is shared across the grid rather than repeated per panel. Clicking a legend entry hides that series in every panel.
 
 ## Limitations
 
 - **One split dimension.** One dimension fills the grid, wrapping into rows. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
-- **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, map, and HTML charts cannot be split.
-- **Panel labels are not configurable.** Each panel is labelled with its dimension value; the font, size, and color are fixed.
-- **Single-view charts only.** A chart with data labels, a reference line, or a second y-axis series cannot be split yet.
+- **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, boxplot, map, and HTML charts cannot be split.
+- **Panel labels are not configurable.** Each panel is labeled with its dimension value; the font, size, and color are fixed.
+- **Single-view charts only.** A chart with data labels, a reference line, or a second Y axis series cannot be split yet.

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -46,15 +46,15 @@ Sorting interacts with this: with **Sort panels by** set to a measure and a desc
 
 ## Interaction with other settings
 
-Chart settings apply to all panels at once — axis titles and formats, colors and palettes, and tooltips are configured once and take effect in every panel.
+Chart settings apply to all panels at once — axis titles and formats, colors and palettes, data labels, reference lines, and tooltips are configured once and take effect in every panel. A reference line is drawn once inside each panel, against that panel's own scale when the scales are independent.
 
-Data labels and reference lines are the exception: a chart using either cannot be split, so the two are never combined. See the limitations below.
+Data labels and reference lines have to be switched on *after* the split, not before — see the limitations below.
 
 A legend is shared across the grid rather than repeated per panel. Clicking a legend entry hides that series in every panel.
 
 ## Limitations
 
-- **One split dimension.** One dimension fills the grid, wrapping into rows. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
+- **One split dimension.** One dimension fills the grid, panel by panel. Splitting by two dimensions at once — one down the rows and another across the columns — is not supported.
 - **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, boxplot, map, and HTML charts cannot be split.
 - **Panel labels are not configurable.** Each panel is labeled with its dimension value; the font, size, and color are fixed.
-- **Single-view charts only.** A chart with data labels, a reference line, or a second Y axis series cannot be split yet.
+- **The split is enabled on a single-view chart.** A chart that already carries data labels, a reference line, or a second Y axis series cannot be split — turn the split on first. The order is the only constraint: once a chart is split, data labels and reference lines can be added freely and are drawn in every panel.

--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -1,0 +1,57 @@
+---
+title: Small multiples
+description: Split a chart into a grid of panels, one per value of a dimension, for side-by-side comparison across segments.
+---
+
+**Small multiples** repeat one chart once per value of a dimension, laying the copies out in a grid. Instead of a single plot with a dozen overlapping series, you get a dozen small panels that can be read and compared at a glance.
+
+It is a setting on an existing chart, not a chart type of its own: a bar, line, area, or scatter chart stays that chart and simply gets drawn per panel.
+
+{/* TODO screenshot: Small multiples section of the Fields tab with a faceted line chart (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Splitting a chart into panels
+
+The **Small multiples** section appears in the Fields tab for bar, line, area, and scatter charts.
+
+Pick a dimension in **Split by** and the chart is replaced by one panel per value of that dimension. Clearing the picker returns the chart to a single plot.
+
+Only dimensions are offered. Splitting by a measure is not supported — a measure has no discrete values to make panels from.
+
+## Options
+
+These options appear once a **Split by** dimension is chosen.
+
+| Option | What it does |
+|---|---|
+| **Columns** | Panels per row, from 1 to 6. The grid wraps and reflows to fit the chart's width. |
+| **Axis scales** | Whether panels share one set of axes (**Shared**) or each scales to its own data (**Independent**). |
+| **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
+| **Sort order** | **Ascending** or **Descending**. |
+| **Show panel titles** | Whether each panel is labelled with its dimension value. |
+| **Max panels** | The largest number of panels to draw. Defaults to 12. |
+
+### Shared vs. independent axis scales
+
+**Shared** is the default, and it is usually what makes small multiples worth using: every panel is drawn against the same axes, so the panels are directly comparable and a taller bar really does mean a bigger number.
+
+Switch to **Independent** when the question is about the *shape* of each series rather than its magnitude — "what does each warehouse's weekly pattern look like", where one high-volume warehouse would otherwise flatten every other panel to a straight line.
+
+### Max panels
+
+Splitting by a high-cardinality dimension would otherwise draw hundreds of panels, each too small to read. **Max panels** bounds that, defaulting to 12.
+
+When a dimension has more values than the cap, the chart draws the first N in the current sort order and reports how many are hidden. Raising the cap draws more panels; the underlying query is unaffected either way, so no data is lost.
+
+Sorting interacts with the cap: with **Sort panels by** set to a measure and a descending order, the cap keeps the top N by that measure — which is usually the more useful set than the first N alphabetically.
+
+## Interaction with other settings
+
+Every other chart setting continues to apply, and applies to all panels at once — axis titles and formats, colors and palettes, data labels, tooltips, and reference lines are configured once and drawn in each panel.
+
+A legend is shared across the grid rather than repeated per panel. Clicking a legend entry hides that series in every panel.
+
+## Limitations
+
+- **One split dimension.** A single grid axis, wrapped into rows by the **Columns** setting. Splitting by two dimensions at once (a row × column matrix) is not supported.
+- **Cartesian charts only.** Bar, line, area, and scatter. Pie, table, KPI, heatmap, map, and HTML charts cannot be split.
+- **Panel title styling** is a visibility toggle; font, size, and color are not configurable.


### PR DESCRIPTION
## Summary

Documents **small multiples** — splitting a chart into a grid of panels, one per value of a dimension.

- New page `charts/configuration/small-multiples`, covering the **Split by** picker, the six options (Columns, Axis scales, Sort panels by, Sort order, Show panel titles, Max panels), how shared vs. independent scales change what the grid is good for, how the panel cap interacts with sorting, and the limitations.
- It lives under `configuration/`, not `chart-types/`: small multiples is a setting applied to bar, line, area, and scatter charts, whereas every `chart-types/` page documents one mark.
- Adds the page to the "Configure charts" index table and the `docs.json` nav, plus a **Split by** row in the series-mapping channel table.

## Test plan

- [x] `docs.json` parses; the new page is in the "Configure charts" group
- [x] Every option name matches the label the user actually sees in the shipped UI
- [ ] Mintlify preview renders
