### PR TITLE
docs: dashboard-agent copy-to-edit, small multiples 5x5 grid, dashboard slug in builder

### DIFF
--- a/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
+++ b/docs-mintlify/docs/explore-analyze/charts/configuration/small-multiples.mdx
@@ -23,7 +23,7 @@ These options appear once a **Split by** dimension is chosen.
 
 | Option | What it does |
 |---|---|
-| **Grid** | Columns × rows, up to 5 × 4. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
+| **Grid** | Columns × rows, up to 5 × 5. Both are preselected from the number of distinct values in the split dimension, so a four-value dimension opens as a 2 × 2 grid. |
 | **Axis scales** | Whether every panel is drawn against the same scale (**Shared**) or each scales to its own data (**Independent**). |
 | **Sort panels by** | Orders the panels by the dimension's own values (**Value**) or by a measure (**Measure**). |
 | **Sort order** | **Ascending** or **Descending**. |
@@ -38,7 +38,7 @@ Switch to **Independent** when the question is about the *shape* of each series 
 
 ### How many panels are drawn
 
-The grid bounds the render: a chart split into 3 × 2 draws at most six panels, so a high-cardinality dimension can never produce hundreds of unreadable ones. The largest grid is 5 × 4, or twenty panels.
+The grid bounds the render: a chart split into 3 × 2 draws at most six panels, so a high-cardinality dimension can never produce hundreds of unreadable ones. The largest grid is 5 × 5, or twenty-five panels.
 
 When a dimension has more values than the grid has tiles, the chart draws the first ones in the current sort order. The underlying query is unaffected, so no data is lost — a bigger grid simply shows more of it.
 

--- a/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/dashboard-agent.mdx
@@ -104,6 +104,20 @@ How it works and what to expect:
 This works the same way on both published dashboards and
 [embedded][ref-embedding] dashboards.
 
+## Copying a dashboard to make an edit
+
+If you ask the agent for a change that would require editing the dashboard
+itself — adding or removing a widget, changing the layout — it never applies
+that change to the dashboard you're viewing. If you can create workbooks
+yourself (the [Explorer role][ref-roles] or above) but don't have edit access
+to *this* dashboard, the agent instead duplicates it into a new workbook you
+own, applies your requested change to that copy, and shows a **Copy created**
+card with an **Open copy in builder** button to take you there. The original
+dashboard is never touched, and only you see the copy.
+
+If you don't have permission to create workbooks (the Viewer role), the agent
+tells you it can't make the change instead of creating a copy.
+
 ## Attachments
 
 You can attach uploaded files to the conversation, and the agent can read their
@@ -137,8 +151,10 @@ it never changes the **saved** dashboard.
 
 - Save its filter or time-granularity changes to the dashboard — they apply to
   your session only and never change what other viewers see
-- Edit the dashboard, or add/remove widgets
-- Create reports or workbooks
+- Edit the dashboard, or add/remove widgets — if you can create workbooks
+  yourself, it offers an editable copy instead; see
+  [Copying a dashboard to make an edit](#copying-a-dashboard-to-make-an-edit)
+- Create reports or workbooks from scratch
 - Change the data model
 
 If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
@@ -152,8 +168,11 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
   it to change something with no control on the dashboard, it explains the
   current state instead of applying a change.
 - **No authoring on published dashboards.** The published Dashboard Agent
-  cannot create reports or build dashboards, edit the saved dashboard, or change
-  the data model. Those live in the [Workbook Agent][ref-workbook-agent].
+  never edits the saved dashboard, or changes the data model. Those live in the
+  [Workbook Agent][ref-workbook-agent]. If your edit request needs dashboard
+  authoring and you can create workbooks, the agent offers an editable copy
+  instead — see
+  [Copying a dashboard to make an edit](#copying-a-dashboard-to-make-an-edit).
 - **Report search covers published reports only.** When the agent searches for
   existing reports, it sees published reports.
 
@@ -163,3 +182,4 @@ If you need any of those, use the [Workbook Agent][ref-workbook-agent] instead.
 [ref-controls]: /docs/explore-analyze/dashboards/widgets/controls
 [ref-control-visibility]: /docs/explore-analyze/dashboards/widgets/controls#visibility
 [ref-embedding]: /embedding/iframe/dashboards
+[ref-roles]: /admin/users-and-permissions/roles-and-permissions

--- a/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
+++ b/docs-mintlify/docs/explore-analyze/dashboards/index.mdx
@@ -48,7 +48,8 @@ dashboard by its slug to drill into it.
 To set it, open the dashboard in the builder, open the **options sidebar**, and
 fill the **Slug** field. Slugs are **unique per deployment** and are resolved
 within the current deployment, so the same model works across environments. The
-dashboard's own URL is unaffected (it stays `publicId`-based).
+dashboard's own URL is unaffected (it stays `publicId`-based). Once set, the
+slug also appears next to the title in the dashboard builder header.
 
 <Note>
 


### PR DESCRIPTION
**Check List**
- [x] Docs have been added / updated if required
- [ ] Tests have been run in packages where changes have been made if available (docs-only change)
- [ ] Linter has been run for changed code (docs-only change)
- [ ] Tests for the changes have been added if not covered yet (docs-only change)

**Description of Changes Made**

Routine audit of recent `cubejs-enterprise` (Cube Cloud) commits against `docs-mintlify`, filtered against the customer-facing criteria, turned up three small doc gaps:

1. **Dashboard Agent copy-to-edit** (`docs/explore-analyze/dashboards/dashboard-agent.mdx`) — a recent change (`feat(dashboards): agent duplicates a view-only dashboard before editing`, CUB-3052) means the agent no longer just refuses an edit request on a dashboard you can't edit: if you can create workbooks yourself (Explorer role or above), it duplicates the dashboard into a new workbook you own and applies the edit there, leaving the original untouched. Added a new section documenting this and corrected the "It can't" / "Limitations" bullets, which were now stale.
2. **Small multiples grid size** (`docs/explore-analyze/charts/configuration/small-multiples.mdx`) — the page said the grid maxes out at 5 × 4 (twenty panels); the shipped `MAX_GRID_COLUMNS`/`MAX_GRID_ROWS` constants and i18n strings (`rows5`) confirm it's actually 5 × 5 (twenty-five panels). Corrected both mentions.
3. **Dashboard slug in builder header** (`docs/explore-analyze/dashboards/index.mdx`) — a recent change surfaces the dashboard's slug next to the title in the builder header once set. Added one clarifying sentence.

No large undocumented features were found in this pass (nothing warranting a new dedicated page / Linear ticket).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01L7VFJBrzgiGeci6TUYohyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7VFJBrzgiGeci6TUYohyx)_