### PR TITLE
docs: reconcile pie/donut and KPI chart pages, document is empty/is not empty filter operators

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
@@ -11,7 +11,7 @@ KPI tiles highlight important metrics and key performance indicators. Rather tha
 
 The KPI visualization starts with a **Number** block that compares the first and second rows of your result for the first numeric column.
 
-To add a new block, click the **+** button inside the visualization and choose the block type. To edit a block, click it in the visualization — the configuration panel updates to show that block's settings.
+To add a new block, click the **+** button inside the visualization and choose the block type. To edit a block, click it in the visualization — the configuration panel updates to show that block's settings, split into a **Data** tab and a **Style** tab.
 
 Reorder blocks by dragging the handle on the left side of each block. Delete a block with the trash icon in its configuration panel.
 
@@ -27,9 +27,8 @@ Displays a single value from your query result.
 |---|---|
 | **Field** | The measure or dimension to display |
 | **Row** | Which row of the result to read from |
+| **Label** | Optional custom title; defaults to the field's name |
 | **Format** | Number formatting (currency, percent, etc.) |
-| **Font size / color** | Text appearance |
-| **Alignment** | Left, center, or right |
 
 {/* TODO screenshot: Number block (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -41,10 +40,8 @@ Displays a current value alongside a previous value with a calculated difference
 |---|---|
 | **Current field / row** | The primary value |
 | **Previous field / row** | The value to compare against — can be a different column or a different row from the same column |
-| **Difference format** | Absolute, percentage, or both |
-| **Positive color / Negative color** | Colors applied based on whether the change is positive or negative |
 
-To compare to a static goal, add a column to your query that always returns the same number (e.g. a calculated field with a constant), then select it as the **Previous** field.
+To compare to a static goal, add a column to your query that always returns the same number (e.g. a calculated field with a constant), then select it as the **Previous** field. Comparison blocks don't have their own format override — values and the calculated difference render using the query's own number formatting. Colors for the positive/negative/neutral states are set on the [Style tab](#per-block-styling).
 
 {/* TODO screenshot: Comparison block showing current vs. previous with colored delta (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -55,28 +52,34 @@ Shows a value relative to a target as a progress bar or circle. Useful for goal 
 | Setting | Description |
 |---|---|
 | **Value field / row** | The current progress value |
-| **Target field / row** | The goal or maximum value |
+| **Use custom goal** | Switch the target from a query field to a fixed number you type in |
+| **Target field / row** | The goal or maximum value (hidden when a custom goal is set) |
+| **Label** | Optional custom title |
 | **Style** | Bar or circle |
-| **Color** | Fill color for the progress indicator |
-
-<Tip>
-To compare against a static number like a quarterly goal, add a calculated field that always returns that number and use it as the **Target** field.
-</Tip>
+| **Width** | Width of the bar or circle, in pixels |
+| **Show percent** | Display the progress as a percentage of the target |
+| **Show target** | Display the target value alongside the progress indicator |
+| **Format** | Number formatting for the progress value |
 
 {/* TODO screenshot: Progress bar block (bar style) and circle style (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ### Sparkline
 
-Renders a compact trend chart — either a bar or line — within the KPI tile. Use this to show the trend behind the headline number.
+Renders a compact trend line — with an optional filled area — within the KPI tile. Use this to show the trend behind the headline number.
 
 | Setting | Description |
 |---|---|
 | **Series measure** | The measure to plot |
 | **Series dimension** | The dimension to use as the X axis (typically a time dimension) |
-| **Chart type** | Bar or line |
-| **Height / Width** | Dimensions of the sparkline in the tile |
+| **Show value** | Display the headline value above the trend line |
+| **Show trend** | Show or hide the trend line/area itself |
+| **Line width** | Thickness of the trend line |
 | **Max points** | Limits the number of data points rendered |
-| **Colors** | Line/fill colors |
+| **Height / Width** | Dimensions of the sparkline in the tile |
+| **Colors** | Line and area-fill colors |
+| **Format** | Number formatting for the headline value |
+
+By default, the headline value is the series measure's own latest value; toggle **Headline uses measure** off to source it from a different column instead.
 
 {/* TODO screenshot: Sparkline block showing a trend line (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -93,6 +96,25 @@ Use text blocks for short labels and headings inside the KPI. For complex layout
 A free-form HTML block rendered inside the KPI tile. Use this for advanced custom layouts that go beyond what the other block types support.
 
 {/* TODO screenshot: HTML block with custom content (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Per-block styling
+
+Every block's Style tab has alignment controls for how its content sits within its own row:
+
+| Setting | Description |
+|---|---|
+| **Horizontal** | Left, center, or right |
+| **Vertical** | Top, middle, or bottom |
+
+Beyond alignment, the available color and font settings depend on the block type:
+
+| Block | Style options |
+|---|---|
+| **Number** | Value color, background color, and font size (in pixels) |
+| **Comparison** | Positive/negative colors for the change, plus a neutral color and background for the unchanged state |
+| **Progress bar, Sparkline, HTML** | Background color |
+
+{/* TODO screenshot: KPI block Style tab showing alignment and appearance controls */}
 
 ## Layout controls
 

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -15,16 +15,50 @@ Standard filled circle. Each slice's arc length is proportional to its value.
 
 ### Donut
 
