### PR TITLE
docs(dashboards): document Dashboard Agent duplicate-then-edit for Explorer-role viewers

### DIFF
--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -114,10 +114,23 @@ contents — text, PDF, ZIP, and image files are supported.
   supported. Confirm this in your deployment before relying on it.
 </Note>
 
+## Editing without edit access to this dashboard
+
+If you have the Explorer role or higher but don't have edit access to this
+specific dashboard's workbook, asking the agent to change something doesn't
+just explain the limitation. Instead, the agent duplicates the dashboard into
+a new workbook that you own, applies your requested change to that copy, and
+hands you off to the new dashboard — the original is never touched. If you do
+have edit access to the dashboard's workbook, the agent edits it in place
+instead.
+
 ## What the Dashboard Agent can and can't do
 
-The published Dashboard Agent can answer questions and adjust your own view, but
-it never changes the **saved** dashboard.
+The published Dashboard Agent can answer questions and adjust your own view,
+but it never changes the **saved** dashboard — unless it duplicates it for you
+first, as described in
+[Editing without edit access to this dashboard](#editing-without-edit-access-to-this-dashboard)
+above.
 
 **It can:**
 
@@ -137,11 +150,16 @@ it never changes the **saved** dashboard.
 
 - Save its filter or time-granularity changes to the dashboard — they apply to
   your session only and never change what other viewers see
-- Edit the dashboard, or add/remove widgets
+- Edit this dashboard directly, or add/remove its widgets — if you have the
+  Explorer role or higher, it duplicates the dashboard into a new workbook
+  and edits the copy instead, or edits in place if you have edit access to
+  the dashboard's workbook; see
+  [Editing without edit access to this dashboard](#editing-without-edit-access-to-this-dashboard)
 - Create reports or workbooks
 - Change the data model
 
-If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
+If you need any of those and don't have the Explorer role or higher, use the
+[Workbook Agent][ref-workbook-agent] instead.
 
 ## Limitations
 
@@ -151,9 +169,12 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
   applies to your session only — it is never saved to the dashboard. If you ask
   it to change something with no control on the dashboard, it explains the
   current state instead of applying a change.
-- **No authoring on published dashboards.** The published Dashboard Agent
-  cannot create reports or build dashboards, edit the saved dashboard, or change
-  the data model. Those live in the [Workbook Agent][ref-workbook-agent].
+- **No authoring on published dashboards for viewers without the Explorer
+  role.** The published Dashboard Agent cannot create reports or build
+  dashboards, edit the saved dashboard, or change the data model. Those live
+  in the [Workbook Agent][ref-workbook-agent]. Explorer-role-and-above viewers
+  get a form of authoring too — see
+  [Editing without edit access to this dashboard](#editing-without-edit-access-to-this-dashboard).
 - **Report search covers published reports only.** When the agent searches for
   existing reports, it sees published reports.
 


### PR DESCRIPTION
**Check List**
- [x] Tests have been run in packages where changes have been made if available
- [x] Linter has been run for changed code
- [ ] Tests for the changes have been added if not covered yet
- [x] Docs have been added / updated if required

**Description of Changes Made**

Routine sweep cross-checking recent `cubejs-enterprise` changes against `docs-mintlify`, filtered through the customer-facing criteria in `cubejs-enterprise/.claude/shared/customer-facing-criteria.md`.

`cubejs-enterprise#13610` (CUB-3052, shipped) changed the published Dashboard Agent's behavior for a viewer who has the Explorer role (or higher) but lacks edit access to the specific dashboard's workbook: asking the agent to change something no longer just explains the limitation — the agent now duplicates the dashboard into a new workbook the viewer owns, applies the change to the copy, and hands the viewer off to the new dashboard. The original dashboard is never touched. Editors with workbook edit access continue to edit in place (pre-existing behavior, confirmed still gated by a separate `editableWorkbookId` signal in the frontend code).

`docs/explore-analyze/dashboards/dashboard-agent.mdx` flatly stated the agent "can't ... Edit the dashboard, or add/remove widgets" for everyone, which is no longer accurate for Explorer-role-and-above viewers. This PR:

- Adds a new **Editing without edit access to this dashboard** section describing the duplicate-then-edit flow.
- Updates the **What the Dashboard Agent can and can't do** intro and the "It can't" bullet to note the exception.
- Updates the **Limitations** section's "no authoring" bullet accordingly.

No code changes; docs only.

(Note: a separate open PR, #11405, documents the *editor* in-place-editing behavior for the same page — that's a distinct pre-existing capability this PR doesn't overlap with, though both touch the same "can/can't" section and may need reconciling at merge time.)

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014LqH3dZ9Vw8NzqBWCqtj1s

---
_Generated by [Claude Code](https://claude.ai/code/session_014LqH3dZ9Vw8NzqBWCqtj1s)_