### PR TITLE
docs: broaden the SQL API truncated post-processing warning beyond ORDER BY

### DIFF
--- a/docs-mintlify/reference/configuration/environment-variables.mdx
+++ b/docs-mintlify/reference/configuration/environment-variables.mdx
@@ -1517,11 +1517,11 @@ If `true`, enables query pushdown in the [SQL API][ref-sql-api].
 ## `CUBESQL_STREAM_MODE`
 
 If `true`, enables the [streaming mode][ref-sql-api-streaming] in the [SQL API][ref-sql-api].
-When enabled, SQL API queries with an explicit `LIMIT` clause can exceed the
-maximum row limit set by
-[`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`](#cubesql_non_streaming_query_max_row_limit)
-and are streamed instead.
-Queries without an explicit `LIMIT` still use [`CUBEJS_DB_QUERY_DEFAULT_LIMIT`](#cubejs_db_query_default_limit).
+When enabled, SQL API queries with no `LIMIT` clause, or with one above the maximum row
+limit set by
+[`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`](#cubesql_non_streaming_query_max_row_limit),
+are streamed instead and aren't capped by it.
+Queries with a `LIMIT` at or below that limit are not streamed.
 
 | Possible Values | Default in Development | Default in Production |
 | --------------- | ---------------------- | --------------------- |

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -434,7 +434,8 @@ If a query of yours has that shape, you can:
   limit in the scan's request — the one `EXPLAIN` prints — and not by the `LIMIT` clause
   in your SQL: it streams when that request has no limit, or one above the cap. So this
   combines with the first workaround only up to a point: a `LIMIT` that reaches the scan
-  turns streaming back off, while one that doesn't, as in the plan above, leaves it on.
+  and is below the cap turns streaming back off, while one that doesn't reach it, as in
+  the plan above, leaves it on.
 - Restructure the query so it is pushed down in full, e.g. by removing the expression
   that prevents it.
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -409,9 +409,13 @@ As you can see, the sorting operation is done after the regular query and the pr
 ```
 
 `ORDER BY` is not the only operation this happens to. Anything left to post-processing
-over an unbounded `CubeScanExecutionPlan` behaves the same way, so `EXPLAIN` is the
-reliable way to tell: if an operation appears *above* `CubeScanExecutionPlan` and no limit
-has reached the scan itself, that operation reads at most the row limit.
+over a regular query that isn't bounded by a small enough limit behaves the same way, so
+`EXPLAIN` is the reliable way to tell. `CubeScanExecutionPlan` prints the request it
+sends: `CubeScanExecutionPlan, Request:` followed by JSON that includes a `limit` key
+(or `CubeScanExecutionPlan, SQL:` when the query is pushed down, in which case there is
+no post-processing to worry about). If that `limit` is `null`, or larger than the number
+of rows you expect the regular query to return, every operation above the scan sees at
+most the row limit.
 
 If a query of yours has that shape, you can:
 
@@ -425,10 +429,11 @@ If a query of yours has that shape, you can:
   defaults to `CUBEJS_DB_QUERY_LIMIT` and can't exceed it — if you've set it explicitly,
   raise it too.
 - Enable [`CUBESQL_STREAM_MODE`][ref-env-cubesql-stream-mode]: streamed queries aren't
-  capped, so there is nothing to truncate.
+  capped, so there is nothing to truncate. Note that a query is only streamed if it has
+  no limit of its own or one above the cap, so this doesn't combine with the first
+  workaround — adding an explicit `LIMIT` below the cap turns streaming back off.
 - Restructure the query so it is pushed down in full, e.g. by removing the expression
   that prevents it.
-
 
 [ref-regular-queries]: /reference/core-data-apis/queries#regular-query
 [ref-queries-wpp]: /reference/core-data-apis/queries#query-with-post-processing

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -410,12 +410,13 @@ As you can see, the sorting operation is done after the regular query and the pr
 
 `ORDER BY` is not the only operation this happens to. Anything left to post-processing
 over a regular query that isn't bounded by a small enough limit behaves the same way, so
-`EXPLAIN` is the reliable way to tell. `CubeScanExecutionPlan` prints the regular query
-it will run: `CubeScanExecutionPlan, Request:` followed by JSON (or
-`CubeScanExecutionPlan, SQL:` when the query is pushed down, in which case there is no
-post-processing to worry about). If that JSON has no `limit` key, or a `limit` larger
-than the number of rows you expect, the row limit is applied when the query runs and
-every operation above the scan sees at most that many rows.
+`EXPLAIN` is the reliable way to tell. `CubeScanExecutionPlan` prints the query it will
+run: `CubeScanExecutionPlan, Request:` followed by JSON, or `CubeScanExecutionPlan, SQL:`
+followed by SQL where the query is pushed down. Pushdown can be partial, so operations
+may still sit above a scan that prints `SQL:`. If the JSON has no `limit` key, or the
+limit in the JSON or the printed SQL is larger than the number of rows you expect, the
+row limit is applied when the query runs and every operation above the scan sees at most
+that many rows.
 
 If a query of yours has that shape, you can:
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -410,12 +410,12 @@ As you can see, the sorting operation is done after the regular query and the pr
 
 `ORDER BY` is not the only operation this happens to. Anything left to post-processing
 over a regular query that isn't bounded by a small enough limit behaves the same way, so
-`EXPLAIN` is the reliable way to tell. `CubeScanExecutionPlan` prints the request it
-sends: `CubeScanExecutionPlan, Request:` followed by JSON that includes a `limit` key
-(or `CubeScanExecutionPlan, SQL:` when the query is pushed down, in which case there is
-no post-processing to worry about). If that `limit` is `null`, or larger than the number
-of rows you expect the regular query to return, every operation above the scan sees at
-most the row limit.
+`EXPLAIN` is the reliable way to tell. `CubeScanExecutionPlan` prints the regular query
+it will run: `CubeScanExecutionPlan, Request:` followed by JSON (or
+`CubeScanExecutionPlan, SQL:` when the query is pushed down, in which case there is no
+post-processing to worry about). If that JSON has no `limit` key, or a `limit` larger
+than the number of rows you expect, the row limit is applied when the query runs and
+every operation above the scan sees at most that many rows.
 
 If a query of yours has that shape, you can:
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -430,9 +430,11 @@ If a query of yours has that shape, you can:
   defaults to `CUBEJS_DB_QUERY_LIMIT` and can't exceed it — if you've set it explicitly,
   raise it too.
 - Enable [`CUBESQL_STREAM_MODE`][ref-env-cubesql-stream-mode]: streamed queries aren't
-  capped, so there is nothing to truncate. Note that a query is only streamed if it has
-  no limit of its own or one above the cap, so this doesn't combine with the first
-  workaround — adding an explicit `LIMIT` below the cap turns streaming back off.
+  capped, so there is nothing to truncate. Whether a query streams is decided by the
+  limit in the scan's request — the one `EXPLAIN` prints — and not by the `LIMIT` clause
+  in your SQL: it streams when that request has no limit, or one above the cap. So this
+  combines with the first workaround only up to a point: a `LIMIT` that reaches the scan
+  turns streaming back off, while one that doesn't, as in the plan above, leaves it on.
 - Restructure the query so it is pushed down in full, e.g. by removing the expression
   that prevents it.
 

--- a/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
+++ b/docs-mintlify/reference/core-data-apis/sql-api/query-format.mdx
@@ -374,15 +374,17 @@ a [regular query][ref-regular-queries].
 
 ### Row limit edge case
 
-If the `ORDER BY` statement can't be pushed down, ordering would be performed during
-[post-processing][ref-queries-wpp]. If there are more than [50,000 rows][ref-query-default-limit]
-in the result set, this can yield incorrect results.
+When part of a query can't be pushed down, that part is performed during
+[post-processing][ref-queries-wpp]. The [regular query][ref-regular-queries] it reads from
+is cut off at [50,000 rows][ref-query-default-limit] unless a smaller limit of its own
+applies, and the post-processing then runs over only those rows, so the result can be
+incorrect without any error being raised.
 
-However, given that queries to Cube are usually aggregated, this is a very rare case;
-anyway, please keep this limitation in mind when designing your queries.
+Aggregated queries usually return far fewer rows than the limit, so this rarely comes up
+in practice; please keep it in mind when designing your queries.
 
 Consider the following query. Because of the `SUM(total_value) + 2` expression
-in the projection of the outer query, thr SQL API can't push down `ORDER BY`:
+in the projection of the outer query, the SQL API can't push down `ORDER BY`:
 
 ```sql
 SELECT
@@ -406,6 +408,27 @@ As you can see, the sorting operation is done after the regular query and the pr
 +--- CubeScanExecutionPlan
 ```
 
+`ORDER BY` is not the only operation this happens to. Anything left to post-processing
+over an unbounded `CubeScanExecutionPlan` behaves the same way, so `EXPLAIN` is the
+reliable way to tell: if an operation appears *above* `CubeScanExecutionPlan` and no limit
+has reached the scan itself, that operation reads at most the row limit.
+
+If a query of yours has that shape, you can:
+
+- Add an explicit `LIMIT` and confirm with `EXPLAIN` that it reaches the scan. It only
+  does so when the limit ends up directly above the regular query — in the plan above a
+  `SortExec` sits in between, so the limit bounds the final output rather than what the
+  sorting reads.
+- Raise [`CUBEJS_DB_QUERY_LIMIT`][ref-env-db-query-limit] so the intermediate result is
+  truncated later. Non-streaming SQL API queries are capped by
+  [`CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT`][ref-env-non-streaming-limit], which
+  defaults to `CUBEJS_DB_QUERY_LIMIT` and can't exceed it — if you've set it explicitly,
+  raise it too.
+- Enable [`CUBESQL_STREAM_MODE`][ref-env-cubesql-stream-mode]: streamed queries aren't
+  capped, so there is nothing to truncate.
+- Restructure the query so it is pushed down in full, e.g. by removing the expression
+  that prevents it.
+
 
 [ref-regular-queries]: /reference/core-data-apis/queries#regular-query
 [ref-queries-wpp]: /reference/core-data-apis/queries#query-with-post-processing
@@ -413,6 +436,9 @@ As you can see, the sorting operation is done after the regular query and the pr
 [ref-data-model-concepts]: /docs/data-modeling/overview
 [ref-measure-types]: /reference/data-modeling/measures#type
 [ref-query-default-limit]: /reference/core-data-apis/queries#row-limit
+[ref-env-db-query-limit]: /reference/configuration/environment-variables#cubejs_db_query_limit
+[ref-env-cubesql-stream-mode]: /reference/configuration/environment-variables#cubesql_stream_mode
+[ref-env-non-streaming-limit]: /reference/configuration/environment-variables#cubesql_non_streaming_query_max_row_limit
 [ref-ref-sql-api]: /reference/core-data-apis/sql-api/reference
 [link-postgres-boolean]: https://www.postgresql.org/docs/current/datatype-boolean.html
 [link-selection-projection]: https://stackoverflow.com/a/1031101


### PR DESCRIPTION
The SQL API's row-limit warning is scoped to `ORDER BY`, but that isn't the actual trigger.

Any operation left to post-processing over a regular query that isn't bounded by a small
enough limit reads at most `CUBEJS_DB_QUERY_LIMIT` rows and computes over just those, so
the result can be wrong with no error raised. Sorting is only one way to get there. As
written, the docs tell someone chasing a wrong result from a different query shape that
their situation is impossible.

What changed:

- Broadened the trigger from "`ORDER BY` can't be pushed down" to any post-processing over
  an unbounded regular query, and kept the "rarely comes up" framing without resting it on
  the `ORDER BY`-only premise.
- Explained how to tell with `EXPLAIN`, which works for any query shape, rather than adding
  a second worked example whose plan output isn't captured here.
- Added the workarounds, with the caveats that actually matter: an explicit `LIMIT` only
  helps when it reaches the scan (a surviving `SortExec` means it doesn't);
  `CUBESQL_NON_STREAMING_QUERY_MAX_ROW_LIMIT` defaults to `CUBEJS_DB_QUERY_LIMIT` and caps
  non-streaming queries separately; streamed queries aren't capped, so nothing is truncated.
- Fixed a `thr` -> `the` typo in the sentence above the first example.

Docs only. `mintlify broken-links --check-anchors` passes and the page was checked in the
local preview.
