### PR TITLE
docs: document undocumented shipped console-ui and MCP features

### DIFF
--- a/docs-mintlify/docs/data-modeling/dev-mode.mdx
+++ b/docs-mintlify/docs/data-modeling/dev-mode.mdx
@@ -10,6 +10,14 @@ When you enter the development mode, you'll have access to your personal API end
 that will track the branch you're on and will be updated automatically when you make
 changes to the data model.
 
+## Creating a branch
+
+Open the branch picker in the deployment topbar and select **Create branch from…** to
+open the **Create branch** dialog. Set a **Branch name**, then pick a **Create from**
+source branch — Cube's own branches are listed first, followed by remote-only branches
+from the connected repository. Creating from a remote-only branch branches from it
+directly; it isn't first imported into Cube.
+
 ## Development flow
 
 ### Save changes

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/kpi.mdx
@@ -28,7 +28,7 @@ Displays a single value from your query result.
 | **Field** | The measure or dimension to display |
 | **Row** | Which row of the result to read from |
 | **Format** | Number formatting (currency, percent, etc.) |
-| **Font size / color** | Text appearance |
+| **Value color / Background / Font size** | Text appearance, set from the Style tab |
 | **Alignment** | Left, center, or right |
 
 {/* TODO screenshot: Number block (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
@@ -42,7 +42,7 @@ Displays a current value alongside a previous value with a calculated difference
 | **Current field / row** | The primary value |
 | **Previous field / row** | The value to compare against — can be a different column or a different row from the same column |
 | **Difference format** | Absolute, percentage, or both |
-| **Positive color / Negative color** | Colors applied based on whether the change is positive or negative |
+| **Positive / Negative / Neutral colors** | Colors applied based on whether the change is positive, negative, or unchanged, set from the Style tab |
 
 To compare to a static goal, add a column to your query that always returns the same number (e.g. a calculated field with a constant), then select it as the **Previous** field.
 
@@ -58,6 +58,7 @@ Shows a value relative to a target as a progress bar or circle. Useful for goal 
 | **Target field / row** | The goal or maximum value |
 | **Style** | Bar or circle |
 | **Color** | Fill color for the progress indicator |
+| **Background** | Fill color behind the block, set from the Style tab |
 
 <Tip>
 To compare against a static number like a quarterly goal, add a calculated field that always returns that number and use it as the **Target** field.
@@ -77,6 +78,7 @@ Renders a compact trend chart — either a bar or line — within the KPI tile. 
 | **Height / Width** | Dimensions of the sparkline in the tile |
 | **Max points** | Limits the number of data points rendered |
 | **Colors** | Line/fill colors |
+| **Background** | Fill color behind the block, set from the Style tab |
 
 {/* TODO screenshot: Sparkline block showing a trend line (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
@@ -92,6 +94,10 @@ Use text blocks for short labels and headings inside the KPI. For complex layout
 
 A free-form HTML block rendered inside the KPI tile. Use this for advanced custom layouts that go beyond what the other block types support.
 
+| Setting | Description |
+|---|---|
+| **Background** | Fill color behind the block, set from the Style tab |
+
 {/* TODO screenshot: HTML block with custom content (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
 ## Layout controls
@@ -103,7 +109,7 @@ KPI tiles have a layout panel that controls how blocks are arranged:
 | **Direction** | Row (blocks side-by-side) or Column (blocks stacked vertically) |
 | **Alignment** | How blocks align on the cross axis |
 | **Justify** | How blocks are distributed along the main axis |
-| **Gap** | Spacing between blocks |
+| **Gap** | Extra spacing between blocks, on top of each block's own internal padding |
 | **Wrap** | Whether blocks wrap to a new line when the tile is narrow |
 
 ## Converting to raw Markdown

--- a/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/chart-types/pie.mdx
@@ -15,15 +15,34 @@ Standard filled circle. Each slice's arc length is proportional to its value.
 
 ### Donut
 
-A pie with a hollow center. Increase the **Inner radius** value in the Style tab to any non-zero value to switch to a donut. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
+A pie with a hollow center. Set **Shape** to **Donut** in the Style tab; the inner radius is fixed, with no separate size control. The hollow center can be used to surface a summary value via a [KPI](/docs/explore-analyze/charts/chart-types/kpi) tile on a dashboard, or simply to reduce visual density.
 
-{/* Screenshot: donut chart — same data as the pie variant, with inner radius applied. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+{/* Screenshot: donut chart — same data as the pie variant, with Shape set to Donut. Place directly below this heading, half-width centered or side-by-side with pie. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
 
-## Inner radius
+## Rings
 
-Drag the **Inner radius** slider in the Style tab or enter a pixel value. Setting it to `0` returns to a full pie.
+Query more than one dimension and the chart splits into concentric rings, one per dimension, each nested by category within the ring above it. Reorder rings by dragging a row in the **Rings** section of the Fields tab; the top row is the innermost ring.
 
-{/* Screenshot: Style tab with the Inner radius control highlighted. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+<Note>
+
+A measure that isn't additive across categories — an average or a distinct count, for example — doesn't sum correctly once split across rings, so only the outer ring's value is exact. The chart shows an inline warning when this applies.
+
+</Note>
+
+## Data labels
+
+Configure labels from the **Data labels** section of the Style tab:
+
+- **Content** — independently toggle **Category**, **Value**, and **Percent**; any combination is allowed. **Value** and **Percent** each carry their own number format, set from the format button next to their toggle.
+- **Position** — **Inside** the slice or **Outside** it.
+- **Ring scope** — on a chart with [rings](#rings), show labels on the **outer ring** only or on **all rings**. Inner rings only ever show **Category**, since **Value** and **Percent** would need per-ring aggregation.
+- **Font size** — in pixels.
+
+{/* Screenshot: Style tab's Data labels section with Category/Value/Percent toggles and format buttons. Place inline, 50% width, right-aligned. (hidden — replace this comment with <Frame><img src="..." /></Frame> when image is ready) */}
+
+## Tooltip fields
+
+By default, the hover tooltip lists every queried field. Narrow it to specific fields, or turn it off, from the **Tooltips** control in the Fields tab.
 
 ## Color and slice ordering
 

