### PR TITLE
feat(cubesql): add `disablePostProcessing` flag to `/v1/cubesql`

### DIFF
--- a/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
+++ b/docs-mintlify/reference/core-data-apis/rest-api/reference.mdx
@@ -411,6 +411,21 @@ This endpoint is part of the [SQL API][ref-sql-api].
 | `query` | The SQL query to run | ✅ Yes |
 | `timezone` | The [time zone][ref-time-zone] for this query in the [TZ Database Name][link-tzdb] format, e.g., `America/Los_Angeles` | ❌ No |
 | `cache` | See [cache control][ref-cache-control]. `stale-if-slow` by default | ❌ No |
+| `disablePostProcessing` | Reject the query instead of post-processing a truncated result. `false` by default. See below | ❌ No |
+
+### Rejecting queries with truncated post-processing
+
+A query that can't be fully pushed down to the data source is completed in memory
+by Cube. When such a query also puts no limit on the data it reads, Cube fetches
+only the first
+[`CUBEJS_DB_QUERY_LIMIT`](/reference/configuration/environment-variables#cubejs_db_query_limit)
+rows and post-processes those, so the result can be wrong without any error.
+
+Set `disablePostProcessing` to `true` to get an error instead. Queries that are
+fully pushed down, and queries whose post-processing reads a result bounded by a
+smaller limit, are unaffected. The check does not apply when
+[`CUBESQL_STREAM_MODE`](/reference/configuration/environment-variables#cubesql_stream_mode)
+is enabled, because nothing is truncated in that case.
 
 ### Headers
 

--- a/packages/cubejs-api-gateway/src/gateway.ts
+++ b/packages/cubejs-api-gateway/src/gateway.ts
@@ -480,7 +480,7 @@ class ApiGateway {
         try {
           await this.assertApiScope('data', req.context?.securityContext);
 
-          await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, req.body.timezone, req.body.throwContinueWait, req.context?.requestId);
+          await this.sqlServer.execSql(req.body.query, res, req.context?.securityContext, req.body.cache, req.body.timezone, req.body.throwContinueWait, req.context?.requestId, req.body.disablePostProcessing);
         } catch (e: any) {
           // Quickfix for https://github.com/cube-js/cube/issues/10450,
           // Right now, it's too complicated to fix the issue correctly, because

--- a/packages/cubejs-api-gateway/src/sql-server.ts
+++ b/packages/cubejs-api-gateway/src/sql-server.ts
@@ -76,8 +76,8 @@ export class SQLServer {
     return this.sqlInterfaceInstance;
   }
 
-  public async execSql(sqlQuery: string, stream: any, securityContext?: any, cacheMode?: CacheMode, timezone?: string, throwContinueWait?: boolean, requestId?: string) {
-    await execSql(this.getSqlInterfaceInstance(), sqlQuery, stream, securityContext, cacheMode, timezone, throwContinueWait, requestId);
+  public async execSql(sqlQuery: string, stream: any, securityContext?: any, cacheMode?: CacheMode, timezone?: string, throwContinueWait?: boolean, requestId?: string, disablePostProcessing?: boolean) {
+    await execSql(this.getSqlInterfaceInstance(), sqlQuery, stream, securityContext, cacheMode, timezone, throwContinueWait, requestId, disablePostProcessing);
   }
 
   public async sql4sql(sqlQuery: string, disablePostProcessing: boolean, securityContext?: unknown): Promise<Sql4SqlResponse> {

--- a/packages/cubejs-api-gateway/test/index.test.ts
+++ b/packages/cubejs-api-gateway/test/index.test.ts
@@ -1356,6 +1356,7 @@ describe('API Gateway', () => {
         undefined,
         undefined,
         expect.any(String),
+        undefined,
       );
     });
 
@@ -1397,6 +1398,7 @@ describe('API Gateway', () => {
         'America/Los_Angeles',
         undefined,
         expect.any(String),
+        undefined,
       );
     });
 
@@ -1434,6 +1436,7 @@ describe('API Gateway', () => {
         undefined,
         true,
         expect.any(String),
+        undefined,
       );
     });
 
@@ -1471,6 +1474,7 @@ describe('API Gateway', () => {
         undefined,
         undefined,
         'test-request-id-12345',
+        undefined,
       );
     });
 
@@ -1502,6 +1506,41 @@ describe('API Gateway', () => {
       const requestId = execSqlMock.mock.calls[0][6];
       expect(requestId).toBeDefined();
       expect(requestId).toMatch(/^[0-9a-f-]+-span-1$/);
+    });
+
+    test('disablePostProcessing can be passed', async () => {
+      const { app, apiGateway } = await createApiGateway();
+
+      const execSqlMock = jest.fn(async (query, stream) => {
+        stream.write(`${JSON.stringify({
+          error: 'Query requires post-processing, which is disabled for this request.'
+        })}\n`);
+        stream.end();
+      });
+
+      apiGateway.getSQLServer().execSql = execSqlMock;
+
+      await request(app)
+        .post('/cubejs-api/v1/cubesql')
+        .set('Content-type', 'application/json')
+        .set('Authorization', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M')
+        .send({
+          query: 'SELECT id FROM test',
+          disablePostProcessing: true,
+        })
+        .responseType('text')
+        .expect(200);
+
+      expect(execSqlMock).toHaveBeenCalledWith(
+        'SELECT id FROM test',
+        expect.anything(),
+        {},
+        undefined,
+        undefined,
+        undefined,
+        expect.any(String),
+        true,
+      );
     });
   });
 

--- a/packages/cubejs-backend-native/js/index.ts
+++ b/packages/cubejs-backend-native/js/index.ts
@@ -440,10 +440,10 @@ export const shutdownInterface = async (instance: SqlInterfaceInstance, shutdown
   await native.shutdownInterface(instance, shutdownMode);
 };
 