-A pie with a hollow center. Increase the **Inner radius** value in the Style tab to any non-zero value to switch to a donut. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
+A pie with a hollow center. Switch to it with the **Shape** control in the Fields tab — a two-option toggle between **Pie** and **Donut**. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
 
-{/* Screenshot: donut chart — same data as the pie variant, with inner radius applied. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+{/* Screenshot: donut chart — same data as the pie variant. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-## Inner radius
+## Rings
 
-Drag the **Inner radius** slider in the Style tab or enter a pixel value. Setting it to `0` returns to a full pie.
+Add more than one dimension to the query and the chart draws them as **concentric rings** instead of a single ring of slices — the first dimension is the innermost ring, and each additional dimension nests around it.
 
-{/* Screenshot: Style tab with the Inner radius control highlighted. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+Drag rows in the **Rings** list (Fields tab) to reorder the nesting. The innermost ring also drives slice color.
+
+<Note>
+Only the outermost ring's values are guaranteed to be accurate for a non-additive measure (e.g. a distinct count) — inner rings sum the measure across the outer rings, which can overstate it. A warning appears in the panel when this applies.
+</Note>
+
+## Measure
+
+The **Measure** field sizes the arcs — pick the measure whose value determines each slice's angle.
+
+## Data labels
+
+Configure labels on the Style tab, under **Data labels**. Each atom is an independent toggle:
+
+| Atom | Description |
+|---|---|
+| **Category** | The dimension value the slice represents |
+| **Value** | The measure value, with its own number format |
+| **Percent** | Share of the total, with its own percent format |
+
+Category and Value are on by default. Toggling the first atom on adds the label layer to the chart; toggling the last one off removes it.
+
+Additional controls appear once at least one atom is on:
+
+| Setting | Description |
+|---|---|
+| **Position** | Inside or outside the slice |
+| **Labeled rings** | For charts with [rings](#rings): show labels on the outer ring only, or on all rings. Inner rings only ever show the Category atom — Value and Percent need per-ring aggregation, which isn't supported. |
+| **Font size** | Label text size, in pixels |
+
+{/* TODO screenshot: pie Data labels panel with Category/Value/Percent toggles, position and font size controls */}
+
+## Tooltips
+
+Choose which fields appear in the tooltip from the **Tooltips** field picker in the Fields tab — none, all fields, or a specific selection.
 
 ## Color and slice ordering
 
