### PR TITLE
fix(tesseract): resolve rollup-join keys declared as time dimensions, and name the failing hop

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
+++ b/packages/cubejs-schema-compiler/src/adapter/PreAggregations.ts
@@ -1089,8 +1089,11 @@ export class PreAggregations {
     join: JoinEdgeWithMembers,
     rollupJoinPreAggName: string,
   ): PreAggregationForQuery {
+    // A join key may be declared as the rollup's time dimension rather than a plain dimension,
+    // and `references.dimensions` doesn't include those.
     const fromPreAggObj = preAggObjsToJoin
-      .filter(p => joinMembers.every(m => !!p.references.dimensions.find(d => m === d)));
+      .filter(p => joinMembers.every(m => !!p.references.dimensions.find(d => m === d) ||
+        !!p.references.timeDimensions.find(td => m === td.dimension)));
     if (!fromPreAggObj.length) {
       const msg = `No rollups found that can be used for a rollup join from "${
         join.from}" (fromMembers: ${JSON.stringify(join.fromMembers)}) to "${join.to}" (toMembers: ${
@@ -1139,7 +1142,9 @@ export class PreAggregations {
   private cubesHintsFromPreAggregation(preAggObj: PreAggregationForQuery): string[][] {
     return R.uniq(
       preAggObj.references.measures.concat(
-        preAggObj.references.dimensions
+        preAggObj.references.dimensions,
+        // A cube may be reached only through the rollup's time dimension.
+        preAggObj.references.timeDimensions.map(td => td.dimension),
       ).map(p => p.split('.').slice(0, -1))
     );
   }

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -1493,4 +1493,94 @@ describe('pre-aggregations', () => {
         .toThrow(/rollupJoinFourCubes/);
     });
   });
+
+  // A join key can be declared as a rollup's time dimension instead of a plain dimension.
+  // Both planners resolve the hop through it — the legacy JS matcher is still reachable, so it
+  // is asserted explicitly rather than left to the Tesseract path.
+  describe('rollupJoin whose join key is a time dimension', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(
+      `
+        cube('td_dates', {
+          sql: \`SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label\`,
+
+          joins: {
+            td_facts: {
+              relationship: 'one_to_many',
+              sql: \`\${CUBE.day} = \${td_facts.day}\`
+            }
+          },
+
+          dimensions: {
+            day: { sql: 'day', type: 'time', primary_key: true },
+            quarter_label: { sql: 'quarter_label', type: 'string' },
+          },
+
+          pre_aggregations: {
+            // \`day\` is the join key, and it is declared here as the time dimension.
+            td_dates_rollup: {
+              dimensions: [quarter_label],
+              timeDimension: day,
+              granularity: 'day'
+            },
+            td_rollup_join: {
+              type: 'rollupJoin',
+              measures: [td_facts.total_amount],
+              dimensions: [quarter_label],
+              timeDimension: td_facts.day,
+              granularity: 'day',
+              rollups: [td_dates_rollup, td_facts.td_facts_rollup]
+            }
+          }
+        });
+
+        cube('td_facts', {
+          sql: \`SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount\`,
+
+          dimensions: {
+            id: { sql: 'id', type: 'number', primary_key: true },
+            day: { sql: 'day', type: 'time' },
+          },
+
+          measures: {
+            total_amount: { sql: 'amount', type: 'sum' },
+          },
+
+          pre_aggregations: {
+            td_facts_rollup: {
+              measures: [total_amount],
+              timeDimension: day,
+              granularity: 'day'
+            }
+          }
+        });
+      `
+    );
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    it.each([
+      ['Tesseract planner', true],
+      ['legacy JS planner', false],
+    ])('resolves the hop through the time dimension (%s)', async (_name, useNativeSqlPlanner) => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: ['td_facts.total_amount'],
+        dimensions: ['td_dates.quarter_label'],
+        timeDimensions: [{
+          dimension: 'td_facts.day',
+          granularity: 'day',
+        }],
+        timezone: 'America/Los_Angeles',
+        preAggregationsSchema: '',
+        useNativeSqlPlanner,
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      expect(preAggregationsDescription.map((d: any) => d.preAggregationId).sort()).toEqual(
+        ['td_dates.td_dates_rollup', 'td_facts.td_facts_rollup']
+      );
+      expect(query.preAggregations?.preAggregationForQuery?.preAggregationName).toEqual('td_rollup_join');
+    });
+  });
 });