-export const execSql = async (instance: SqlInterfaceInstance, sqlQuery: string, stream: any, securityContext?: any, cacheMode: CacheMode = 'stale-if-slow', timezone?: string, throwContinueWait?: boolean, requestId?: string): Promise<void> => {
+export const execSql = async (instance: SqlInterfaceInstance, sqlQuery: string, stream: any, securityContext?: any, cacheMode: CacheMode = 'stale-if-slow', timezone?: string, throwContinueWait?: boolean, requestId?: string, disablePostProcessing?: boolean): Promise<void> => {
   const native = loadNative();
 
-  await native.execSql(instance, sqlQuery, stream, securityContext ? JSON.stringify(securityContext) : null, cacheMode, timezone, throwContinueWait, requestId);
+  await native.execSql(instance, sqlQuery, stream, securityContext ? JSON.stringify(securityContext) : null, cacheMode, timezone, throwContinueWait, requestId, disablePostProcessing);
 };
 
 // TODO parse result from native code

--- a/packages/cubejs-backend-native/src/node_export.rs
+++ b/packages/cubejs-backend-native/src/node_export.rs
@@ -1,8 +1,10 @@
+use cubesql::compile::datafusion::scalar::ScalarValue;
+use cubesql::compile::datafusion::variable::VarType;
 use cubesql::compile::parser::parse_sql_to_statement;
-use cubesql::compile::{convert_statement_to_cube_query, get_df_batches};
+use cubesql::compile::{convert_statement_to_cube_query, get_df_batches, DatabaseVariable};
 use cubesql::config::processing_loop::ShutdownMode;
 use cubesql::sql::dataframe::arrow_to_column_type;
-use cubesql::sql::ColumnType;
+use cubesql::sql::{ColumnType, CUBESQL_DISABLE_POST_PROCESSING_VAR};
 use cubesql::transport::{SpanId, TransportService};
 use futures::StreamExt;
 
@@ -243,6 +245,7 @@ async fn handle_sql_query(
     timezone: Option<String>,
     throw_continue_wait: bool,
     request_id: Option<String>,
+    disable_post_processing: bool,
 ) -> Result<(), CubeError> {
     let span_id = Some(Arc::new(SpanId::new(
         request_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
@@ -299,6 +302,16 @@ async fn handle_sql_query(
                 .write()
                 .expect("failed to unlock session throw_continue_wait for change");
             *cm = throw_continue_wait;
+        }
+
+        if disable_post_processing {
+            session.state.set_variables(vec![DatabaseVariable {
+                name: CUBESQL_DISABLE_POST_PROCESSING_VAR.to_string(),
+                value: ScalarValue::Boolean(Some(true)),
+                var_type: VarType::UserDefined,
+                readonly: false,
+                additional_params: None,
+            }]);
         }
 
         let session_clone = Arc::clone(&session);
@@ -601,6 +614,14 @@ fn exec_sql(mut cx: FunctionContext) -> JsResult<JsValue> {
         Err(_) => None,
     };
 
+    let disable_post_processing: bool = match cx.argument::<JsValue>(8) {
+        Ok(val) => match val.downcast::<JsBoolean, _>(&mut cx) {
+            Ok(v) => v.value(&mut cx),
+            Err(_) => false,
+        },
+        Err(_) => false,
+    };
+
     let js_stream_on_fn = Arc::new(
         node_stream
             .get::<JsFunction, _, _>(&mut cx, "on")?
@@ -654,6 +675,7 @@ fn exec_sql(mut cx: FunctionContext) -> JsResult<JsValue> {
             timezone,
             throw_continue_wait,
             request_id,
+            disable_post_processing,
         )
         .await;
 

--- a/packages/cubejs-backend-native/test/sql.test.ts
+++ b/packages/cubejs-backend-native/test/sql.test.ts
@@ -655,4 +655,105 @@ describe('SQLInterface', () => {
       }
     }
   );
+
+  // `disablePostProcessing` on /v1/cubesql reaches the planner as a session
+  // variable, and the planner rejects a query only when the post-processing it
+  // needs would run over an intermediate result truncated to
+  // CUBEJS_DB_QUERY_LIMIT rows. A window function is never pushed down to Cube
+  // and this query puts no limit on the scan underneath it, so it is exactly
+  // that case.
+  //
+  // Truncation only happens off the streaming path - with stream mode on the
+  // scan streams every row instead - so the whole check is inert under
+  // CUBESQL_STREAM_MODE, which rust-cubesql.yml sets for this suite. Every test
+  // in this block would then assert nothing while reporting green, so skip it
+  // outright and let the CI report say so.
+  //
+  // Clearing the variable from here does not work: the deletion is visible in
+  // JS, but the native config is built from the real process environment, which
+  // jest's sandboxed `process.env` does not write through to. Coverage of this
+  // path in CI therefore rests on the Rust tests in `test_post_processing.rs`,
+  // which run without stream mode; what is lost here is the JS -> native
+  // argument wiring, which only these tests exercise.
+  const describeUnlessStreamMode =
+    process.env.CUBESQL_STREAM_MODE === 'true' ? describe.skip : describe;
+
+  describeUnlessStreamMode('disablePostProcessing', () => {
+    const UNBOUNDED_POST_PROCESSING_SQL =
+      'SELECT customer_gender, SUM(count) OVER () FROM KibanaSampleDataEcommerce GROUP BY customer_gender, count;';
+
+    async function execSqlCollectingLines(
+      sql: string,
+      disablePostProcessing?: boolean
+    ) {
+      const instance = await native.registerInterface({
+        ...interfaceMethods(),
+        canSwitchUserForSession: (_payload: any) => true,
+      });
+
+      let buf = '';
+      const lines: any[] = [];
+      const write = jest.fn((chunk, _enc, callback) => {
+        const raw = (buf + chunk.toString('utf-8')).split('\n');
+        buf = raw.pop() || '';
+        for (const l of raw) {
+          if (l.trim().length) {
+            lines.push(JSON.parse(l));
+          }
+        }
+        callback();
+      });
+
+      try {
+        await native.execSql(
+          instance,
+          sql,
+          new Writable({ write }),
+          { foo: 'bar' },
+          'stale-if-slow',
+          undefined,
+          undefined,
+          undefined,
+          disablePostProcessing
+        );
+      } finally {
+        await native.shutdownInterface(instance, 'fast');
+      }
+
+      return lines;
+    }
+
+    // The planning error is what's under test, not what the fake transport does
+    // afterwards: `interfaceMethods()` answers every non-streaming load with an
+    // error of its own, so a query that gets past planning still produces an
+    // error line - just not this one.
+    function rejectedForPostProcessing(lines: any[]) {
+      return lines.some((o) => o.error?.includes('post-processing'));
+    }
+
+    test('rejects post-processing over a truncated intermediate result', async () => {
+      const lines = await execSqlCollectingLines(
+        UNBOUNDED_POST_PROCESSING_SQL,
+        true
+      );
+
+      expect(rejectedForPostProcessing(lines)).toBe(true);
+      expect(lines.find((o) => o.schema)).toBeUndefined();
+    });
+
+    test('runs the same query when the flag is not passed', async () => {
+      const lines = await execSqlCollectingLines(UNBOUNDED_POST_PROCESSING_SQL);
+
+      expect(rejectedForPostProcessing(lines)).toBe(false);
+    });
+
+    test('leaves a fully pushed down query alone', async () => {
+      const lines = await execSqlCollectingLines(
+        'SELECT customer_gender, MEASURE(count) AS cnt FROM KibanaSampleDataEcommerce GROUP BY 1;',
+        true
+      );
+
+      expect(rejectedForPostProcessing(lines)).toBe(false);
+    });
+  });
 });

--- a/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/cost.rs
@@ -4,13 +4,14 @@ use std::{
 
 use crate::{
     compile::rewrite::{
-        rules::utils::granularity_str_to_int_order, CubeScanUngrouped, CubeScanWrapped,
-        DimensionName, LogicalPlanLanguage, MemberErrorPriority, ScalarUDFExprFun,
-        TimeDimensionGranularity, WrappedSelectPushToCube, WrappedSelectUngroupedScan,
+        rules::utils::granularity_str_to_int_order, CubeScanLimit, CubeScanUngrouped,
+        CubeScanWrapped, DimensionName, LogicalPlanLanguage, MemberErrorPriority, ScalarUDFExprFun,
+        TimeDimensionGranularity, WrappedSelectLimit, WrappedSelectPushToCube,
+        WrappedSelectUngroupedScan,
     },
     transport::{MetaContext, V1CubeMetaDimensionExt},
 };
-use egg::{Analysis, EGraph, Id, Language, RecExpr};
+use egg::{Analysis, EClass, EGraph, Id, Language, RecExpr};
 use indexmap::IndexSet;
 
 #[derive(Debug)]
@@ -241,6 +242,8 @@ impl BestCubePlan {
             ast_size: 1,
             ungrouped_nodes,
             unwrapped_subqueries,
+            // Will be filled in finalize
+            truncated_post_processing_scans: 0,
         }
     }
 }
@@ -264,6 +267,10 @@ pub struct CubePlanCostOptions {
 /// - `non_pushed_down_window` > `wrapper_nodes` - prefer to always push down window functions
 /// - `non_pushed_down_limit_sort` > `wrapper_nodes` - prefer to always push down limit-sort expressions
 /// - `wrapped_select_non_push_to_cube` > `wrapped_select_ungrouped_scan` - otherwise cost would prefer any aggregation, even non-push-to-Cube
+/// - `truncated_post_processing_scans` > `wrapper_nodes` - post-processing truncated data is
+///   wrong, not just slow, so it outranks the tiers that trade post-processing against wrappers.
+///   It has to stay *below* `table_scans` and `non_detected_cube_scans` though: a plan that never
+///   detected a cube scan has nothing to truncate and would otherwise win on this tier.
 /// - match errors by priority - optimize for more specific errors
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct CubePlanCost {
@@ -280,6 +287,10 @@ pub struct CubePlanCost {
     non_pushed_down_grouping_sets: i64,
     non_pushed_down_limit_sort: i64,
     joins: usize,
+    /// Pushed-down subtrees whose result is truncated to `CUBEJS_DB_QUERY_LIMIT` rows and then
+    /// post-processed in memory - the plan shape that silently returns wrong results. Counted
+    /// only when the caller asked for it, see [`CubePlanTopDownState::max_intermediate_rows`].
+    truncated_post_processing_scans: usize,
     wrapper_nodes: i64,
     ast_size_outside_wrapper: usize,
     wrapped_select_non_push_to_cube: usize,
@@ -301,6 +312,12 @@ pub struct CubePlanCost {
     ast_size: usize,
     ast_size_inside_wrapper: usize,
     ungrouped_nodes: usize,
+}
+
+impl CubePlanCost {
+    pub fn truncated_post_processing_scans(&self) -> usize {
+        self.truncated_post_processing_scans
+    }
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -366,16 +383,19 @@ impl CubePlanCost {
             ast_size_inside_wrapper: self.ast_size_inside_wrapper + other.ast_size_inside_wrapper,
             ungrouped_nodes: self.ungrouped_nodes + other.ungrouped_nodes,
             unwrapped_subqueries: self.unwrapped_subqueries + other.unwrapped_subqueries,
+            truncated_post_processing_scans: self.truncated_post_processing_scans
+                + other.truncated_post_processing_scans,
         }
     }
 
     pub fn finalize(
         &self,
-        state: &CubePlanState,
-        sort_state: &SortState,
+        top_down_state: &CubePlanTopDownState,
         enode: &LogicalPlanLanguage,
         options: CubePlanCostOptions,
     ) -> Self {
+        let state = &top_down_state.wrapped;
+        let sort_state = &top_down_state.limit;
         let ast_size_outside_wrapper = match state {
             CubePlanState::Wrapped => 0,
             CubePlanState::Unwrapped(size) => *size,
@@ -390,6 +410,10 @@ impl CubePlanCost {
         Self {
             replacers: self.replacers,
             penalized_ast_size_outside_wrapper,
+            // Only ever set on the root of a pushed-down subtree, so this counts boundaries
+            // rather than every node above one.
+            truncated_post_processing_scans: self.truncated_post_processing_scans
+                + top_down_state.truncated_post_processing as usize,
             table_scans: self.table_scans,
             filters: self.filters,
             non_detected_cube_scans: match state {
@@ -742,6 +766,19 @@ impl TopDownCost for CubePlanCost {
 pub struct CubePlanTopDownState {
     wrapped: CubePlanState,
     limit: SortState,
+    /// Whether any ancestor of the current node post-processes in memory. Reset upon entering a
+    /// pushed-down subtree, where there is no in-memory work left to do.
+    post_processing_above: bool,
+    /// Set when the current node is the root of a pushed-down subtree - a `CubeScanWrapper`, or a
+    /// `CubeScan` that is not wrapped - that feeds post-processing above it and is not bounded by
+    /// a limit fitting into `max_intermediate_rows`. Such a subtree is silently truncated to that
+    /// many rows at execution time (see `CubeScanExecutionPlan::execute` and
+    /// `CubeScanWrapperNode::set_max_limit_for_node`), so the post-processing above it runs on
+    /// partial data and can return a wrong answer with no error.
+    truncated_post_processing: bool,
+    /// Row count a pushed-down subtree is truncated to, i.e. `CUBEJS_DB_QUERY_LIMIT`.
+    /// `None`, the default, turns off `truncated_post_processing` entirely.
+    max_intermediate_rows: Option<usize>,
 }
 
 impl CubePlanTopDownState {
@@ -749,7 +786,18 @@ impl CubePlanTopDownState {
         Self {
             wrapped: CubePlanState::Unwrapped(0),
             limit: SortState::None,
+            post_processing_above: false,
+            truncated_post_processing: false,
+            max_intermediate_rows: None,
         }
+    }
+
+    /// Starts tracking pushed-down subtrees that get truncated to `max_intermediate_rows` before
+    /// being post-processed, which makes [`CubePlanCost::truncated_post_processing_scans`] count
+    /// them. `None` leaves the tracking off, for when nothing asked for the check or streaming
+    /// is on and there is no truncation to detect.
+    pub fn with_max_intermediate_rows(&mut self, max_intermediate_rows: Option<usize>) {
+        self.max_intermediate_rows = max_intermediate_rows;
     }
 
     pub fn is_wrapped<A>(
@@ -774,6 +822,97 @@ impl CubePlanTopDownState {
             }
         }
         return true;
+    }
+
+    /// Whether the pushed-down subtree rooted at `node` returns at most `max_rows` rows.
+    ///
+    /// An eclass can hold several alternatives, and extraction has not picked one yet, so this
+    /// only reports `true` when every alternative is bounded. Anything it can't prove bounded -
+    /// including a wrapper input that isn't a plain `WrappedSelect` - counts as unbounded, which
+    /// biases towards pushing the query down rather than towards post-processing truncated data.
+    fn is_bounded<A>(
+        node: &LogicalPlanLanguage,
+        max_rows: usize,
+        egraph: &EGraph<LogicalPlanLanguage, A>,
+    ) -> bool
+    where
+        A: Analysis<LogicalPlanLanguage>,
+    {
+        match node {
+            LogicalPlanLanguage::CubeScan(cube_scan) => {
+                let limit_id = cube_scan[4];
+                Self::all_nodes(&egraph[limit_id], |node| {
+                    matches!(
+                        node,
+                        LogicalPlanLanguage::CubeScanLimit(CubeScanLimit(Some(limit)))
+                            if *limit <= max_rows
+                    )
+                })
+            }
+            // Whatever tops the wrapped plan decides how many rows come back, which is what
+            // `CubeScanWrapperNode::set_max_limit_for_node` clamps. Usually that's a
+            // `WrappedSelect`, whose limit lands in the generated SQL while the `CubeScan`
+            // beneath it stays limitless - but a wrapper straight over a `CubeScan` is just as
+            // real, and there the scan's own limit is the one that counts.
+            LogicalPlanLanguage::CubeScanWrapper(cube_scan_wrapper) => {
+                let input_id = cube_scan_wrapper[0];
+                Self::all_nodes(&egraph[input_id], |node| match node {
+                    LogicalPlanLanguage::WrappedSelect(wrapped_select) => {
+                        let limit_id = wrapped_select[10];
+                        Self::all_nodes(&egraph[limit_id], |node| {
+                            matches!(
+                                node,
+                                LogicalPlanLanguage::WrappedSelectLimit(WrappedSelectLimit(Some(
+                                    limit
+                                ))) if *limit <= max_rows
+                            )
+                        })
+                    }
+                    LogicalPlanLanguage::CubeScan(_) => Self::is_bounded(node, max_rows, egraph),
+                    _ => false,
+                })
+            }
+            _ => true,
+        }
+    }
+
+    fn all_nodes<D>(
+        eclass: &EClass<LogicalPlanLanguage, D>,
+        predicate: impl Fn(&LogicalPlanLanguage) -> bool,
+    ) -> bool {
+        !eclass.nodes.is_empty() && eclass.nodes.iter().all(predicate)
+    }
+
+    /// Whether `node` is an operator that does its work in memory, and therefore post-processes
+    /// whatever is under it when it sits outside a wrapper.
+    ///
+    /// Deliberately not the node list behind `ast_size_outside_wrapper`. That one exists to
+    /// weight a cost, where missing a node only makes a plan look slightly cheaper than it is;
+    /// this one decides whether a query is rejected, where missing a node means accepting a
+    /// query the flag promised to reject and handing back a wrong answer. `Distinct` is the
+    /// case in point: it is absent there, and `Distinct` over a wrapper is exactly the shape
+    /// that would slip through.
+    ///
+    /// Keep in sync with the `LogicalPlan` variants handled in
+    /// [`crate::compile::rewrite::converter`] - anything that survives to execution and is not
+    /// pushed down belongs here.
+    fn is_post_processing(node: &LogicalPlanLanguage) -> bool {
+        matches!(
+            node,
+            LogicalPlanLanguage::Aggregate(_)
+                | LogicalPlanLanguage::CrossJoin(_)
+                | LogicalPlanLanguage::Distinct(_)
+                | LogicalPlanLanguage::Filter(_)
+                | LogicalPlanLanguage::Join(_)
+                | LogicalPlanLanguage::Limit(_)
+                | LogicalPlanLanguage::Projection(_)
+                | LogicalPlanLanguage::Repartition(_)
+                | LogicalPlanLanguage::Sort(_)
+                | LogicalPlanLanguage::Subquery(_)
+                | LogicalPlanLanguage::TableUDFs(_)
+                | LogicalPlanLanguage::Union(_)
+                | LogicalPlanLanguage::Window(_)
+        )
     }
 }
 
@@ -818,7 +957,46 @@ impl TopDownState<LogicalPlanLanguage> for CubePlanTopDownState {
             _ => SortState::None,
         };
 
-        Self { wrapped, limit }
+        // Only in-memory nodes count, so this stops accumulating once inside a pushed-down
+        // subtree.
+        //
+        // Kept pinned to `false` when the tracking is off: this is part of the extractor's cache
+        // key, and a value that varies by position in the plan would split every eclass into
+        // several entries for no gain on the default path.
+        let post_processing_above = self.max_intermediate_rows.is_some()
+            && match wrapped {
+                CubePlanState::Wrapped | CubePlanState::Wrapper => false,
+                CubePlanState::Unwrapped(_) => {
+                    self.post_processing_above || Self::is_post_processing(node)
+                }
+            };
+
+        // Guarded on `self.post_processing_above` rather than the value just computed: what
+        // matters is what sits *above* this node, and the root of a pushed-down subtree never
+        // post-processes anything itself.
+        let truncated_post_processing = match self.max_intermediate_rows {
+            Some(max_rows) if self.post_processing_above => match node {
+                LogicalPlanLanguage::CubeScanWrapper(_) => {
+                    !Self::is_bounded(node, max_rows, egraph)
+                }
+                // A wrapped `CubeScan` is not the root of the pushed-down subtree, the
+                // `CubeScanWrapper` above it is; counting both would report every pushdown plan
+                // as truncated.
+                LogicalPlanLanguage::CubeScan(_) if !self.is_wrapped(node, egraph) => {
+                    !Self::is_bounded(node, max_rows, egraph)
+                }
+                _ => false,
+            },
+            _ => false,
+        };
+
+        Self {
+            wrapped,
+            limit,
+            post_processing_above,
+            truncated_post_processing,
+            max_intermediate_rows: self.max_intermediate_rows,
+        }
     }
 }
 
@@ -835,12 +1013,105 @@ impl TopDownCostFunction<LogicalPlanLanguage, CubePlanTopDownState, CubePlanCost
     ) -> CubePlanCost {
         CubePlanCost::finalize(
             &cost,
-            &state.wrapped,
-            &state.limit,
+            state,
             node,
             CubePlanCostOptions {
                 penalize_post_processing: self.penalize_post_processing,
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_ROWS: usize = 50_000;
+
+    /// A `CubeScan` with `limit`. Every child slot points at the limit eclass, which is fine
+    /// because [`CubePlanTopDownState::is_bounded`] only ever reads the limit.
+    fn add_cube_scan(egraph: &mut EGraph<LogicalPlanLanguage, ()>, limit: Option<usize>) -> Id {
+        let limit_id = egraph.add(LogicalPlanLanguage::CubeScanLimit(CubeScanLimit(limit)));
+        egraph.add(LogicalPlanLanguage::CubeScan([limit_id; 11]))
+    }
+
+    fn add_wrapped_select(
+        egraph: &mut EGraph<LogicalPlanLanguage, ()>,
+        limit: Option<usize>,
+    ) -> Id {
+        let limit_id = egraph.add(LogicalPlanLanguage::WrappedSelectLimit(WrappedSelectLimit(
+            limit,
+        )));
+        let mut children = [limit_id; 17];
+        children[10] = limit_id;
+        egraph.add(LogicalPlanLanguage::WrappedSelect(children))
+    }
+
+    fn add_wrapper(egraph: &mut EGraph<LogicalPlanLanguage, ()>, input: Id) -> Id {
+        egraph.add(LogicalPlanLanguage::CubeScanWrapper([input; 2]))
+    }
+
+    fn is_bounded(egraph: &EGraph<LogicalPlanLanguage, ()>, id: Id) -> bool {
+        let node = egraph[id].nodes[0].clone();
+        CubePlanTopDownState::is_bounded(&node, MAX_ROWS, egraph)
+    }
+
+    #[test]
+    fn test_is_bounded_cube_scan() {
+        let mut egraph = EGraph::<LogicalPlanLanguage, ()>::default();
+
+        let bounded = add_cube_scan(&mut egraph, Some(100));
+        let unbounded = add_cube_scan(&mut egraph, None);
+        let over_limit = add_cube_scan(&mut egraph, Some(MAX_ROWS + 1));
+
+        assert!(is_bounded(&egraph, bounded));
+        assert!(!is_bounded(&egraph, unbounded));
+        // Clamped down to `MAX_ROWS` at execution time, so the rows above it are lost.
+        assert!(!is_bounded(&egraph, over_limit));
+    }
+
+    /// A wrapper can sit straight on a `CubeScan` instead of on a `WrappedSelect` -
+    /// `CubeScanWrapperNode::set_max_limit_for_node` handles both - and then it is the scan's own
+    /// limit that bounds the result. Reporting those as unbounded rejects queries that are
+    /// perfectly safe, purely because of which representation extraction landed on.
+    #[test]
+    fn test_is_bounded_wrapper_over_cube_scan() {
+        let mut egraph = EGraph::<LogicalPlanLanguage, ()>::default();
+
+        let bounded = add_cube_scan(&mut egraph, Some(100));
+        let bounded = add_wrapper(&mut egraph, bounded);
+        let unbounded = add_cube_scan(&mut egraph, None);
+        let unbounded = add_wrapper(&mut egraph, unbounded);
+
+        assert!(is_bounded(&egraph, bounded));
+        assert!(!is_bounded(&egraph, unbounded));
+    }
+
+    #[test]
+    fn test_is_bounded_wrapper_over_wrapped_select() {
+        let mut egraph = EGraph::<LogicalPlanLanguage, ()>::default();
+
+        let bounded = add_wrapped_select(&mut egraph, Some(100));
+        let bounded = add_wrapper(&mut egraph, bounded);
+        let unbounded = add_wrapped_select(&mut egraph, None);
+        let unbounded = add_wrapper(&mut egraph, unbounded);
+
+        assert!(is_bounded(&egraph, bounded));
+        assert!(!is_bounded(&egraph, unbounded));
+    }
+
+    /// Extraction has not picked an alternative yet, so a wrapper input that could still turn
+    /// out to be something unrecognised stays unbounded.
+    #[test]
+    fn test_is_bounded_wrapper_over_unknown_input_is_conservative() {
+        let mut egraph = EGraph::<LogicalPlanLanguage, ()>::default();
+
+        let scan = add_cube_scan(&mut egraph, Some(100));
+        let wrapper = add_wrapper(&mut egraph, scan);
+        let other = egraph.add(LogicalPlanLanguage::EmptyRelation([scan; 3]));
+        egraph.union(scan, other);
+        egraph.rebuild();
+
+        assert!(!is_bounded(&egraph, wrapper));
     }
 }

--- a/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
+++ b/rust/cubesql/cubesql/src/compile/rewrite/rewriter.rs
@@ -15,7 +15,9 @@ use crate::{
         CubeContext,
     },
     config::ConfigObj,
-    sql::database_variables::postgres::session_vars::CUBESQL_PENALIZE_POST_PROCESSING_VAR,
+    sql::database_variables::postgres::session_vars::{
+        CUBESQL_DISABLE_POST_PROCESSING_VAR, CUBESQL_PENALIZE_POST_PROCESSING_VAR,
+    },
     sql::{compiler_cache::CompilerCacheEntry, AuthContextRef},
     transport::{MetaContext, SpanId},
     CubeError,
@@ -344,31 +346,62 @@ impl Rewriter {
             .rewrite_rules(cache_entry, true)
             .await?;
 
-        let penalize_post_processing = self
+        let session_bool_var = |name: &str| match self
             .cube_context
             .session_state
-            .get_variable(CUBESQL_PENALIZE_POST_PROCESSING_VAR)
-            .map(|v| v.value);
-        let penalize_post_processing = match penalize_post_processing {
+            .get_variable(name)
+            .map(|v| v.value)
+        {
             Some(ScalarValue::Boolean(val)) => val.unwrap_or(false),
             _ => false,
         };
+        let penalize_post_processing = session_bool_var(CUBESQL_PENALIZE_POST_PROCESSING_VAR);
+        let disable_post_processing = session_bool_var(CUBESQL_DISABLE_POST_PROCESSING_VAR);
+
+        // In streaming mode a limitless scan streams every row instead of being cut off at
+        // `CUBEJS_DB_QUERY_LIMIT`, so there's no truncation for post-processing to be wrong about.
+        //
+        // Nothing clamps the configured limit to a positive number, and casting a negative one
+        // would wrap into `usize::MAX` and quietly turn the guard off. Saturate to zero instead:
+        // a scan truncated to no rows at all bounds nothing, so every plan that post-processes
+        // one is rejected, which is the same answer a limit of zero already gets.
+        let config_obj = &cube_context.sessions.server.config_obj;
+        let max_intermediate_rows = (disable_post_processing && !config_obj.stream_mode())
+            .then(|| config_obj.non_streaming_query_max_row_limit().max(0) as usize);
 
         let (plan, qtrace_egraph_iterations, qtrace_best_graph) =
             tokio::task::spawn_blocking(move || {
                 let (runner, qtrace_egraph_iterations) =
                     Self::run_rewrites(&cube_context, egraph, rules, "final")?;
 
-                // TODO maybe check replacers and penalized_ast_size_outside_wrapper right after extraction?
+                let mut top_down_state = CubePlanTopDownState::new();
+                top_down_state.with_max_intermediate_rows(max_intermediate_rows);
+
+                // TODO maybe check replacers right after extraction?
                 let mut extractor = TopDownExtractor::new(
                     &runner.egraph,
                     BestCubePlan::new(cube_context.meta.clone(), penalize_post_processing),
-                    CubePlanTopDownState::new(),
+                    top_down_state,
                 );
                 let Some((best_cost, best)) = extractor.find_best(root) else {
                     return Err(CubeError::rewrite("Unable to find best plan".to_string()));
                 };
                 log::debug!("Best cost: {:#?}", best_cost);
+
+                // Counted only when the caller asked for it, so a non-zero count means the best
+                // plan available still post-processes a result that would be silently truncated.
+                if let Some(max_intermediate_rows) = max_intermediate_rows {
+                    if best_cost.truncated_post_processing_scans() > 0 {
+                        return Err(CubeError::user(format!(
+                            "Query requires post-processing, which is disabled for this request. \
+                            It can not be fully pushed down to the data source, and the \
+                            intermediate result it would be post-processed from is truncated to \
+                            {max_intermediate_rows} rows (CUBEJS_DB_QUERY_LIMIT), which can \
+                            silently produce incorrect results. Rewrite the query so it can be \
+                            pushed down, or limit it to {max_intermediate_rows} rows or fewer."
+                        )));
+                    }
+                }
 
                 let qtrace_best_graph = if Qtrace::is_enabled() {
                     best.as_ref().to_vec()

--- a/rust/cubesql/cubesql/src/compile/test/mod.rs
+++ b/rust/cubesql/cubesql/src/compile/test/mod.rs
@@ -2,7 +2,7 @@ use super::{convert_sql_to_cube_query, CompilationResult, QueryPlan};
 use crate::{
     compile::{
         engine::df::{scan::MemberField, wrapper::SqlQuery},
-        DatabaseProtocol, StatusFlags,
+        DatabaseProtocol, DatabaseVariable, StatusFlags,
     },
     config::{ConfigObj, ConfigObjImpl},
     sql::{
@@ -20,7 +20,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use cubeclient::models::V1CubeMetaType;
-use datafusion::{arrow::datatypes::SchemaRef, dataframe::DataFrame as DFDataFrame};
+use datafusion::{
+    arrow::datatypes::SchemaRef, dataframe::DataFrame as DFDataFrame, scalar::ScalarValue,
+    variable::VarType,
+};
 use std::future::Future;
 use std::{collections::HashMap, env, ops::Deref, sync::Arc};
 use uuid::Uuid;
@@ -42,6 +45,8 @@ pub mod test_df_execution;
 pub mod test_filters;
 #[cfg(test)]
 pub mod test_introspection;
+#[cfg(test)]
+pub mod test_post_processing;
 #[cfg(test)]
 pub mod test_udfs;
 #[cfg(test)]
@@ -1166,6 +1171,17 @@ impl TestContext {
     pub async fn convert_sql_to_cube_query(&self, query: &str) -> CompilationResult<QueryPlan> {
         // TODO push to_string() deeper
         convert_sql_to_cube_query(&query.to_string(), self.meta.clone(), self.session.clone()).await
+    }
+
+    /// Sets a boolean session variable, the way the native bridge does it for a single request.
+    pub fn set_session_flag(&self, name: &str, value: bool) {
+        self.session.state.set_variables(vec![DatabaseVariable {
+            name: name.to_string(),
+            value: ScalarValue::Boolean(Some(value)),
+            var_type: VarType::UserDefined,
+            readonly: false,
+            additional_params: None,
+        }]);
     }
 
     pub async fn execute_query_with_flags(

--- a/rust/cubesql/cubesql/src/compile/test/test_post_processing.rs
+++ b/rust/cubesql/cubesql/src/compile/test/test_post_processing.rs
@@ -1,0 +1,147 @@
+use datafusion::logical_plan::LogicalPlan;
+
+use crate::{
+    compile::{
+        test::{init_testing_logger, LogicalPlanTestUtils, TestContext},
+        DatabaseProtocol,
+    },
+    sql::CUBESQL_DISABLE_POST_PROCESSING_VAR,
+};
+
+/// A window function is never pushed down to Cube, so the plan keeps a `WindowAggr` over a
+/// `CubeScan` that has no limit of its own - at execution time that scan is cut off at
+/// `CUBEJS_DB_QUERY_LIMIT` rows and the window is computed over whatever made it through.
+const UNBOUNDED_POST_PROCESSING_QUERY: &str = "SELECT customer_gender, SUM(count) OVER () \
+     FROM KibanaSampleDataEcommerce GROUP BY customer_gender, count";
+
+async fn context_with_post_processing_disabled() -> TestContext {
+    init_testing_logger();
+    let ctx = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+    ctx.set_session_flag(CUBESQL_DISABLE_POST_PROCESSING_VAR, true);
+    ctx
+}
+
+/// Also pins where `truncated_post_processing_scans` sits in `CubePlanCost`: ranked above
+/// `table_scans`, a plan that never detected a cube scan becomes the cheapest way to score zero
+/// on that tier, and this query comes back as an unrejected `TableScan` plan instead of an error.
+#[tokio::test]
+async fn test_disable_post_processing_rejects_truncated_intermediate_result() {
+    let ctx = context_with_post_processing_disabled().await;
+
+    let err = ctx
+        .convert_sql_to_cube_query(UNBOUNDED_POST_PROCESSING_QUERY)
+        .await
+        .expect_err("post-processing over a truncated intermediate result should be rejected");
+
+    let err = err.to_string();
+    assert!(
+        err.contains("post-processing") && err.contains("50000"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_post_processing_allowed_by_default() {
+    init_testing_logger();
+    let ctx = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+
+    ctx.convert_sql_to_cube_query(UNBOUNDED_POST_PROCESSING_QUERY)
+        .await
+        .expect("post-processing should be allowed unless it was explicitly disabled");
+}
+
+/// There is nothing to truncate without a cube scan, so these stay allowed - unlike under the
+/// blanket `cubesql_penalize_post_processing` used by `sql4sql`.
+#[tokio::test]
+async fn test_disable_post_processing_allows_query_without_cube_scan() {
+    let ctx = context_with_post_processing_disabled().await;
+
+    ctx.convert_sql_to_cube_query("SELECT COUNT(*) FROM information_schema.tables")
+        .await
+        .expect("a query that reads no cube should not be affected");
+}
+
+#[tokio::test]
+async fn test_disable_post_processing_allows_full_pushdown() {
+    let ctx = context_with_post_processing_disabled().await;
+
+    let plan = ctx
+        .convert_sql_to_cube_query(
+            "SELECT customer_gender, AVG(avgPrice) FROM KibanaSampleDataEcommerce GROUP BY 1",
+        )
+        .await
+        .expect("a query that needs no post-processing should not be affected");
+
+    assert!(
+        matches!(plan.as_logical_plan(), LogicalPlan::Extension(_)),
+        "expected a plan with nothing on top of the scan, got: {}",
+        plan.as_logical_plan().display_indent()
+    );
+}
+
+/// The point of scoping the check to truncated intermediate results: post-processing that reads
+/// every row it is supposed to can't silently produce a wrong answer, so it stays allowed.
+#[tokio::test]
+async fn test_disable_post_processing_allows_bounded_intermediate_result() {
+    let ctx = context_with_post_processing_disabled().await;
+
+    let plan = ctx
+        .convert_sql_to_cube_query(
+            "SELECT DATE_PART('doy', order_date) FROM KibanaSampleDataEcommerce LIMIT 100",
+        )
+        .await
+        .expect("post-processing over a limited scan should not be affected");
+
+    // Guards the point of the test: `datepart` is evaluated in memory, over a scan the `LIMIT`
+    // was pushed into. If this ever becomes a full pushdown, the test stops proving anything.
+    let plan = plan.as_logical_plan();
+    assert!(
+        matches!(plan, LogicalPlan::Projection(_)),
+        "expected post-processing on top of the scan, got: {}",
+        plan.display_indent()
+    );
+    assert_eq!(plan.find_cube_scan().request.limit, Some(100));
+}
+
+/// `Distinct` is an in-memory operator, but it is absent from the node list behind
+/// `ast_size_outside_wrapper`, so deriving "is there post-processing above" from that list let
+/// this shape through: `Distinct` sits directly on the scan, nothing else above it, and the
+/// scan carries no limit. Answering it from the truncated first `CUBEJS_DB_QUERY_LIMIT` rows
+/// drops distinct values, and the flag reported success while doing it.
+///
+/// Here the plan is salvageable - `DISTINCT` pushes into a wrapper - so the fix shows up as a
+/// full pushdown rather than an error. Guarding on the plan shape rather than on `Ok` keeps the
+/// test honest: `Ok` alone is exactly what the bug produced.
+#[tokio::test]
+async fn test_disable_post_processing_counts_distinct_as_post_processing() {
+    let query = "SELECT DISTINCT MEASURE(count) FROM KibanaSampleDataEcommerce";
+
+    {
+        let ctx = TestContext::new(DatabaseProtocol::PostgreSQL).await;
+        let plan = ctx.convert_sql_to_cube_query(query).await.unwrap();
+        let plan = plan.as_logical_plan();
+        assert!(
+            matches!(plan, LogicalPlan::Distinct(_)),
+            "expected the unguarded plan to post-process with Distinct, got: {}",
+            plan.display_indent()
+        );
+        assert_eq!(
+            plan.find_cube_scan().request.limit,
+            None,
+            "the scan feeding Distinct has to be unbounded for this test to mean anything"
+        );
+    }
+
+    let ctx = context_with_post_processing_disabled().await;
+    let plan = ctx
+        .convert_sql_to_cube_query(query)
+        .await
+        .expect("DISTINCT pushes into a wrapper, so a safe plan exists");
+
+    assert!(
+        matches!(plan.as_logical_plan(), LogicalPlan::Extension(_)),
+        "expected Distinct to be pushed down rather than run over a truncated scan, got: {}",
+        plan.as_logical_plan().display_indent()
+    );
+}

--- a/rust/cubesql/cubesql/src/sql/database_variables/postgres/session_vars.rs
+++ b/rust/cubesql/cubesql/src/sql/database_variables/postgres/session_vars.rs
@@ -2,7 +2,16 @@ use datafusion::scalar::ScalarValue;
 
 use crate::compile::{DatabaseVariable, DatabaseVariables};
 
+/// Makes any post-processing prohibitively expensive during plan extraction, so a plan that can
+/// be fully pushed down always wins. Used by `sql4sql`, which can only return SQL for a plan
+/// that needs no post-processing at all.
 pub const CUBESQL_PENALIZE_POST_PROCESSING_VAR: &str = "cubesql_penalize_post_processing";
+
+/// Same, but only for post-processing that runs over an intermediate result truncated to
+/// `CUBEJS_DB_QUERY_LIMIT` rows, and the query is rejected outright when such a plan is the best
+/// one available. Post-processing over a result bounded by a smaller limit is left alone: it
+/// reads all the rows it is supposed to, so it can't silently produce wrong results.
+pub const CUBESQL_DISABLE_POST_PROCESSING_VAR: &str = "cubesql_disable_post_processing";
 
 pub fn defaults() -> DatabaseVariables {
     let variables = [
@@ -69,6 +78,11 @@ pub fn defaults() -> DatabaseVariables {
         // Custom cube[sql] variables
         DatabaseVariable::user_defined(
             CUBESQL_PENALIZE_POST_PROCESSING_VAR.to_string(),
+            ScalarValue::Boolean(Some(false)),
+            None,
+        ),
+        DatabaseVariable::user_defined(
+            CUBESQL_DISABLE_POST_PROCESSING_VAR.to_string(),
             ScalarValue::Boolean(Some(false)),
             None,
         ),

--- a/rust/cubesql/cubesql/src/sql/mod.rs
+++ b/rust/cubesql/cubesql/src/sql/mod.rs
@@ -15,7 +15,9 @@ pub use auth_service::{
     AuthContext, AuthContextRef, AuthenticateResponse, HttpAuthContext, SqlAuthDefaultImpl,
     SqlAuthService, SqlAuthServiceAuthenticateRequest,
 };
-pub use database_variables::postgres::session_vars::CUBESQL_PENALIZE_POST_PROCESSING_VAR;
+pub use database_variables::postgres::session_vars::{
+    CUBESQL_DISABLE_POST_PROCESSING_VAR, CUBESQL_PENALIZE_POST_PROCESSING_VAR,
+};
 pub use postgres::*;
 pub use server_manager::ServerManager;
 pub use session::{Session, SessionProperties, SessionState};


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [x] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required


**Description of Changes Made**

This PR adds an opt-in `disablePostProcessing` flag to `/v1/cubesql` that rejects queries whose post-processing would run over a result silently truncated to `CUBEJS_DB_QUERY_LIMIT` rows.

A query that can't be fully pushed down is completed in memory over at most `CUBEJS_DB_QUERY_LIMIT` rows. When nothing bounds the pushed-down subtree, that result is truncated and the post-processing above it returns a wrong answer with no error.

Setting `disablePostProcessing` on the request rejects those queries. Plans whose post-processing reads a result bounded by a smaller limit are left alone, as are plans with no cube scan at all: neither can be truncated. Inert under `CUBESQL_STREAM_MODE`, where the scan streams every row.

Extraction counts the offending plan shape in a new `truncated_post_processing_scans` cost, so a fully pushed-down plan wins where one exists; the request only fails when none does.

Related tests are included.