-Slices are colored using the active [color palette](/docs/explore-analyze/charts/configuration/color-and-stacking) in palette order, matched to the sort order of your query results. To change which slice appears first, adjust the sort in the results table.
+Slices are colored using the active [color palette](/docs/explore-analyze/charts/configuration/color-and-stacking) in palette order, matched to the sort order of your query results. To change which slice appears first, adjust the sort in the results table. For a chart with [rings](#rings), the innermost ring's dimension drives slice color.

--- a/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/widgets/controls.mdx
@@ -18,9 +18,11 @@ The available operators depend on the type of the underlying dimension:
 
 | Dimension type | Operators |
 |---|---|
-| **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null` |
+| **String** | `is`, `is not`, `contains`, `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`, `is null`, `is not null`, `is empty`, `is not empty` |
 | **Number** | `is`, `is not`, `greater than`, `greater than or equal`, `less than`, `less than or equal`, `is null`, `is not null` |
 | **Time** | `is`, `is not`, `before date`, `before or on date`, `after date`, `after or on date`, `between`, `relative date`, `is null`, `is not null` |
+
+`is empty` / `is not empty` test for an empty string and take no value — distinct from `is null` / `is not null`, which test for a missing value.
 
 ### Single vs. multiple selection
 

--- a/docs-mintlify/reference/data-modeling/view.mdx
+++ b/docs-mintlify/reference/data-modeling/view.mdx
@@ -369,7 +369,8 @@ Operators use the same labels data consumers see in the workbook filter bar —
 what you see in the filter bar is what you type: `is`, `is not`, `after date`,
 `after or on date`, `before date`, `before or on date`, `between`, `contains`,
 `not contains`, `starts with`, `not starts with`, `ends with`, `not ends with`,
-`is null`, `is not null`.
+`is null`, `is not null`, `is empty`, `is not empty`. The last two are for
+string members only, and test for an empty string rather than a missing value.
 
 Operators are case-insensitive and whitespace-tolerant. Internal type names and
 REST API aliases (e.g. `equals`, `gte`, `inDateRange`) are also accepted.


### PR DESCRIPTION
## Summary

Found while cross-checking recent `cubejs-enterprise` merges against `docs-mintlify` for undocumented customer-facing changes.

- **Pie & donut** (`docs/explore-analyze/charts/chart-types/pie.mdx`): the donut shape used to be documented as "drag the Inner radius slider to any non-zero value" — that control was removed in favor of an explicit **Shape** (Pie/Donut) toggle (CUB-3183). Also documents features that shipped with no docs at all: concentric **Rings** for multi-dimension pies (CUB-3180), the **Measure** field, the rebuilt **Data labels** panel (content atoms, position, labeled rings, CUB-3185), and the **Tooltips** field picker.
- **KPI** (`docs/explore-analyze/charts/chart-types/kpi.mdx`):
  - Added the **Label** and **Value format** settings to the Progress bar and Sparkline block tables, and the **Show percent** / **Show target** / **Show value** / **Show trend** toggles (CUB-2945, #13113).
  - Removed two rows that don't correspond to any shipped control: Sparkline's "Chart type: Bar or line" (sparklines are a line/area only — no such selector exists) and Comparison's "Difference format" (there's no format override for Comparison blocks).
  - Added a **Per-block styling** section documenting the Style tab's per-block alignment (horizontal/vertical) and the color/font settings that vary by block type — previously only partially described under the Number block.
- **Filter operators**: documented the new `is empty` / `is not empty` string operators (CUB-3231, [cubejs-enterprise#13456](https://github.com/cubedevinc/cubejs-enterprise/pull/13456)) in the dashboard Filter widget's operator table (`docs/explore-analyze/dashboards/widgets/controls.mdx`) and in `default_ui_filters`'s operator list (`reference/data-modeling/view.mdx`), with a note distinguishing them from the existing `is null` / `is not null` null-checks.

All of the above were verified by reading the shipping source in `cubejs-enterprise` (component code + i18n strings), not just PR titles, per the customer-facing docs criteria.

Not included in this PR: the new **Dashboard Apps** authoring editor (CUB-3544) is a large, brand-new feature with no existing docs home and some open product questions, so it's tracked separately as [CUB-3657](https://linear.app/cube-d3/issue/CUB-3657) rather than a surgical edit here.

## Test plan

- [ ] `cd docs-mintlify && yarn dev` and spot-check the four edited pages render correctly
- [ ] Confirm the Pie & donut and KPI tables match the current console-ui builder panels
- [ ] Confirm `is empty` / `is not empty` appear in the workbook filter bar's string operator list

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TvMcL9EcctAbHbSvPLU6Ai)_