--- a/docs-mintlify/docs/integrations/mcp-server.mdx
+++ b/docs-mintlify/docs/integrations/mcp-server.mdx
@@ -211,7 +211,7 @@ neither `listDeployments` nor the `chat` selection can reach an excluded deploym
 
 ## Available actions
 
-The MCP server exposes 16 tools, grouped below.
+The MCP server exposes 20 tools, grouped below.
 
 Every tool runs as the authenticated user. Queries respect the same
 [permissions][ref-roles] as the rest of Cube, including row-level security — MCP is a new
@@ -277,6 +277,8 @@ default. Users without it never see them.
 | `writeDataModelFile` | Creates or overwrites a model source file on the dev branch (whole-file replacement). Recompiles the model and reports `valid` plus any `validationError`. | Destructive — prompts |
 | `deleteDataModelFile` | Deletes a model source file on the dev branch. | Destructive — prompts |
 | `getDataModelChanges` | Shows the diff of the dev branch against its parent — the pending changes, for review before committing. | Read-only |
+| `getBranchDiff` | Diffs any branch against a base (the deploy branch by default), returning the changed files with insertion/deletion counts and the unified diff. Unlike `getDataModelChanges`, this works for any branch, not just a dev branch versus its immediate parent. | Read-only |
+| `getDeploymentEnv` | Lists the deployment's environment variables, with secret-looking values redacted. Useful for confirming configuration — an export bucket setting, say — when a pre-aggregation build fails. | Read-only |
 
 #### How model edits stay safe
 
@@ -293,10 +295,22 @@ into the MCP server:
   from the Cube UI, as described in [Development mode][ref-dev-mode]. The MCP server
   deliberately exposes no commit tool — an AI client can prepare changes, but only a
   person can ship them.
-- **Registration is permission-gated.** The six tools above are only offered to users
+- **Registration is permission-gated.** The eight tools above are only offered to users
   whose role allows editing the semantic model.
 
 Review pending work with `getDataModelChanges` before you commit.
+
+### Pre-aggregations
+
+Gated by the same permission as data model editing. A query alone can't prove a
+[pre-aggregation][ref-pre-aggs] rollup was actually used, and an external pre-aggregation
+can fail in configuration-specific ways — a missing export bucket, denied permissions —
+that only a build surfaces.
+
+| Tool | Description | Access |
+| --- | --- | --- |
+| `getPreAggregationStatus` | Lists pre-aggregations with their partition counts, how many have built, the newest build time, and the exact error if a build failed. | Read-only |
+| `buildPreAggregation` | Queues an on-demand build of one pre-aggregation and returns once it's accepted. The build runs asynchronously — poll `getPreAggregationStatus` afterwards for the result. | Write |
 
 ## Example workflows
 
@@ -362,3 +376,4 @@ publish it.
 [ref-workbooks]: /docs/explore-analyze/workbooks
 [ref-dashboards]: /docs/explore-analyze/dashboards
 [ref-dev-mode]: /docs/data-modeling/dev-mode
+[ref-pre-aggs]: /admin/monitoring/pre-aggregations


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required

Found while cross-checking recently shipped Cube Cloud (cubejs-enterprise) features against docs-mintlify — these had shipped (customer-visible, not behind an inactive flag) but weren't reflected in the docs yet.

**Description of Changes Made**

- **`docs/explore-analyze/charts/chart-types/pie.mdx`** — the pie/donut chart builder was reworked (cubedevinc/cubejs-enterprise#13580): the old "Inner radius" slider is gone, replaced by a Pie/Donut **Shape** selector; multiple dimensions now split the chart into concentric, reorderable **Rings** (with a non-additive-measure warning); a new **Data labels** section supports independent Category/Value/Percent content, per-atom number formats, inside/outside position, ring scope, and font size; and tooltip fields are now configurable. Updated the page to match.
- **`docs/explore-analyze/charts/chart-types/kpi.mdx`** — KPI blocks got per-block Style-tab controls (cubedevinc/cubejs-enterprise#13162, already covered by the in-app changelog): value color/background/font size on Number, a Neutral change color on Comparison, and a background on Progress/Sparkline/HTML blocks. Also documented that block spacing now lives inside each block rather than only in the Gap setting.
- **`docs/integrations/mcp-server.mdx`** — four new MCP tools shipped (cubedevinc/cubejs-enterprise#13634): `getBranchDiff`, `getDeploymentEnv`, `getPreAggregationStatus`, and `buildPreAggregation`, all gated behind the same data-model-editing permission as the existing six tools. Updated the tool count (16 → 20) and added rows/a new subsection for them.
- **`docs/data-modeling/dev-mode.mdx`** — added a short "Creating a branch" section documenting the branch picker's **Create branch from…** dialog (cubedevinc/cubejs-enterprise#13552), which lets you branch from an explicitly chosen source (including remote-only branches) instead of only the currently checked-out branch. This page previously had no section on creating a branch at all.

**Test plan**
- Read-only documentation change; no code paths affected.
- Verified terminology (control labels, tool names, permission gating) against the corresponding console-ui/ai-engineer source and i18n locale strings in cubejs-enterprise.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01JSyofMxTLFxVUCo5y8TRM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSyofMxTLFxVUCo5y8TRM6)_