### PR TITLE
docs: correct the dashboard time granularity claim about custom granularities

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -86,7 +86,7 @@ By default, viewers can choose between **day**, **week**, **month**, **quarter**
 
 For time dimensions backed by a `TIMESTAMP` or `DATETIME` column, sub-day granularities (**second**, **minute**, **hour**) are also available. `DATE`-typed columns don't expose sub-day granularities, since they would bucket the entire day into a single point.
 
-Custom granularities defined in the [data model][ref-granularities] appear in the list alongside the built-in granularities.
+Custom granularities defined in the [data model][ref-granularities] aren't offered in this list yet — the switcher exposes the built-in granularities only.
 
 ### Default granularity
 


### PR DESCRIPTION
The dashboard **Time Granularity** control docs claim that custom granularities defined in the data model show up in the switcher alongside the built-in ones. They don't — the control offers the built-in granularities only.

The grain list the widget renders is a fixed set of the standard units, and custom granularities never reach that surface in the first place: the semantic-view member type the dashboard reads has no `granularities` field, so there is nothing for the picker to merge in. Saving clamps to the same fixed set as well.

This corrects the line to describe what the control actually does, leaving "yet" in place since the capability is planned.