--- a/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/pre-aggregations.test.ts
@@ -1155,4 +1155,342 @@ describe('pre-aggregations', () => {
       expect(query.buildSqlAndParams()[0]).toMatch(/orders/);
     });
   });
+
+  // @link https://github.com/cube-js/cube/issues/11362
+  //
+  // A `rollupJoin` matches a chain of any length, as long as every leg rollup declares the
+  // dimensions its own hops join on — not just the dimensions the query selects. The join is
+  // resolved hop by hop, and each hop looks for a leg rollup containing that hop's join key on
+  // each side; a rollup missing its key makes the hop unresolvable and the whole join is
+  // rejected with "No rollups found that can be used for rollup join".
+  //
+  // That requirement is easy to miss on an interior cube, whose rollup needs the *upstream*
+  // hop's key as well as its own selected dimension — `cube_x.xxx` below needs `dim_w`, which
+  // no query ever selects. Chain length is not itself a limit: 4- and 5-cube chains match on
+  // the same terms a 3-cube chain does ('rollupJoin pre-aggregation with three cubes' in
+  // test/integration/postgres/pre-aggregations.test.ts).
+  describe('rollupJoin matching over long join chains', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(
+      `
+        cube('cube_v', {
+          sql: \`SELECT -1 as id, 'dim_v' as dim_v, 'dim_w' as dim_w\`,
+
+          joins: {
+            cube_w: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_w} = \${cube_w.dim_w}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_v: { sql: 'dim_v', type: 'string' },
+            dim_w: { sql: 'dim_w', type: 'string' },
+          },
+
+          pre_aggregations: {
+            vvv: {
+              dimensions: [dim_v, dim_w]
+            },
+            rollupJoinFiveCubes: {
+              type: 'rollupJoin',
+              dimensions: [
+                dim_v,
+                cube_w.dim_w,
+                cube_x.dim_x,
+                cube_y.dim_y,
+                cube_z.dim_z
+              ],
+              rollups: [
+                vvv,
+                cube_w.www,
+                cube_x.xxx,
+                cube_y.yyy,
+                cube_z.zzz
+              ]
+            }
+          }
+        });
+
+        cube('cube_w', {
+          sql: \`SELECT 0 as id, 'dim_w' as dim_w\`,
+
+          joins: {
+            cube_x: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_w} = \${cube_x.dim_w}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_w: { sql: 'dim_w', type: 'string' },
+          },
+
+          pre_aggregations: {
+            www: {
+              dimensions: [dim_w]
+            },
+            rollupJoinFourCubes: {
+              type: 'rollupJoin',
+              dimensions: [
+                dim_w,
+                cube_x.dim_x,
+                cube_y.dim_y,
+                cube_z.dim_z
+              ],
+              rollups: [
+                www,
+                cube_x.xxx,
+                cube_y.yyy,
+                cube_z.zzz
+              ]
+            }
+          }
+        });
+
+        cube('cube_x', {
+          sql: \`SELECT 1 as id, 'dim_w' as dim_w, 'dim_x' as dim_x\`,
+
+          joins: {
+            cube_y: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_x} = \${cube_y.dim_x}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_w: { sql: 'dim_w', type: 'string' },
+            dim_x: { sql: 'dim_x', type: 'string' },
+          },
+
+          pre_aggregations: {
+            // dim_w is the cube_w -> cube_x join key; no query selects it, but the hop
+            // cannot resolve without it.
+            xxx: {
+              dimensions: [dim_w, dim_x]
+            }
+          }
+        });
+
+        cube('cube_y', {
+          sql: \`SELECT 2 as id, 'dim_x' as dim_x, 'dim_y' as dim_y\`,
+
+          joins: {
+            cube_z: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_y} = \${cube_z.dim_y}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_x: { sql: 'dim_x', type: 'string' },
+            dim_y: { sql: 'dim_y', type: 'string' },
+          },
+
+          pre_aggregations: {
+            yyy: {
+              dimensions: [dim_x, dim_y]
+            }
+          }
+        });
+
+        cube('cube_z', {
+          sql: \`SELECT 3 as id, 'dim_y' as dim_y, 'dim_z' as dim_z\`,
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_y: { sql: 'dim_y', type: 'string' },
+            dim_z: { sql: 'dim_z', type: 'string' },
+          },
+
+          pre_aggregations: {
+            zzz: {
+              dimensions: [dim_y, dim_z]
+            }
+          }
+        });
+      `
+    );
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    // A matched rollupJoin is reported as its leg rollups, which are what actually get built;
+    // the join itself is named only on preAggregationForQuery.
+    it('matches a 4-cube chain (cube_w -> cube_x -> cube_y -> cube_z) for a dimensions-only query', async () => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [],
+        dimensions: ['cube_w.dim_w', 'cube_x.dim_x', 'cube_y.dim_y', 'cube_z.dim_z'],
+        timezone: 'America/Los_Angeles',
+        preAggregationsSchema: '',
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      expect(preAggregationsDescription.map((d: any) => d.preAggregationId).sort()).toEqual(
+        ['cube_w.www', 'cube_x.xxx', 'cube_y.yyy', 'cube_z.zzz']
+      );
+      expect(query.preAggregations?.preAggregationForQuery?.canUsePreAggregation).toEqual(true);
+      expect(query.preAggregations?.preAggregationForQuery?.preAggregationName).toEqual('rollupJoinFourCubes');
+
+      // Matching is only half of it — the join has to assemble, which is what would break if
+      // the resolved edges were rooted or ordered wrongly.
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toMatch(/cube_w__dim_w/);
+      expect(sql).toMatch(/cube_z__dim_z/);
+    });
+
+    it('matches a 5-cube chain, so chain length is not the limit', async () => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [],
+        dimensions: ['cube_v.dim_v', 'cube_w.dim_w', 'cube_x.dim_x', 'cube_y.dim_y', 'cube_z.dim_z'],
+        timezone: 'America/Los_Angeles',
+        preAggregationsSchema: '',
+      });
+
+      const preAggregationsDescription: any = query.preAggregations?.preAggregationsDescription();
+      expect(preAggregationsDescription.map((d: any) => d.preAggregationId).sort()).toEqual(
+        ['cube_v.vvv', 'cube_w.www', 'cube_x.xxx', 'cube_y.yyy', 'cube_z.zzz']
+      );
+      expect(query.preAggregations?.preAggregationForQuery?.canUsePreAggregation).toEqual(true);
+      expect(query.preAggregations?.preAggregationForQuery?.preAggregationName).toEqual('rollupJoinFiveCubes');
+
+      const [sql] = query.buildSqlAndParams();
+      expect(sql).toMatch(/cube_v__dim_v/);
+      expect(sql).toMatch(/cube_z__dim_z/);
+    });
+  });
+
+  // The counterpart to the chain tests above: the same 4-cube shape, with the interior rollup
+  // missing the upstream hop's join key. This is what #11362 actually reported.
+  describe('rollupJoin over a chain whose interior rollup omits its join key', () => {
+    const { compiler, joinGraph, cubeEvaluator } = prepareJsCompiler(
+      `
+        cube('cube_w', {
+          sql: \`SELECT 0 as id, 'dim_w' as dim_w\`,
+
+          joins: {
+            cube_x: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_w} = \${cube_x.dim_w}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_w: { sql: 'dim_w', type: 'string' },
+          },
+
+          pre_aggregations: {
+            www: {
+              dimensions: [dim_w]
+            },
+            rollupJoinFourCubes: {
+              type: 'rollupJoin',
+              dimensions: [
+                dim_w,
+                cube_x.dim_x,
+                cube_y.dim_y,
+                cube_z.dim_z
+              ],
+              rollups: [
+                www,
+                cube_x.xxx,
+                cube_y.yyy,
+                cube_z.zzz
+              ]
+            }
+          }
+        });
+
+        cube('cube_x', {
+          sql: \`SELECT 1 as id, 'dim_w' as dim_w, 'dim_x' as dim_x\`,
+
+          joins: {
+            cube_y: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_x} = \${cube_y.dim_x}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_w: { sql: 'dim_w', type: 'string' },
+            dim_x: { sql: 'dim_x', type: 'string' },
+          },
+
+          pre_aggregations: {
+            // Omits dim_w, the cube_w -> cube_x join key.
+            xxx: {
+              dimensions: [dim_x]
+            }
+          }
+        });
+
+        cube('cube_y', {
+          sql: \`SELECT 2 as id, 'dim_x' as dim_x, 'dim_y' as dim_y\`,
+
+          joins: {
+            cube_z: {
+              relationship: 'many_to_one',
+              sql: \`\${CUBE.dim_y} = \${cube_z.dim_y}\`
+            }
+          },
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_x: { sql: 'dim_x', type: 'string' },
+            dim_y: { sql: 'dim_y', type: 'string' },
+          },
+
+          pre_aggregations: {
+            yyy: {
+              dimensions: [dim_x, dim_y]
+            }
+          }
+        });
+
+        cube('cube_z', {
+          sql: \`SELECT 3 as id, 'dim_y' as dim_y, 'dim_z' as dim_z\`,
+
+          dimensions: {
+            id: { sql: 'id', type: 'string', primary_key: true },
+            dim_y: { sql: 'dim_y', type: 'string' },
+            dim_z: { sql: 'dim_z', type: 'string' },
+          },
+
+          pre_aggregations: {
+            zzz: {
+              dimensions: [dim_y, dim_z]
+            }
+          }
+        });
+      `
+    );
+
+    beforeAll(async () => {
+      await compiler.compile();
+    });
+
+    it('rejects the join, naming the unresolvable hop and the unmatched member', async () => {
+      const query = new PostgresQuery({ joinGraph, cubeEvaluator, compiler }, {
+        measures: [],
+        dimensions: ['cube_w.dim_w', 'cube_x.dim_x', 'cube_y.dim_y', 'cube_z.dim_z'],
+        timezone: 'America/Los_Angeles',
+        preAggregationsSchema: '',
+      });
+
+      // Naming the hop, the unmatched member and the rollupJoin is the whole value of the
+      // error — 'No rollups found' alone gives the author nothing to act on.
+      expect(() => query.preAggregations?.preAggregationsDescription())
+        .toThrow(/No rollups found that can be used for a rollup join from "cube_w".*to "cube_x"/);
+      expect(() => query.preAggregations?.preAggregationsDescription())
+        .toThrow(/cube_x\.dim_w/);
+      expect(() => query.preAggregations?.preAggregationsDescription())
+        .toThrow(/rollupJoinFourCubes/);
+    });
+  });
 });

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -234,6 +234,7 @@ impl PreAggregationsCompiler {
                 &measures,
                 &all_dimensions,
                 &rollups,
+                name,
             )?)
         } else {
             let cube = self
@@ -417,6 +418,7 @@ impl PreAggregationsCompiler {
         measures: &Vec<Rc<MemberSymbol>>,
         all_dimensions: &Vec<Rc<MemberSymbol>>,
         rollups: &Vec<String>,
+        rollup_join_name: &PreAggregationFullName,
     ) -> Result<PreAggregationJoin, CubeError> {
         let all_symbols = measures
             .iter()
@@ -465,7 +467,9 @@ impl PreAggregationsCompiler {
 
         let items = not_existing_joins
             .iter()
-            .map(|item| self.make_pre_aggregation_join_item(&pre_aggrs_for_join, item))
+            .map(|item| {
+                self.make_pre_aggregation_join_item(&pre_aggrs_for_join, item, rollup_join_name)
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         let res = PreAggregationJoin {
@@ -479,11 +483,20 @@ impl PreAggregationsCompiler {
         &self,
         pre_aggrs_for_join: &Vec<Rc<CompiledPreAggregation>>,
         join_item: &ResolvedJoinItem,
+        rollup_join_name: &PreAggregationFullName,
     ) -> Result<PreAggregationJoinItem, CubeError> {
-        let from_pre_aggr =
-            self.find_pre_aggregation_for_join(pre_aggrs_for_join, &join_item.from_members)?;
-        let to_pre_aggr =
-            self.find_pre_aggregation_for_join(pre_aggrs_for_join, &join_item.to_members)?;
+        let from_pre_aggr = self.find_pre_aggregation_for_join(
+            pre_aggrs_for_join,
+            &join_item.from_members,
+            join_item,
+            rollup_join_name,
+        )?;
+        let to_pre_aggr = self.find_pre_aggregation_for_join(
+            pre_aggrs_for_join,
+            &join_item.to_members,
+            join_item,
+            rollup_join_name,
+        )?;
 
         let res = PreAggregationJoinItem {
             from: from_pre_aggr.source.clone(),
@@ -499,27 +512,70 @@ impl PreAggregationsCompiler {
         &self,
         pre_aggrs_for_join: &Vec<Rc<CompiledPreAggregation>>,
         members: &Vec<Rc<MemberSymbol>>,
+        join_item: &ResolvedJoinItem,
+        rollup_join_name: &PreAggregationFullName,
     ) -> Result<Rc<CompiledPreAggregation>, CubeError> {
         let found_pre_aggr = pre_aggrs_for_join
             .iter()
             .filter(|pa| {
                 members
                     .iter()
-                    .all(|m| pa.dimensions.iter().any(|pa_m| m == pa_m))
+                    .all(|m| Self::pre_aggregation_covers_join_member(pa, m))
             })
             .collect_vec();
         if found_pre_aggr.is_empty() {
             return Err(CubeError::user(format!(
-                "No rollups found that can be used for rollup join"
+                "No rollups found that can be used for a rollup join from \"{}\" (fromMembers: {}) to \"{}\" (toMembers: {}). Check the \"{}\" pre-aggregation definition — every rollup must declare the dimensions its own joins are on, including keys the query doesn't select",
+                join_item.original_from,
+                Self::format_join_members(&join_item.from_members),
+                join_item.original_to,
+                Self::format_join_members(&join_item.to_members),
+                rollup_join_name.name,
             )));
         }
         if found_pre_aggr.len() > 1 {
             return Err(CubeError::user(format!(
-                "Multiple rollups found that can be used for rollup join"
+                "Multiple rollups found that can be used for a rollup join from \"{}\" to \"{}\" in the \"{}\" pre-aggregation: {}",
+                join_item.original_from,
+                join_item.original_to,
+                rollup_join_name.name,
+                found_pre_aggr
+                    .iter()
+                    .map(|pa| format!("{}.{}", pa.cube_name, pa.name))
+                    .join(", "),
             )));
         }
 
         Ok(found_pre_aggr[0].clone())
+    }
+
+    /// Whether `member` — one side of a join hop — is available in `pre_aggr`.
+    ///
+    /// A join key may be declared as any kind of member, so this looks at the same collections
+    /// `build_join_source` uses to derive the target join hints. Time dimensions are stored
+    /// granularity-wrapped (`orders.created_at_day`), while a join key resolves to the bare
+    /// dimension, so they are compared through their base symbol.
+    fn pre_aggregation_covers_join_member(
+        pre_aggr: &CompiledPreAggregation,
+        member: &Rc<MemberSymbol>,
+    ) -> bool {
+        let matches_directly = pre_aggr
+            .dimensions
+            .iter()
+            .chain(pre_aggr.segments.iter())
+            .any(|pa_m| member == pa_m);
+
+        matches_directly
+            || pre_aggr.time_dimensions.iter().any(|pa_m| {
+                pa_m.as_time_dimension()
+                    .map(|td| td.base_symbol() == member)
+                    .unwrap_or(false)
+                    || member == pa_m
+            })
+    }
+
+    fn format_join_members(members: &Vec<Rc<MemberSymbol>>) -> String {
+        members.iter().map(|m| m.full_name()).join(", ")
     }
 
     pub fn compile_all_pre_aggregations(
@@ -1090,5 +1146,66 @@ mod tests {
             }
             _ => panic!("Expected PreAggregationSource::Join"),
         }
+    }
+
+    #[test]
+    fn test_compile_rollup_join_with_time_dimension_key() {
+        let schema = MockSchema::from_yaml_file("common/rollup_join_time_dimension_key.yaml");
+        let test_context = TestContext::new(schema).unwrap();
+        let query_tools = test_context.query_tools().clone();
+
+        let cube_names = vec!["td_dates".to_string(), "td_facts".to_string()];
+        let mut compiler = PreAggregationsCompiler::try_new(query_tools, &cube_names).unwrap();
+
+        let pre_agg_name =
+            PreAggregationFullName::new("td_dates".to_string(), "td_rollup_join".to_string());
+        let compiled = compiler.compile_pre_aggregation(&pre_agg_name).unwrap();
+
+        // The join key `day` is each rollup's time_dimension rather than a plain dimension,
+        // so the hop resolves only if the lookup reaches past `dimensions`.
+        match compiled.source.as_ref() {
+            PreAggregationSource::Join(join) => {
+                assert_eq!(join.items.len(), 1, "Should have one join item");
+                match join.items[0].to.as_ref() {
+                    PreAggregationSource::Single(table) => {
+                        assert_eq!(table.name, "td_facts_rollup");
+                    }
+                    _ => panic!("Expected Single source"),
+                }
+            }
+            _ => panic!("Expected PreAggregationSource::Join"),
+        }
+    }
+
+    #[test]
+    fn test_rollup_join_error_names_the_unresolvable_hop() {
+        let schema = MockSchema::from_yaml_file("common/rollup_join_missing_key.yaml");
+        let test_context = TestContext::new(schema).unwrap();
+        let query_tools = test_context.query_tools().clone();
+
+        let cube_names = vec!["mk_orders".to_string(), "mk_customers".to_string()];
+        let mut compiler = PreAggregationsCompiler::try_new(query_tools, &cube_names).unwrap();
+
+        let pre_agg_name =
+            PreAggregationFullName::new("mk_orders".to_string(), "mk_rollup_join".to_string());
+        let err = compiler
+            .compile_pre_aggregation(&pre_agg_name)
+            .expect_err("A rollup missing its join key cannot resolve the hop");
+        let msg = err.to_string();
+
+        // The message has to identify which hop failed and which members went unmatched —
+        // without them the only actionable detail is absent.
+        assert!(msg.contains("mk_orders"), "should name the hop: {}", msg);
+        assert!(msg.contains("mk_customers"), "should name the hop: {}", msg);
+        assert!(
+            msg.contains("mk_customers.customer_id"),
+            "should name the unmatched member: {}",
+            msg
+        );
+        assert!(
+            msg.contains("mk_rollup_join"),
+            "should name the rollupJoin: {}",
+            msg
+        );
     }
 }

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/logical_plan/optimizers/pre_aggregation/pre_aggregations_compiler.rs
@@ -551,26 +551,18 @@ impl PreAggregationsCompiler {
 
     /// Whether `member` — one side of a join hop — is available in `pre_aggr`.
     ///
-    /// A join key may be declared as any kind of member, so this looks at the same collections
-    /// `build_join_source` uses to derive the target join hints. Time dimensions are stored
-    /// granularity-wrapped (`orders.created_at_day`), while a join key resolves to the bare
-    /// dimension, so they are compared through their base symbol.
+    /// A join key resolves to a dimension, which the rollup may have declared either plainly or
+    /// as its time dimension. Time dimensions are stored granularity-wrapped
+    /// (`orders.created_at_day`), so they are compared through their base symbol.
     fn pre_aggregation_covers_join_member(
         pre_aggr: &CompiledPreAggregation,
         member: &Rc<MemberSymbol>,
     ) -> bool {
-        let matches_directly = pre_aggr
-            .dimensions
-            .iter()
-            .chain(pre_aggr.segments.iter())
-            .any(|pa_m| member == pa_m);
-
-        matches_directly
+        pre_aggr.dimensions.iter().any(|pa_m| member == pa_m)
             || pre_aggr.time_dimensions.iter().any(|pa_m| {
                 pa_m.as_time_dimension()
                     .map(|td| td.base_symbol() == member)
                     .unwrap_or(false)
-                    || member == pa_m
             })
     }
 

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_missing_key.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_missing_key.yaml
@@ -1,0 +1,60 @@
+# A rollupJoin whose leg rollup omits the dimension its own join is on, so the hop cannot be
+# resolved. The rejection message is what tells the author which rollup to fix.
+cubes:
+  - name: mk_orders
+    sql: "SELECT 1 as id, 1 as customer_id, 10 as amount"
+
+    joins:
+      - name: mk_customers
+        relationship: many_to_one
+        sql: "{CUBE.customer_id} = {mk_customers.customer_id}"
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: customer_id
+        type: number
+        sql: customer_id
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: mk_orders_rollup
+        type: rollup
+        measures:
+          - total_amount
+        dimensions:
+          - customer_id
+      - name: mk_rollup_join
+        type: rollupJoin
+        measures:
+          - total_amount
+        dimensions:
+          - mk_customers.customer_name
+        rollups:
+          - mk_orders.mk_orders_rollup
+          - mk_customers.mk_customers_rollup
+
+  - name: mk_customers
+    sql: "SELECT 1 as customer_id, 'Acme' as customer_name"
+
+    dimensions:
+      - name: customer_id
+        type: number
+        sql: customer_id
+        primary_key: true
+      - name: customer_name
+        type: string
+        sql: customer_name
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      # Omits customer_id, the mk_orders -> mk_customers join key.
+      - name: mk_customers_rollup
+        type: rollup
+        dimensions:
+          - customer_name

--- a/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key.yaml
+++ b/rust/cube/cubesqlplanner/cubesqlplanner/src/test_fixtures/schemas/yaml_files/common/rollup_join_time_dimension_key.yaml
@@ -1,0 +1,65 @@
+# A rollupJoin whose join key is declared as a `time_dimension` on one leg rather than as a
+# plain dimension. Resolving the join must look at every member collection a rollup can
+# declare a key in, not only `dimensions`.
+cubes:
+  - name: td_facts
+    sql: "SELECT 1 as id, '2026-01-01'::timestamp as day, 10 as amount"
+
+    dimensions:
+      - name: id
+        type: number
+        sql: id
+        primary_key: true
+      - name: day
+        type: time
+        sql: day
+    measures:
+      - name: total_amount
+        type: sum
+        sql: amount
+    pre_aggregations:
+      - name: td_facts_rollup
+        type: rollup
+        measures:
+          - total_amount
+        time_dimension: day
+        granularity: day
+
+  - name: td_dates
+    sql: "SELECT '2026-01-01'::timestamp as day, 'Q1' as quarter_label"
+
+    joins:
+      - name: td_facts
+        relationship: one_to_many
+        sql: "{CUBE.day} = {td_facts.day}"
+    dimensions:
+      - name: day
+        type: time
+        sql: day
+        primary_key: true
+      - name: quarter_label
+        type: string
+        sql: quarter_label
+    measures:
+      - name: count
+        type: count
+        sql: "COUNT(*)"
+    pre_aggregations:
+      # `day` is the join key and is declared as the rollup's time_dimension.
+      - name: td_dates_rollup
+        type: rollup
+        dimensions:
+          - quarter_label
+        time_dimension: day
+        granularity: day
+      - name: td_rollup_join
+        type: rollupJoin
+        measures:
+          - td_facts.total_amount
+        dimensions:
+          - quarter_label
+        time_dimension: td_facts.day
+        granularity: day
+        rollups:
+          - td_dates.td_dates_rollup
+          - td_facts.td_facts_rollup


### PR DESCRIPTION
> [!WARNING]
> **Superseded — do not merge.** Review proved this emits an unexecutable join: both planners
> render `ON "td_dates__day" = "td_facts__day"` while the leg rollups only ever materialize
> `td_facts__day_day`. Master rejected such a schema with an actionable `No rollups found`; this
> branch accepts it and produces SQL that fails at execution — a worse failure mode than the one
> it replaced. Back to CORE-724 for re-planning as an ON-clause alias-resolution fix.
> Details, the executed before/after, and the open granularity question are in the planning doc.
> The docs PR #11470 is independent and unaffected.

## What this was trying to fix

The ticket reported that a `rollup_join` over a 4-cube chain fails where the 3-cube one matches, and
inferred a chain-depth limit in Tesseract. **There is no depth limit** — 4- and 5-cube chains match on
master on the same terms a 3-cube chain does. The inherited regression test failed for two reasons of
its own: its interior rollup declared only `[dim_x]`, not `dim_w` (the key on its own side of the new
hop), and it asserted the rollupJoin's own id appears in `preAggregationsDescription()`, which never
happens for a matched rollupJoin — you get the leg rollups, with the join named on
`preAggregationForQuery`.

A real defect was found next door: **a join key declared as a rollup's time dimension was invisible to
the lookup** that matches a hop to its leg rollups, so such a chain never resolved at any length. Both
planners had their own copy — Tesseract's `find_pre_aggregation_for_join` matched `dimensions` only,
and the JS `preAggObjForJoin` checked `references.dimensions`, which excludes `timeDimensions`.

## Why the fix is wrong

Widening the match predicate lets the hop resolve, but nothing teaches the **ON-clause renderer** that
the key lives in a granularity-suffixed column. The JS `sqlResolveFn` in
`PreAggregations.rollupPreAggregation` returns the bare `member.aliasName()`, and on the Rust side the
join-members loop in `PreAggregation::all_dimensions_refererences` runs *after* the time-dimensions
loop and overwrites `td_facts.day -> td_facts__day_day` with `td_facts__day` — which also corrupts the
query's own time dimension, rendered as `date_trunc('day', "td_facts__day") "td_facts__day_day"`.

No test caught it because the time-dimension test — the only one covering the actual fix — asserts
matching (`preAggregationsDescription()`, `preAggregationName`) and not rendering. The 4-/5-cube chain
tests in this PR do assert the SQL assembles; that one didn't meet the same bar.

## What is still worth keeping

- The refuted premise and the fixture diagnosis.
- The Tesseract error message, which now names the failing hop, the unmatched members, and which
  `rollup_join` to fix — a bare `No rollups found that can be used for rollup join` is why this was
  filed as a depth bug. Sound on its own merits, independent of the matching change.
- The 4- and 5-cube chain tests, which assert the SQL assembles rather than only that matching
  succeeded.

Refs #11362
